### PR TITLE
Preserve explicit-onehot PPA diagnostics

### DIFF
--- a/control_plane/control_plane/artifact_policy.py
+++ b/control_plane/control_plane/artifact_policy.py
@@ -73,4 +73,8 @@ def is_transportable_expected_output(path_text: str) -> bool:
             path.name.startswith(prefix) for prefix in _ALLOWED_DATASET_PREFIXES
         ):
             return True
+    if rel_path.startswith("runs/designs/"):
+        name = PurePosixPath(rel_path).name
+        if name == "timing_debug_report.md" or name.endswith("_fsm_diagnostic.json"):
+            return True
     return any(rel_path.endswith(suffix) for suffix in _ALLOWED_RUNS_SUFFIXES)

--- a/control_plane/control_plane/tests/test_artifact_policy.py
+++ b/control_plane/control_plane/tests/test_artifact_policy.py
@@ -13,6 +13,22 @@ def test_transportable_expected_output_rejects_campaign_artifacts_dir() -> None:
     )
 
 
+def test_transportable_expected_output_allows_design_local_fsm_diagnostic_and_timing_report() -> None:
+    base = "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv"
+
+    assert is_transportable_expected_output(f"{base}/explicit_onehot_fsm_diagnostic.json")
+    assert is_transportable_expected_output(f"{base}/trials/trial_001/explicit_onehot_fsm_diagnostic.json")
+    assert is_transportable_expected_output(f"{base}/timing_debug_report.md")
+
+
+def test_transportable_expected_output_rejects_design_local_source_rtl_and_manifests() -> None:
+    base = "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv"
+
+    assert not is_transportable_expected_output(f"{base}/1_synth.v")
+    assert not is_transportable_expected_output(f"{base}/generated_sv2v.v")
+    assert not is_transportable_expected_output(f"{base}/manifest.json")
+
+
 def test_transportable_expected_output_allows_compact_attention_kv_dataset() -> None:
     assert is_transportable_expected_output(
         "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"

--- a/control_plane/control_plane/tests/test_artifact_stage.py
+++ b/control_plane/control_plane/tests/test_artifact_stage.py
@@ -210,3 +210,29 @@ def test_collect_expected_output_artifacts_includes_large_attention_schedule_dat
     assert artifacts[0].metadata["transport_policy"] == "inline_text_evidence"
     assert "inline_utf8" not in artifacts[0].metadata
     assert artifacts[1].metadata["inline_utf8"] == "# endpoint schedule\n"
+
+
+def test_collect_expected_output_artifacts_includes_design_local_diagnostic_and_timing_report(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    base = (
+        "runs/designs/npu_blocks/"
+        "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv"
+    )
+    diagnostic_rel = f"{base}/explicit_onehot_fsm_diagnostic.json"
+    report_rel = f"{base}/timing_debug_report.md"
+    _write_json(repo_root / diagnostic_rel, {"promotion_valid": False, "promotion_reasons": ["status is flow_failed, not ok"]})
+    (repo_root / report_rel).write_text("# timing debug\n", encoding="utf-8")
+
+    artifacts = collect_expected_output_artifacts(
+        repo_root=str(repo_root),
+        expected_outputs=[diagnostic_rel, report_rel],
+    )
+
+    assert [artifact.path for artifact in artifacts] == [diagnostic_rel, report_rel]
+    assert all(artifact.kind == "expected_output" for artifact in artifacts)
+    assert all(artifact.metadata["transport_policy"] == "inline_text_evidence" for artifact in artifacts)
+    assert artifacts[0].metadata["inline_utf8"].startswith("{\n")
+    assert artifacts[1].metadata["inline_utf8"] == "# timing debug\n"

--- a/control_plane/control_plane/tests/test_worker_executor.py
+++ b/control_plane/control_plane/tests/test_worker_executor.py
@@ -759,6 +759,100 @@ def test_worker_marks_failed_run_when_command_fails() -> None:
             assert run.result_payload["retry_decision"]["requeue"] is False
 
 
+def test_worker_stages_design_local_diagnostic_and_timing_report_on_failure() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        init_git_repo(repo_root)
+        db_path = Path(td) / "cp.db"
+        engine = create_engine(f"sqlite+pysqlite:///{db_path}", future=True)
+        create_all(engine)
+        item_id = "item_fail_with_diagnostic"
+        metrics_rel = f"runs/campaigns/{item_id}/metrics.csv"
+        diagnostic_rel = (
+            "runs/designs/npu_blocks/"
+            "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/"
+            "explicit_onehot_fsm_diagnostic.json"
+        )
+        report_rel = (
+            "runs/designs/npu_blocks/"
+            "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/"
+            "timing_debug_report.md"
+        )
+        with Session(engine) as session:
+            seed_ready_work_item(session, item_id=item_id, repo_root=repo_root, failing=False)
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            work_item.assigned_machine_key = "worker-1"
+            work_item.state = WorkItemState.READY
+            work_item.command_manifest = [
+                {
+                    "name": "write_metrics_and_diagnostic",
+                    "run": (
+                        "python3 -c \"from pathlib import Path; "
+                        f"metrics=Path('{metrics_rel}'); "
+                        f"diagnostic=Path('{diagnostic_rel}'); "
+                        f"report=Path('{report_rel}'); "
+                        "metrics.parent.mkdir(parents=True, exist_ok=True); "
+                        "diagnostic.parent.mkdir(parents=True, exist_ok=True); "
+                        "report.parent.mkdir(parents=True, exist_ok=True); "
+                        "metrics.write_text('metric,value\\nlatency,1\\n', encoding='utf-8'); "
+                        "diagnostic.write_text('{\\n"
+                        "\\\"promotion_valid\\\": false,\\n"
+                        "\\\"promotion_reasons\\\": [\\\"status is flow_failed, not ok\\\"]\\n"
+                        "}\\n', encoding='utf-8'); "
+                        "report.write_text('# timing debug\\n', encoding='utf-8')\""
+                    ),
+                },
+                {
+                    "name": "fail_step",
+                    "run": "python3 -c \"import sys; sys.exit(3)\"",
+                },
+            ]
+            work_item.expected_outputs = [metrics_rel, diagnostic_rel, report_rel]
+            session.commit()
+
+        session_factory = build_session_factory(engine)
+        results = run_worker(
+            session_factory,
+            config=WorkerConfig(
+                repo_root=str(repo_root),
+                machine_key="worker-1",
+                capabilities={"platform": "nangate45", "flow": "openroad"},
+                capability_filter={"platform": "nangate45", "flow": "openroad"},
+                lease_seconds=60,
+                heartbeat_seconds=1,
+            ),
+            max_items=1,
+        )
+
+        assert len(results) == 1
+        assert results[0].status == "failed"
+
+        with Session(engine) as session:
+            run = session.query(Run).filter_by(run_key=results[0].run_key).one()
+            payload = dict(run.result_payload or {})
+            expected_artifacts = {
+                artifact.path: artifact for artifact in run.artifacts if artifact.kind == "expected_output"
+            }
+            assert run.status == RunStatus.FAILED
+            assert payload["failure_classification"]["category"] == "command_failure"
+            assert diagnostic_rel in expected_artifacts
+            assert report_rel in expected_artifacts
+            assert (
+                expected_artifacts[diagnostic_rel].metadata_["transport_policy"]
+                == "inline_text_evidence"
+            )
+            assert (
+                expected_artifacts[report_rel].metadata_["transport_policy"]
+                == "inline_text_evidence"
+            )
+            assert (
+                expected_artifacts[diagnostic_rel].metadata_["inline_utf8"]
+                == '{\n"promotion_valid": false,\n"promotion_reasons": ["status is flow_failed, not ok"]\n}\n'
+            )
+            assert expected_artifacts[report_rel].metadata_["inline_utf8"] == "# timing debug\n"
+
+
 def test_worker_marks_command_timeout_terminal() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/evaluation_requests.json
@@ -241,9 +241,10 @@
       ],
       "expected_result": {
         "direction": "measure_shared_score_multivalue_cluster_explicit_onehot_fsm_ppa",
-        "reason": "Retry the same explicit-onehot config/sweep/baseline after the guard config-selection fix. Promotion still requires the selected config path to match the generated design, the strict explicit_onehot exact-state diagnostic bound to the measured row and synthesized netlist, a successful 8 ns row with critical_path_ns<=8, and exact post-synthesis 7/11-bit state widths."
+        "reason": "R1 retried the same explicit-onehot config/sweep/baseline after the guard config-selection fix and reached successful PNR, but the post-PNR strict explicit_onehot checker still failed. Because explicit_onehot_fsm_diagnostic.json was not transported from that run, the exact checker failure cause remains unavailable."
       },
-      "status": "pending_implementation_merge"
+      "status": "failed_non_promotable",
+      "status_reason": "Successful PNR evidence exists for r1, but the strict post-synthesis checker failed and the diagnostic artifact was not transported, so the exact cause is not confirmed. The row is not promoted. A checker-only rescue remains conditional on preserving the evaluator's exact 1_synth.v and materializing the already DB-transported metrics artifact without rerunning OpenROAD; no dispatchable follow-up item is queued until that path exists."
     }
   ],
   "source_commit": "b968b50997ff980dd0a367ff0fe7c98d4f89b7fb"

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json
@@ -271,9 +271,10 @@
       ],
       "expected_result": {
         "direction": "measure_shared_score_multivalue_cluster_explicit_onehot_fsm_ppa",
-        "reason": "Retry the same explicit-onehot config/sweep/baseline after the guard config-selection fix. Promotion still requires the selected config path to match the generated design, the strict explicit_onehot exact-state diagnostic bound to the measured row and synthesized netlist, a successful 8 ns row with critical_path_ns<=8, and exact post-synthesis 7/11-bit state widths."
+        "reason": "R1 retried the same explicit-onehot config/sweep/baseline after the guard config-selection fix and reached successful PNR, but the post-PNR strict explicit_onehot checker still failed. Because explicit_onehot_fsm_diagnostic.json was not transported from that run, the exact checker failure cause remains unavailable."
       },
-      "status": "pending_implementation_merge"
+      "status": "failed_non_promotable",
+      "status_reason": "Successful PNR evidence exists for r1, but the strict post-synthesis checker failed and the diagnostic artifact was not transported, so the exact cause is not confirmed. The row is not promoted. A checker-only rescue remains conditional on preserving the evaluator's exact 1_synth.v and materializing the already DB-transported metrics artifact without rerunning OpenROAD; no dispatchable follow-up item is queued until that path exists."
     }
   ],
   "baseline_refs": [

--- a/npu/eval/check_attention_decode_score_multivalue_cluster_binary_fsm.py
+++ b/npu/eval/check_attention_decode_score_multivalue_cluster_binary_fsm.py
@@ -104,7 +104,7 @@ _DECL_ITEM_RE = re.compile(
 )
 _ABSOLUTE_PATH_RE = re.compile(r"(?<![A-Za-z0-9_.-])/(?:[^\s:]+/?)+")
 
-_SignalEvidence = dict[str, dict[str, set[int] | set[tuple[int, int]]]]
+_DeclarationEvidence = dict[str, dict[str, set[int] | set[tuple[int, int]]]]
 
 
 def _parse_params_json(value: str) -> dict[str, object]:
@@ -153,24 +153,17 @@ def _iter_declaration_items(statement: str):
         yield match
 
 
-def _empty_signal_evidence(expected_signal_indices: dict[str, set[int]]) -> _SignalEvidence:
-    return {
-        signal: {"packed": set(), "bits": set()}
-        for signal in expected_signal_indices
-    }
+def _empty_declaration_evidence() -> dict[str, set[int] | set[tuple[int, int]]]:
+    return {"packed": set(), "bits": set()}
 
 
-def _load_netlist_signal_evidence(
-    path: Path, expected_signal_indices: dict[str, set[int]]
-) -> _SignalEvidence:
-    evidence = _empty_signal_evidence(expected_signal_indices)
+def _load_netlist_signal_evidence(path: Path) -> _DeclarationEvidence:
+    evidence: _DeclarationEvidence = {}
     text = _strip_verilog_comments(path.read_text(encoding="utf-8"))
     for statement in text.split(";"):
         for match in _iter_declaration_items(statement):
             name = _normalize_verilog_identifier(match.group("name"))
-            if name not in expected_signal_indices:
-                continue
-            signal_data = evidence[name]
+            signal_data = evidence.setdefault(name, _empty_declaration_evidence())
             msb = match.group("msb")
             lsb = match.group("lsb")
             bit = match.group("bit")
@@ -184,8 +177,79 @@ def _load_netlist_signal_evidence(
     return evidence
 
 
+def _candidate_signal_names(
+    signal: str, evidence: _DeclarationEvidence
+) -> list[tuple[str, str]]:
+    if signal in evidence:
+        return [(signal, "exact")]
+    suffix = f".{signal}"
+    return [
+        (name, "qualified_suffix")
+        for name in sorted(evidence)
+        if name.endswith(suffix)
+    ]
+
+
+def _serialize_signal_candidate(
+    *,
+    candidate_name: str,
+    match_type: str,
+    signal_data: dict[str, set[int] | set[tuple[int, int]]],
+    width_valid: bool,
+    reasons: list[str],
+) -> dict[str, object]:
+    packed = cast(set[tuple[int, int]], signal_data["packed"])
+    bits = cast(set[int], signal_data["bits"])
+    return {
+        "name": candidate_name,
+        "match_type": match_type,
+        "width_valid": width_valid,
+        "reasons": reasons,
+        "observed_packed_ranges": [
+            {"msb": msb, "lsb": lsb} for msb, lsb in sorted(packed)
+        ],
+        "observed_bit_indices": sorted(bits),
+    }
+
+
+def _serialize_signal_evidence(
+    *,
+    expected_indices: set[int],
+    selected_name: str | None = None,
+    match_type: str | None = None,
+    selected_data: dict[str, set[int] | set[tuple[int, int]]] | None = None,
+    candidate_declarations: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    packed: set[tuple[int, int]] = set()
+    bits: set[int] = set()
+    if selected_data is not None:
+        packed = cast(set[tuple[int, int]], selected_data["packed"])
+        bits = cast(set[int], selected_data["bits"])
+    return {
+        "expected_bit_indices": sorted(expected_indices),
+        "matched_declaration": selected_name,
+        "match_type": match_type,
+        "observed_packed_ranges": [
+            {"msb": msb, "lsb": lsb} for msb, lsb in sorted(packed)
+        ],
+        "observed_bit_indices": sorted(bits),
+        "candidate_declarations": list(candidate_declarations or []),
+    }
+
+
+def _empty_serialized_signal_evidence(
+    expected_signal_indices: dict[str, set[int]]
+) -> dict[str, dict[str, object]]:
+    return {
+        signal: _serialize_signal_evidence(expected_indices=indices)
+        for signal, indices in expected_signal_indices.items()
+    }
+
+
 def _load_signal_indices_or_widths(
+    *,
     signal: str,
+    candidate_name: str,
     signal_data: dict[str, set[int] | set[tuple[int, int]]],
     expected_signal_indices: dict[str, set[int]],
 ) -> set[int]:
@@ -195,10 +259,14 @@ def _load_signal_indices_or_widths(
     if not isinstance(packed, set) or not isinstance(bits, set):
         raise TypeError(f"invalid internal evidence for {signal}")
 
+    if packed and bits:
+        raise ValueError(
+            f"invalid declaration for {signal}: candidate {candidate_name} mixes packed and bit declarations"
+        )
     if packed:
         if len(packed) != 1:
             raise ValueError(
-                f"invalid declaration for {signal}: multiple packed ranges present"
+                f"invalid declaration for {signal}: candidate {candidate_name} has multiple packed ranges present"
             )
         msb, lsb = next(iter(packed))
         expected_width = len(expected_indices)
@@ -207,7 +275,7 @@ def _load_signal_indices_or_widths(
         high = max(msb, lsb)
         if observed_width != expected_width or low != 0 or high != expected_width - 1:
             raise ValueError(
-                f"invalid width for {signal}: packed range [{msb}:{lsb}] is "
+                f"invalid width for {signal}: candidate {candidate_name} packed range [{msb}:{lsb}] is "
                 f"incompatible with allowed indices {sorted(expected_indices)}"
             )
         return set(range(expected_width))
@@ -218,7 +286,7 @@ def _load_signal_indices_or_widths(
     out_of_range = set(bits) - expected_indices
     if out_of_range:
         raise ValueError(
-            f"invalid width for {signal}: bit indices include out-of-range indices {sorted(out_of_range)}"
+            f"invalid width for {signal}: candidate {candidate_name} bit indices include out-of-range indices {sorted(out_of_range)}"
         )
     return set(bits)
 
@@ -240,51 +308,114 @@ def _optional_int(value: object) -> int | str | None:
         return _portable_text(text)
 
 
-def _serialize_signal_evidence(
-    evidence: _SignalEvidence, expected_signal_indices: dict[str, set[int]]
-) -> dict[str, object]:
-    serialized: dict[str, object] = {}
-    for signal, signal_data in evidence.items():
-        packed = cast(set[tuple[int, int]], signal_data["packed"])
-        bits = cast(set[int], signal_data["bits"])
-        serialized[signal] = {
-            "expected_bit_indices": sorted(expected_signal_indices[signal]),
-            "observed_packed_ranges": [
-                {"msb": msb, "lsb": lsb} for msb, lsb in sorted(packed)
-            ],
-            "observed_bit_indices": sorted(bits),
-        }
-    return serialized
-
-
 def _inspect_netlist_widths(
     path: Path, expected_signal_indices: dict[str, set[int]]
 ) -> tuple[dict[str, object], bool, list[str]]:
-    empty = _empty_signal_evidence(expected_signal_indices)
+    empty = _empty_serialized_signal_evidence(expected_signal_indices)
     try:
-        evidence = _load_netlist_signal_evidence(path, expected_signal_indices)
+        evidence = _load_netlist_signal_evidence(path)
     except (OSError, UnicodeError) as exc:
-        return _serialize_signal_evidence(empty, expected_signal_indices), False, [
+        return empty, False, [
             f"netlist_read_failed:{type(exc).__name__}"
         ]
 
     reasons: list[str] = []
+    serialized: dict[str, object] = {}
     for signal in expected_signal_indices:
-        try:
-            observed = _load_signal_indices_or_widths(signal, evidence[signal], expected_signal_indices)
-        except ValueError as exc:
-            reasons.append(str(exc))
-            continue
-        if not observed:
+        candidates = _candidate_signal_names(signal, evidence)
+        if not candidates:
+            serialized[signal] = _serialize_signal_evidence(
+                expected_indices=expected_signal_indices[signal]
+            )
             reasons.append(f"missing declaration for {signal}")
-        elif observed != expected_signal_indices[signal]:
-            missing = sorted(expected_signal_indices[signal] - observed)
-            extra = sorted(observed - expected_signal_indices[signal])
-            if missing:
-                reasons.append(f"missing declaration for {signal}: missing indices {missing}")
-            if extra:
-                reasons.append(f"invalid width for {signal}: out-of-range indices {extra}")
-    return _serialize_signal_evidence(evidence, expected_signal_indices), not reasons, reasons
+            continue
+
+        candidate_declarations: list[dict[str, object]] = []
+        valid_candidates: list[tuple[str, str, dict[str, set[int] | set[tuple[int, int]]]]] = []
+        candidate_reasons: list[str] = []
+        for candidate_name, match_type in candidates:
+            candidate_data = evidence[candidate_name]
+            try:
+                observed = _load_signal_indices_or_widths(
+                    signal=signal,
+                    candidate_name=candidate_name,
+                    signal_data=candidate_data,
+                    expected_signal_indices=expected_signal_indices,
+                )
+            except ValueError as exc:
+                reason_list = [str(exc)]
+                candidate_reasons.extend(reason_list)
+                candidate_declarations.append(
+                    _serialize_signal_candidate(
+                        candidate_name=candidate_name,
+                        match_type=match_type,
+                        signal_data=candidate_data,
+                        width_valid=False,
+                        reasons=reason_list,
+                    )
+                )
+                continue
+
+            reason_list: list[str] = []
+            if not observed:
+                reason_list = [f"missing declaration for {signal}"]
+            elif observed != expected_signal_indices[signal]:
+                missing = sorted(expected_signal_indices[signal] - observed)
+                if missing:
+                    reason_list.append(
+                        f"missing declaration for {signal}: candidate {candidate_name} missing indices {missing}"
+                    )
+            if reason_list:
+                candidate_reasons.extend(reason_list)
+            else:
+                valid_candidates.append((candidate_name, match_type, candidate_data))
+            candidate_declarations.append(
+                _serialize_signal_candidate(
+                    candidate_name=candidate_name,
+                    match_type=match_type,
+                    signal_data=candidate_data,
+                    width_valid=not reason_list,
+                    reasons=reason_list,
+                )
+            )
+
+        if candidates[0][1] == "exact":
+            candidate_name, match_type = candidates[0]
+            candidate_data = evidence[candidate_name]
+            serialized[signal] = _serialize_signal_evidence(
+                expected_indices=expected_signal_indices[signal],
+                selected_name=candidate_name,
+                match_type=match_type,
+                selected_data=candidate_data,
+                candidate_declarations=candidate_declarations,
+            )
+            if not valid_candidates:
+                reasons.extend(candidate_reasons or [f"missing declaration for {signal}"])
+            continue
+
+        if len(valid_candidates) == 1:
+            candidate_name, match_type, candidate_data = valid_candidates[0]
+            serialized[signal] = _serialize_signal_evidence(
+                expected_indices=expected_signal_indices[signal],
+                selected_name=candidate_name,
+                match_type=match_type,
+                selected_data=candidate_data,
+                candidate_declarations=candidate_declarations,
+            )
+            continue
+
+        serialized[signal] = _serialize_signal_evidence(
+            expected_indices=expected_signal_indices[signal],
+            candidate_declarations=candidate_declarations,
+        )
+        if len(valid_candidates) > 1:
+            reasons.append(
+                f"ambiguous qualified declaration for {signal}: multiple exact-width candidates "
+                f"{sorted(name for name, _, _ in valid_candidates)}"
+            )
+        else:
+            reasons.extend(candidate_reasons or [f"missing declaration for {signal}"])
+    return serialized, not reasons, reasons
 
 
 def _sha256_file(path: Path) -> str:
@@ -406,14 +537,9 @@ def _row_diagnostic(
         flow_variant=flow_variant,
     )
     netlist_exists = netlist_path.is_file()
-    signal_evidence: dict[str, object] = {
-        signal: {
-            "expected_bit_indices": sorted(indices),
-            "observed_packed_ranges": [],
-            "observed_bit_indices": [],
-        }
-        for signal, indices in profile.expected_signal_indices.items()
-    }
+    signal_evidence: dict[str, object] = _empty_serialized_signal_evidence(
+        profile.expected_signal_indices
+    )
     width_valid = False
     promotion_reasons: list[str] = []
     netlist_sha256: str | None = None
@@ -531,14 +657,7 @@ def validate_binary_fsm_metrics(
         "expected_logical_netlist_path": None,
         "netlist_exists": False,
         "netlist_sha256": None,
-        "signals": {
-            signal: {
-                "expected_bit_indices": sorted(indices),
-                "observed_packed_ranges": [],
-                "observed_bit_indices": [],
-            }
-            for signal, indices in profile.expected_signal_indices.items()
-        },
+        "signals": _empty_serialized_signal_evidence(profile.expected_signal_indices),
         "width_valid": False,
         "promotion_valid": False,
         "promotion_reasons": [],

--- a/tests/test_check_attention_decode_score_multivalue_cluster_binary_fsm.py
+++ b/tests/test_check_attention_decode_score_multivalue_cluster_binary_fsm.py
@@ -91,6 +91,33 @@ module top;
 endmodule
 """
 
+VALID_QUALIFIED_SUFFIX_EXPLICIT_ONEHOT_DECLARATIONS = """\
+module top;
+  wire [6:0] \\cluster_ctrl/state_q ;
+  wire [10:0] \\cluster_ctrl/reducer.state ;
+endmodule
+"""
+
+AMBIGUOUS_QUALIFIED_SUFFIX_EXPLICIT_ONEHOT_DECLARATIONS = """\
+module top;
+  wire [6:0] \\cluster_a/state_q ;
+  wire [6:0] \\cluster_b/state_q ;
+  wire [10:0] \\cluster_ctrl/reducer.state ;
+endmodule
+"""
+
+PARTIAL_QUALIFIED_SUFFIX_EXPLICIT_ONEHOT_DECLARATIONS = """\
+module top;
+  wire \\cluster_ctrl/state_q[0] ;
+  wire \\cluster_ctrl/state_q[1] ;
+  wire \\cluster_ctrl/state_q[2] ;
+  wire \\cluster_ctrl/state_q[3] ;
+  wire \\cluster_ctrl/state_q[4] ;
+  wire \\cluster_ctrl/state_q[5] ;
+  wire [10:0] \\cluster_ctrl/reducer.state ;
+endmodule
+"""
+
 
 def _synth_results_dir(root: Path) -> Path:
     return root / "orfs" / "flow" / "results"
@@ -437,6 +464,48 @@ def test_check_attention_decode_score_multivalue_cluster_binary_fsm_accepts_expl
         assert diagnostic["promotion_valid"] is True
 
 
+def test_check_attention_decode_score_multivalue_cluster_binary_fsm_accepts_unique_qualified_suffix_candidates() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        metrics = _metrics_path(root)
+        _write_netlist(
+            root,
+            flow_variant=EXPLICIT_ONEHOT_VARIANT,
+            body=VALID_QUALIFIED_SUFFIX_EXPLICIT_ONEHOT_DECLARATIONS,
+        )
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    critical_path_ns=7.2,
+                    result_path=(
+                        "runs/designs/npu_blocks/"
+                        "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json"
+                    ),
+                    tag=EXPLICIT_ONEHOT_TAG,
+                    flow_variant=EXPLICIT_ONEHOT_VARIANT,
+                    synth_args=None,
+                )
+            ],
+        )
+        diagnostic_out = metrics.parent / "explicit_onehot_fsm_diagnostic.json"
+
+        proc = _run_checker(
+            metrics,
+            synth_results_dir=_synth_results_dir(root),
+            diagnostic_out=diagnostic_out,
+            profile="explicit_onehot",
+        )
+
+        assert proc.returncode == 0, proc.stderr
+        diagnostic = json.loads(diagnostic_out.read_text(encoding="utf-8"))
+        assert diagnostic["signals"]["state_q"]["matched_declaration"] == "cluster_ctrl.state_q"
+        assert diagnostic["signals"]["state_q"]["match_type"] == "qualified_suffix"
+        assert diagnostic["signals"]["reducer.state"]["matched_declaration"] == "cluster_ctrl.reducer.state"
+        assert diagnostic["promotion_valid"] is True
+
+
 def test_check_attention_decode_score_multivalue_cluster_binary_fsm_targeted_profile_relies_on_post_synth_widths() -> None:
     with tempfile.TemporaryDirectory() as td:
         root = Path(td)
@@ -717,6 +786,76 @@ def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_expl
         assert "invalid width for reducer.state" in proc.stderr
 
 
+def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_ambiguous_qualified_suffix_candidates() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        metrics = _metrics_path(root)
+        _write_netlist(
+            root,
+            flow_variant=EXPLICIT_ONEHOT_VARIANT,
+            body=AMBIGUOUS_QUALIFIED_SUFFIX_EXPLICIT_ONEHOT_DECLARATIONS,
+        )
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    critical_path_ns=7.2,
+                    result_path=(
+                        "runs/designs/npu_blocks/"
+                        "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json"
+                    ),
+                    tag=EXPLICIT_ONEHOT_TAG,
+                    flow_variant=EXPLICIT_ONEHOT_VARIANT,
+                    synth_args=None,
+                )
+            ],
+        )
+        proc = _run_checker(
+            metrics,
+            synth_results_dir=_synth_results_dir(root),
+            profile="explicit_onehot",
+        )
+
+        assert proc.returncode != 0
+        assert "ambiguous qualified declaration for state_q" in proc.stderr
+
+
+def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_partial_qualified_suffix_candidate() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        metrics = _metrics_path(root)
+        _write_netlist(
+            root,
+            flow_variant=EXPLICIT_ONEHOT_VARIANT,
+            body=PARTIAL_QUALIFIED_SUFFIX_EXPLICIT_ONEHOT_DECLARATIONS,
+        )
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    critical_path_ns=7.2,
+                    result_path=(
+                        "runs/designs/npu_blocks/"
+                        "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json"
+                    ),
+                    tag=EXPLICIT_ONEHOT_TAG,
+                    flow_variant=EXPLICIT_ONEHOT_VARIANT,
+                    synth_args=None,
+                )
+            ],
+        )
+        proc = _run_checker(
+            metrics,
+            synth_results_dir=_synth_results_dir(root),
+            profile="explicit_onehot",
+        )
+
+        assert proc.returncode != 0
+        assert "missing declaration for state_q: candidate cluster_ctrl.state_q missing indices [6]" in proc.stderr
+
+
 @pytest.mark.parametrize(
     "declaration",
     [INVALID_STATE_Q, INVALID_STATE_Q_BIT],
@@ -759,5 +898,40 @@ def test_check_attention_decode_score_multivalue_cluster_binary_fsm_rejects_when
             ],
         )
         proc = _run_checker(metrics, synth_results_dir=_synth_results_dir(Path(td)))
+        assert proc.returncode != 0
+        assert "missing exact netlist" in proc.stderr
+
+
+def test_check_attention_decode_score_multivalue_cluster_binary_fsm_does_not_promote_from_source_rtl_without_exact_netlist() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        metrics = _metrics_path(root)
+        design_dir = metrics.parent
+        design_dir.mkdir(parents=True, exist_ok=True)
+        (design_dir / "generated_sv2v.v").write_text(VALID_EXPLICIT_ONEHOT_PACKED_NETLIST_DECLARATIONS, encoding="utf-8")
+        (design_dir / "manifest.json").write_text('{"source":"rtl"}\n', encoding="utf-8")
+        _write_metrics(
+            metrics,
+            [
+                _write_row(
+                    status="ok",
+                    critical_path_ns=7.2,
+                    result_path=(
+                        "runs/designs/npu_blocks/"
+                        "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/result.json"
+                    ),
+                    tag=EXPLICIT_ONEHOT_TAG,
+                    flow_variant=EXPLICIT_ONEHOT_VARIANT,
+                    synth_args=None,
+                )
+            ],
+        )
+
+        proc = _run_checker(
+            metrics,
+            synth_results_dir=_synth_results_dir(root),
+            profile="explicit_onehot",
+        )
+
         assert proc.returncode != 0
         assert "missing exact netlist" in proc.stderr


### PR DESCRIPTION
## Summary
- transport design-local FSM diagnostics and timing reports even when the worker command fails
- accept only exact or one unambiguous qualified post-synthesis signal declaration with the required width
- keep explicit-onehot r1 non-promotable and document a conditional evidence rescue without defining a non-executable rerun item

## Root cause
The r1 OpenROAD sweep completed, but its strict checker failed and the diagnostic was excluded by the expected-output transport allowlist. Cleanup therefore removed the evidence needed to distinguish a real width failure from a synthesized-name parser mismatch.

## Validation
- `49 passed` in focused checker/artifact/failed-worker tests
- `python3 scripts/validate_runs.py`
