### PR TITLE
Add service-aware multivalue cluster frontier recost

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -48,6 +48,12 @@ _CLUSTER_ACTIVITY_POWER_V16_EXACT_STATE_DIAGNOSTIC = (
     "explicit_onehot_fsm_diagnostic.json"
 )
 _CLUSTER_ACTIVITY_POWER_V16_MIN_SEQUENTIAL_REGISTER_ACTIVITY_COVERAGE = 1.0
+_MULTIVALUE_INTEGRATED_SERVICE_BASE_ITEM = (
+    "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1"
+)
+_MULTIVALUE_INTEGRATED_SERVICE_DEFAULT_ITEM = (
+    "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1"
+)
 
 
 @dataclass(frozen=True)
@@ -150,6 +156,27 @@ def _cluster_activity_power_item_for_consumer(
 def _gqa_folded_activity_lanes(item_id: str) -> int | None:
     match = _GQA_FOLDED_ACTIVITY_LANES_RE.search(_retry_base(item_id))
     return int(match.group(1)) if match else None
+
+
+def _multivalue_integrated_service_item_for_consumer(
+    *, depends_on_item_ids: list[str] | None
+) -> str:
+    prefix = _MULTIVALUE_INTEGRATED_SERVICE_BASE_ITEM
+    candidate_item_ids = [
+        str(dep).strip()
+        for dep in (depends_on_item_ids or [])
+        if str(dep).strip() == prefix or str(dep).strip().startswith(f"{prefix}_r")
+    ]
+    if not candidate_item_ids:
+        return _MULTIVALUE_INTEGRATED_SERVICE_DEFAULT_ITEM
+
+    def _rank(candidate: str) -> int:
+        match = _RETRY_SUFFIX_RE.search(candidate)
+        if not match:
+            return 0
+        return int(match.group(0)[2:])
+
+    return max(candidate_item_ids, key=_rank)
 
 
 def _proposal_dir(repo_root: Path, proposal_path: str | None) -> Path | None:
@@ -7181,13 +7208,30 @@ def _decoder_attention_decode_score_multivalue_cluster_frontier_evidence(
         f"{base}/decoder_attention_decode_score_local_cluster_frontier__"
         "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2.json"
     )
-    cluster_activity_power_item = _cluster_activity_power_item_for_consumer(
-        item_id=item_id,
-        depends_on_item_ids=depends_on_item_ids,
-    )
+    explicit_cluster_activity = [
+        str(dep).strip()
+        for dep in (depends_on_item_ids or [])
+        if str(dep).strip().startswith(
+            "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_"
+        )
+    ]
+    if explicit_cluster_activity:
+        cluster_activity_power_item = _cluster_activity_power_item_for_consumer(
+            item_id=item_id,
+            depends_on_item_ids=depends_on_item_ids,
+        )
+    else:
+        cluster_activity_power_item = "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v16"
     activity_power = (
         f"{base}/decoder_attention_decode_score_multivalue_cluster_activity_power__"
         f"{cluster_activity_power_item}.json"
+    )
+    integrated_service_item = _multivalue_integrated_service_item_for_consumer(
+        depends_on_item_ids=depends_on_item_ids
+    )
+    integrated_service = (
+        f"{base}/decoder_attention_decode_score_multivalue_integrated_service__"
+        f"{integrated_service_item}.json"
     )
     cluster_counts = "1,2,4,8,16,32"
     out = f"{base}/decoder_attention_decode_score_multivalue_cluster_frontier__{item_id}.json"
@@ -7196,16 +7240,17 @@ def _decoder_attention_decode_score_multivalue_cluster_frontier_evidence(
         "inputs": {
             "decode_score_multivalue_cluster_frontier_prior_frontier": prior,
             "decode_score_multivalue_cluster_frontier_activity_power": activity_power,
+            "decode_score_multivalue_cluster_frontier_integrated_service": integrated_service,
             "decode_score_multivalue_cluster_frontier_cluster_counts": cluster_counts,
             "decode_score_multivalue_cluster_frontier_out": out,
             "decode_score_multivalue_cluster_frontier_report": report,
             "decode_score_multivalue_cluster_frontier_scope": (
                 "Recost the corrected local-cluster frontier using the measured shared-score multivalue "
-                "cluster active-energy audit, exact full-head fill/replay/divider cycles, and cluster-count "
-                "tradeoffs from 1 through 32 while preserving the unchanged precision contract from "
-                "equivalence. Keep this evidence-only, do not claim total-token energy yet, and leave "
-                "no-stall scheduling, value-memory composition, NoC composition, and HBM service as explicit "
-                "remaining abstractions."
+                "cluster active-energy audit plus deterministic integrated-service c1/c2/c4/c8/c16/c32 "
+                "completion ratios over the fixed p128/b4/q4/rl2 round-robin policy. Scale only the "
+                "activity-backed full-context per-wave cluster service cycles, preserve the unchanged "
+                "precision contract from equivalence, do not claim total-token energy, and keep HBM, "
+                "NoC composition, and service-fabric PPA/energy as explicit remaining abstractions."
             ),
         },
         "commands": [
@@ -7215,6 +7260,7 @@ def _decoder_attention_decode_score_multivalue_cluster_frontier_evidence(
                     "python3 -m npu.eval.audit_attention_decode_score_multivalue_cluster_frontier "
                     f"--prior-frontier-json {prior} "
                     f"--activity-power-json {activity_power} "
+                    f"--integrated-service-json {integrated_service} "
                     f"--cluster-counts {cluster_counts} "
                     f"--out {out} --out-md {report}"
                 ),

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -19,6 +19,7 @@ from control_plane.services.l2_task_generator import (
     Layer2CampaignGenerateRequest,
     Layer2TaskGenerationError,
     _cluster_activity_power_item_for_consumer,
+    _multivalue_integrated_service_item_for_consumer,
     generate_l2_campaign_task,
 )
 
@@ -8352,6 +8353,54 @@ def test_cluster_activity_power_item_for_consumer_selects_v16_for_cluster_fronti
     )
 
 
+def test_multivalue_integrated_service_item_for_consumer_prefers_latest_retry() -> None:
+    assert _multivalue_integrated_service_item_for_consumer(depends_on_item_ids=None) == (
+        "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1"
+    )
+    assert _multivalue_integrated_service_item_for_consumer(
+        depends_on_item_ids=[
+            "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1",
+            "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r2",
+            "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
+        ]
+    ) == "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r2"
+
+
+def test_multivalue_cluster_frontier_request_manifests_remain_dependency_gated() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    proposal_dir = (
+        repo_root
+        / "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1"
+    )
+    expected_depends = {
+        "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v16",
+        "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
+    }
+
+    for manifest_name, items_key in (
+        ("proposal.json", "required_evaluations"),
+        ("evaluation_requests.json", "requested_items"),
+    ):
+        manifest = json.loads((proposal_dir / manifest_name).read_text(encoding="utf-8"))
+        assert "Replace with the merge commit" in manifest["source_commit_note"] if manifest_name == "evaluation_requests.json" else True
+        if manifest_name == "evaluation_requests.json":
+            note = manifest["source_commit_note"]
+            assert "already-merged/materialized" not in note
+            assert "READY but not yet materialized" in note
+            assert "activity-power v16 remains pending" in note
+        items = {item["item_id"]: item for item in manifest[items_key]}
+        revision = items["l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1"]
+        assert set(revision["depends_on_item_ids"]) == expected_depends
+        assert revision["requires_materialized_refs"] is True
+        assert revision["status"] == "pending_implementation_merge"
+        assert "not ready for normal dispatch" in revision["notes"]
+        assert "dependency-gated" in revision["notes"]
+        assert "READY but not yet materialized" in revision["notes"]
+        assert "July 24, 2026" in revision["notes"]
+        assert "merged/materialized" in revision["expected_result"]["reason"]
+
+
 def test_gqa_folded_activity_request_manifests_require_cluster_activity_power_v16() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     proposal_dir = (
@@ -8684,9 +8733,18 @@ def test_generate_l2_campaign_task_cluster_frontier_uses_cluster_activity_v2_dep
                 in run
             )
             assert (
+                "--integrated-service-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_decode_score_multivalue_integrated_service__"
+                "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1.json"
+                in run
+            )
+            assert (
                 decoder_inputs["decode_score_multivalue_cluster_frontier_activity_power"].endswith(
                     "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2.json"
                 )
+            )
+            assert decoder_inputs["decode_score_multivalue_cluster_frontier_integrated_service"].endswith(
+                "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1.json"
             )
             assert (
                 "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1.json"
@@ -8781,7 +8839,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_frontier
                 Layer2CampaignGenerateRequest(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
-                    item_id="l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
+                    item_id="l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
                     requested_by="@tester",
                     source_commit=source_commit,
                     abstraction_layer="decoder_attention_decode_score_multivalue_cluster_frontier",
@@ -8812,7 +8870,14 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_frontier
                 "--activity-power-json "
                 "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_attention_decode_score_multivalue_cluster_activity_power__"
-                "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1.json"
+                "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v16.json"
+                in run
+            )
+            assert (
+                "--integrated-service-json "
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_decode_score_multivalue_integrated_service__"
+                "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1.json"
                 in run
             )
             assert "--cluster-counts 1,2,4,8,16,32" in run
@@ -8823,29 +8888,34 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_frontier
             )
             assert (
                 decoder_inputs["decode_score_multivalue_cluster_frontier_activity_power"].endswith(
-                    "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1.json"
+                    "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v16.json"
+                )
+            )
+            assert (
+                decoder_inputs["decode_score_multivalue_cluster_frontier_integrated_service"].endswith(
+                    "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1.json"
                 )
             )
             assert (
                 decoder_inputs["decode_score_multivalue_cluster_frontier_cluster_counts"]
                 == "1,2,4,8,16,32"
             )
-            assert "exact full-head fill/replay/divider cycles" in decoder_inputs[
+            assert "deterministic integrated-service c1/c2/c4/c8/c16/c32" in decoder_inputs[
                 "decode_score_multivalue_cluster_frontier_scope"
             ]
-            assert "do not claim total-token energy yet" in decoder_inputs[
+            assert "do not claim total-token energy" in decoder_inputs[
                 "decode_score_multivalue_cluster_frontier_scope"
             ]
             assert (
                 decoder_inputs["decode_score_multivalue_cluster_frontier_out"]
                 == "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_attention_decode_score_multivalue_cluster_frontier__"
-                "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1.json"
+                "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1.json"
             )
             assert any(
                 output.endswith(
                     "decoder_attention_decode_score_multivalue_cluster_frontier__"
-                    "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1.md"
+                    "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1.md"
                 )
                 for output in work_item.task_request.request_payload["task"]["expected_outputs"]
             )

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/evaluation_requests.json
@@ -1,7 +1,7 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
-  "source_commit": "db2f9ae94fc10860c5d9a5b0384d5dbd6f6b71bd",
-  "source_commit_note": "Keep this evidence-only frontier recost pending until strict shared-score multivalue activity-power v16 is merged and its evidence is materialized. Activity-power v13 is invalid, v14 was superseded before dispatch, and targeted-binary v15 was canceled after 31.8h runtime; this request does not claim that v16 evidence exists.",
+  "source_commit": "48b75806a96b6e281f080de5e3539dbdfd2f9217",
+  "source_commit_note": "Replace with the merge commit that contains this service-aware frontier recost update after merge and before dispatch. The frontier implementation itself is still local here, integrated-service compact r1 evidence is READY but not yet materialized, and activity-power v16 remains pending; do not dispatch this frontier revision until both dependency evidence items are merged/materialized.",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
@@ -19,9 +19,39 @@
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "recast_shared_score_multivalue_cluster_frontier",
-        "reason": "Keep this frontier pending until strict activity-power v16 is merged and materialized; targeted-binary v15 was canceled after 31.8h runtime and must not be consumed. Only then may ranking charge exact full-head cycles, valid measured active-cluster energy, and area/QKV tradeoffs together while keeping precision fixed from the merged equivalence result and withholding any total-token energy claim."
+        "reason": "Preserve this item only as superseded history. It reused no-stall activity full-context cycles directly and therefore cannot serve as the service-aware frontier recost once the intended integrated-service compact r1 evidence is actually merged/materialized."
       },
-      "status": "pending_implementation_merge"
+      "status": "superseded_before_merge",
+      "superseded_by_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
+      "notes": "The activity-backed frontier shape remains useful history, but it must not be dispatched without the integrated-service completion-ratio calibration being merged/materialized."
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
+      "task_type": "l2_campaign",
+      "objective": "Recost the shared-score multivalue decode cluster frontier using the corrected local-cluster frontier v2, strict activity-backed cluster energy, and deterministic integrated-service completion ratios for c1/c2/c4/c8/c16/c32 across cluster counts 1/2/4/8/16/32.",
+      "evaluation_mode": "frontier_recost",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_frontier",
+      "comparison_role": "shared_score_multivalue_cluster_frontier_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v16",
+        "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "revision": {
+        "reason": "service_aware_completion_ratio_calibration",
+        "supersedes_item_ids": [
+          "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1"
+        ]
+      },
+      "expected_result": {
+        "direction": "recast_shared_score_multivalue_cluster_frontier",
+        "reason": "Use deterministic integrated-service completion ratios from compact r1 evidence, once merged/materialized, to scale activity-backed full-context per-wave cluster service cycles for c1/c2/c4/c8/c16/c32, while preserving strict activity-backed power requirements, withholding total-token energy, and explicitly limiting the calibration to the probe's 128-context, 128-value-dimension, no-HBM, no-service-fabric-PPA/energy scope."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "This revision remains dependency-gated and is not ready for normal dispatch. As of July 24, 2026, integrated-service compact r1 evidence is READY but not yet materialized, activity-power v16 remains pending, and both inputs must merge/materialize before dispatch."
     }
   ]
 }

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/proposal.json
@@ -6,12 +6,13 @@
   "kind": "architecture",
   "title": "Shared-score multivalue cluster frontier recost for Llama7B",
   "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_frontier",
-  "hypothesis": "Once the shared-score multivalue cluster carries measured active-cluster energy and the corrected local-cluster frontier v2 remains the prior bound, the Llama7B recost can replace the repeated-score-fill architecture bound with exact full-head cycles, measured active energy, and cluster-count area/QKV tradeoffs while keeping precision unchanged from the merged equivalence proof.",
+  "hypothesis": "Once the shared-score multivalue cluster carries measured active-cluster energy, the corrected local-cluster frontier v2 remains the prior bound, and activity-power v16 plus integrated-service compact r1 evidence are both merged/materialized, the Llama7B recost can replace the repeated-score-fill architecture bound with service-aware full-head cycles, measured active energy, and cluster-count area/QKV tradeoffs while keeping precision unchanged from the merged equivalence proof.",
   "direct_comparison": {
-    "primary_question": "Across 1, 2, 4, 8, 16, and 32 shared-score clusters, how does the measured multivalue architecture trade exact full-head cycles and active-cluster energy against area/QKV cost relative to the corrected local-cluster frontier v2?",
+    "primary_question": "Across 1, 2, 4, 8, 16, and 32 shared-score clusters, how does the measured multivalue architecture trade service-aware full-head cycles and active-cluster energy against area/QKV cost relative to the corrected local-cluster frontier v2?",
     "baseline": "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
     "include": [
       "exact full-head score-fill, value-replay, divider, and aggregate cycles taken from the multivalue cluster frontier audit",
+      "dimensionless integrated-service completion ratios from deterministic c1/c2/c4/c8/c16/c32 fixed-policy cases to scale per-wave full-context service cycles",
       "measured active-cluster energy derived from the shared-score activity-power evidence",
       "area and QKV tradeoff across cluster counts 1, 2, 4, 8, 16, and 32",
       "unchanged arithmetic and precision contract inherited from l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
@@ -19,7 +20,8 @@
     ],
     "exclude": [
       "do not claim total-token energy yet from the active-cluster measurement alone",
-      "do not treat no-stall service, value-memory composition, NoC composition, or HBM service as already closed",
+      "do not treat service-aware latency calibration as service-fabric PPA/energy closure",
+      "do not treat value-memory composition, NoC composition, or HBM service as already closed",
       "do not overwrite or erase the corrected local-cluster frontier v2 evidence; keep it as the prior lower-bound reference"
     ],
     "metrics": [
@@ -37,13 +39,14 @@
     ]
   },
   "expected_benefit": [
-    "replaces the repeated-score-fill lower bound with a measured shared-score frontier recost",
+    "replaces the repeated-score-fill lower bound with a service-aware shared-score frontier recost",
     "makes the exact cycle, energy, and area/QKV tradeoffs explicit for deployable cluster counts",
     "preserves the already-proven precision contract without reopening a new quality claim"
   ],
   "risks": [
     "measured active-cluster energy may still leave the shared-score design unattractive at some cluster counts",
-    "full-head recost remains sensitive to unclosed no-stall, value-memory, NoC, and HBM abstractions",
+    "full-head recost remains sensitive to the microkernel-scale integrated-service calibration plus unclosed value-memory, NoC, and HBM abstractions",
+    "until activity-power v16 and integrated-service compact r1 are both merged/materialized, this frontier revision remains dependency-gated and cannot be dispatched normally",
     "the active-cluster measurement is insufficient for any total-token energy ranking until wider composition closes"
   ],
   "required_evaluations": [
@@ -63,28 +66,64 @@
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "recast_shared_score_multivalue_cluster_frontier",
-        "reason": "Keep this frontier pending until strict activity-power v16 is merged and materialized; targeted-binary v15 was canceled after 31.8h runtime and must not be consumed. Only then may ranking charge exact full-head cycles, valid measured active-cluster energy, and area/QKV tradeoffs together while keeping precision fixed from the merged equivalence result and withholding any total-token energy claim."
+        "reason": "Keep this frontier only as superseded history. It used no-stall full-head cycles directly and therefore missed the intended integrated-service c1/c2/c4/c8/c16/c32 latency penalty ratios required for service-aware recost. Preserve the evidence record, but do not use it for updated ranking."
       },
-      "status": "pending_implementation_merge"
+      "status": "superseded_before_merge",
+      "superseded_by_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
+      "notes": "This original request established the activity-backed frontier recost shape, but it predates the compact integrated-service r1 evidence path and therefore understates service-aware latency by reusing no-stall full-context cycles directly."
+    },
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
+      "task_type": "l2_campaign",
+      "objective": "Recost the shared-score multivalue decode cluster frontier using the corrected local-cluster frontier v2, strict activity-backed cluster energy, and deterministic integrated-service completion ratios for c1/c2/c4/c8/c16/c32 across cluster counts 1/2/4/8/16/32.",
+      "evaluation_mode": "frontier_recost",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_frontier",
+      "comparison_role": "shared_score_multivalue_cluster_frontier_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2",
+        "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v16",
+        "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "revision": {
+        "reason": "service_aware_completion_ratio_calibration",
+        "supersedes_item_ids": [
+          "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1"
+        ]
+      },
+      "expected_result": {
+        "direction": "recast_shared_score_multivalue_cluster_frontier",
+        "reason": "Use deterministic integrated-service completion ratios from compact r1 evidence, once merged/materialized, to scale activity-backed full-context per-wave cluster service cycles for c1/c2/c4/c8/c16/c32, while preserving strict activity-backed power requirements, withholding total-token energy, and explicitly limiting the calibration to the probe's 128-context, 128-value-dimension, no-HBM, no-service-fabric-PPA/energy scope."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "This revision consumes the compact integrated-service r1 evidence path rather than reusing no-stall cycles directly, but as of July 24, 2026 it remains dependency-gated and is not ready for normal dispatch: integrated-service compact r1 is READY but not yet materialized, activity-power v16 remains pending, and both inputs must merge/materialize before dispatch."
     }
   ],
   "baseline_refs": [
     "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_local_cluster_frontier__l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2.json",
     "control_plane/shadow_exports/l2_decisions/l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v2.json",
-    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_activity_power__l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v16.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_integrated_service__l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1.json",
     "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json",
-    "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json"
+    "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/proposal.json"
   ],
   "knowledge_refs": [
     "npu/eval/audit_attention_decode_score_multivalue_cluster_frontier.py",
+    "npu/eval/probe_attention_decode_score_multivalue_integrated_service.py",
     "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/evaluation_requests.json",
-    "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json"
+    "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json",
+    "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/evaluation_requests.json"
   ],
   "remaining_abstractions_after_this_step": [
-    "No-stall service remains a model-level abstraction rather than a measured integrated scheduling result.",
+    "Integrated-service completion ratios calibrate only latency and service-window duration from a bounded 128-context/128-value-dimension microkernel probe.",
     "Value-memory composition is still external to this cluster-level recost and must be closed separately.",
     "NoC composition remains open; this frontier does not include full transport contention or routing-energy closure.",
     "HBM service remains open; this recost is not a full memory-system closure.",
+    "The service ratio calibrates latency and service-window leakage only; cluster dynamic energy remains the activity-backed no-stall command estimate, and added stall/fabric switching dynamic energy is excluded, so reported energy remains a lower-bound component estimate.",
+    "Service-fabric PPA and service-fabric energy remain excluded from this recost.",
     "Measured active-cluster energy is not yet a total-token energy claim."
   ]
 }

--- a/npu/eval/audit_attention_decode_score_multivalue_cluster_frontier.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_cluster_frontier.py
@@ -16,6 +16,44 @@ _EXPECTED_ACTIVITY_MODEL = "decoder_attention_decode_score_multivalue_cluster_ac
 _EXPECTED_ACTIVITY_DECISION = "activity_backed_cluster_power_measured"
 _EXPECTED_EQUIVALENCE_DECISION = "decode_score_multivalue_cluster_equivalence_pass"
 _EXPECTED_PRECISION_STATUS = "unchanged_integer_contract_from_merged_multivalue_equivalence"
+_EXPECTED_INTEGRATED_SERVICE_MODEL = "llm_decoder_attention_decode_score_multivalue_integrated_service_probe_v1"
+_EXPECTED_INTEGRATED_SERVICE_DECISION = "pass"
+_EXPECTED_INTEGRATED_SERVICE_DIAGNOSIS = "multivalue_integrated_service_probe_passed"
+_EXPECTED_SERVICE_POLICY = {
+    "packet_w": 128,
+    "banks": 4,
+    "req_queue_depth": 4,
+    "resp_queue_depth": 4,
+    "bank_queue_depth": 4,
+    "read_latency": 2,
+    "arb_mode": "round_robin",
+    "locality_burst_max": 2,
+}
+_EXPECTED_SERVICE_CASE_IDS = {
+    1: "c1_p128_b4_rr",
+    2: "c2_p128_b4_rr",
+    4: "c4_p128_b4_rr",
+    8: "c8_p128_b4_rr",
+    16: "c16_p128_b4_rr",
+    32: "c32_p128_b4_rr",
+}
+_SERVICE_CALIBRATION_LIMITATIONS = [
+    (
+        "Integrated-service calibration comes from a 128-context, 128-value-dimension "
+        "shared-score microkernel probe rather than full decoder sequence composition."
+    ),
+    "HBM/DRAM service is excluded from the integrated-service calibration.",
+    "Service-fabric PPA and service-fabric energy are excluded from this frontier recost.",
+    (
+        "The service completion ratio calibrates latency and service-window leakage only; "
+        "cluster dynamic energy remains the activity-backed no-stall command estimate."
+    ),
+    (
+        "Added stall-driven or service-fabric switching dynamic energy is excluded, so the "
+        "reported energy is a lower-bound component estimate rather than a full serviced-token energy."
+    ),
+    "Total token energy remains incomplete; only activity-backed cluster energy is reported.",
+]
 
 
 def _load(path: Path) -> JsonDict:
@@ -116,6 +154,103 @@ def _validated_activity_best(activity_report: JsonDict) -> JsonDict:
     return best
 
 
+def _service_ratio_cases(
+    service_report: JsonDict, cluster_counts: list[int]
+) -> tuple[dict[int, JsonDict], JsonDict]:
+    if service_report.get("model") != _EXPECTED_INTEGRATED_SERVICE_MODEL:
+        raise ValueError("integrated-service report has an unexpected model")
+    if service_report.get("decision") != _EXPECTED_INTEGRATED_SERVICE_DECISION:
+        raise ValueError("integrated-service report has an unexpected decision")
+    diagnosis = service_report.get("diagnosis")
+    if not isinstance(diagnosis, dict) or diagnosis.get("decision") != _EXPECTED_INTEGRATED_SERVICE_DIAGNOSIS:
+        raise ValueError("integrated-service report has an unexpected diagnosis")
+    cases = service_report.get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise ValueError("integrated-service report lacks cases")
+    requested = set(cluster_counts)
+    ratios: dict[int, JsonDict] = {}
+    for cluster_count in sorted(requested):
+        expected_case_id = _EXPECTED_SERVICE_CASE_IDS.get(cluster_count)
+        if expected_case_id is None:
+            raise ValueError(f"no deterministic integrated-service case is defined for c{cluster_count}")
+        matches = [
+            case for case in cases if isinstance(case, dict) and str(case.get("case_id")) == expected_case_id
+        ]
+        if len(matches) != 1:
+            raise ValueError(f"integrated-service report must contain exactly one {expected_case_id} case")
+        case = matches[0]
+        config = case.get("config")
+        baseline = case.get("baseline_no_stall")
+        integrated = case.get("integrated_service")
+        gates = case.get("gates")
+        if not isinstance(config, dict) or not isinstance(baseline, dict) or not isinstance(integrated, dict):
+            raise ValueError(f"{expected_case_id} lacks config/baseline/integrated sections")
+        if not isinstance(gates, dict):
+            raise ValueError(f"{expected_case_id} lacks gate status")
+        if not all(bool(gates.get(key)) for key in ("hash_gate_ok", "protocol_gate_ok", "count_gate_ok")):
+            raise ValueError(f"{expected_case_id} did not keep all integrated-service gates green")
+        if integrated.get("exact_match") is not True:
+            raise ValueError(f"{expected_case_id} lacks exact integrated-service hash equivalence")
+        if integrated.get("no_protocol_errors") is not True:
+            raise ValueError(f"{expected_case_id} reported integrated-service protocol errors")
+        if integrated.get("no_drop_duplicate_deadlock_timeout") is not True:
+            raise ValueError(f"{expected_case_id} lacks integrated-service liveness/drop coverage")
+        if integrated.get("cycle_bound_ok") is not True:
+            raise ValueError(f"{expected_case_id} violated the integrated-service cycle bound")
+        if _positive_int(config.get("cluster_count"), f"{expected_case_id} cluster_count") != cluster_count:
+            raise ValueError(f"{expected_case_id} cluster_count does not match the requested frontier point")
+        for field, expected in _EXPECTED_SERVICE_POLICY.items():
+            value = config.get(field)
+            if field == "arb_mode":
+                if str(value).strip() != str(expected):
+                    raise ValueError(f"{expected_case_id} must keep deterministic {field}={expected}")
+            else:
+                if _positive_int(value, f"{expected_case_id} {field}") != int(expected):
+                    raise ValueError(f"{expected_case_id} must keep deterministic {field}={expected}")
+        baseline_cycle = _positive_int(
+            baseline.get("completion_cycle"), f"{expected_case_id} no-stall baseline completion_cycle"
+        )
+        integrated_cycle = _positive_int(
+            integrated.get("completion_cycle"), f"{expected_case_id} integrated completion_cycle"
+        )
+        if integrated_cycle < baseline_cycle:
+            raise ValueError(f"{expected_case_id} integrated completion_cycle fell below the no-stall baseline")
+        ratios[cluster_count] = {
+            "case_id": expected_case_id,
+            "cluster_count": cluster_count,
+            "baseline_completion_cycle": baseline_cycle,
+            "integrated_completion_cycle": integrated_cycle,
+            "completion_ratio": integrated_cycle / baseline_cycle,
+            "config": {
+                "packet_w": int(config["packet_w"]),
+                "banks": int(config["banks"]),
+                "req_queue_depth": int(config["req_queue_depth"]),
+                "resp_queue_depth": int(config["resp_queue_depth"]),
+                "bank_queue_depth": int(config["bank_queue_depth"]),
+                "read_latency": int(config["read_latency"]),
+                "arb_mode": str(config["arb_mode"]),
+                "locality_burst_max": int(config["locality_burst_max"]),
+            },
+        }
+    return ratios, {
+        "report_model": _EXPECTED_INTEGRATED_SERVICE_MODEL,
+        "report_decision": _EXPECTED_INTEGRATED_SERVICE_DECISION,
+        "report_diagnosis": _EXPECTED_INTEGRATED_SERVICE_DIAGNOSIS,
+        "ratio_definition": "integrated_service.completion_cycle / baseline_no_stall.completion_cycle",
+        "scaled_target": "activity-backed full-context per-wave cluster service cycles",
+        "probe_contract": {
+            "microkernel_context_tokens": 128,
+            "microkernel_value_dim": 128,
+            "consumed_case_ids": [
+                _EXPECTED_SERVICE_CASE_IDS[count] for count in sorted(requested)
+            ],
+            "resource_policy": dict(_EXPECTED_SERVICE_POLICY),
+        },
+        "limitations": list(_SERVICE_CALIBRATION_LIMITATIONS),
+        "cases": [ratios[count] for count in sorted(requested)],
+    }
+
+
 def _activity_energy(activity: JsonDict) -> JsonDict:
     phases = activity.get("phases")
     if not isinstance(phases, list) or not phases:
@@ -158,6 +293,7 @@ def _row(
     activity_clock_ns: float,
     energy: JsonDict,
     dense_tile: JsonDict,
+    service_ratio_case: JsonDict,
 ) -> JsonDict:
     heads = _positive_int(schedule["attention_heads"], "attention heads")
     layers = _positive_int(schedule["layers"], "layers")
@@ -189,7 +325,11 @@ def _row(
     qkv_work = hidden**2 + 2 * hidden * kv_heads * head_dim
     qkv_cycles = math.ceil(qkv_work / (dense_count * dense_macs)) if dense_count else None
     waves = math.ceil(heads / cluster_count)
-    attention_cycles = waves * command_cycles
+    service_ratio = _positive(
+        service_ratio_case["completion_ratio"], f"c{cluster_count} integrated-service completion ratio"
+    )
+    per_wave_service_cycles = math.ceil(command_cycles * service_ratio)
+    attention_cycles = waves * per_wave_service_cycles
     fixed_cycles = _nonnegative_int(
         schedule.get("command_dispatch_cycles", 0), "command dispatch cycles"
     ) + _nonnegative_int(
@@ -211,13 +351,23 @@ def _row(
     dynamic_j = active_commands_per_token * float(energy["dynamic_j_per_head_command"])
     leakage_j = deployed_command_slots * float(
         energy["service_window_leakage_j_per_head_command"]
-    )
+    ) * service_ratio
     component_energy_j = dynamic_j + leakage_j
     return {
         "candidate_id": f"decode_score_multivalue_cluster_c{cluster_count}",
         "cluster_count": cluster_count,
         "head_commands_per_layer": heads,
         "cluster_waves_per_layer": waves,
+        "service_no_stall_full_context_cycles_per_wave": command_cycles,
+        "service_completion_ratio": round(service_ratio, 12),
+        "service_calibrated_full_context_cycles_per_wave": per_wave_service_cycles,
+        "service_calibration_case_id": service_ratio_case["case_id"],
+        "service_calibration_microkernel_no_stall_completion_cycle": service_ratio_case[
+            "baseline_completion_cycle"
+        ],
+        "service_calibration_microkernel_integrated_completion_cycle": service_ratio_case[
+            "integrated_completion_cycle"
+        ],
         "dense_qkv_tile_count": dense_count,
         "dense_qkv_useful_parallelism_limit": qkv_useful_limit,
         "qkv_cycles": qkv_cycles,
@@ -252,8 +402,9 @@ def _row(
         "attention_cluster_dynamic_energy_mj_per_token": dynamic_j * 1.0e3,
         "attention_cluster_service_window_leakage_energy_mj_per_token": leakage_j * 1.0e3,
         "attention_cluster_modeled_service_energy_mj_per_token": component_energy_j * 1.0e3,
+        "energy_lower_bound_component_estimate": True,
         "energy_status": (
-            "activity_backed_attention_cluster_service_windows_only_"
+            "activity_backed_cluster_dynamic_plus_service_window_leakage_lower_bound_component_estimate_"
             "total_token_energy_incomplete"
         ),
     }
@@ -285,10 +436,15 @@ def _pareto(rows: list[JsonDict]) -> list[JsonDict]:
 
 
 def build_report(
-    *, prior_frontier_json: Path, activity_power_json: Path, cluster_counts: list[int]
+    *,
+    prior_frontier_json: Path,
+    activity_power_json: Path,
+    integrated_service_json: Path,
+    cluster_counts: list[int],
 ) -> JsonDict:
     prior = _load(prior_frontier_json)
     activity_report = _load(activity_power_json)
+    integrated_service_report = _load(integrated_service_json)
     best = _validated_activity_best(activity_report)
     schedule, schedule_source = _source_schedule(prior, prior_frontier_json)
     hidden = _positive_int(schedule["hidden_size"], "hidden size")
@@ -319,6 +475,9 @@ def build_report(
         "activity clock",
     )
     energy = _activity_energy(activity)
+    service_ratios, service_calibration = _service_ratio_cases(
+        integrated_service_report, validated_cluster_counts
+    )
     phase_cycles = {
         str(phase.get("phase", phase.get("name", f"phase_{index}"))): int(
             phase["full_context_cycles"]
@@ -334,6 +493,7 @@ def build_report(
             activity_clock_ns=activity_clock_ns,
             energy=energy,
             dense_tile=dense_tile,
+            service_ratio_case=service_ratios[count],
         )
         for count in validated_cluster_counts
     ]
@@ -349,6 +509,7 @@ def build_report(
         "inputs": {
             "prior_frontier_json": str(prior_frontier_json),
             "activity_power_json": str(activity_power_json),
+            "integrated_service_json": str(integrated_service_json),
             "source_schedule_json": schedule_source,
         },
         "schedule_contract": {
@@ -359,10 +520,11 @@ def build_report(
             "sequence_length": int(schedule["sequence_length"]),
             "layers": int(schedule["layers"]),
             "full_head_commands_per_layer": int(schedule["attention_heads"]),
-            "full_head_command_cycles": command_cycles,
-            "full_head_phase_cycles": phase_cycles,
+            "full_head_command_cycles_no_stall_baseline": command_cycles,
+            "full_head_phase_cycles_no_stall_baseline": phase_cycles,
             "sequence_sharding_supported": False,
         },
+        "service_cycle_calibration": service_calibration,
         "selected_cluster": {
             "candidate_id": best.get("candidate_id"),
             "flow_variant": best.get("flow_variant"),
@@ -384,20 +546,23 @@ def build_report(
         "promotion_status": "component_frontier_promoted_full_architecture_promotion_blocked",
         "remaining_abstractions": [
             (
-                "Value memory is modeled as ready/no-stall with the measured one-cycle "
-                "response contract."
+                "On-chip shared value-service latency is calibrated from deterministic c1/c2/c4/c8/c16/c32 "
+                "integrated-service ratios, but the calibration is still a 128-context/128-value-dimension "
+                "microkernel proxy rather than full decoder memory-system composition."
             ),
             (
-                "Producer, Q/K/V transport, NoC, HBM/DRAM, off-cluster value memory, "
+                "Producer, Q/K/V transport, NoC, off-cluster value memory, HBM/DRAM, "
                 "and clock-tree composition are outside this frontier."
             ),
             "Dense QKV tile PPA is measured independently and composed by an area/schedule model.",
             "FakeRAM uses Nangate45 proxy LEF/Liberty views without SRAM compiler signoff.",
             "Score multiplier and shift derivation remain external to the cluster boundary.",
             (
-                "Total token energy is incomplete; only activity-backed attention-cluster "
-                "dynamic energy and service-window leakage are reported. Leakage outside "
-                "the modeled cluster service windows is not included."
+                "Total token energy is incomplete; the integrated-service ratio calibrates latency and "
+                "service-window leakage only, while activity-backed attention-cluster dynamic energy remains "
+                "the no-stall command estimate. Added stall/fabric switching dynamic energy, service-fabric "
+                "PPA/energy, and leakage outside the modeled cluster service windows are not included, so "
+                "the reported energy is a lower-bound component estimate."
             ),
             (
                 "Sequence sharding and cross-cluster head reduction are not implemented, "
@@ -409,6 +574,7 @@ def build_report(
 
 def _write_markdown(payload: JsonDict, path: Path) -> None:
     best = payload["best_throughput_candidate"]
+    calibration = payload["service_cycle_calibration"]
     lines = [
         "# Llama7B shared-score multivalue cluster frontier",
         "",
@@ -423,18 +589,29 @@ def _write_markdown(payload: JsonDict, path: Path) -> None:
             "- attention-cluster service-window leakage: "
             f"`{best['attention_cluster_service_window_leakage_energy_mj_per_token']}` mJ/token"
         ),
+        (
+            "- integrated-service calibration: "
+            f"`{best['service_calibration_case_id']}` ratio=`{best['service_completion_ratio']}` "
+            f"scaled from `{best['service_no_stall_full_context_cycles_per_wave']}` to "
+            f"`{best['service_calibrated_full_context_cycles_per_wave']}` cycles/wave"
+        ),
         "- total-token energy: `incomplete`",
+        (
+            "- calibration limits: "
+            f"{'; '.join(str(item) for item in calibration['limitations'])}"
+        ),
         "",
         (
-            "| candidate | clusters | waves/layer | QKV tiles | latency us | token/s | "
+            "| candidate | clusters | waves/layer | ratio | cycles/wave | QKV tiles | latency us | token/s | "
             "area mm2 | modeled service mJ/token |"
         ),
-        "|---|---:|---:|---:|---:|---:|---:|---:|",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
     ]
     for row in payload["rows"]:
         lines.append(
             f"| {row['candidate_id']} | {row['cluster_count']} | "
-            f"{row['cluster_waves_per_layer']} | {row['dense_qkv_tile_count']} | "
+            f"{row['cluster_waves_per_layer']} | {row['service_completion_ratio']} | "
+            f"{row['service_calibrated_full_context_cycles_per_wave']} | {row['dense_qkv_tile_count']} | "
             f"{row['latency_us']} | {row['token_throughput_per_s']} | "
             f"{row['embodied_logic_plus_shared_sram_area_mm2']} | "
             f"{row['attention_cluster_modeled_service_energy_mj_per_token']} |"
@@ -449,6 +626,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--prior-frontier-json", type=Path, required=True)
     parser.add_argument("--activity-power-json", type=Path, required=True)
+    parser.add_argument("--integrated-service-json", type=Path, required=True)
     parser.add_argument("--cluster-counts", default="1,2,4,8,16,32")
     parser.add_argument("--out", type=Path, required=True)
     parser.add_argument("--out-md", type=Path, required=True)
@@ -456,6 +634,7 @@ def main() -> int:
     payload = build_report(
         prior_frontier_json=args.prior_frontier_json,
         activity_power_json=args.activity_power_json,
+        integrated_service_json=args.integrated_service_json,
         cluster_counts=[int(value) for value in args.cluster_counts.split(",")],
     )
     args.out.parent.mkdir(parents=True, exist_ok=True)

--- a/npu/eval/probe_attention_decode_score_multivalue_integrated_service.py
+++ b/npu/eval/probe_attention_decode_score_multivalue_integrated_service.py
@@ -1810,6 +1810,11 @@ def validate_report(payload: JsonDict) -> None:
         raise ValueError("report version must be 1")
     if payload.get("model") != "llm_decoder_attention_decode_score_multivalue_integrated_service_probe_v1":
         raise ValueError("unexpected report model")
+    if payload.get("decision") != "pass":
+        raise ValueError("integrated-service report decision must be pass")
+    diagnosis = payload.get("diagnosis")
+    if not isinstance(diagnosis, dict) or diagnosis.get("decision") != "multivalue_integrated_service_probe_passed":
+        raise ValueError("integrated-service report diagnosis must record a passed probe")
     if payload.get("exclusions") != REPORT_EXCLUSIONS:
         raise ValueError(f"report exclusions must explicitly be {', '.join(REPORT_EXCLUSIONS)}")
     contract = payload.get("report_contract")
@@ -1854,6 +1859,8 @@ def validate_report(payload: JsonDict) -> None:
         raise ValueError("report must contain summary")
     if int(summary.get("validated_case_count", 0)) != len(cases):
         raise ValueError("summary validated_case_count mismatch")
+    if not all(bool(summary.get(key)) for key in ("all_hash_gates_passed", "all_protocol_gates_passed", "all_count_gates_passed")):
+        raise ValueError("summary must record all report gates as passed")
     selected_scale_point = payload.get("selected_scale_point")
     if not isinstance(selected_scale_point, dict):
         raise ValueError("report must contain selected_scale_point")

--- a/tests/test_attention_decode_score_multivalue_cluster_frontier.py
+++ b/tests/test_attention_decode_score_multivalue_cluster_frontier.py
@@ -11,7 +11,61 @@ def _write(path: Path, payload: dict) -> Path:
     return path
 
 
-def _inputs(tmp_path: Path) -> tuple[Path, Path]:
+def _service_report(tmp_path: Path) -> Path:
+    cases = []
+    for cluster_count, ratio in (
+        (1, 1.25),
+        (2, 1.375),
+        (4, 1.5),
+        (8, 1.625),
+        (16, 1.75),
+        (32, 2.0),
+    ):
+        case_id = f"c{cluster_count}_p128_b4_rr"
+        baseline_cycle = 80
+        integrated_cycle = int(baseline_cycle * ratio)
+        cases.append(
+            {
+                "case_id": case_id,
+                "decision": "pass",
+                "config": {
+                    "cluster_count": cluster_count,
+                    "packet_w": 128,
+                    "banks": 4,
+                    "req_queue_depth": 4,
+                    "resp_queue_depth": 4,
+                    "bank_queue_depth": 4,
+                    "read_latency": 2,
+                    "arb_mode": "round_robin",
+                    "locality_burst_max": 2,
+                },
+                "baseline_no_stall": {"completion_cycle": baseline_cycle},
+                "integrated_service": {
+                    "completion_cycle": integrated_cycle,
+                    "exact_match": True,
+                    "no_protocol_errors": True,
+                    "no_drop_duplicate_deadlock_timeout": True,
+                    "cycle_bound_ok": True,
+                },
+                "gates": {
+                    "hash_gate_ok": True,
+                    "protocol_gate_ok": True,
+                    "count_gate_ok": True,
+                },
+            }
+        )
+    return _write(
+        tmp_path / "integrated_service.json",
+        {
+            "model": "llm_decoder_attention_decode_score_multivalue_integrated_service_probe_v1",
+            "decision": "pass",
+            "diagnosis": {"decision": "multivalue_integrated_service_probe_passed"},
+            "cases": cases,
+        },
+    )
+
+
+def _inputs(tmp_path: Path) -> tuple[Path, Path, Path]:
     source = _write(
         tmp_path / "source.json",
         {
@@ -89,53 +143,92 @@ def _inputs(tmp_path: Path) -> tuple[Path, Path]:
             },
         },
     )
-    return prior, activity
+    service = _service_report(tmp_path)
+    return prior, activity, service
 
 
 def test_recost_uses_full_head_commands_activity_energy_and_linked_schedule(tmp_path: Path) -> None:
-    prior, activity = _inputs(tmp_path)
+    prior, activity, service = _inputs(tmp_path)
     report = build_report(
-        prior_frontier_json=prior, activity_power_json=activity, cluster_counts=[1, 2, 4, 8, 16, 32]
+        prior_frontier_json=prior,
+        activity_power_json=activity,
+        integrated_service_json=service,
+        cluster_counts=[1, 2, 4, 8, 16, 32],
     )
 
     rows = {row["cluster_count"]: row for row in report["rows"]}
     assert report["inputs"]["source_schedule_json"].endswith("source.json")
+    assert report["inputs"]["integrated_service_json"].endswith("integrated_service.json")
     assert report["schedule_contract"]["full_head_commands_per_layer"] == 32
-    assert report["schedule_contract"]["full_head_command_cycles"] == 300
-    assert report["schedule_contract"]["full_head_phase_cycles"] == {"fill": 200, "replay": 100}
+    assert report["schedule_contract"]["full_head_command_cycles_no_stall_baseline"] == 300
+    assert report["schedule_contract"]["full_head_phase_cycles_no_stall_baseline"] == {
+        "fill": 200,
+        "replay": 100,
+    }
+    assert report["service_cycle_calibration"]["probe_contract"]["microkernel_context_tokens"] == 128
+    assert report["service_cycle_calibration"]["probe_contract"]["microkernel_value_dim"] == 128
     assert rows[1]["cluster_waves_per_layer"] == 32
     assert rows[32]["cluster_waves_per_layer"] == 1
-    assert rows[32]["attention_cycles"] == 300
+    assert rows[32]["service_completion_ratio"] == pytest.approx(2.0)
+    assert rows[32]["service_no_stall_full_context_cycles_per_wave"] == 300
+    assert rows[32]["service_calibrated_full_context_cycles_per_wave"] == 600
+    assert rows[32]["attention_cycles"] == 600
     assert rows[32]["clock_ns"] == 8.0
     assert rows[32]["dense_qkv_tile_count"] == 640
     assert rows[1]["attention_cluster_dynamic_energy_mj_per_token"] == pytest.approx(
         rows[32]["attention_cluster_dynamic_energy_mj_per_token"]
     )
-    assert rows[1]["attention_cluster_service_window_leakage_energy_mj_per_token"] == pytest.approx(
+    assert rows[32]["energy_lower_bound_component_estimate"] is True
+    assert (
         rows[32]["attention_cluster_service_window_leakage_energy_mj_per_token"]
+        > rows[1]["attention_cluster_service_window_leakage_energy_mj_per_token"]
     )
     assert "attention_cluster_leakage_energy_mj_per_token" not in rows[32]
-    assert "service_windows_only" in rows[32]["energy_status"]
+    assert "lower_bound_component_estimate" in rows[32]["energy_status"]
+    assert any(
+        "service completion ratio calibrates latency and service-window leakage only" in item
+        for item in report["service_cycle_calibration"]["limitations"]
+    )
+    assert any(
+        "lower-bound component estimate" in item
+        for item in report["service_cycle_calibration"]["limitations"]
+    )
     assert report["precision"]["decision"] == "decode_score_multivalue_cluster_equivalence_pass"
     assert report["precision"]["final_tensor_hash"] == "final"
     assert report["promotion_status"].endswith("full_architecture_promotion_blocked")
+    assert "lower-bound component estimate" in " ".join(
+        report["remaining_abstractions"]
+    )
+    assert "service-fabric PPA/energy" in " ".join(
+        report["remaining_abstractions"]
+    )
 
 
 def test_recost_rejects_unpromoted_activity_and_unsupported_cluster_count(tmp_path: Path) -> None:
-    prior, activity = _inputs(tmp_path)
+    prior, activity, service = _inputs(tmp_path)
     payload = json.loads(activity.read_text(encoding="utf-8"))
     payload["promotion_gate_pass"] = False
     activity.write_text(json.dumps(payload), encoding="utf-8")
     with pytest.raises(ValueError, match="promotion gate"):
-        build_report(prior_frontier_json=prior, activity_power_json=activity, cluster_counts=[1])
+        build_report(
+            prior_frontier_json=prior,
+            activity_power_json=activity,
+            integrated_service_json=service,
+            cluster_counts=[1],
+        )
 
-    _, activity = _inputs(tmp_path)
+    _, activity, service = _inputs(tmp_path)
     with pytest.raises(ValueError, match="cluster count"):
-        build_report(prior_frontier_json=prior, activity_power_json=activity, cluster_counts=[64])
+        build_report(
+            prior_frontier_json=prior,
+            activity_power_json=activity,
+            integrated_service_json=service,
+            cluster_counts=[64],
+        )
 
 
 def test_recost_reserves_retained_noncompute_logic_from_compute_budget(tmp_path: Path) -> None:
-    prior, activity = _inputs(tmp_path)
+    prior, activity, service = _inputs(tmp_path)
     prior_payload = json.loads(prior.read_text(encoding="utf-8"))
     source = Path(prior_payload["inputs"]["prior_frontier_json"])
     source_payload = json.loads(source.read_text(encoding="utf-8"))
@@ -153,6 +246,7 @@ def test_recost_reserves_retained_noncompute_logic_from_compute_budget(tmp_path:
     report = build_report(
         prior_frontier_json=prior,
         activity_power_json=activity,
+        integrated_service_json=service,
         cluster_counts=[1],
     )
 
@@ -189,7 +283,7 @@ def test_recost_rejects_invalid_activity_promotion_contract(
     bad_value: object,
     message: str,
 ) -> None:
-    prior, activity = _inputs(tmp_path)
+    prior, activity, service = _inputs(tmp_path)
     payload = json.loads(activity.read_text(encoding="utf-8"))
     target = payload
     for field in field_path[:-1]:
@@ -201,12 +295,13 @@ def test_recost_rejects_invalid_activity_promotion_contract(
         build_report(
             prior_frontier_json=prior,
             activity_power_json=activity,
+            integrated_service_json=service,
             cluster_counts=[1],
         )
 
 
 def test_recost_rejects_schedule_clock_slower_than_activity_clock(tmp_path: Path) -> None:
-    prior, activity = _inputs(tmp_path)
+    prior, activity, service = _inputs(tmp_path)
     prior_payload = json.loads(prior.read_text(encoding="utf-8"))
     source = Path(prior_payload["inputs"]["prior_frontier_json"])
     source_payload = json.loads(source.read_text(encoding="utf-8"))
@@ -217,6 +312,7 @@ def test_recost_rejects_schedule_clock_slower_than_activity_clock(tmp_path: Path
         build_report(
             prior_frontier_json=prior,
             activity_power_json=activity,
+            integrated_service_json=service,
             cluster_counts=[1],
         )
 
@@ -235,7 +331,7 @@ def test_recost_rejects_nonpositive_or_fractional_activity_cycles(
     field_path: tuple[object, ...],
     bad_value: object,
 ) -> None:
-    prior, activity = _inputs(tmp_path)
+    prior, activity, service = _inputs(tmp_path)
     payload = json.loads(activity.read_text(encoding="utf-8"))
     target = payload
     for field in field_path[:-1]:
@@ -247,15 +343,89 @@ def test_recost_rejects_nonpositive_or_fractional_activity_cycles(
         build_report(
             prior_frontier_json=prior,
             activity_power_json=activity,
+            integrated_service_json=service,
             cluster_counts=[1],
         )
 
 
 def test_recost_rejects_nondivisor_cluster_count(tmp_path: Path) -> None:
-    prior, activity = _inputs(tmp_path)
+    prior, activity, service = _inputs(tmp_path)
     with pytest.raises(ValueError, match="does not divide 32 heads"):
         build_report(
             prior_frontier_json=prior,
             activity_power_json=activity,
+            integrated_service_json=service,
             cluster_counts=[3],
         )
+
+
+@pytest.mark.parametrize(
+    ("mutator", "message"),
+    [
+        (lambda payload: payload.__setitem__("model", "wrong-model"), "unexpected model"),
+        (lambda payload: payload.__setitem__("decision", "fail"), "unexpected decision"),
+        (
+            lambda payload: payload.__setitem__("diagnosis", {"decision": "wrong"}),
+            "unexpected diagnosis",
+        ),
+        (
+            lambda payload: payload["cases"].pop(),
+            "must contain exactly one c32_p128_b4_rr case",
+        ),
+        (
+            lambda payload: payload["cases"][0]["config"].__setitem__("packet_w", 256),
+            "deterministic packet_w=128",
+        ),
+        (
+            lambda payload: payload["cases"][0]["gates"].__setitem__("count_gate_ok", False),
+            "did not keep all integrated-service gates green",
+        ),
+        (
+            lambda payload: payload["cases"][0]["integrated_service"].__setitem__("exact_match", False),
+            "lacks exact integrated-service hash equivalence",
+        ),
+        (
+            lambda payload: payload["cases"][0]["integrated_service"].__setitem__("completion_cycle", 40),
+            "fell below the no-stall baseline",
+        ),
+    ],
+)
+def test_recost_rejects_invalid_integrated_service_report(
+    tmp_path: Path,
+    mutator,
+    message: str,
+) -> None:
+    prior, activity, service = _inputs(tmp_path)
+    payload = json.loads(service.read_text(encoding="utf-8"))
+    mutator(payload)
+    service.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=message):
+        build_report(
+            prior_frontier_json=prior,
+            activity_power_json=activity,
+            integrated_service_json=service,
+            cluster_counts=[1, 2, 4, 8, 16, 32],
+        )
+
+
+def test_recost_does_not_substitute_microkernel_completion_cycles_for_full_context_cycles(
+    tmp_path: Path,
+) -> None:
+    prior, activity, service = _inputs(tmp_path)
+    report = build_report(
+        prior_frontier_json=prior,
+        activity_power_json=activity,
+        integrated_service_json=service,
+        cluster_counts=[32],
+    )
+
+    row = report["rows"][0]
+    assert row["service_calibration_microkernel_no_stall_completion_cycle"] == 80
+    assert row["service_calibration_microkernel_integrated_completion_cycle"] == 160
+    assert row["service_calibrated_full_context_cycles_per_wave"] == 600
+    assert row["service_calibrated_full_context_cycles_per_wave"] != row[
+        "service_calibration_microkernel_integrated_completion_cycle"
+    ]
+    assert row["attention_cycles"] == 600
+    assert row["attention_cycles"] > row["service_no_stall_full_context_cycles_per_wave"]

--- a/tests/test_attention_decode_score_multivalue_integrated_service.py
+++ b/tests/test_attention_decode_score_multivalue_integrated_service.py
@@ -532,6 +532,21 @@ def test_integrated_service_validate_report_rejects_incomplete_evidence() -> Non
         {"cases": [_case(case_id="validate", cluster_count=2, packet_w=128, banks=2, arb_mode="round_robin")]}
     )
     broken = json.loads(json.dumps(report))
+    broken["decision"] = "fail"
+    with pytest.raises(ValueError, match="decision must be pass"):
+        validate_report(broken)
+
+    broken = json.loads(json.dumps(report))
+    broken["diagnosis"]["decision"] = "multivalue_integrated_service_probe_failed"
+    with pytest.raises(ValueError, match="diagnosis must record a passed probe"):
+        validate_report(broken)
+
+    broken = json.loads(json.dumps(report))
+    broken["summary"]["all_hash_gates_passed"] = False
+    with pytest.raises(ValueError, match="summary must record all report gates as passed"):
+        validate_report(broken)
+
+    broken = json.loads(json.dumps(report))
     broken["exclusions"] = REPORT_EXCLUSIONS[:-1]
     with pytest.raises(ValueError, match="exclusions"):
         validate_report(broken)


### PR DESCRIPTION
## Summary
- consume compact integrated-service evidence in the Llama7B multivalue-cluster frontier recost
- apply fixed-resource p128/b4/q4/rl2 round-robin completion ratios to full-context service cycles
- add fail-closed report validation and a dependency-gated r1 frontier request

## Modeling boundary
The service ratio calibrates latency and service-window leakage only. Cluster dynamic energy remains the activity-backed no-stall command estimate; added stall/fabric switching energy and service-fabric PPA are excluded, so energy remains a lower-bound component estimate.

The recost item remains blocked until strict activity-power v16 and compact integrated-service r1 evidence are both materialized.

## Validation
- `39 passed` for frontier and integrated-service tests
- `4 passed` for focused L2 generator contract tests
- `python3 scripts/validate_runs.py`
