### PR TITLE
Add exact onehot r2 retry and v16 linkage

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -41,7 +41,7 @@ _CLUSTER_ACTIVITY_POWER_V16_FLOW_VARIANT = (
 )
 _CLUSTER_ACTIVITY_POWER_V16_SYNTH_ARGS = ""
 _CLUSTER_ACTIVITY_POWER_V16_PNR_ITEM = (
-    "l1_decoder_attention_decode_score_multivalue_cluster_pnr_explicit_onehot_fsm_8ns_v1"
+    "l1_decoder_attention_decode_score_multivalue_cluster_pnr_explicit_onehot_fsm_8ns_v1_r2"
 )
 _CLUSTER_ACTIVITY_POWER_V16_EXACT_STATE_DIAGNOSTIC = (
     "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/"

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -3217,7 +3217,7 @@ def test_generate_l1_sweep_task_adds_explicit_onehot_retry_profile_and_diagnosti
                     out_root="runs/designs/npu_blocks",
                     item_id=(
                         "l1_decoder_attention_decode_score_multivalue_cluster_pnr_"
-                        "explicit_onehot_fsm_8ns_v1_r1"
+                        "explicit_onehot_fsm_8ns_v1_r2"
                     ),
                     requested_by="@tester",
                     source_commit=source_commit,
@@ -3231,7 +3231,27 @@ def test_generate_l1_sweep_task_adds_explicit_onehot_retry_profile_and_diagnosti
                 for command in work_item.command_manifest
                 if command["name"] == "check_attention_decode_score_multivalue_cluster_explicit_onehot"
             ]
+            run_block_sweep = next(
+                command
+                for command in work_item.command_manifest
+                if command["name"] == "run_block_sweep"
+            )
             assert len(checker_commands) == 1
+            assert run_block_sweep["run"] == (
+                "export PATH=/oss-cad-suite/bin:$PATH && "
+                "python3 npu/synth/run_block_sweep.py "
+                "--design_dir runs/designs/npu_blocks/"
+                "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv "
+                "--platform nangate45 "
+                "--top attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv "
+                "--sweep runs/campaigns/npu/decode_score_multivalue_cluster_v1/sweeps/"
+                "nangate45_decode_score_multivalue_cluster_8ns_explicit_onehot_fsm_v1.json "
+                "--out_root runs/designs/npu_blocks "
+                "--macro_manifest runs/designs/npu_blocks/"
+                "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/"
+                "macro_manifest.json "
+                "--skip_existing"
+            )
             assert (
                 "--config runs/designs/npu_blocks/"
                 "attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/"
@@ -3303,7 +3323,7 @@ def test_binary_fsm_retry_profile_requires_exact_config_and_sweep() -> None:
 
     explicit_item_id = (
         "l1_decoder_attention_decode_score_multivalue_cluster_pnr_"
-        "explicit_onehot_fsm_8ns_v1_r1"
+        "explicit_onehot_fsm_8ns_v1_r2"
     )
     explicit_config = (
         "runs/designs/npu_blocks/"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -8283,7 +8283,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_activity
             )
             assert (
                 "--source-pnr-item-id "
-                "l1_decoder_attention_decode_score_multivalue_cluster_pnr_explicit_onehot_fsm_8ns_v1"
+                "l1_decoder_attention_decode_score_multivalue_cluster_pnr_explicit_onehot_fsm_8ns_v1_r2"
                 in run
             )
             assert (
@@ -8300,7 +8300,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_activity
             )
             assert (
                 decoder_inputs["decode_score_multivalue_cluster_source_pnr_item_id"]
-                == "l1_decoder_attention_decode_score_multivalue_cluster_pnr_explicit_onehot_fsm_8ns_v1"
+                == "l1_decoder_attention_decode_score_multivalue_cluster_pnr_explicit_onehot_fsm_8ns_v1_r2"
             )
             assert (
                 decoder_inputs["decode_score_multivalue_cluster_exact_state_diagnostic_json"]

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
-  "source_commit_note": "PR #1413 merged complete block_weight VCD/FSM provenance, PR #1414 merged the binary-FSM PNR point, and PR #1415 merged strict v14 row selection and 100% routed-state coverage. v3_r2 was superseded because it reused the same sweep hash. V14 now depends on `l1_decoder_attention_decode_score_multivalue_cluster_pnr_binary_fsm_8ns_v3_r3`; neither this retry implementation nor its result is claimed merged here.",
+  "source_commit_note": "PR #1413 merged complete block_weight VCD/FSM provenance, PR #1414 merged the binary-FSM PNR point, and PR #1415 merged strict v14 row selection and 100% routed-state coverage. PR #1430 merged the explicit-onehot activity-power implementation, and PR #1438 now preserves future strict-checker diagnostics while tightening row-to-diagnostic matching. The completed explicit-onehot r1 PNR row is still non-promotable because its strict diagnostic was lost, so v16 now waits on the post-proposal-merge explicit-onehot r2 exact-sweep retry rather than any checker-only recovery path.",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
@@ -502,12 +502,12 @@
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v16",
       "task_type": "l2_campaign",
-      "objective": "Measure shared-score multivalue-cluster activity-backed power only after the explicit-onehot 8ns PNR item passes, using config_explicit_onehot_fsm.json, decode_score_multivalue_cluster_v1_8ns_explicit_onehot_fsm_v1_proxy_die_2500, empty/default SYNTH_ARGS, and the materialized strict explicit_onehot explicit_onehot_fsm_diagnostic.json. Require direct routed phase VCD, 100% sequential output coverage, matched==applied, zero query/apply errors, finite positive every-phase power, and no vectorless, fallback, stale-row, or mismatched-diagnostic evidence.",
+      "objective": "Measure shared-score multivalue-cluster activity-backed power only if the explicit-onehot r2 exact-sweep retry becomes promotion-valid for strict explicit-state checking, using config_explicit_onehot_fsm.json, decode_score_multivalue_cluster_v1_8ns_explicit_onehot_fsm_v1_proxy_die_2500, empty/default SYNTH_ARGS, and the materialized strict explicit_onehot explicit_onehot_fsm_diagnostic.json bound to that exact row. Require direct routed phase VCD, 100% sequential output coverage, matched==applied, zero query/apply errors, finite positive every-phase power, and no vectorless, fallback, stale-row, or mismatched-diagnostic evidence.",
       "evaluation_mode": "frontier_detail",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
       "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
       "depends_on_item_ids": [
-        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_explicit_onehot_fsm_8ns_v1",
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_explicit_onehot_fsm_8ns_v1_r2",
         "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
       ],
       "requires_merged_inputs": true,
@@ -520,10 +520,11 @@
       },
       "expected_result": {
         "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
-        "reason": "v16 accepts only config_explicit_onehot_fsm.json and decode_score_multivalue_cluster_v1_8ns_explicit_onehot_fsm_v1_proxy_die_2500 with empty/default SYNTH_ARGS, requires the materialized strict explicit_onehot explicit_onehot_fsm_diagnostic.json to be promotion-valid and bound to the exact measured metrics row identity and config/netlist hashes, preserves all existing quality/equivalence/direct-VCD/macro/clock/numeric/artifact gates, enforces 1.0 sequential-output coverage plus matched==applied and zero query/apply errors, and forbids vectorless, fallback, stale-row, clamped, substituted, heuristic, mismatched-diagnostic, or otherwise relaxed evidence."
+        "reason": "v16 accepts only config_explicit_onehot_fsm.json and decode_score_multivalue_cluster_v1_8ns_explicit_onehot_fsm_v1_proxy_die_2500 with empty/default SYNTH_ARGS, requires the materialized strict explicit_onehot explicit_onehot_fsm_diagnostic.json to be promotion-valid and bound to the exact r2 measured metrics row identity plus config/netlist hashes, preserves all existing quality/equivalence/direct-VCD/macro/clock/numeric/artifact gates, enforces 1.0 sequential-output coverage plus matched==applied and zero query/apply errors, and forbids vectorless, fallback, stale-row, clamped, substituted, heuristic, mismatched-diagnostic, or otherwise relaxed evidence. R2 is an executable exact-sweep retry that runs the same run_block_sweep command and may reuse evaluator-local cache only when the required FSM-capture cache matches exactly."
       },
-      "status": "pending_implementation_merge",
-      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_explicit_onehot_fsm_8ns_v1"
+      "status": "blocked_on_prerequisite",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_explicit_onehot_fsm_8ns_v1_r2",
+      "status_reason": "Blocked and non-dispatchable pending a promotion-valid strict explicit_onehot result from the r2 exact-sweep retry after proposal merge. Explicit-onehot r1 completed PNR, but its strict post-synthesis checker failed and the diagnostic artifact was lost, so no promotion-valid strict explicit_onehot evidence exists for the exact row/config/netlist identity. PR #1430 merged the implementation, and PR #1438 preserves future diagnostics and tightens matching. Keep fail-closed exact row/config/netlist/VCD gates; if a future explicit replacement item is needed, it must supersede v16 rather than dispatch from this state."
     }
   ],
   "source_commit": "b968b50997ff980dd0a367ff0fe7c98d4f89b7fb"

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1/proposal.json
@@ -453,17 +453,17 @@
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v16",
       "task_type": "l2_campaign",
-      "objective": "Measure shared-score multivalue-cluster activity-backed power only after the explicit-onehot 8ns PNR item passes, using config_explicit_onehot_fsm.json, decode_score_multivalue_cluster_v1_8ns_explicit_onehot_fsm_v1_proxy_die_2500, empty/default SYNTH_ARGS, and the materialized strict explicit_onehot explicit_onehot_fsm_diagnostic.json. Require direct routed phase VCD, 100% sequential output coverage, matched==applied, zero query/apply errors, finite positive every-phase power, and no vectorless, fallback, stale-row, or mismatched-diagnostic evidence.",
+      "objective": "Measure shared-score multivalue-cluster activity-backed power only if the explicit-onehot r2 exact-sweep retry becomes promotion-valid for strict explicit-state checking, using config_explicit_onehot_fsm.json, decode_score_multivalue_cluster_v1_8ns_explicit_onehot_fsm_v1_proxy_die_2500, empty/default SYNTH_ARGS, and the materialized strict explicit_onehot explicit_onehot_fsm_diagnostic.json bound to that exact row. Require direct routed phase VCD, 100% sequential output coverage, matched==applied, zero query/apply errors, finite positive every-phase power, and no vectorless, fallback, stale-row, or mismatched-diagnostic evidence.",
       "evaluation_mode": "frontier_detail",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster_activity_power",
       "comparison_role": "shared_score_multivalue_cluster_activity_power_gate",
       "depends_on_item_ids": [
-        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_explicit_onehot_fsm_8ns_v1",
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_explicit_onehot_fsm_8ns_v1_r2",
         "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
-      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_explicit_onehot_fsm_8ns_v1",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_explicit_onehot_fsm_8ns_v1_r2",
       "revision": {
         "reason": "explicit_onehot_fsm_postroute_activity_mapping",
         "invalidates_item_ids": [
@@ -472,9 +472,10 @@
       },
       "expected_result": {
         "direction": "record_shared_score_multivalue_cluster_activity_power_gate",
-        "reason": "v16 accepts only config_explicit_onehot_fsm.json and decode_score_multivalue_cluster_v1_8ns_explicit_onehot_fsm_v1_proxy_die_2500 with empty/default SYNTH_ARGS, requires the materialized strict explicit_onehot explicit_onehot_fsm_diagnostic.json to be promotion-valid and bound to the exact measured metrics row identity and config/netlist hashes, preserves all existing quality/equivalence/direct-VCD/macro/clock/numeric/artifact gates, enforces 1.0 sequential-output coverage plus matched==applied and zero query/apply errors, and forbids vectorless, fallback, stale-row, clamped, substituted, heuristic, mismatched-diagnostic, or otherwise relaxed evidence."
+        "reason": "v16 accepts only config_explicit_onehot_fsm.json and decode_score_multivalue_cluster_v1_8ns_explicit_onehot_fsm_v1_proxy_die_2500 with empty/default SYNTH_ARGS, requires the materialized strict explicit_onehot explicit_onehot_fsm_diagnostic.json to be promotion-valid and bound to the exact r2 measured metrics row identity plus config/netlist hashes, preserves all existing quality/equivalence/direct-VCD/macro/clock/numeric/artifact gates, enforces 1.0 sequential-output coverage plus matched==applied and zero query/apply errors, and forbids vectorless, fallback, stale-row, clamped, substituted, heuristic, mismatched-diagnostic, or otherwise relaxed evidence. R2 is an executable exact-sweep retry that runs the same run_block_sweep command and may reuse evaluator-local cache only when the required FSM-capture cache matches exactly."
       },
-      "status": "pending_implementation_merge"
+      "status": "blocked_on_prerequisite",
+      "status_reason": "Blocked and non-dispatchable pending a promotion-valid strict explicit_onehot result from the r2 exact-sweep retry after proposal merge. Explicit-onehot r1 completed PNR, but its strict post-synthesis checker failed and the diagnostic artifact was lost, so no promotion-valid strict explicit_onehot evidence exists for the exact row/config/netlist identity. PR #1430 merged the implementation, and PR #1438 preserves future diagnostics and tightens matching. Keep fail-closed exact row/config/netlist/VCD gates; if a future explicit replacement item is needed, it must supersede v16 rather than dispatch from this state."
     }
   ],
   "baseline_refs": [

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/evaluation_requests.json
@@ -244,7 +244,34 @@
         "reason": "R1 retried the same explicit-onehot config/sweep/baseline after the guard config-selection fix and reached successful PNR, but the post-PNR strict explicit_onehot checker still failed. Because explicit_onehot_fsm_diagnostic.json was not transported from that run, the exact checker failure cause remains unavailable."
       },
       "status": "failed_non_promotable",
-      "status_reason": "Successful PNR evidence exists for r1, but the strict post-synthesis checker failed and the diagnostic artifact was not transported, so the exact cause is not confirmed. The row is not promoted. A checker-only rescue remains conditional on preserving the evaluator's exact 1_synth.v and materializing the already DB-transported metrics artifact without rerunning OpenROAD; no dispatchable follow-up item is queued until that path exists."
+      "status_reason": "Successful PNR evidence exists for r1, but the strict post-synthesis checker failed and the diagnostic artifact was not transported, so the exact cause is not confirmed. The row is not promoted."
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_explicit_onehot_fsm_8ns_v1_r2",
+      "task_type": "l1_sweep",
+      "objective": "Run one executable exact-sweep retry of the 8 ns explicit-onehot FSM candidate with the exact existing explicit-onehot config/sweep, merged equivalence prerequisite, and PR #1438 strict-checker plus failed-run diagnostic transport. This executes the same run_block_sweep command, may reuse an evaluator-local cached result only when the required FSM-capture cache matches exactly, and otherwise reruns full OpenROAD; it is not checker-only.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster",
+      "comparison_role": "shared_score_multivalue_cluster_explicit_onehot_fsm_pnr",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config_explicit_onehot_fsm.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_cluster_v1/sweeps/nangate45_decode_score_multivalue_cluster_8ns_explicit_onehot_fsm_v1.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+      "prior_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_explicit_onehot_fsm_8ns_v1_r1"
+      ],
+      "expected_result": {
+        "direction": "measure_shared_score_multivalue_cluster_explicit_onehot_fsm_ppa",
+        "reason": "R2 reruns the exact explicit-onehot sweep command once on the same config/sweep/baseline with PR #1438 strict explicit_onehot checker matching and failed-run diagnostic transport, so promotion can require exact row-bound diagnostic evidence instead of inferred failure state. It may reuse an evaluator-local cached result only when the required FSM-capture cache matches exactly; otherwise it reruns full OpenROAD. This retry is not checker-only."
+      },
+      "status": "pending_proposal_merge",
+      "status_reason": "Will be queued after proposal merge as an executable exact-sweep retry, not a checker-only rescue. It will execute the exact existing explicit-onehot run_block_sweep command with merged equivalence, materialized refs, and PR #1438 strict-checker diagnostic transport; evaluator-local cache reuse is acceptable only when the required FSM-capture cache matches exactly, otherwise the sweep reruns full OpenROAD."
     }
   ],
   "source_commit": "b968b50997ff980dd0a367ff0fe7c98d4f89b7fb"

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json
@@ -274,7 +274,34 @@
         "reason": "R1 retried the same explicit-onehot config/sweep/baseline after the guard config-selection fix and reached successful PNR, but the post-PNR strict explicit_onehot checker still failed. Because explicit_onehot_fsm_diagnostic.json was not transported from that run, the exact checker failure cause remains unavailable."
       },
       "status": "failed_non_promotable",
-      "status_reason": "Successful PNR evidence exists for r1, but the strict post-synthesis checker failed and the diagnostic artifact was not transported, so the exact cause is not confirmed. The row is not promoted. A checker-only rescue remains conditional on preserving the evaluator's exact 1_synth.v and materializing the already DB-transported metrics artifact without rerunning OpenROAD; no dispatchable follow-up item is queued until that path exists."
+      "status_reason": "Successful PNR evidence exists for r1, but the strict post-synthesis checker failed and the diagnostic artifact was not transported, so the exact cause is not confirmed. The row is not promoted."
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_explicit_onehot_fsm_8ns_v1_r2",
+      "task_type": "l1_sweep",
+      "objective": "Run one executable exact-sweep retry of the 8 ns explicit-onehot FSM candidate with the exact existing explicit-onehot config/sweep, merged equivalence prerequisite, and PR #1438 strict-checker plus failed-run diagnostic transport. This executes the same run_block_sweep command, may reuse an evaluator-local cached result only when the required FSM-capture cache matches exactly, and otherwise reruns full OpenROAD; it is not checker-only.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_cluster",
+      "comparison_role": "shared_score_multivalue_cluster_explicit_onehot_fsm_pnr",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/config_explicit_onehot_fsm.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_cluster_v1/sweeps/nangate45_decode_score_multivalue_cluster_8ns_explicit_onehot_fsm_v1.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_8ns_v2",
+      "prior_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_cluster_pnr_explicit_onehot_fsm_8ns_v1_r1"
+      ],
+      "expected_result": {
+        "direction": "measure_shared_score_multivalue_cluster_explicit_onehot_fsm_ppa",
+        "reason": "R2 reruns the exact explicit-onehot sweep command once on the same config/sweep/baseline with PR #1438 strict explicit_onehot checker matching and failed-run diagnostic transport, so promotion can require exact row-bound diagnostic evidence instead of inferred failure state. It may reuse an evaluator-local cached result only when the required FSM-capture cache matches exactly; otherwise it reruns full OpenROAD. This retry is not checker-only."
+      },
+      "status": "pending_proposal_merge",
+      "status_reason": "Will be queued after proposal merge as an executable exact-sweep retry, not a checker-only rescue. It will execute the exact existing explicit-onehot run_block_sweep command with merged equivalence, materialized refs, and PR #1438 strict-checker diagnostic transport; evaluator-local cache reuse is acceptable only when the required FSM-capture cache matches exactly, otherwise the sweep reruns full OpenROAD."
     }
   ],
   "baseline_refs": [


### PR DESCRIPTION
## Summary
- add an executable exact-sweep explicit-onehot r2 retry after the lost r1 diagnostic
- bind strict activity-power v16 to the promotion-valid r2 row and diagnostic
- update generator tests to prove r2 runs the sweep, exact guard, strict checker, and transports diagnostics

## Retry behavior
R2 is not checker-only. It executes the existing `run_block_sweep` command with `--skip_existing`; evaluator-local cache is reused only when required FSM-capture evidence matches exactly, otherwise OpenROAD reruns. PR #1438 ensures future failed-run diagnostics are transported.

## Validation
- `2 passed` focused L1 retry tests
- `3 passed` focused L2 v16/dependency tests
- `python3 scripts/validate_runs.py`
