### PR TITLE
Add physical multivalue service memory path

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -734,6 +734,65 @@ def _read_config_target(
                 },
             ],
         )
+    elif "top_name" in cfg and "attention_decode_score_multivalue_service" in cfg:
+        top_name = str(cfg["top_name"]).strip()
+        if not top_name:
+            raise Layer1TaskGenerationError(f"top_name must not be empty in {config_path}")
+        try:
+            design_dir = str(config_path.parent.resolve().relative_to(repo_root.resolve()))
+        except ValueError as exc:
+            raise Layer1TaskGenerationError(
+                f"decode-score multivalue service config must live under repo_root/runs/designs/...: {config_path}"
+            ) from exc
+        design_name = config_path.parent.name
+        macro_manifest = f"{design_dir}/macro_manifest.json"
+        return Layer1ConfigTarget(
+            design_kind="block",
+            design_name=design_name,
+            expected_metrics_path=block_metrics_path(design_name),
+            expected_report_paths=[f"{design_dir}/timing_debug_report.md"],
+            commands=[
+                {
+                    "name": "generate_attention_decode_score_multivalue_service_rtl",
+                    "run": _with_oss_cad_path(
+                        "python3 npu/rtlgen/gen_attention_decode_score_multivalue_service.py "
+                        f"--config {config_rel} --out {design_dir}/verilog"
+                    ),
+                },
+                {
+                    "name": "check_attention_decode_score_multivalue_service_guard",
+                    "run": (
+                        "python3 npu/eval/check_attention_decode_score_multivalue_service_guard.py "
+                        f"--design-dir {design_dir} --config {config_rel}"
+                    ),
+                },
+                {
+                    "name": "run_block_sweep",
+                    "run": _with_oss_cad_path(
+                        "python3 npu/synth/run_block_sweep.py "
+                        f"--design_dir {design_dir} --platform {{platform}} --top {top_name} "
+                        f"--sweep {{sweep_path}} --out_root {out_root} "
+                        f"--macro_manifest {macro_manifest} "
+                        + (f"--make_target {make_target} " if make_target else "")
+                        + "--skip_existing"
+                    ),
+                },
+                {
+                    "name": "check_attention_decode_score_multivalue_service_physical",
+                    "run": (
+                        "python3 npu/eval/check_attention_decode_score_multivalue_service_physical.py "
+                        f"--design-dir {design_dir} --metrics-path {design_dir}/metrics.csv --sweep {{sweep_path}}"
+                    ),
+                },
+                {
+                    "name": "extract_attention_decode_score_multivalue_service_timing_paths",
+                    "run": (
+                        "python3 npu/eval/extract_openroad_timing_summary.py "
+                        f"--design-dir {design_dir} --out {design_dir}/timing_debug_report.md --max-paths 8"
+                    ),
+                },
+            ],
+        )
     elif "top_name" in cfg and "attention_decode_score_multivalue_gqa_array" in cfg:
         top_name = str(cfg["top_name"]).strip()
         if not top_name:

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -868,6 +868,65 @@ def _write_example_attention_decode_score_multivalue_cluster_repo(repo_root: Pat
     return str(config_path.relative_to(repo_root)), str(sweep_path.relative_to(repo_root))
 
 
+def _write_example_attention_decode_score_multivalue_service_repo(repo_root: Path) -> tuple[str, str]:
+    design_dir = (
+        repo_root
+        / "runs"
+        / "designs"
+        / "npu_blocks"
+        / "attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr"
+    )
+    design_dir.mkdir(parents=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr",
+                "attention_decode_score_multivalue_service": {
+                    "cluster_count": 2,
+                    "max_blocks": 16,
+                    "packet_w": 128,
+                    "banks": 4,
+                    "req_queue_depth": 4,
+                    "resp_queue_depth": 4,
+                    "bank_queue_depth": 4,
+                    "read_latency": 2,
+                    "arb_mode": "round_robin",
+                    "locality_burst_max": 2,
+                    "score_scale_lanes_per_cycle": 1,
+                    "value_memory_backend": "macro_banked_4x16x64x32",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (design_dir / "macro_manifest.json").write_text("{}\n", encoding="utf-8")
+    sweep_path = (
+        repo_root
+        / "runs"
+        / "campaigns"
+        / "npu"
+        / "decode_score_multivalue_service_v1"
+        / "sweeps"
+        / "nangate45_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_3700.json"
+    )
+    sweep_path.parent.mkdir(parents=True)
+    sweep_path.write_text(
+        json.dumps(
+            {
+                "flow_params": {
+                    "CLOCK_PERIOD": [10],
+                    "PLACE_DENSITY": [0.4],
+                    "SYNTH_HIERARCHICAL": [1],
+                    "SYNTH_MEMORY_MAX_BITS": [65536],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    return str(config_path.relative_to(repo_root)), str(sweep_path.relative_to(repo_root))
+
+
 def _write_attention_decode_score_multivalue_cluster_targeted_binary_config(
     repo_root: Path,
 ) -> str:
@@ -3020,6 +3079,86 @@ def test_generate_l1_sweep_task_supports_attention_decode_score_multivalue_clust
                 "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/metrics.csv",
                 "runs/designs/npu_blocks/attention_decode_score_multivalue_cluster_int8_m1x8_iterdiv/timing_debug_report.md",
             ]
+
+
+def test_generate_l1_sweep_task_supports_attention_decode_score_multivalue_service_configs() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_attention_decode_score_multivalue_service_repo(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/npu_blocks",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_decode_score_multivalue_service",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert [command["name"] for command in work_item.command_manifest] == [
+                "generate_attention_decode_score_multivalue_service_rtl",
+                "check_attention_decode_score_multivalue_service_guard",
+                "run_block_sweep",
+                "check_attention_decode_score_multivalue_service_physical",
+                "extract_attention_decode_score_multivalue_service_timing_paths",
+                "build_runs_index",
+                "validate",
+            ]
+            assert "gen_attention_decode_score_multivalue_service.py" in work_item.command_manifest[0]["run"]
+            assert "check_attention_decode_score_multivalue_service_guard.py" in work_item.command_manifest[1]["run"]
+            assert (
+                "--config runs/designs/npu_blocks/"
+                "attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr/config.json"
+                in work_item.command_manifest[1]["run"]
+            )
+            assert "--top attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr" in work_item.command_manifest[2]["run"]
+            assert (
+                "--macro_manifest runs/designs/npu_blocks/"
+                "attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr/macro_manifest.json"
+                in work_item.command_manifest[2]["run"]
+            )
+            assert "check_attention_decode_score_multivalue_service_physical.py" in work_item.command_manifest[3]["run"]
+            assert work_item.expected_outputs == [
+                "runs/designs/npu_blocks/attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr/metrics.csv",
+                "runs/designs/npu_blocks/attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr/timing_debug_report.md",
+            ]
+
+
+def test_multivalue_service_pnr_proposal_keeps_c2_gated_on_c1_dependency() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    proposal_dir = (
+        repo_root
+        / "docs"
+        / "proposals"
+        / "prop_l1_decoder_attention_decode_score_multivalue_service_pnr_v1"
+    )
+    proposal = json.loads((proposal_dir / "proposal.json").read_text(encoding="utf-8"))
+    evaluation_requests = json.loads((proposal_dir / "evaluation_requests.json").read_text(encoding="utf-8"))
+
+    c1_item_id = "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1"
+    service_dep_id = "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1"
+    proposal_by_id = {entry["item_id"]: entry for entry in proposal["required_evaluations"]}
+    request_by_id = {entry["item_id"]: entry for entry in evaluation_requests["requested_items"]}
+
+    c2_proposal = proposal_by_id["l1_decoder_attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_pnr_v1"]
+    c2_request = request_by_id["l1_decoder_attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_pnr_v1"]
+
+    assert c2_proposal["status"] == "conditional_follow_on"
+    assert c2_request["status"] == "conditional_follow_on"
+    assert c2_proposal["depends_on_item_ids"] == [service_dep_id, c1_item_id]
+    assert c2_request["depends_on_item_ids"] == [service_dep_id, c1_item_id]
+    assert c1_item_id in (proposal_dir / "design_brief.md").read_text(encoding="utf-8")
 
 
 def test_generate_l1_sweep_task_adds_bridge_checker_for_exact_8ns_multivalue_cluster_item() -> None:

--- a/docs/proposals/prop_l1_decoder_attention_decode_score_multivalue_service_pnr_v1/design_brief.md
+++ b/docs/proposals/prop_l1_decoder_attention_decode_score_multivalue_service_pnr_v1/design_brief.md
@@ -1,0 +1,45 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_l1_decoder_attention_decode_score_multivalue_service_pnr_v1`
+- `title`: `First physical prep for multivalue composed service`
+
+## Problem
+The integrated shared-score multivalue service now has merged functional probe
+evidence, but there is no dependency-gated Layer 1 path that can generate the
+actual composed RTL, prove macro evidence for both score banks and value
+storage, and reject undersized c1/c2 Nangate45 sweeps before dispatch.
+
+## Hypothesis
+A first physical patch anchored on `c1` at
+`p128/b4/q4/rl2/round_robin`, with an exact-capacity `4 banks x 16 lanes` of
+`fakeram45_64x32` value-memory macros and strict perimeter/macro guards, is
+enough to make the composed service physically dispatchable without dragging
+`c4/c8/c16/c32` into the same change. `c2` remains a conditional follow-on once
+the same physical contract is proven cleanly on the current monolithic wrapper,
+and its requested item now depends explicitly on
+`l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1`.
+
+## Scope
+- include:
+  - L1 generator wiring for `gen_attention_decode_score_multivalue_service.py`
+  - strict pre-PPA guard and post-sweep checker
+  - checked-in c1/c2 configs and Nangate45 sweeps
+  - exact `4 bank x 16 lane x 64 row fakeram45_64x32` physical value-memory
+    contract for `max_blocks=16`, while keeping behavioral mode for functional
+    simulation and macro/backend equivalence testing
+  - proposal items that depend on
+    `l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1`
+- exclude:
+  - c4/c8/activity work in this patch
+  - c16/c32 dispatch in this patch
+  - OpenROAD execution in this patch
+
+## Follow-On Gates
+- `c2` remains conditional on the corrected c1 macro-backed implementation and
+  evidence remaining clean after merge, with an explicit dependency on
+  `l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1`.
+- `c8` remains a later-gated follow-up after c1/c2 runtime and feasibility are
+  materialized.
+- `c16` and `c32` remain later-gated follow-ups after `c8` proves both runtime
+  practicality and physical feasibility.

--- a/docs/proposals/prop_l1_decoder_attention_decode_score_multivalue_service_pnr_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_decode_score_multivalue_service_pnr_v1/evaluation_requests.json
@@ -1,0 +1,58 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_decode_score_multivalue_service_pnr_v1",
+  "source_commit_note": "Replace with the merge commit that contains this corrected c1-first physical-prep patch before dispatch.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the composed multivalue service at c1 using the exact 4-bank x 16-lane fakeram45_64x32 value-memory macro contract and a conservative 3.0 mm die envelope.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_service",
+      "comparison_role": "composed_service_c1_physical_prep",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_v1",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_service_v1/sweeps/nangate45_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_composed_multivalue_service_c1_ppa",
+        "reason": "Record total composed PPA as the authoritative metric while using the single-cluster baseline only as implementation-context sensitivity, not intrinsic additive fabric PPA."
+      },
+      "status": "pending_implementation_merge"
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_pnr_v1",
+      "task_type": "l1_sweep",
+      "objective": "Conditionally measure the composed multivalue service at c2 using the exact 4-bank x 16-lane fakeram45_64x32 value-memory macro contract and a 3.7 mm hierarchy comparison sweep only after the corrected c1 physical path is accepted.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_service",
+      "comparison_role": "composed_service_c2_physical_prep",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_service_v1/sweeps/nangate45_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_3700.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
+        "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_composed_multivalue_service_c2_ppa",
+        "reason": "Require at least one 10 ns c2 hierarchy mode to pass at the pin/macro-derived 3.7 mm envelope; if both modes fail, stop the monolithic path and do not advance later service scales."
+      },
+      "status": "conditional_follow_on",
+      "notes": "No exact merged cluster-only c2 baseline exists yet; c2 deltas must therefore be treated as implementation-context observations only, and the item stays gated behind accepted c1 macro-backed evidence through an explicit dependency on l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1."
+    }
+  ],
+  "follow_on_notes": [
+    "c2 is intentionally kept conditional behind accepted c1 macro-backed evidence and now depends explicitly on l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1.",
+    "c8 is intentionally deferred from this first patch and remains a later-gated follow-up after c1/c2 feasibility is materialized.",
+    "c16 and c32 remain later-gated follow-ups after c8 runtime and physical feasibility are proven."
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_decode_score_multivalue_service_pnr_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_decode_score_multivalue_service_pnr_v1/proposal.json
@@ -1,0 +1,78 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_decode_score_multivalue_service_pnr_v1",
+  "created_utc": "2026-07-24T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "physical_prep",
+  "title": "First physical prep for multivalue composed service",
+  "abstraction_layer": "decoder_attention_decode_score_multivalue_service",
+  "hypothesis": "After the compact integrated-service r1 probe is merged and materialized, c1 can become a dispatchable physical-prep point, with c2 held as a conditional follow-on, if the actual composed service generator emits exact macro evidence for both score banks and a shared 4-bank x 16-lane x 64-row fakeram45_64x32 value store, and if the sweeps respect macro/pin-derived die bounds.",
+  "direct_comparison": {
+    "primary_question": "Can the actual composed multivalue service be hardened as c1/c2 physical-prep points without silently substituting registers for value memory or under-sizing the die for macro and perimeter demand?",
+    "include": [
+      "actual p128/b4/q4/rl2/round_robin composed service RTL",
+      "exact 4-bank x 16-lane fakeram45_64x32 value-memory physical contract for max_blocks=16",
+      "behavioral generator mode retained for functional simulation only",
+      "strict c1/c2 guard plus post-sweep checker",
+      "dependency on l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1"
+    ],
+    "exclude": [
+      "no c4/c8/activity implementation in this patch",
+      "no c16/c32 dispatch in this patch",
+      "no OpenROAD execution in this patch"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the composed multivalue service at c1 using the exact 4-bank x 16-lane fakeram45_64x32 value-memory macro contract and a conservative 3.0 mm die envelope.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_service",
+      "comparison_role": "composed_service_c1_physical_prep",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_v1",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_service_v1/sweeps/nangate45_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_composed_multivalue_service_c1_ppa",
+        "reason": "Record total composed PPA as authoritative while using the single-cluster baseline only as implementation-context sensitivity."
+      },
+      "status": "pending_implementation_merge"
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_pnr_v1",
+      "task_type": "l1_sweep",
+      "objective": "Conditionally measure the composed multivalue service at c2 using the exact 4-bank x 16-lane fakeram45_64x32 value-memory macro contract and a 3.7 mm hierarchy comparison sweep only after the corrected c1 physical path is accepted.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_service",
+      "comparison_role": "composed_service_c2_physical_prep",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_service_v1/sweeps/nangate45_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_3700.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
+        "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_composed_multivalue_service_c2_ppa",
+        "reason": "Require at least one 10 ns c2 hierarchy mode to pass at the pin/macro-derived 3.7 mm envelope; if both fail, stop the monolithic path."
+      },
+      "status": "conditional_follow_on"
+    }
+  ],
+  "follow_on_gates": [
+    "c2 remains conditional until the corrected c1 macro-backed implementation and evidence scope are accepted, and the requested item now depends explicitly on l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1.",
+    "c8 remains a later-gated follow-up after c1/c2 runtime and physical feasibility are materialized.",
+    "c16 and c32 remain later-gated follow-ups after c8 proves both runtime practicality and physical feasibility."
+  ]
+}

--- a/npu/eval/check_attention_decode_score_multivalue_service_guard.py
+++ b/npu/eval/check_attention_decode_score_multivalue_service_guard.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Validate the composed multivalue service before physical evaluation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+
+
+_SCORE_BANK_BLACKBOX = "fakeram45_2048x39"
+_SCORE_BANK_BLACKBOX_VERILOG = "npu/rtl/fakeram45_2048x39_blackbox.v"
+_SCORE_BANK_LEF = "/orfs/flow/platforms/nangate45/lef/fakeram45_2048x39.lef"
+_SCORE_BANK_LIB = "/orfs/flow/platforms/nangate45/lib/fakeram45_2048x39.lib"
+_VALUE_MEM_BLACKBOX = "fakeram45_64x32"
+_VALUE_MEM_BLACKBOX_VERILOG = "npu/rtl/fakeram45_64x32_blackbox.v"
+_VALUE_MEM_LEF = "/orfs/flow/platforms/nangate45/lef/fakeram45_64x32.lef"
+_VALUE_MEM_LIB = "/orfs/flow/platforms/nangate45/lib/fakeram45_64x32.lib"
+_SUPPORTED_CLUSTER_COUNTS = {1, 2}
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _resolve_selected_config(*, design_dir: Path, selected: Path | None) -> Path:
+    config_path = selected or (design_dir / "config.json")
+    config_path = config_path.resolve()
+    if not config_path.exists():
+        raise SystemExit(f"missing config: {config_path}")
+    try:
+        relative_path = config_path.relative_to(design_dir)
+    except ValueError as exc:
+        raise SystemExit(f"selected config must live under design-dir: {config_path}") from exc
+    if len(relative_path.parts) != 1:
+        raise SystemExit(
+            f"selected config must be a direct child of design-dir, got: {relative_path.as_posix()}"
+        )
+    return config_path
+
+
+def _require(mapping: dict[str, object], key: str, expected: object, label: str) -> None:
+    if mapping.get(key) != expected:
+        raise SystemExit(f"{label} {key} must be {expected}")
+
+
+def _source_w(cluster_count: int) -> int:
+    return max(1, (cluster_count - 1).bit_length())
+
+
+def _top_pin_bits(cluster_count: int) -> int:
+    source_w = _source_w(cluster_count)
+    return (1487 + source_w) + (cluster_count * (687 + source_w))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--design-dir", type=Path, required=True)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="Config used to generate the design; defaults to <design-dir>/config.json",
+    )
+    args = parser.parse_args()
+
+    design_dir = args.design_dir.resolve()
+    config_path = _resolve_selected_config(design_dir=design_dir, selected=args.config)
+    rtl_dir = design_dir / "verilog"
+    paths = {
+        "config": config_path,
+        "generated": rtl_dir / "config.json",
+        "manifest": rtl_dir / "attention_decode_score_multivalue_service_manifest.json",
+        "generated_macro_manifest": rtl_dir / "macro_manifest.json",
+        "design_macro_manifest": design_dir / "macro_manifest.json",
+        "top": rtl_dir / "top.v",
+    }
+    for path in paths.values():
+        if not path.is_file():
+            raise SystemExit(f"missing decode-score multivalue service artifact: {path}")
+
+    config = _load_json(paths["config"])
+    generated_config = _load_json(paths["generated"])
+    if config != generated_config:
+        raise SystemExit("generated config does not match source config")
+    body = config.get("attention_decode_score_multivalue_service")
+    if not isinstance(body, dict):
+        raise SystemExit("config must contain attention_decode_score_multivalue_service object")
+
+    expected_config = {
+        "max_blocks": 16,
+        "packet_w": 128,
+        "banks": 4,
+        "req_queue_depth": 4,
+        "resp_queue_depth": 4,
+        "bank_queue_depth": 4,
+        "read_latency": 2,
+        "arb_mode": "round_robin",
+        "locality_burst_max": 2,
+        "score_scale_lanes_per_cycle": 1,
+        "value_memory_backend": "macro_banked_4x16x64x32",
+    }
+    for key, expected in expected_config.items():
+        _require(body, key, expected, "service config")
+    cluster_count = int(body.get("cluster_count", 0))
+    if cluster_count not in _SUPPORTED_CLUSTER_COUNTS:
+        raise SystemExit("service config cluster_count must be exactly one of 1 or 2 for this first physical patch")
+
+    top_name = str(config.get("top_name") or "")
+    expected_suffix = f"_c{cluster_count}_p128_b4_q4_rl2_rr"
+    if expected_suffix not in top_name:
+        raise SystemExit("service top_name must encode c/p/b/q/rl/rr physical point")
+
+    manifest = _load_json(paths["manifest"])
+    expected_manifest = {
+        "top_name": top_name,
+        "generator": "npu/rtlgen/gen_attention_decode_score_multivalue_service.py",
+        "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_onchip_service_v1",
+        "cluster_count": cluster_count,
+        "max_blocks": 16,
+        "packet_w": 128,
+        "banks": 4,
+        "req_queue_depth": 4,
+        "resp_queue_depth": 4,
+        "bank_queue_depth": 4,
+        "read_latency": 2,
+        "arb_mode": "round_robin",
+        "locality_burst_max": 2,
+        "value_dimensions": 128,
+        "value_slices": 16,
+        "score_scale_lanes_per_cycle": 1,
+        "fsm_encoding": "default",
+        "value_memory_backend": "macro_banked_4x16x64x32",
+        "value_memory_promotable": True,
+        "score_bank_macro_count": 56 * cluster_count,
+        "value_memory_macro_count": 64,
+        "total_macro_count": (56 * cluster_count) + 64,
+        "shared_result_egress": "single_ready_valid_round_robin_hold_reg_v2",
+        "shared_result_egress_initiation_interval": 1,
+        "shared_result_egress_stall_semantics": "stable_until_handshake",
+        "response_metadata_guard": "single_outstanding_per_cluster_v1",
+        "top_pin_bits": _top_pin_bits(cluster_count),
+    }
+    for key, expected in expected_manifest.items():
+        _require(manifest, key, expected, "generated manifest")
+
+    cluster_manifest = manifest.get("submodule_manifests", {}).get("multivalue_cluster", {})
+    _require(cluster_manifest, "semantic_profile", "decode_m1x8_shared_score_16x8d_value_iterdiv_v1", "embedded cluster manifest")
+    _require(cluster_manifest, "score_bank_macro_count", 56, "embedded cluster manifest")
+
+    design_macro_manifest = _load_json(paths["design_macro_manifest"])
+    generated_macro_manifest = _load_json(paths["generated_macro_manifest"])
+    if design_macro_manifest != generated_macro_manifest:
+        raise SystemExit("design macro_manifest.json must match generated verilog/macro_manifest.json exactly")
+    _require(design_macro_manifest, "design_id", top_name, "macro manifest")
+    _require(design_macro_manifest, "module", top_name, "macro manifest")
+    _require(design_macro_manifest, "platform", "nangate45", "macro manifest")
+    _require(design_macro_manifest, "flow_variant", "decode_score_multivalue_service_v1", "macro manifest")
+    _require(
+        design_macro_manifest,
+        "blackboxes",
+        [_SCORE_BANK_BLACKBOX, _VALUE_MEM_BLACKBOX],
+        "macro manifest",
+    )
+    _require(
+        design_macro_manifest,
+        "additional_lefs",
+        [_SCORE_BANK_LEF, _VALUE_MEM_LEF],
+        "macro manifest",
+    )
+    _require(
+        design_macro_manifest,
+        "additional_libs",
+        [_SCORE_BANK_LIB, _VALUE_MEM_LIB],
+        "macro manifest",
+    )
+    _require(design_macro_manifest, "additional_gds", [], "macro manifest")
+    _require(
+        design_macro_manifest,
+        "blackbox_verilog",
+        [_SCORE_BANK_BLACKBOX_VERILOG, _VALUE_MEM_BLACKBOX_VERILOG],
+        "macro manifest",
+    )
+
+    macro_params = design_macro_manifest.get("manifest_params", {})
+    expected_macro_params = {
+        "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_onchip_service_v1",
+        "cluster_count": cluster_count,
+        "score_bank_macro_count": 56 * cluster_count,
+        "value_memory_backend": "macro_banked_4x16x64x32",
+        "value_memory_macro_count": 64,
+        "value_memory_bank_count": 4,
+        "value_memory_macros_per_bank": 16,
+        "value_memory_macro_depth": 64,
+        "value_memory_logical_depth_per_bank": 64,
+        "value_memory_logical_depth_total": 256,
+        "value_memory_macro_overprovision_factor": 1,
+        "value_memory_lane_width_bits": 32,
+        "value_memory_physical_contract": "banked_4x16x64x32_exact_capacity",
+        "value_memory_promotable": True,
+        "total_macro_count": (56 * cluster_count) + 64,
+        "packet_w": 128,
+        "banks": 4,
+        "max_blocks": 16,
+        "read_latency": 2,
+        "arb_mode": "round_robin",
+        "locality_burst_max": 2,
+        "score_scale_lanes_per_cycle": 1,
+        "score_passes_per_command": 1,
+        "value_slices": 16,
+        "shared_result_egress": "single_ready_valid_round_robin_hold_reg_v2",
+        "top_pin_bits": _top_pin_bits(cluster_count),
+        "macro_eval_excludes_io_pads": True,
+    }
+    for key, expected in expected_macro_params.items():
+        _require(macro_params, key, expected, "macro manifest")
+    if int(macro_params.get("minimum_core_side_um", 0)) <= 0:
+        raise SystemExit("macro manifest minimum_core_side_um must be positive")
+    if int(macro_params.get("minimum_die_side_um", 0)) <= int(macro_params.get("minimum_core_side_um", 0)):
+        raise SystemExit("macro manifest minimum_die_side_um must exceed minimum_core_side_um")
+
+    rtl = paths["top"].read_text(encoding="utf-8", errors="replace")
+    cluster_top = f"{top_name}__cluster"
+    if f"localparam integer CLUSTERS = {cluster_count};" not in rtl:
+        raise SystemExit("service RTL must bind CLUSTERS to the requested cluster_count")
+    required_tokens = (
+        "noc_ready_valid_router #(",
+        "noc_value_matrix_reassembler #(",
+        "banked_value_memory_service #(",
+        ".MEMORY_IMPL(1)",
+        "for (gi = 0; gi < CLUSTERS; gi = gi + 1) begin : gen_cluster",
+        f"{cluster_top} u_cluster (",
+        "shared_result_valid_q",
+        "result_rr_cursor_q",
+        "candidate_valid_count_r",
+        "protocol_error_q || (|cluster_protocol_error) || (|reassembler_protocol_error)",
+        "gen_value_macro_backend",
+        "fakeram45_64x32 u_value_mem_lane",
+        "macro_capture_pending_q",
+        "bank_from_addr(preload_addr) == macro_bank_gi",
+    )
+    for token in required_tokens:
+        if token not in rtl:
+            raise SystemExit(f"service RTL missing semantic token: {token}")
+    for forbidden in ("equivalence_hash", "result_hash", "sha256", "checksum"):
+        if re.search(rf"\b{re.escape(forbidden)}\b", rtl, flags=re.IGNORECASE):
+            raise SystemExit(f"service RTL contains forbidden abstraction token: {forbidden}")
+    if "behavioral_only_non_promotable" in rtl:
+        raise SystemExit("service RTL must not embed a behavioral-only physical contract")
+
+    print(
+        json.dumps(
+            {
+                "design": top_name,
+                "guard": "attention_decode_score_multivalue_service_v1",
+                "cluster_count": cluster_count,
+                "top_pin_bits": _top_pin_bits(cluster_count),
+                "status": "ok",
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/check_attention_decode_score_multivalue_service_physical.py
+++ b/npu/eval/check_attention_decode_score_multivalue_service_physical.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Validate the physical sweep contract for the composed multivalue service."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+
+_EXPECTED_FLOW_VARIANT_PREFIX = "decode_score_multivalue_service"
+_EXPECTED_CLOCK_PERIOD = 10.0
+_EXPECTED_PLACE_DENSITY = 0.4
+_EXPECTED_SYNTH_HIERARCHICAL = 1
+_EXPECTED_SYNTH_MEMORY_MAX_BITS = 65536
+_EXPECTED_RESULT_TOKEN = "attention_decode_score_multivalue_service"
+_EXPECTED_AREAS = {
+    1: {"die_side_um": 3000, "core_side_um": 2950, "modes": ("macro_conservative_c1_die_3000",)},
+    2: {
+        "die_side_um": 3700,
+        "core_side_um": 3650,
+        "modes": ("flattened_wrapper", "hierarchical_macro"),
+    },
+}
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _first_mapping(payload: dict[str, object], *keys: str) -> dict[str, object]:
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, dict):
+            return value
+    return {}
+
+
+def _parse_params_json(value: str) -> dict[str, object]:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError("empty params_json")
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        if len(text) >= 2 and text[0] == '"' and text[-1] == '"':
+            parsed = json.loads(text[1:-1].replace('""', '"'))
+        else:
+            raise
+    if not isinstance(parsed, dict):
+        raise ValueError("params_json did not decode to a JSON object")
+    return parsed
+
+
+def _to_str(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _to_int(value: object) -> int | None:
+    try:
+        return int(str(value).strip())
+    except Exception:
+        return None
+
+
+def _parse_area(value: str) -> tuple[float, float]:
+    parts = _to_str(value).split()
+    if len(parts) != 4:
+        raise ValueError(f"invalid area box: {value}")
+    x0, y0, x1, y1 = [float(part) for part in parts]
+    return max(0.0, x1 - x0), max(0.0, y1 - y0)
+
+
+def _variant_candidates(base_flow_variant: str, mode_name: str) -> set[str]:
+    return {base_flow_variant, f"{base_flow_variant}_{mode_name}"}
+
+
+def _read_metrics_rows(metrics_path: Path) -> list[dict[str, str]]:
+    with metrics_path.open(newline="", encoding="utf-8") as stream:
+        return [row for row in csv.DictReader(stream) if row]
+
+
+def _resolve_repo_path(path_text: str) -> Path:
+    return Path(path_text).resolve() if Path(path_text).is_absolute() else (Path.cwd() / path_text).resolve()
+
+
+def _matching_row(
+    rows: list[dict[str, str]],
+    *,
+    flow_variants: set[str],
+    die_side_um: int,
+    core_side_um: int,
+) -> dict[str, str] | None:
+    expected_die = f"0 0 {die_side_um} {die_side_um}"
+    expected_core = f"50 50 {core_side_um} {core_side_um}"
+    for row in rows:
+        if _to_str(row.get("status")).lower() != "ok":
+            continue
+        if _EXPECTED_RESULT_TOKEN not in _to_str(row.get("result_path", "")):
+            continue
+        try:
+            params = _parse_params_json(_to_str(row.get("params_json", "")))
+        except Exception:
+            continue
+        if _to_str(params.get("FLOW_VARIANT")) not in flow_variants:
+            continue
+        try:
+            if float(_to_str(params.get("CLOCK_PERIOD", ""))) != _EXPECTED_CLOCK_PERIOD:
+                continue
+            if float(_to_str(row.get("critical_path_ns", "inf"))) > _EXPECTED_CLOCK_PERIOD:
+                continue
+        except ValueError:
+            continue
+        if _to_str(params.get("DIE_AREA")) != expected_die:
+            continue
+        if _to_str(params.get("CORE_AREA")) != expected_core:
+            continue
+        return row
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--design-dir", type=Path, required=True)
+    parser.add_argument("--metrics-path", type=Path, required=True)
+    parser.add_argument("--sweep", type=Path, required=True)
+    args = parser.parse_args()
+
+    design_dir = args.design_dir.resolve()
+    metrics_path = args.metrics_path.resolve()
+    sweep_path = args.sweep.resolve()
+    if not metrics_path.exists():
+        raise SystemExit(f"missing metrics.csv: {metrics_path}")
+    if not sweep_path.exists():
+        raise SystemExit(f"missing sweep json: {sweep_path}")
+
+    config = _load_json(design_dir / "config.json")
+    macro_manifest = _load_json(design_dir / "macro_manifest.json")
+    body = config.get("attention_decode_score_multivalue_service")
+    if not isinstance(body, dict):
+        raise SystemExit("config must contain attention_decode_score_multivalue_service object")
+    cluster_count = int(body.get("cluster_count", 0))
+    if cluster_count not in _EXPECTED_AREAS:
+        raise SystemExit(f"unsupported cluster_count for first-patch physical service sweep: {cluster_count}")
+
+    sweep = _load_json(sweep_path)
+    flow_params = _first_mapping(sweep, "flow_params", "parameters")
+    base_flow_variant = _to_str(
+        (flow_params.get("FLOW_VARIANT") or [""])[0]
+        if isinstance(flow_params.get("FLOW_VARIANT"), list)
+        else flow_params.get("FLOW_VARIANT")
+    )
+    if not base_flow_variant.startswith(_EXPECTED_FLOW_VARIANT_PREFIX):
+        raise SystemExit("service sweep FLOW_VARIANT must identify the composed service flow")
+    clock_values = flow_params.get("CLOCK_PERIOD")
+    if clock_values != [10] and clock_values != [_EXPECTED_CLOCK_PERIOD]:
+        raise SystemExit("service sweep CLOCK_PERIOD must be exactly [10]")
+    if flow_params.get("PLACE_DENSITY") != [_EXPECTED_PLACE_DENSITY]:
+        raise SystemExit("service sweep PLACE_DENSITY must be exactly [0.4]")
+    if flow_params.get("SYNTH_HIERARCHICAL") != [_EXPECTED_SYNTH_HIERARCHICAL]:
+        raise SystemExit("service sweep SYNTH_HIERARCHICAL must be exactly [1]")
+    if flow_params.get("SYNTH_MEMORY_MAX_BITS") != [_EXPECTED_SYNTH_MEMORY_MAX_BITS]:
+        raise SystemExit("service sweep SYNTH_MEMORY_MAX_BITS must be exactly [65536]")
+
+    expected = _EXPECTED_AREAS[cluster_count]
+    mode_compare = sweep.get("mode_compare")
+    expected_modes = list(expected["modes"])
+    if cluster_count == 2:
+        if not isinstance(mode_compare, dict):
+            raise SystemExit("c2 service sweep must use mode_compare for flattened/hierarchical comparison")
+        modes = mode_compare.get("modes")
+        if not isinstance(modes, list) or [mode.get("name") for mode in modes] != expected_modes:
+            raise SystemExit("c2 service sweep must contain flattened_wrapper and hierarchical_macro modes in order")
+        for mode in modes:
+            if mode.get("use_macro") is not True:
+                raise SystemExit("c2 service sweep modes must preserve macro usage")
+            overrides = mode.get("param_overrides")
+            if not isinstance(overrides, dict):
+                raise SystemExit("c2 service sweep modes must define param_overrides")
+            expected_die = f"0 0 {expected['die_side_um']} {expected['die_side_um']}"
+            expected_core = f"50 50 {expected['core_side_um']} {expected['core_side_um']}"
+            if _to_str(overrides.get("DIE_AREA")) != expected_die:
+                raise SystemExit("c2 service sweep DIE_AREA must be 0 0 3700 3700")
+            if _to_str(overrides.get("CORE_AREA")) != expected_core:
+                raise SystemExit("c2 service sweep CORE_AREA must be 50 50 3650 3650")
+        if _to_int(modes[0].get("param_overrides", {}).get("SYNTH_HIERARCHICAL")) != 0:
+            raise SystemExit("flattened_wrapper mode must override SYNTH_HIERARCHICAL=0")
+        if _to_int(modes[1].get("param_overrides", {}).get("SYNTH_HIERARCHICAL")) != 1:
+            raise SystemExit("hierarchical_macro mode must override SYNTH_HIERARCHICAL=1")
+    else:
+        if not isinstance(mode_compare, dict):
+            raise SystemExit("service sweep must use mode_compare with a single explicit macro mode")
+        modes = mode_compare.get("modes")
+        if not isinstance(modes, list) or len(modes) != 1 or modes[0].get("name") != expected_modes[0]:
+            raise SystemExit("service sweep single-mode contract does not match expected die policy")
+        if modes[0].get("use_macro") is not True:
+            raise SystemExit("service sweep must preserve macro usage")
+        overrides = modes[0].get("param_overrides")
+        if not isinstance(overrides, dict):
+            raise SystemExit("service sweep mode must define param_overrides")
+        expected_die = f"0 0 {expected['die_side_um']} {expected['die_side_um']}"
+        expected_core = f"50 50 {expected['core_side_um']} {expected['core_side_um']}"
+        if _to_str(overrides.get("DIE_AREA")) != expected_die:
+            raise SystemExit(f"service sweep DIE_AREA must be {expected_die}")
+        if _to_str(overrides.get("CORE_AREA")) != expected_core:
+            raise SystemExit(f"service sweep CORE_AREA must be {expected_core}")
+
+    min_core_side_um = int(macro_manifest.get("manifest_params", {}).get("minimum_core_side_um", 0))
+    min_die_side_um = int(macro_manifest.get("manifest_params", {}).get("minimum_die_side_um", 0))
+    if int(expected["core_side_um"]) < min_core_side_um:
+        raise SystemExit("service sweep core side violates macro-manifest minimum_core_side_um")
+    if int(expected["die_side_um"]) < min_die_side_um:
+        raise SystemExit("service sweep die side violates macro-manifest minimum_die_side_um")
+
+    rows = _read_metrics_rows(metrics_path)
+    matched_rows: list[dict[str, str]] = []
+    for mode_name in expected_modes:
+        row = _matching_row(
+            rows,
+            flow_variants=_variant_candidates(base_flow_variant, mode_name),
+            die_side_um=int(expected["die_side_um"]),
+            core_side_um=int(expected["core_side_um"]),
+        )
+        if row is not None:
+            matched_rows.append(row)
+
+    if cluster_count == 2 and len(matched_rows) == 0:
+        raise SystemExit(
+            "stop_monolithic_path: both c2 hierarchy modes failed to produce a 10ns status=ok row "
+            "at DIE_AREA=0 0 3700 3700 / CORE_AREA=50 50 3650 3650"
+        )
+    if cluster_count != 2 and len(matched_rows) != len(expected_modes):
+        raise SystemExit(
+            "missing required 10ns composed-service row for the configured die/core envelope"
+        )
+
+    expected_macro_manifest_path = (design_dir / "macro_manifest.json").resolve()
+    for row in matched_rows:
+        work_result_json = _to_str(row.get("work_result_json", ""))
+        if not work_result_json:
+            raise SystemExit("matched service metrics row must record work_result_json")
+        result_payload = _load_json(_resolve_repo_path(work_result_json))
+        macro_manifest_path = _to_str(result_payload.get("macro_manifest_path", ""))
+        if not macro_manifest_path:
+            raise SystemExit("matched service result.json must record macro_manifest_path")
+        if _resolve_repo_path(macro_manifest_path) != expected_macro_manifest_path:
+            raise SystemExit("matched service result.json macro_manifest_path does not match design macro_manifest.json")
+
+    print(
+        json.dumps(
+            {
+                "design": str(config.get("top_name") or ""),
+                "checker": "attention_decode_score_multivalue_service_physical_v1",
+                "cluster_count": cluster_count,
+                "matched_rows": len(matched_rows),
+                "status": "ok",
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/rtl/fakeram45_64x32_blackbox.v
+++ b/npu/rtl/fakeram45_64x32_blackbox.v
@@ -1,0 +1,11 @@
+(* blackbox *)
+module fakeram45_64x32 (
+    output wire [31:0] rd_out,
+    input  wire [5:0]  addr_in,
+    input  wire        we_in,
+    input  wire [31:0] wd_in,
+    input  wire [31:0] w_mask_in,
+    input  wire        clk,
+    input  wire        ce_in
+);
+endmodule

--- a/npu/rtlgen/gen_attention_decode_score_multivalue_service.py
+++ b/npu/rtlgen/gen_attention_decode_score_multivalue_service.py
@@ -27,6 +27,27 @@ _SIM_RTL_PATHS = (
     "npu/sim/rtl/noc_value_matrix_reassembler.sv",
 )
 
+_SCORE_BANK_BLACKBOX = "fakeram45_2048x39"
+_SCORE_BANK_BLACKBOX_VERILOG = "npu/rtl/fakeram45_2048x39_blackbox.v"
+_SCORE_BANK_LEF = "/orfs/flow/platforms/nangate45/lef/fakeram45_2048x39.lef"
+_SCORE_BANK_LIB = "/orfs/flow/platforms/nangate45/lib/fakeram45_2048x39.lib"
+_SCORE_BANK_SIZE_UM = (206.910, 219.800)
+_SCORE_BANK_MACROS_PER_CLUSTER = 56
+
+_VALUE_MEM_BLACKBOX = "fakeram45_64x32"
+_VALUE_MEM_BLACKBOX_VERILOG = "npu/rtl/fakeram45_64x32_blackbox.v"
+_VALUE_MEM_LEF = "/orfs/flow/platforms/nangate45/lef/fakeram45_64x32.lef"
+_VALUE_MEM_LIB = "/orfs/flow/platforms/nangate45/lib/fakeram45_64x32.lib"
+_VALUE_MEM_SIZE_UM = (20.140, 61.600)
+_VALUE_MEM_MACRO_COUNT = 64
+_VALUE_MEM_BANKS = 4
+_VALUE_MEM_MACROS_PER_BANK = 16
+_VALUE_MEM_MACRO_DEPTH = 64
+_VALUE_MEM_LOGICAL_DEPTH = 256
+_VALUE_MEM_LOGICAL_DEPTH_PER_BANK = 64
+_TOP_LEVEL_CORE_MARGIN_UM = 50
+_PIN_PITCH_UM = 4.0
+
 
 def _load(path: Path) -> JsonDict:
     payload = json.loads(path.read_text(encoding="utf-8"))
@@ -65,6 +86,7 @@ def _validate(config: JsonDict) -> JsonDict:
     locality_burst_max = int(body.get("locality_burst_max", 2))
     score_scale_lanes_per_cycle = int(body.get("score_scale_lanes_per_cycle", 1))
     fsm_encoding = str(body.get("fsm_encoding", "default")).strip().lower()
+    value_memory_backend = str(body.get("value_memory_backend", "behavioral")).strip().lower()
 
     if cluster_count < 1 or cluster_count > 32:
         raise SystemExit("cluster_count must be in [1, 32]")
@@ -86,6 +108,15 @@ def _validate(config: JsonDict) -> JsonDict:
         raise SystemExit("score_scale_lanes_per_cycle must be one of 1,2,4,8")
     if fsm_encoding not in {"default", "binary"}:
         raise SystemExit("fsm_encoding must be default or binary")
+    if value_memory_backend not in {"behavioral", "macro_banked_4x16x64x32"}:
+        raise SystemExit("value_memory_backend must be behavioral or macro_banked_4x16x64x32")
+    if value_memory_backend == "macro_banked_4x16x64x32":
+        if max_blocks != 16:
+            raise SystemExit("macro_banked_4x16x64x32 requires max_blocks=16")
+        if banks != _VALUE_MEM_BANKS:
+            raise SystemExit("macro_banked_4x16x64x32 requires banks=4")
+        if read_latency != 2:
+            raise SystemExit("macro_banked_4x16x64x32 requires read_latency=2")
 
     return {
         "top_name": top_name,
@@ -101,6 +132,107 @@ def _validate(config: JsonDict) -> JsonDict:
         "locality_burst_max": locality_burst_max,
         "score_scale_lanes_per_cycle": score_scale_lanes_per_cycle,
         "fsm_encoding": fsm_encoding,
+        "value_memory_backend": value_memory_backend,
+    }
+
+
+def _source_w(cluster_count: int) -> int:
+    return _clog2(cluster_count)
+
+
+def _total_top_pin_bits(cluster_count: int) -> int:
+    source_w = _source_w(cluster_count)
+    base_bits = 1487 + source_w
+    per_cluster_bits = 687 + source_w
+    return base_bits + (cluster_count * per_cluster_bits)
+
+
+def _value_memory_macro_count(params: JsonDict) -> int:
+    if params["value_memory_backend"] != "macro_banked_4x16x64x32":
+        return 0
+    return _VALUE_MEM_MACRO_COUNT
+
+
+def _minimum_core_side_um(params: JsonDict) -> int:
+    score_bank_area = (
+        int(params["cluster_count"])
+        * _SCORE_BANK_MACROS_PER_CLUSTER
+        * _SCORE_BANK_SIZE_UM[0]
+        * _SCORE_BANK_SIZE_UM[1]
+    )
+    value_memory_area = (
+        _value_memory_macro_count(params) * _VALUE_MEM_SIZE_UM[0] * _VALUE_MEM_SIZE_UM[1]
+    )
+    macro_bound_um = math.sqrt((score_bank_area + value_memory_area) / 0.4)
+    pin_bound_um = (_total_top_pin_bits(int(params["cluster_count"])) * _PIN_PITCH_UM) / 4.0
+    return int(math.ceil(max(macro_bound_um, pin_bound_um)))
+
+
+def _generated_macro_manifest(*, top_name: str, params: JsonDict) -> JsonDict:
+    value_memory_backend = str(params["value_memory_backend"])
+    score_bank_macro_count = int(params["cluster_count"]) * _SCORE_BANK_MACROS_PER_CLUSTER
+    value_memory_macro_count = _value_memory_macro_count(params)
+    blackboxes = [_SCORE_BANK_BLACKBOX]
+    additional_lefs = [_SCORE_BANK_LEF]
+    additional_libs = [_SCORE_BANK_LIB]
+    blackbox_verilog = [_SCORE_BANK_BLACKBOX_VERILOG]
+    if value_memory_macro_count:
+        blackboxes.append(_VALUE_MEM_BLACKBOX)
+        additional_lefs.append(_VALUE_MEM_LEF)
+        additional_libs.append(_VALUE_MEM_LIB)
+        blackbox_verilog.append(_VALUE_MEM_BLACKBOX_VERILOG)
+    minimum_core_side_um = _minimum_core_side_um(params)
+    return {
+        "version": "0.1",
+        "design_id": top_name,
+        "module": top_name,
+        "platform": "nangate45",
+        "flow_variant": "decode_score_multivalue_service_v1",
+        "blackboxes": blackboxes,
+        "additional_lefs": additional_lefs,
+        "additional_libs": additional_libs,
+        "additional_gds": [],
+        "blackbox_verilog": blackbox_verilog,
+        "source": {
+            "mode": "generated_composed_multivalue_service",
+            "generator": "npu/rtlgen/gen_attention_decode_score_multivalue_service.py",
+            "config": f"runs/designs/npu_blocks/{top_name}/config.json",
+        },
+        "manifest_params": {
+            "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_onchip_service_v1",
+            "cluster_count": int(params["cluster_count"]),
+            "score_bank_macro_count": score_bank_macro_count,
+            "value_memory_backend": value_memory_backend,
+            "value_memory_macro_count": value_memory_macro_count,
+            "value_memory_bank_count": _VALUE_MEM_BANKS if value_memory_macro_count else 0,
+            "value_memory_macros_per_bank": _VALUE_MEM_MACROS_PER_BANK if value_memory_macro_count else 0,
+            "value_memory_macro_depth": _VALUE_MEM_MACRO_DEPTH if value_memory_macro_count else 0,
+            "value_memory_logical_depth_per_bank": _VALUE_MEM_LOGICAL_DEPTH_PER_BANK if value_memory_macro_count else 0,
+            "value_memory_logical_depth_total": _VALUE_MEM_LOGICAL_DEPTH if value_memory_macro_count else 0,
+            "value_memory_macro_overprovision_factor": 1 if value_memory_macro_count else 0,
+            "value_memory_lane_width_bits": 32 if value_memory_macro_count else 0,
+            "value_memory_physical_contract": (
+                "banked_4x16x64x32_exact_capacity"
+                if value_memory_macro_count
+                else "behavioral_only_non_promotable"
+            ),
+            "value_memory_promotable": bool(value_memory_macro_count),
+            "total_macro_count": score_bank_macro_count + value_memory_macro_count,
+            "packet_w": int(params["packet_w"]),
+            "banks": int(params["banks"]),
+            "max_blocks": int(params["max_blocks"]),
+            "read_latency": int(params["read_latency"]),
+            "arb_mode": str(params["arb_mode"]),
+            "locality_burst_max": int(params["locality_burst_max"]),
+            "score_scale_lanes_per_cycle": int(params["score_scale_lanes_per_cycle"]),
+            "score_passes_per_command": 1,
+            "value_slices": 16,
+            "shared_result_egress": "single_ready_valid_round_robin_hold_reg_v2",
+            "top_pin_bits": _total_top_pin_bits(int(params["cluster_count"])),
+            "minimum_core_side_um": minimum_core_side_um,
+            "minimum_die_side_um": minimum_core_side_um + (2 * _TOP_LEVEL_CORE_MARGIN_UM),
+            "macro_eval_excludes_io_pads": True,
+        },
     }
 
 
@@ -114,6 +246,7 @@ def _wrapper(*, top_name: str, params: JsonDict, cluster_top: str) -> str:
     read_latency = int(params["read_latency"])
     locality_burst_max = int(params["locality_burst_max"])
     arb_mode = 0 if params["arb_mode"] == "round_robin" else 1
+    memory_impl = 1 if params["value_memory_backend"] == "macro_banked_4x16x64x32" else 0
     source_w = _clog2(cluster_count)
     frag_idx_w = _clog2(512 // packet_w)
     return f"""// Auto-generated by npu/rtlgen/gen_attention_decode_score_multivalue_service.py
@@ -425,7 +558,8 @@ module {top_name} (
     .BANKS({banks}),
     .BANK_QUEUE_DEPTH({bank_queue_depth}),
     .READ_LATENCY({read_latency}),
-    .INIT_FROM_GENERATOR(0)
+    .INIT_FROM_GENERATOR(0),
+    .MEMORY_IMPL({memory_impl})
   ) u_service (
     .clk(clk),
     .rst_n(rst_n),
@@ -616,6 +750,14 @@ def generate(config: JsonDict, out_dir: Path) -> None:
             for rel in _SIM_RTL_PATHS
         ],
     ]
+    if params["value_memory_backend"] == "macro_banked_4x16x64x32":
+        dependency_sources.append(
+            {
+                "path": _VALUE_MEM_BLACKBOX_VERILOG,
+                "sha256": _sha256_file(REPO_ROOT / _VALUE_MEM_BLACKBOX_VERILOG),
+            }
+        )
+    macro_manifest = _generated_macro_manifest(top_name=top_name, params=params)
     manifest = {
         "version": 1,
         "generator": "npu/rtlgen/gen_attention_decode_score_multivalue_service.py",
@@ -635,18 +777,31 @@ def generate(config: JsonDict, out_dir: Path) -> None:
         "value_slices": 16,
         "score_scale_lanes_per_cycle": params["score_scale_lanes_per_cycle"],
         "fsm_encoding": params["fsm_encoding"],
+        "value_memory_backend": params["value_memory_backend"],
+        "value_memory_promotable": bool(_value_memory_macro_count(params)),
+        "score_bank_macro_count": int(params["cluster_count"]) * _SCORE_BANK_MACROS_PER_CLUSTER,
+        "value_memory_macro_count": _value_memory_macro_count(params),
+        "total_macro_count": int(params["cluster_count"]) * _SCORE_BANK_MACROS_PER_CLUSTER + _value_memory_macro_count(params),
+        "top_pin_bits": _total_top_pin_bits(int(params["cluster_count"])),
+        "minimum_core_side_um": _minimum_core_side_um(params),
+        "minimum_die_side_um": _minimum_core_side_um(params) + (2 * _TOP_LEVEL_CORE_MARGIN_UM),
         "shared_result_egress": "single_ready_valid_round_robin_hold_reg_v2",
         "shared_result_egress_initiation_interval": 1,
         "shared_result_egress_stall_semantics": "stable_until_handshake",
         "response_metadata_guard": "single_outstanding_per_cluster_v1",
         "dependency_sources": dependency_sources,
         "generated_top_sha256": _sha256_text(top_text),
+        "generated_macro_manifest_sha256": _sha256_text(json.dumps(macro_manifest, sort_keys=True)),
         "submodule_manifests": {
             "multivalue_cluster": cluster_manifest,
         },
     }
     (out_dir / "attention_decode_score_multivalue_service_manifest.json").write_text(
         json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out_dir / "macro_manifest.json").write_text(
+        json.dumps(macro_manifest, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
 

--- a/npu/sim/rtl/banked_value_memory_service.sv
+++ b/npu/sim/rtl/banked_value_memory_service.sv
@@ -16,7 +16,8 @@ module banked_value_memory_service #(
   parameter integer BANK_QUEUE_DEPTH = 2,
   parameter integer READ_LATENCY = 2,
   parameter integer COUNTER_W = 32,
-  parameter integer INIT_FROM_GENERATOR = 0
+  parameter integer INIT_FROM_GENERATOR = 0,
+  parameter integer MEMORY_IMPL = 0
 ) (
   input wire clk,
   input wire rst_n,
@@ -67,6 +68,10 @@ module banked_value_memory_service #(
   localparam integer REQ_TAG_LSB = REQ_SRC_LSB + SOURCE_W;
   localparam integer REQ_ADDR_LSB = REQ_TAG_LSB + TAG_W;
   localparam integer REQ_SLICE_LSB = REQ_ADDR_LSB + ADDR_W;
+  localparam integer VALUE_MACRO_W = 32;
+  localparam integer VALUE_MACRO_LANES = VALUE_W / VALUE_MACRO_W;
+  localparam integer VALUE_MACRO_DEPTH = 64;
+  localparam integer VALUE_MACRO_ADDR_W = 6;
 
   wire [BANKS-1:0] bank_fifo_in_valid;
   wire [BANKS-1:0] bank_fifo_in_ready;
@@ -75,6 +80,7 @@ module banked_value_memory_service #(
   wire [BANKS-1:0] bank_launch_fire;
   wire [BANKS*REQ_META_W-1:0] bank_fifo_out_bus;
   wire [BANKS*BANK_COUNT_W-1:0] bank_fifo_occupancy_bus;
+  wire [BANKS*VALUE_W-1:0] macro_bank_read_matrix_bus;
 
   reg [BANKS-1:0] bank_busy;
   reg [SOURCE_W-1:0] active_source [0:BANKS-1];
@@ -85,6 +91,8 @@ module banked_value_memory_service #(
   reg [FRAG_IDX_W-1:0] active_fragment [0:BANKS-1];
   reg [LAT_W-1:0] bank_latency [0:BANKS-1];
   reg [BANKS-1:0] bank_ready_fragment_r;
+  reg [BANKS-1:0] macro_read_pending_q;
+  reg [BANKS-1:0] macro_capture_pending_q;
   reg [BANK_PTR_W-1:0] resp_rr_cursor;
   reg [BANK_PTR_W-1:0] resp_grant_bank_r;
   reg resp_lock_valid_r;
@@ -93,7 +101,7 @@ module banked_value_memory_service #(
   reg [REQ_OCC_W-1:0] req_occupancy_sum_r;
   reg [RESP_OCC_W-1:0] resp_occupancy_sum_r;
 
-  reg [VALUE_W-1:0] value_mem [0:STORE_ENTRY_COUNT-1];
+  reg [VALUE_W-1:0] behavioral_value_mem [0:STORE_ENTRY_COUNT-1];
 
   integer occ_bank_i;
   integer seq_bank_i;
@@ -162,6 +170,16 @@ module banked_value_memory_service #(
     end
   endfunction
 
+  function [VALUE_MACRO_ADDR_W-1:0] macro_bank_row;
+    input [ADDR_W-1:0] addr;
+    input [VALUE_SLICE_W-1:0] value_slice;
+    integer row_index;
+    begin
+      row_index = ((addr / BANKS) * VALUE_SLICE_COUNT) + value_slice;
+      macro_bank_row = row_index[VALUE_MACRO_ADDR_W-1:0];
+    end
+  endfunction
+
   function [VALUE_W-1:0] generated_matrix;
     input integer addr;
     input integer value_slice;
@@ -218,8 +236,49 @@ module banked_value_memory_service #(
 
       assign bank_fifo_in_valid[bank_gi] =
         req_valid && (bank_from_addr(req_addr) == bank_gi[BANK_SEL_W-1:0]);
-      assign bank_fifo_out_ready[bank_gi] = !bank_busy[bank_gi] && bank_fifo_out_valid[bank_gi];
+      assign bank_fifo_out_ready[bank_gi] =
+        !bank_busy[bank_gi] &&
+        bank_fifo_out_valid[bank_gi] &&
+        !(preload_fire && (bank_from_addr(preload_addr) == bank_gi[BANK_SEL_W-1:0]) && (MEMORY_IMPL != 0));
       assign bank_launch_fire[bank_gi] = bank_fifo_out_valid[bank_gi] && bank_fifo_out_ready[bank_gi];
+    end
+
+    if (MEMORY_IMPL != 0) begin : gen_value_macro_backend
+      genvar macro_bank_gi;
+      for (macro_bank_gi = 0; macro_bank_gi < BANKS; macro_bank_gi = macro_bank_gi + 1) begin : gen_value_bank
+        wire bank_preload_fire;
+        wire bank_read_fire;
+        wire [VALUE_MACRO_ADDR_W-1:0] bank_macro_addr;
+        wire [ADDR_W-1:0] bank_launch_addr;
+        wire [VALUE_SLICE_W-1:0] bank_launch_slice;
+
+        assign bank_preload_fire =
+          preload_fire && (bank_from_addr(preload_addr) == macro_bank_gi[BANK_SEL_W-1:0]);
+        assign bank_launch_addr =
+          meta_addr(bank_fifo_out_bus[(macro_bank_gi * REQ_META_W) +: REQ_META_W]);
+        assign bank_launch_slice =
+          meta_slice(bank_fifo_out_bus[(macro_bank_gi * REQ_META_W) +: REQ_META_W]);
+        assign bank_read_fire =
+          bank_launch_fire[macro_bank_gi] && (bank_launch_addr < STORE_DEPTH[ADDR_W-1:0]);
+        assign bank_macro_addr = bank_preload_fire ?
+          macro_bank_row(preload_addr, preload_value_slice) :
+          macro_bank_row(bank_launch_addr, bank_launch_slice);
+
+        genvar value_lane_gi;
+        for (value_lane_gi = 0; value_lane_gi < VALUE_MACRO_LANES; value_lane_gi = value_lane_gi + 1) begin : gen_value_lane
+          fakeram45_64x32 u_value_mem_lane (
+            .rd_out(macro_bank_read_matrix_bus[
+              (macro_bank_gi * VALUE_W) + (value_lane_gi * VALUE_MACRO_W) +: VALUE_MACRO_W
+            ]),
+            .addr_in(bank_macro_addr),
+            .we_in(bank_preload_fire),
+            .wd_in(preload_matrix[(value_lane_gi * VALUE_MACRO_W) +: VALUE_MACRO_W]),
+            .w_mask_in({VALUE_MACRO_W{bank_preload_fire}}),
+            .clk(clk),
+            .ce_in(bank_preload_fire || bank_read_fire)
+          );
+        end
+      end
     end
   endgenerate
 
@@ -289,13 +348,36 @@ module banked_value_memory_service #(
       $error("banked_value_memory_service STORE_DEPTH exceeds ADDR_W encoding");
       $finish(1);
     end
+    if (MEMORY_IMPL != 0) begin
+      if (BANKS != 4) begin
+        $error("macro-backed banked_value_memory_service requires BANKS=4, got %0d", BANKS);
+        $finish(1);
+      end
+      if (STORE_DEPTH != 16) begin
+        $error("macro-backed banked_value_memory_service requires STORE_DEPTH=16, got %0d", STORE_DEPTH);
+        $finish(1);
+      end
+      if (READ_LATENCY != 2) begin
+        $error("macro-backed banked_value_memory_service requires READ_LATENCY=2, got %0d", READ_LATENCY);
+        $finish(1);
+      end
+      if (VALUE_MACRO_LANES != 16) begin
+        $error("macro-backed banked_value_memory_service requires sixteen 32-bit value lanes");
+        $finish(1);
+      end
+      if ((STORE_ENTRY_COUNT / BANKS) != VALUE_MACRO_DEPTH) begin
+        $error("macro-backed banked_value_memory_service requires exact 64-entry per-bank depth, got %0d",
+               (STORE_ENTRY_COUNT / BANKS));
+        $finish(1);
+      end
+    end
     for (init_i = 0; init_i < STORE_ENTRY_COUNT; init_i = init_i + 1) begin
       if (INIT_FROM_GENERATOR != 0) begin
         init_addr = init_i / VALUE_SLICE_COUNT;
         init_slice = init_i % VALUE_SLICE_COUNT;
-        value_mem[init_i] = generated_matrix(init_addr, init_slice);
+        behavioral_value_mem[init_i] = generated_matrix(init_addr, init_slice);
       end else begin
-        value_mem[init_i] = {VALUE_W{1'b0}};
+        behavioral_value_mem[init_i] = {VALUE_W{1'b0}};
       end
     end
   end
@@ -304,6 +386,8 @@ module banked_value_memory_service #(
   always @(posedge clk or negedge rst_n) begin
     if (!rst_n) begin
       bank_busy <= {BANKS{1'b0}};
+      macro_read_pending_q <= {BANKS{1'b0}};
+      macro_capture_pending_q <= {BANKS{1'b0}};
       for (seq_bank_i = 0; seq_bank_i < BANKS; seq_bank_i = seq_bank_i + 1) begin
         active_source[seq_bank_i] <= {SOURCE_W{1'b0}};
         active_tag[seq_bank_i] <= {TAG_W{1'b0}};
@@ -323,9 +407,9 @@ module banked_value_memory_service #(
       req_max_occupancy <= {COUNTER_W{1'b0}};
       resp_max_occupancy <= {COUNTER_W{1'b0}};
     end else begin
-      if (preload_fire && (preload_addr < STORE_DEPTH[ADDR_W-1:0])) begin
+      if ((MEMORY_IMPL == 0) && preload_fire && (preload_addr < STORE_DEPTH[ADDR_W-1:0])) begin
         preload_idx = store_index(preload_addr, preload_value_slice);
-        value_mem[preload_idx] <= preload_matrix;
+        behavioral_value_mem[preload_idx] <= preload_matrix;
       end
 
       if (req_fire) begin
@@ -337,6 +421,16 @@ module banked_value_memory_service #(
       end
 
       for (seq_bank_i = 0; seq_bank_i < BANKS; seq_bank_i = seq_bank_i + 1) begin
+        if (macro_read_pending_q[seq_bank_i]) begin
+          macro_read_pending_q[seq_bank_i] <= 1'b0;
+          macro_capture_pending_q[seq_bank_i] <= 1'b1;
+        end
+        if (macro_capture_pending_q[seq_bank_i]) begin
+          active_matrix[seq_bank_i] <=
+            macro_bank_read_matrix_bus[(seq_bank_i * VALUE_W) +: VALUE_W];
+          macro_capture_pending_q[seq_bank_i] <= 1'b0;
+        end
+
         if (bank_launch_fire[seq_bank_i]) begin
           bank_busy[seq_bank_i] <= 1'b1;
           active_source[seq_bank_i] <=
@@ -348,19 +442,24 @@ module banked_value_memory_service #(
           active_slice[seq_bank_i] <=
             meta_slice(bank_fifo_out_bus[(seq_bank_i * REQ_META_W) +: REQ_META_W]);
           active_fragment[seq_bank_i] <= {FRAG_IDX_W{1'b0}};
-          if (READ_LATENCY == 0) begin
-            bank_latency[seq_bank_i] <= {LAT_W{1'b0}};
-          end else begin
-            bank_latency[seq_bank_i] <= READ_LATENCY[LAT_W-1:0];
-          end
+          bank_latency[seq_bank_i] <= READ_LATENCY[LAT_W-1:0];
           if (meta_addr(bank_fifo_out_bus[(seq_bank_i * REQ_META_W) +: REQ_META_W]) <
               STORE_DEPTH[ADDR_W-1:0]) begin
-            active_matrix[seq_bank_i] <=
-              value_mem[store_index(
-                meta_addr(bank_fifo_out_bus[(seq_bank_i * REQ_META_W) +: REQ_META_W]),
-                meta_slice(bank_fifo_out_bus[(seq_bank_i * REQ_META_W) +: REQ_META_W]))];
+            if (MEMORY_IMPL == 0) begin
+              active_matrix[seq_bank_i] <=
+                behavioral_value_mem[store_index(
+                  meta_addr(bank_fifo_out_bus[(seq_bank_i * REQ_META_W) +: REQ_META_W]),
+                  meta_slice(bank_fifo_out_bus[(seq_bank_i * REQ_META_W) +: REQ_META_W]))];
+              macro_read_pending_q[seq_bank_i] <= 1'b0;
+              macro_capture_pending_q[seq_bank_i] <= 1'b0;
+            end else begin
+              macro_read_pending_q[seq_bank_i] <= 1'b1;
+              macro_capture_pending_q[seq_bank_i] <= 1'b0;
+            end
           end else begin
             active_matrix[seq_bank_i] <= {VALUE_W{1'b0}};
+            macro_read_pending_q[seq_bank_i] <= 1'b0;
+            macro_capture_pending_q[seq_bank_i] <= 1'b0;
           end
         end else if (bank_busy[seq_bank_i] && (bank_latency[seq_bank_i] != {LAT_W{1'b0}})) begin
           bank_latency[seq_bank_i] <=

--- a/npu/sim/rtl/fakeram45_64x32_model.sv
+++ b/npu/sim/rtl/fakeram45_64x32_model.sv
@@ -1,0 +1,44 @@
+`timescale 1ns/1ps
+
+module fakeram45_64x32 (
+  output wire [31:0] rd_out,
+  input  wire [5:0]  addr_in,
+  input  wire        we_in,
+  input  wire [31:0] wd_in,
+  input  wire [31:0] w_mask_in,
+  input  wire        clk,
+  input  wire        ce_in
+);
+  reg [31:0] mem [0:63];
+  reg [5:0] addr_q;
+  reg [31:0] rd_out_q;
+  integer idx;
+  integer bit_i;
+  reg [31:0] write_word;
+
+  assign rd_out = rd_out_q;
+
+  initial begin
+    addr_q = 6'd0;
+    rd_out_q = 32'd0;
+    for (idx = 0; idx < 64; idx = idx + 1) begin
+      mem[idx] = 32'd0;
+    end
+  end
+
+  always @(posedge clk) begin
+    rd_out_q <= mem[addr_q];
+    if (ce_in) begin
+      write_word = mem[addr_in];
+      if (we_in) begin
+        for (bit_i = 0; bit_i < 32; bit_i = bit_i + 1) begin
+          if (w_mask_in[bit_i]) begin
+            write_word[bit_i] = wd_in[bit_i];
+          end
+        end
+        mem[addr_in] <= write_word;
+      end
+      addr_q <= addr_in;
+    end
+  end
+endmodule

--- a/runs/campaigns/npu/decode_score_multivalue_service_v1/sweeps/nangate45_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000.json
+++ b/runs/campaigns/npu/decode_score_multivalue_service_v1/sweeps/nangate45_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000.json
@@ -1,0 +1,35 @@
+{
+  "tag_prefix": "decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1",
+  "flow_params": {
+    "TAG": [
+      "decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1"
+    ],
+    "FLOW_VARIANT": [
+      "decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1"
+    ],
+    "CLOCK_PERIOD": [
+      10
+    ],
+    "PLACE_DENSITY": [
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "mode_compare": {
+    "modes": [
+      {
+        "name": "macro_conservative_c1_die_3000",
+        "use_macro": true,
+        "param_overrides": {
+          "DIE_AREA": "0 0 3000 3000",
+          "CORE_AREA": "50 50 2950 2950"
+        }
+      }
+    ]
+  }
+}

--- a/runs/campaigns/npu/decode_score_multivalue_service_v1/sweeps/nangate45_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_3700.json
+++ b/runs/campaigns/npu/decode_score_multivalue_service_v1/sweeps/nangate45_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_3700.json
@@ -1,0 +1,45 @@
+{
+  "tag_prefix": "decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_3700_v1",
+  "flow_params": {
+    "TAG": [
+      "decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_3700_v1"
+    ],
+    "FLOW_VARIANT": [
+      "decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_3700_v1"
+    ],
+    "CLOCK_PERIOD": [
+      10
+    ],
+    "PLACE_DENSITY": [
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "mode_compare": {
+    "modes": [
+      {
+        "name": "flattened_wrapper",
+        "use_macro": true,
+        "param_overrides": {
+          "SYNTH_HIERARCHICAL": 0,
+          "DIE_AREA": "0 0 3700 3700",
+          "CORE_AREA": "50 50 3650 3650"
+        }
+      },
+      {
+        "name": "hierarchical_macro",
+        "use_macro": true,
+        "param_overrides": {
+          "SYNTH_HIERARCHICAL": 1,
+          "DIE_AREA": "0 0 3700 3700",
+          "CORE_AREA": "50 50 3650 3650"
+        }
+      }
+    ]
+  }
+}

--- a/runs/designs/npu_blocks/attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr/config.json
+++ b/runs/designs/npu_blocks/attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr/config.json
@@ -1,0 +1,17 @@
+{
+  "top_name": "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr",
+  "attention_decode_score_multivalue_service": {
+    "cluster_count": 1,
+    "max_blocks": 16,
+    "packet_w": 128,
+    "banks": 4,
+    "req_queue_depth": 4,
+    "resp_queue_depth": 4,
+    "bank_queue_depth": 4,
+    "read_latency": 2,
+    "arb_mode": "round_robin",
+    "locality_burst_max": 2,
+    "score_scale_lanes_per_cycle": 1,
+    "value_memory_backend": "macro_banked_4x16x64x32"
+  }
+}

--- a/runs/designs/npu_blocks/attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr/macro_manifest.json
+++ b/runs/designs/npu_blocks/attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr/macro_manifest.json
@@ -1,0 +1,60 @@
+{
+  "additional_gds": [],
+  "additional_lefs": [
+    "/orfs/flow/platforms/nangate45/lef/fakeram45_2048x39.lef",
+    "/orfs/flow/platforms/nangate45/lef/fakeram45_64x32.lef"
+  ],
+  "additional_libs": [
+    "/orfs/flow/platforms/nangate45/lib/fakeram45_2048x39.lib",
+    "/orfs/flow/platforms/nangate45/lib/fakeram45_64x32.lib"
+  ],
+  "blackbox_verilog": [
+    "npu/rtl/fakeram45_2048x39_blackbox.v",
+    "npu/rtl/fakeram45_64x32_blackbox.v"
+  ],
+  "blackboxes": [
+    "fakeram45_2048x39",
+    "fakeram45_64x32"
+  ],
+  "design_id": "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr",
+  "flow_variant": "decode_score_multivalue_service_v1",
+  "manifest_params": {
+    "arb_mode": "round_robin",
+    "banks": 4,
+    "cluster_count": 1,
+    "locality_burst_max": 2,
+    "macro_eval_excludes_io_pads": true,
+    "max_blocks": 16,
+    "minimum_core_side_um": 2563,
+    "minimum_die_side_um": 2663,
+    "packet_w": 128,
+    "read_latency": 2,
+    "score_bank_macro_count": 56,
+    "score_passes_per_command": 1,
+    "score_scale_lanes_per_cycle": 1,
+    "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_onchip_service_v1",
+    "shared_result_egress": "single_ready_valid_round_robin_hold_reg_v2",
+    "top_pin_bits": 2176,
+    "total_macro_count": 120,
+    "value_memory_backend": "macro_banked_4x16x64x32",
+    "value_memory_bank_count": 4,
+    "value_memory_lane_width_bits": 32,
+    "value_memory_logical_depth_per_bank": 64,
+    "value_memory_logical_depth_total": 256,
+    "value_memory_macro_count": 64,
+    "value_memory_macro_depth": 64,
+    "value_memory_macro_overprovision_factor": 1,
+    "value_memory_macros_per_bank": 16,
+    "value_memory_physical_contract": "banked_4x16x64x32_exact_capacity",
+    "value_memory_promotable": true,
+    "value_slices": 16
+  },
+  "module": "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr",
+  "platform": "nangate45",
+  "source": {
+    "config": "runs/designs/npu_blocks/attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr/config.json",
+    "generator": "npu/rtlgen/gen_attention_decode_score_multivalue_service.py",
+    "mode": "generated_composed_multivalue_service"
+  },
+  "version": "0.1"
+}

--- a/runs/designs/npu_blocks/attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr/config.json
+++ b/runs/designs/npu_blocks/attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr/config.json
@@ -1,0 +1,17 @@
+{
+  "top_name": "attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr",
+  "attention_decode_score_multivalue_service": {
+    "cluster_count": 2,
+    "max_blocks": 16,
+    "packet_w": 128,
+    "banks": 4,
+    "req_queue_depth": 4,
+    "resp_queue_depth": 4,
+    "bank_queue_depth": 4,
+    "read_latency": 2,
+    "arb_mode": "round_robin",
+    "locality_burst_max": 2,
+    "score_scale_lanes_per_cycle": 1,
+    "value_memory_backend": "macro_banked_4x16x64x32"
+  }
+}

--- a/runs/designs/npu_blocks/attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr/macro_manifest.json
+++ b/runs/designs/npu_blocks/attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr/macro_manifest.json
@@ -1,0 +1,60 @@
+{
+  "additional_gds": [],
+  "additional_lefs": [
+    "/orfs/flow/platforms/nangate45/lef/fakeram45_2048x39.lef",
+    "/orfs/flow/platforms/nangate45/lef/fakeram45_64x32.lef"
+  ],
+  "additional_libs": [
+    "/orfs/flow/platforms/nangate45/lib/fakeram45_2048x39.lib",
+    "/orfs/flow/platforms/nangate45/lib/fakeram45_64x32.lib"
+  ],
+  "blackbox_verilog": [
+    "npu/rtl/fakeram45_2048x39_blackbox.v",
+    "npu/rtl/fakeram45_64x32_blackbox.v"
+  ],
+  "blackboxes": [
+    "fakeram45_2048x39",
+    "fakeram45_64x32"
+  ],
+  "design_id": "attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr",
+  "flow_variant": "decode_score_multivalue_service_v1",
+  "manifest_params": {
+    "arb_mode": "round_robin",
+    "banks": 4,
+    "cluster_count": 2,
+    "locality_burst_max": 2,
+    "macro_eval_excludes_io_pads": true,
+    "max_blocks": 16,
+    "minimum_core_side_um": 3597,
+    "minimum_die_side_um": 3697,
+    "packet_w": 128,
+    "read_latency": 2,
+    "score_bank_macro_count": 112,
+    "score_passes_per_command": 1,
+    "score_scale_lanes_per_cycle": 1,
+    "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_onchip_service_v1",
+    "shared_result_egress": "single_ready_valid_round_robin_hold_reg_v2",
+    "top_pin_bits": 2864,
+    "total_macro_count": 176,
+    "value_memory_backend": "macro_banked_4x16x64x32",
+    "value_memory_bank_count": 4,
+    "value_memory_lane_width_bits": 32,
+    "value_memory_logical_depth_per_bank": 64,
+    "value_memory_logical_depth_total": 256,
+    "value_memory_macro_count": 64,
+    "value_memory_macro_depth": 64,
+    "value_memory_macro_overprovision_factor": 1,
+    "value_memory_macros_per_bank": 16,
+    "value_memory_physical_contract": "banked_4x16x64x32_exact_capacity",
+    "value_memory_promotable": true,
+    "value_slices": 16
+  },
+  "module": "attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr",
+  "platform": "nangate45",
+  "source": {
+    "config": "runs/designs/npu_blocks/attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr/config.json",
+    "generator": "npu/rtlgen/gen_attention_decode_score_multivalue_service.py",
+    "mode": "generated_composed_multivalue_service"
+  },
+  "version": "0.1"
+}

--- a/tests/test_attention_decode_score_multivalue_integrated_service.py
+++ b/tests/test_attention_decode_score_multivalue_integrated_service.py
@@ -69,12 +69,14 @@ def test_multivalue_service_generator_manifest(tmp_path: Path) -> None:
             "arb_mode": "locality_first_bounded",
             "locality_burst_max": 3,
             "score_scale_lanes_per_cycle": 1,
+            "value_memory_backend": "behavioral",
         },
     }
     generate(config, tmp_path)
     manifest = json.loads(
         (tmp_path / "attention_decode_score_multivalue_service_manifest.json").read_text(encoding="utf-8")
     )
+    macro_manifest = json.loads((tmp_path / "macro_manifest.json").read_text(encoding="utf-8"))
     assert manifest["semantic_profile"] == "decode_m1x8_shared_score_16x8d_value_iterdiv_onchip_service_v1"
     assert manifest["cluster_count"] == 4
     assert manifest["packet_w"] == 256
@@ -85,6 +87,47 @@ def test_multivalue_service_generator_manifest(tmp_path: Path) -> None:
     assert manifest["shared_result_egress_stall_semantics"] == "stable_until_handshake"
     assert manifest["response_metadata_guard"] == "single_outstanding_per_cluster_v1"
     assert manifest["submodule_manifests"]["multivalue_cluster"]["result_beats_per_command"] == 16
+    assert macro_manifest["manifest_params"]["score_bank_macro_count"] == 224
+    assert macro_manifest["manifest_params"]["value_memory_backend"] == "behavioral"
+    assert macro_manifest["manifest_params"]["value_memory_promotable"] is False
+
+
+def test_multivalue_service_generator_banked_4x16x64x32_macro_contract(tmp_path: Path) -> None:
+    config = {
+        "top_name": "attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr",
+        "attention_decode_score_multivalue_service": {
+            "cluster_count": 2,
+            "max_blocks": 16,
+            "packet_w": 128,
+            "banks": 4,
+            "req_queue_depth": 4,
+            "resp_queue_depth": 4,
+            "bank_queue_depth": 4,
+            "read_latency": 2,
+            "arb_mode": "round_robin",
+            "locality_burst_max": 2,
+            "score_scale_lanes_per_cycle": 1,
+            "value_memory_backend": "macro_banked_4x16x64x32",
+        },
+    }
+    generate(config, tmp_path)
+    manifest = json.loads(
+        (tmp_path / "attention_decode_score_multivalue_service_manifest.json").read_text(encoding="utf-8")
+    )
+    macro_manifest = json.loads((tmp_path / "macro_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["value_memory_backend"] == "macro_banked_4x16x64x32"
+    assert manifest["value_memory_macro_count"] == 64
+    assert manifest["total_macro_count"] == 176
+    assert macro_manifest["manifest_params"]["value_memory_macro_count"] == 64
+    assert macro_manifest["manifest_params"]["value_memory_macros_per_bank"] == 16
+    assert macro_manifest["manifest_params"]["value_memory_macro_depth"] == 64
+    assert macro_manifest["manifest_params"]["value_memory_logical_depth_per_bank"] == 64
+    assert macro_manifest["manifest_params"]["value_memory_logical_depth_total"] == 256
+    assert macro_manifest["manifest_params"]["value_memory_macro_overprovision_factor"] == 1
+    assert (
+        macro_manifest["manifest_params"]["value_memory_physical_contract"]
+        == "banked_4x16x64x32_exact_capacity"
+    )
 
 
 def test_integrated_service_default_cases_cover_requested_surface() -> None:

--- a/tests/test_banked_value_memory_service.py
+++ b/tests/test_banked_value_memory_service.py
@@ -1,0 +1,560 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _tool(name: str) -> str | None:
+    path = shutil.which(name)
+    if path is not None:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    if fallback.exists():
+        return str(fallback)
+    return None
+
+
+_SUMMARY_RE = re.compile(
+    r"SUMMARY backend_match=(\d+) "
+    r"accepted=(\d+) emitted=(\d+) fragments=(\d+) bank_conflict=(\d+) response_block=(\d+) "
+    r"req_max=(\d+) resp_max=(\d+) completion_cycle=(\d+) "
+    r"beh_req_hash=([0-9a-fA-F]+) macro_req_hash=([0-9a-fA-F]+) "
+    r"beh_resp_hash=([0-9a-fA-F]+) macro_resp_hash=([0-9a-fA-F]+)"
+)
+
+
+_TB = r"""
+`timescale 1ns/1ps
+
+module banked_value_memory_service_backend_tb;
+  localparam integer PACKET_W = 128;
+  localparam integer VALUE_W = 512;
+  localparam integer SOURCE_W = 2;
+  localparam integer TAG_W = 8;
+  localparam integer ADDR_W = 14;
+  localparam integer VALUE_SLICE_W = 4;
+  localparam integer STORE_DEPTH = 16;
+  localparam integer BANKS = 4;
+  localparam integer BANK_QUEUE_DEPTH = 4;
+  localparam integer READ_LATENCY = 2;
+  localparam integer COUNTER_W = 32;
+  localparam integer REQUEST_COUNT = 16;
+  localparam integer EXPECTED_FRAGMENTS = REQUEST_COUNT * (VALUE_W / PACKET_W);
+
+  reg clk;
+  reg rst_n;
+
+  reg preload_valid;
+  wire preload_ready_beh;
+  wire preload_ready_macro;
+  reg [ADDR_W-1:0] preload_addr;
+  reg [VALUE_SLICE_W-1:0] preload_value_slice;
+  reg [VALUE_W-1:0] preload_matrix;
+
+  reg req_valid;
+  wire req_ready_beh;
+  wire req_ready_macro;
+  reg [SOURCE_W-1:0] req_source;
+  reg [TAG_W-1:0] req_tag;
+  reg [ADDR_W-1:0] req_addr;
+  reg [VALUE_SLICE_W-1:0] req_value_slice;
+
+  wire resp_valid_beh;
+  wire resp_valid_macro;
+  reg resp_ready;
+  wire [SOURCE_W-1:0] resp_source_beh;
+  wire [SOURCE_W-1:0] resp_source_macro;
+  wire [TAG_W-1:0] resp_tag_beh;
+  wire [TAG_W-1:0] resp_tag_macro;
+  wire [ADDR_W-1:0] resp_addr_beh;
+  wire [ADDR_W-1:0] resp_addr_macro;
+  wire [VALUE_SLICE_W-1:0] resp_value_slice_beh;
+  wire [VALUE_SLICE_W-1:0] resp_value_slice_macro;
+  wire [1:0] resp_fragment_idx_beh;
+  wire [1:0] resp_fragment_idx_macro;
+  wire resp_last_beh;
+  wire resp_last_macro;
+  wire [PACKET_W-1:0] resp_data_beh;
+  wire [PACKET_W-1:0] resp_data_macro;
+
+  wire [COUNTER_W-1:0] accepted_req_count_beh;
+  wire [COUNTER_W-1:0] accepted_req_count_macro;
+  wire [COUNTER_W-1:0] emitted_resp_count_beh;
+  wire [COUNTER_W-1:0] emitted_resp_count_macro;
+  wire [COUNTER_W-1:0] bank_conflict_count_beh;
+  wire [COUNTER_W-1:0] bank_conflict_count_macro;
+  wire [COUNTER_W-1:0] response_block_cycles_beh;
+  wire [COUNTER_W-1:0] response_block_cycles_macro;
+  wire [COUNTER_W-1:0] req_current_occupancy_beh;
+  wire [COUNTER_W-1:0] req_current_occupancy_macro;
+  wire [COUNTER_W-1:0] req_max_occupancy_beh;
+  wire [COUNTER_W-1:0] req_max_occupancy_macro;
+  wire [COUNTER_W-1:0] resp_current_occupancy_beh;
+  wire [COUNTER_W-1:0] resp_current_occupancy_macro;
+  wire [COUNTER_W-1:0] resp_max_occupancy_beh;
+  wire [COUNTER_W-1:0] resp_max_occupancy_macro;
+
+  reg [ADDR_W-1:0] req_plan_addr [0:REQUEST_COUNT-1];
+  reg [VALUE_SLICE_W-1:0] req_plan_slice [0:REQUEST_COUNT-1];
+  reg [SOURCE_W-1:0] req_plan_source [0:REQUEST_COUNT-1];
+  integer cycle;
+  integer fragment_count;
+  integer completion_cycle_beh;
+  integer completion_cycle_macro;
+  reg [63:0] req_hash_beh;
+  reg [63:0] req_hash_macro;
+  reg [63:0] resp_hash_beh;
+  reg [63:0] resp_hash_macro;
+  integer req_index;
+  integer guard_cycles;
+
+  function [63:0] mix64;
+    input [63:0] state;
+    input [63:0] word;
+    begin
+      mix64 = {state[56:0], state[63:57]} ^ (word + 64'h9e3779b97f4a7c15);
+    end
+  endfunction
+
+  function [511:0] make_matrix;
+    input [ADDR_W-1:0] addr;
+    input [VALUE_SLICE_W-1:0] value_slice;
+    integer lane_i;
+    reg [31:0] word_value;
+    reg [15:0] low_word;
+    begin
+      make_matrix = {VALUE_W{1'b0}};
+      for (lane_i = 0; lane_i < 16; lane_i = lane_i + 1) begin
+        low_word = (((addr * 16) + value_slice) * 17 + lane_i) & 16'hffff;
+        word_value = {
+          8'h80 ^ addr[7:0],
+          4'ha ^ value_slice,
+          lane_i[3:0],
+          low_word
+        };
+        make_matrix[(lane_i * 32) +: 32] = word_value;
+      end
+    end
+  endfunction
+
+  task automatic clear_inputs;
+    begin
+      preload_valid = 1'b0;
+      preload_addr = {ADDR_W{1'b0}};
+      preload_value_slice = {VALUE_SLICE_W{1'b0}};
+      preload_matrix = {VALUE_W{1'b0}};
+      req_valid = 1'b0;
+      req_source = {SOURCE_W{1'b0}};
+      req_tag = {TAG_W{1'b0}};
+      req_addr = {ADDR_W{1'b0}};
+      req_value_slice = {VALUE_SLICE_W{1'b0}};
+    end
+  endtask
+
+  task automatic drive_idle_cycle;
+    begin
+      @(negedge clk);
+      clear_inputs();
+    end
+  endtask
+
+  task automatic drive_preload_cycle;
+    input [ADDR_W-1:0] addr;
+    input [VALUE_SLICE_W-1:0] value_slice;
+    begin
+      @(negedge clk);
+      if (preload_ready_beh !== preload_ready_macro) begin
+        $fatal(1, "preload_ready mismatch before preload");
+      end
+      clear_inputs();
+      preload_valid = 1'b1;
+      preload_addr = addr;
+      preload_value_slice = value_slice;
+      preload_matrix = make_matrix(addr, value_slice);
+    end
+  endtask
+
+  task automatic drive_request_cycle;
+    input integer plan_index;
+    input integer issue_preload;
+    input [ADDR_W-1:0] preload_addr_i;
+    input [VALUE_SLICE_W-1:0] preload_slice_i;
+    reg issued;
+    begin
+      issued = 1'b0;
+      while (!issued) begin
+        @(negedge clk);
+        if (req_ready_beh !== req_ready_macro) begin
+          $fatal(1, "req_ready mismatch before request %0d", plan_index);
+        end
+        clear_inputs();
+        if (req_ready_beh) begin
+          req_valid = 1'b1;
+          req_source = req_plan_source[plan_index];
+          req_tag = plan_index[TAG_W-1:0];
+          req_addr = req_plan_addr[plan_index];
+          req_value_slice = req_plan_slice[plan_index];
+          if (issue_preload != 0) begin
+            preload_valid = 1'b1;
+            preload_addr = preload_addr_i;
+            preload_value_slice = preload_slice_i;
+            preload_matrix = make_matrix(preload_addr_i, preload_slice_i);
+          end
+          issued = 1'b1;
+        end
+      end
+    end
+  endtask
+
+  banked_value_memory_service #(
+    .PACKET_W(PACKET_W),
+    .VALUE_W(VALUE_W),
+    .SOURCE_W(SOURCE_W),
+    .TAG_W(TAG_W),
+    .ADDR_W(ADDR_W),
+    .VALUE_SLICE_W(VALUE_SLICE_W),
+    .STORE_DEPTH(STORE_DEPTH),
+    .BANKS(BANKS),
+    .BANK_QUEUE_DEPTH(BANK_QUEUE_DEPTH),
+    .READ_LATENCY(READ_LATENCY),
+    .COUNTER_W(COUNTER_W),
+    .INIT_FROM_GENERATOR(0),
+    .MEMORY_IMPL(0)
+  ) u_behavioral (
+    .clk(clk),
+    .rst_n(rst_n),
+    .preload_valid(preload_valid),
+    .preload_ready(preload_ready_beh),
+    .preload_addr(preload_addr),
+    .preload_value_slice(preload_value_slice),
+    .preload_matrix(preload_matrix),
+    .req_valid(req_valid),
+    .req_ready(req_ready_beh),
+    .req_source(req_source),
+    .req_tag(req_tag),
+    .req_addr(req_addr),
+    .req_value_slice(req_value_slice),
+    .resp_valid(resp_valid_beh),
+    .resp_ready(resp_ready),
+    .resp_source(resp_source_beh),
+    .resp_tag(resp_tag_beh),
+    .resp_addr(resp_addr_beh),
+    .resp_value_slice(resp_value_slice_beh),
+    .resp_fragment_idx(resp_fragment_idx_beh),
+    .resp_last(resp_last_beh),
+    .resp_data(resp_data_beh),
+    .accepted_req_count(accepted_req_count_beh),
+    .emitted_resp_count(emitted_resp_count_beh),
+    .bank_conflict_count(bank_conflict_count_beh),
+    .response_block_cycles(response_block_cycles_beh),
+    .req_current_occupancy(req_current_occupancy_beh),
+    .req_max_occupancy(req_max_occupancy_beh),
+    .resp_current_occupancy(resp_current_occupancy_beh),
+    .resp_max_occupancy(resp_max_occupancy_beh)
+  );
+
+  banked_value_memory_service #(
+    .PACKET_W(PACKET_W),
+    .VALUE_W(VALUE_W),
+    .SOURCE_W(SOURCE_W),
+    .TAG_W(TAG_W),
+    .ADDR_W(ADDR_W),
+    .VALUE_SLICE_W(VALUE_SLICE_W),
+    .STORE_DEPTH(STORE_DEPTH),
+    .BANKS(BANKS),
+    .BANK_QUEUE_DEPTH(BANK_QUEUE_DEPTH),
+    .READ_LATENCY(READ_LATENCY),
+    .COUNTER_W(COUNTER_W),
+    .INIT_FROM_GENERATOR(0),
+    .MEMORY_IMPL(1)
+  ) u_macro (
+    .clk(clk),
+    .rst_n(rst_n),
+    .preload_valid(preload_valid),
+    .preload_ready(preload_ready_macro),
+    .preload_addr(preload_addr),
+    .preload_value_slice(preload_value_slice),
+    .preload_matrix(preload_matrix),
+    .req_valid(req_valid),
+    .req_ready(req_ready_macro),
+    .req_source(req_source),
+    .req_tag(req_tag),
+    .req_addr(req_addr),
+    .req_value_slice(req_value_slice),
+    .resp_valid(resp_valid_macro),
+    .resp_ready(resp_ready),
+    .resp_source(resp_source_macro),
+    .resp_tag(resp_tag_macro),
+    .resp_addr(resp_addr_macro),
+    .resp_value_slice(resp_value_slice_macro),
+    .resp_fragment_idx(resp_fragment_idx_macro),
+    .resp_last(resp_last_macro),
+    .resp_data(resp_data_macro),
+    .accepted_req_count(accepted_req_count_macro),
+    .emitted_resp_count(emitted_resp_count_macro),
+    .bank_conflict_count(bank_conflict_count_macro),
+    .response_block_cycles(response_block_cycles_macro),
+    .req_current_occupancy(req_current_occupancy_macro),
+    .req_max_occupancy(req_max_occupancy_macro),
+    .resp_current_occupancy(resp_current_occupancy_macro),
+    .resp_max_occupancy(resp_max_occupancy_macro)
+  );
+
+  always #5 clk = ~clk;
+
+  always @(posedge clk) begin
+    cycle <= cycle + 1;
+    if (rst_n) begin
+      if (req_valid && req_ready_beh && req_ready_macro) begin
+        req_hash_beh <= mix64(
+          req_hash_beh,
+          {44'd0, req_source, req_tag, req_addr[7:0], req_value_slice, cycle[7:0]}
+        );
+        req_hash_macro <= mix64(
+          req_hash_macro,
+          {44'd0, req_source, req_tag, req_addr[7:0], req_value_slice, cycle[7:0]}
+        );
+      end
+      if (resp_valid_beh && resp_ready) begin
+        fragment_count <= fragment_count + 1;
+        resp_hash_beh <= mix64(
+          resp_hash_beh,
+          resp_data_beh[63:0] ^ resp_data_beh[127:64] ^
+          {40'd0, resp_source_beh, resp_tag_beh, resp_addr_beh[7:0], resp_value_slice_beh, resp_fragment_idx_beh, resp_last_beh}
+        );
+        if (resp_last_beh && (completion_cycle_beh < 0) &&
+            (emitted_resp_count_beh + 1 == REQUEST_COUNT)) begin
+          completion_cycle_beh <= cycle;
+        end
+      end
+      if (resp_valid_macro && resp_ready) begin
+        resp_hash_macro <= mix64(
+          resp_hash_macro,
+          resp_data_macro[63:0] ^ resp_data_macro[127:64] ^
+          {40'd0, resp_source_macro, resp_tag_macro, resp_addr_macro[7:0], resp_value_slice_macro, resp_fragment_idx_macro, resp_last_macro}
+        );
+        if (resp_last_macro && (completion_cycle_macro < 0) &&
+            (emitted_resp_count_macro + 1 == REQUEST_COUNT)) begin
+          completion_cycle_macro <= cycle;
+        end
+      end
+    end
+  end
+
+  always @(*) begin
+    resp_ready = rst_n && ((cycle % 7) != 3);
+  end
+
+  always @(negedge clk) begin
+    if (!rst_n) begin
+      if (resp_valid_beh !== resp_valid_macro) begin
+        $fatal(1, "resp_valid mismatch during reset release");
+      end
+    end else begin
+      if (preload_ready_beh !== preload_ready_macro) begin
+        $fatal(1, "preload_ready mismatch");
+      end
+      if (req_ready_beh !== req_ready_macro) begin
+        $fatal(1, "req_ready mismatch");
+      end
+      if (resp_valid_beh !== resp_valid_macro) begin
+        $fatal(1, "resp_valid mismatch cycle=%0d", cycle);
+      end
+      if (accepted_req_count_beh !== accepted_req_count_macro ||
+          emitted_resp_count_beh !== emitted_resp_count_macro ||
+          bank_conflict_count_beh !== bank_conflict_count_macro ||
+          response_block_cycles_beh !== response_block_cycles_macro ||
+          req_current_occupancy_beh !== req_current_occupancy_macro ||
+          req_max_occupancy_beh !== req_max_occupancy_macro ||
+          resp_current_occupancy_beh !== resp_current_occupancy_macro ||
+          resp_max_occupancy_beh !== resp_max_occupancy_macro) begin
+        $fatal(1, "counter mismatch cycle=%0d", cycle);
+      end
+      if (resp_valid_beh) begin
+        if (resp_source_beh !== resp_source_macro ||
+            resp_tag_beh !== resp_tag_macro ||
+            resp_addr_beh !== resp_addr_macro ||
+            resp_value_slice_beh !== resp_value_slice_macro ||
+            resp_fragment_idx_beh !== resp_fragment_idx_macro ||
+            resp_last_beh !== resp_last_macro ||
+            resp_data_beh !== resp_data_macro) begin
+          $fatal(1, "response payload mismatch cycle=%0d", cycle);
+        end
+      end
+    end
+  end
+
+  initial begin
+    clk = 1'b0;
+    rst_n = 1'b0;
+    cycle = 0;
+    fragment_count = 0;
+    completion_cycle_beh = -1;
+    completion_cycle_macro = -1;
+    req_hash_beh = 64'h0123_4567_89ab_cdef;
+    req_hash_macro = 64'h0123_4567_89ab_cdef;
+    resp_hash_beh = 64'hfedc_ba98_7654_3210;
+    resp_hash_macro = 64'hfedc_ba98_7654_3210;
+    clear_inputs();
+
+    req_plan_addr[0] = 14'd0;   req_plan_slice[0] = 4'd0;  req_plan_source[0] = 2'd0;
+    req_plan_addr[1] = 14'd1;   req_plan_slice[1] = 4'd1;  req_plan_source[1] = 2'd1;
+    req_plan_addr[2] = 14'd2;   req_plan_slice[2] = 4'd2;  req_plan_source[2] = 2'd2;
+    req_plan_addr[3] = 14'd3;   req_plan_slice[3] = 4'd3;  req_plan_source[3] = 2'd3;
+    req_plan_addr[4] = 14'd4;   req_plan_slice[4] = 4'd5;  req_plan_source[4] = 2'd0;
+    req_plan_addr[5] = 14'd5;   req_plan_slice[5] = 4'd6;  req_plan_source[5] = 2'd1;
+    req_plan_addr[6] = 14'd6;   req_plan_slice[6] = 4'd7;  req_plan_source[6] = 2'd2;
+    req_plan_addr[7] = 14'd7;   req_plan_slice[7] = 4'd8;  req_plan_source[7] = 2'd3;
+    req_plan_addr[8] = 14'd8;   req_plan_slice[8] = 4'd10; req_plan_source[8] = 2'd0;
+    req_plan_addr[9] = 14'd9;   req_plan_slice[9] = 4'd11; req_plan_source[9] = 2'd1;
+    req_plan_addr[10] = 14'd10; req_plan_slice[10] = 4'd12; req_plan_source[10] = 2'd2;
+    req_plan_addr[11] = 14'd11; req_plan_slice[11] = 4'd13; req_plan_source[11] = 2'd3;
+    req_plan_addr[12] = 14'd12; req_plan_slice[12] = 4'd15; req_plan_source[12] = 2'd0;
+    req_plan_addr[13] = 14'd13; req_plan_slice[13] = 4'd14; req_plan_source[13] = 2'd1;
+    req_plan_addr[14] = 14'd14; req_plan_slice[14] = 4'd9;  req_plan_source[14] = 2'd2;
+    req_plan_addr[15] = 14'd15; req_plan_slice[15] = 4'd4;  req_plan_source[15] = 2'd3;
+
+    repeat (3) @(negedge clk);
+    rst_n = 1'b1;
+
+    for (req_index = 0; req_index < 12; req_index = req_index + 1) begin
+      drive_preload_cycle(req_plan_addr[req_index], req_plan_slice[req_index]);
+    end
+    drive_idle_cycle();
+
+    drive_request_cycle(0, 1, req_plan_addr[13], req_plan_slice[13]);
+    drive_request_cycle(1, 1, req_plan_addr[14], req_plan_slice[14]);
+    drive_request_cycle(2, 1, req_plan_addr[15], req_plan_slice[15]);
+    drive_request_cycle(3, 1, req_plan_addr[12], req_plan_slice[12]);
+    for (req_index = 4; req_index < REQUEST_COUNT; req_index = req_index + 1) begin
+      drive_request_cycle(req_index, 0, {ADDR_W{1'b0}}, {VALUE_SLICE_W{1'b0}});
+    end
+
+    guard_cycles = 0;
+    while ((emitted_resp_count_beh < REQUEST_COUNT) || (emitted_resp_count_macro < REQUEST_COUNT) ||
+           resp_valid_beh || resp_valid_macro) begin
+      drive_idle_cycle();
+      guard_cycles = guard_cycles + 1;
+      if (guard_cycles > 600) begin
+        $fatal(
+          1,
+          "timeout waiting for service completion accepted=%0d emitted=%0d req_occ=%0d resp_occ=%0d resp_valid=%0d",
+          accepted_req_count_beh,
+          emitted_resp_count_beh,
+          req_current_occupancy_beh,
+          resp_current_occupancy_beh,
+          resp_valid_beh
+        );
+      end
+    end
+
+    if (req_hash_beh !== req_hash_macro) begin
+      $fatal(1, "request hash mismatch");
+    end
+    if (resp_hash_beh !== resp_hash_macro) begin
+      $fatal(1, "response hash mismatch");
+    end
+    if (completion_cycle_beh !== completion_cycle_macro) begin
+      $fatal(1, "completion cycle mismatch");
+    end
+    if (accepted_req_count_beh !== REQUEST_COUNT || emitted_resp_count_beh !== REQUEST_COUNT) begin
+      $fatal(1, "unexpected request/response completion counts");
+    end
+    if (fragment_count !== EXPECTED_FRAGMENTS) begin
+      $fatal(1, "unexpected fragment count %0d", fragment_count);
+    end
+
+    $display(
+      "SUMMARY backend_match=1 accepted=%0d emitted=%0d fragments=%0d bank_conflict=%0d response_block=%0d req_max=%0d resp_max=%0d completion_cycle=%0d beh_req_hash=%016x macro_req_hash=%016x beh_resp_hash=%016x macro_resp_hash=%016x",
+      accepted_req_count_beh,
+      emitted_resp_count_beh,
+      fragment_count,
+      bank_conflict_count_beh,
+      response_block_cycles_beh,
+      req_max_occupancy_beh,
+      resp_max_occupancy_beh,
+      completion_cycle_beh,
+      req_hash_beh,
+      req_hash_macro,
+      resp_hash_beh,
+      resp_hash_macro
+    );
+    $finish;
+  end
+endmodule
+"""
+
+
+def test_banked_value_memory_service_macro_backend_matches_behavioral(tmp_path: Path) -> None:
+    iverilog = _tool("iverilog")
+    vvp = _tool("vvp")
+    if iverilog is None or vvp is None:
+        pytest.skip("iverilog/vvp unavailable")
+
+    tb_path = tmp_path / "banked_value_memory_service_backend_tb.sv"
+    simv_path = tmp_path / "banked_value_memory_service_backend_tb.vvp"
+    tb_path.write_text(_TB, encoding="utf-8")
+
+    compile_run = subprocess.run(
+        [
+            iverilog,
+            "-g2012",
+            "-s",
+            "banked_value_memory_service_backend_tb",
+            "-o",
+            str(simv_path),
+            str(tb_path),
+            str(REPO_ROOT / "npu/sim/rtl/noc_ready_valid_fifo.sv"),
+            str(REPO_ROOT / "npu/sim/rtl/banked_value_memory_service.sv"),
+            str(REPO_ROOT / "npu/sim/rtl/fakeram45_64x32_model.sv"),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert compile_run.returncode == 0, compile_run.stderr
+
+    sim_run = subprocess.run(
+        [vvp, str(simv_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert sim_run.returncode == 0, sim_run.stderr or sim_run.stdout
+
+    match = _SUMMARY_RE.search(sim_run.stdout)
+    assert match is not None, sim_run.stdout
+    (
+        backend_match,
+        accepted,
+        emitted,
+        fragments,
+        bank_conflict,
+        response_block,
+        req_max,
+        resp_max,
+        completion_cycle,
+        beh_req_hash,
+        macro_req_hash,
+        beh_resp_hash,
+        macro_resp_hash,
+    ) = match.groups()
+
+    assert backend_match == "1"
+    assert accepted == "16"
+    assert emitted == "16"
+    assert fragments == "64"
+    assert int(bank_conflict) > 0
+    assert int(response_block) > 0
+    assert int(req_max) > 0
+    assert int(resp_max) > 0
+    assert int(completion_cycle) > 0
+    assert beh_req_hash == macro_req_hash
+    assert beh_resp_hash == macro_resp_hash

--- a/tests/test_check_attention_decode_score_multivalue_service_guard.py
+++ b/tests/test_check_attention_decode_score_multivalue_service_guard.py
@@ -1,0 +1,51 @@
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+from npu.rtlgen.gen_attention_decode_score_multivalue_service import generate
+
+
+def _config(top_name: str, cluster_count: int) -> dict:
+    return {
+        "top_name": top_name,
+        "attention_decode_score_multivalue_service": {
+            "cluster_count": cluster_count,
+            "max_blocks": 16,
+            "packet_w": 128,
+            "banks": 4,
+            "req_queue_depth": 4,
+            "resp_queue_depth": 4,
+            "bank_queue_depth": 4,
+            "read_latency": 2,
+            "arb_mode": "round_robin",
+            "locality_burst_max": 2,
+            "score_scale_lanes_per_cycle": 1,
+            "value_memory_backend": "macro_banked_4x16x64x32",
+        },
+    }
+
+
+def test_service_guard_accepts_c2_banked_4x16x64x32_macro_contract(tmp_path: Path) -> None:
+    design_dir = tmp_path / "attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr"
+    design_dir.mkdir()
+    config = _config("attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr", 2)
+    (design_dir / "config.json").write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    generate(config, design_dir / "verilog")
+    generated_macro_manifest = (design_dir / "verilog" / "macro_manifest.json").read_text(encoding="utf-8")
+    (design_dir / "macro_manifest.json").write_text(generated_macro_manifest, encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/check_attention_decode_score_multivalue_service_guard.py",
+            "--design-dir",
+            str(design_dir),
+            "--config",
+            str(design_dir / "config.json"),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_check_attention_decode_score_multivalue_service_physical.py
+++ b/tests/test_check_attention_decode_score_multivalue_service_physical.py
@@ -1,0 +1,139 @@
+import csv
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+from npu.rtlgen.gen_attention_decode_score_multivalue_service import generate
+
+
+def _config(top_name: str, cluster_count: int) -> dict:
+    return {
+        "top_name": top_name,
+        "attention_decode_score_multivalue_service": {
+            "cluster_count": cluster_count,
+            "max_blocks": 16,
+            "packet_w": 128,
+            "banks": 4,
+            "req_queue_depth": 4,
+            "resp_queue_depth": 4,
+            "bank_queue_depth": 4,
+            "read_latency": 2,
+            "arb_mode": "round_robin",
+            "locality_burst_max": 2,
+            "score_scale_lanes_per_cycle": 1,
+            "value_memory_backend": "macro_banked_4x16x64x32",
+        },
+    }
+
+
+def test_service_physical_checker_accepts_c2_hierarchical_row(tmp_path: Path) -> None:
+    repo_root = Path.cwd()
+    design_dir = tmp_path / "attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr"
+    design_dir.mkdir()
+    config = _config("attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr", 2)
+    (design_dir / "config.json").write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    generate(config, design_dir / "verilog")
+    generated_macro_manifest = (design_dir / "verilog" / "macro_manifest.json").read_text(encoding="utf-8")
+    (design_dir / "macro_manifest.json").write_text(generated_macro_manifest, encoding="utf-8")
+
+    sweep_path = tmp_path / "nangate45_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_3700.json"
+    sweep_path.write_text(
+        json.dumps(
+            {
+                "tag_prefix": "decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_3700_v1",
+                "flow_params": {
+                    "TAG": ["decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_3700_v1"],
+                    "FLOW_VARIANT": ["decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_3700_v1"],
+                    "CLOCK_PERIOD": [10],
+                    "PLACE_DENSITY": [0.4],
+                    "SYNTH_HIERARCHICAL": [1],
+                    "SYNTH_MEMORY_MAX_BITS": [65536],
+                },
+                "mode_compare": {
+                    "modes": [
+                        {
+                            "name": "flattened_wrapper",
+                            "use_macro": True,
+                            "param_overrides": {
+                                "SYNTH_HIERARCHICAL": 0,
+                                "DIE_AREA": "0 0 3700 3700",
+                                "CORE_AREA": "50 50 3650 3650",
+                            },
+                        },
+                        {
+                            "name": "hierarchical_macro",
+                            "use_macro": True,
+                            "param_overrides": {
+                                "SYNTH_HIERARCHICAL": 1,
+                                "DIE_AREA": "0 0 3700 3700",
+                                "CORE_AREA": "50 50 3650 3650",
+                            },
+                        },
+                    ]
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    result_json = work_dir / "result.json"
+    result_json.write_text(
+        json.dumps({"macro_manifest_path": str((design_dir / "macro_manifest.json").resolve())}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    metrics_path = design_dir / "metrics.csv"
+    with metrics_path.open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.DictWriter(
+            stream,
+            fieldnames=[
+                "design",
+                "platform",
+                "status",
+                "critical_path_ns",
+                "params_json",
+                "result_path",
+                "work_result_json",
+            ],
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "design": design_dir.name,
+                "platform": "nangate45",
+                "status": "ok",
+                "critical_path_ns": "9.8",
+                "params_json": json.dumps(
+                    {
+                        "FLOW_VARIANT": "decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_3700_v1_hierarchical_macro",
+                        "CLOCK_PERIOD": 10,
+                        "DIE_AREA": "0 0 3700 3700",
+                        "CORE_AREA": "50 50 3650 3650",
+                    }
+                ),
+                "result_path": f"runs/designs/npu_blocks/{design_dir.name}/work/mock",
+                    "work_result_json": str(result_json),
+                }
+            )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/check_attention_decode_score_multivalue_service_physical.py",
+            "--design-dir",
+            str(design_dir),
+            "--metrics-path",
+            str(metrics_path),
+            "--sweep",
+            str(sweep_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- embody the multivalue service value store as four independently accessible banks of sixteen `fakeram45_64x32` macros
- add cycle-accurate behavioral/macro equivalence coverage and strict physical guards/manifests
- add c1-first Layer 1 evaluation preparation with c2 explicitly dependent on accepted c1 evidence

## Why
The service-aware frontier recost still excludes measured service-fabric PPA. The first implementation used a shared single-port memory that serialized the four logical banks and captured synchronous SRAM output too early. This patch preserves the `p128/b4` service semantics and gives the composed wrapper a valid Nangate45 macro path.

## Validation
- `7 passed, 60 deselected` across focused multivalue service, physical guard, and Layer 1 generator tests
- actual `iverilog`/`vvp` behavioral-versus-macro backend equivalence test passed
- `scripts/validate_runs.py --skip_eval_queue` passed

## Evaluation boundary
Only c1 should run first. The c2 request is explicitly dependent on accepted c1 physical evidence; c8 and larger scales remain deferred.