### PR TITLE
Measure composed c1 multivalue service activity power

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -54,6 +54,12 @@ _MULTIVALUE_INTEGRATED_SERVICE_BASE_ITEM = (
 _MULTIVALUE_INTEGRATED_SERVICE_DEFAULT_ITEM = (
     "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1"
 )
+_MULTIVALUE_SERVICE_C1_PNR_ITEM = (
+    "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1"
+)
+_MULTIVALUE_SERVICE_C1_DESIGN = (
+    "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr"
+)
 
 
 @dataclass(frozen=True)
@@ -7321,6 +7327,75 @@ def _decoder_attention_decode_score_multivalue_integrated_service_evidence(
     }
 
 
+def _decoder_attention_decode_score_multivalue_service_activity_power_evidence(
+    *, item_id: str, depends_on_item_ids: list[str] | None = None
+) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    design = _MULTIVALUE_SERVICE_C1_DESIGN
+    config = f"runs/designs/npu_blocks/{design}/config.json"
+    metrics_csv = f"runs/designs/npu_blocks/{design}/metrics.csv"
+    equivalence_json = (
+        f"{base}/decoder_attention_decode_score_multivalue_cluster_equivalence__"
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1.json"
+    )
+    integrated_service_item = _multivalue_integrated_service_item_for_consumer(
+        depends_on_item_ids=depends_on_item_ids
+    )
+    integrated_service_json = (
+        f"{base}/decoder_attention_decode_score_multivalue_integrated_service__"
+        f"{integrated_service_item}.json"
+    )
+    orfs_design_config = f"/orfs/flow/designs/nangate45/{design}/config.mk"
+    activity_dir = "/tmp/rtlgen_multivalue_service_c1_activity"
+    out = f"{base}/decoder_attention_decode_score_multivalue_service_activity_power__{item_id}.json"
+    report = f"{base}/decoder_attention_decode_score_multivalue_service_activity_power__{item_id}.md"
+    return {
+        "inputs": {
+            "decode_score_multivalue_service_c1_config": config,
+            "decode_score_multivalue_service_c1_pnr_metrics_csv": metrics_csv,
+            "decode_score_multivalue_service_c1_source_pnr_item_id": _MULTIVALUE_SERVICE_C1_PNR_ITEM,
+            "decode_score_multivalue_service_c1_equivalence_json": equivalence_json,
+            "decode_score_multivalue_service_c1_integrated_service_json": integrated_service_json,
+            "decode_score_multivalue_service_c1_orfs_design_config": orfs_design_config,
+            "decode_score_multivalue_service_c1_activity_dir": activity_dir,
+            "decode_score_multivalue_service_activity_power_out": out,
+            "decode_score_multivalue_service_activity_power_report": report,
+            "decode_score_multivalue_service_activity_power_scope": (
+                "Audit strict c1 routed composed-service activity power after merged/materialized "
+                "integrated-service, c1 PNR, and shared-score multivalue cluster-equivalence evidence. "
+                "Measure only direct routed component service-window energy, inherit the exact integer "
+                "precision contract from the merged equivalence proof, do not force bank3 activity, keep "
+                "VCD/ODB/SPEF evaluator-local, and do not claim total-token energy."
+            ),
+            "decode_score_multivalue_service_activity_power_promotion_gate": (
+                "Promotion requires a timing-feasible 10 ns c1 routed row, exact integrated-service c1 "
+                "hash/protocol/count gates, explicit annotation coverage, finite positive routed power, "
+                "and a direct service-window measurement rather than compositional token-energy accounting."
+            ),
+            "decode_score_multivalue_service_activity_power_local_only_artifacts": ["VCD", "ODB", "SPEF"],
+        },
+        "commands": [
+            {
+                "name": "audit_decode_score_multivalue_service_activity_power",
+                "run": (
+                    "python3 -m npu.eval.audit_attention_decode_score_multivalue_service_activity_power "
+                    f"--config {config} "
+                    f"--c1-metrics-csv {metrics_csv} "
+                    f"--equivalence-json {equivalence_json} "
+                    f"--integrated-service-json {integrated_service_json} "
+                    f"--orfs-design-config {orfs_design_config} "
+                    "--clock-period-ns 10 "
+                    f"--activity-dir {activity_dir} "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            }
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_decode_score_multivalue_gqa_group_frontier_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     evidence_version = _gqa_evidence_version_for_consumer(item_id)
@@ -10981,6 +11056,7 @@ def _build_payload(
         "decoder_attention_decode_score_multivalue_gqa_array_equivalence",
         "decoder_attention_decode_score_multivalue_cluster_activity_power",
         "decoder_attention_decode_score_multivalue_integrated_service",
+        "decoder_attention_decode_score_multivalue_service_activity_power",
         "decoder_attention_decode_score_multivalue_gqa_group_activity_power",
         "decoder_attention_decode_score_tile_frontier",
         "decoder_attention_decode_score_local_cluster_frontier",
@@ -11246,6 +11322,11 @@ def _build_payload(
                 item_id=item_id,
                 proposal_id=proposal_id,
                 proposal_path=proposal_path,
+            )
+        elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_service_activity_power":
+            decoder_evidence = _decoder_attention_decode_score_multivalue_service_activity_power_evidence(
+                item_id=item_id,
+                depends_on_item_ids=depends_on_item_ids,
             )
         elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_gqa_group_activity_power":
             decoder_evidence = _decoder_attention_decode_score_multivalue_gqa_group_activity_power_evidence(

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -8401,6 +8401,45 @@ def test_multivalue_cluster_frontier_request_manifests_remain_dependency_gated()
         assert "merged/materialized" in revision["expected_result"]["reason"]
 
 
+def test_service_activity_power_request_manifests_remain_dependency_gated() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    proposal_dir = (
+        repo_root
+        / "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1"
+    )
+    expected_depends = {
+        "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
+        "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
+    }
+
+    for manifest_name, items_key in (
+        ("proposal.json", "required_evaluations"),
+        ("evaluation_requests.json", "requested_items"),
+    ):
+        manifest = json.loads((proposal_dir / manifest_name).read_text(encoding="utf-8"))
+        if manifest_name == "evaluation_requests.json":
+            note = manifest["source_commit_note"]
+            assert "Replace with the merge commit" in note
+            assert "July 25, 2026" in note
+            assert "not materialized in the repository checkout" in note
+        item = manifest[items_key][0]
+        assert (
+            item["item_id"]
+            == "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1"
+        )
+        assert set(item["depends_on_item_ids"]) == expected_depends
+        assert item["requires_merged_inputs"] is True
+        assert item["requires_materialized_refs"] is True
+        assert item["status"] == "pending_implementation_merge"
+        assert "dependency-gated" in item["notes"]
+        assert "not ready for normal dispatch" in item["notes"]
+        assert "July 25, 2026" in item["notes"]
+        assert "shared-score multivalue cluster-equivalence JSON path" in item["notes"]
+        assert "direct routed service-window energy" in item["expected_result"]["reason"]
+        assert "bank3 inactivity unforced" in item["expected_result"]["reason"]
+
+
 def test_gqa_folded_activity_request_manifests_require_cluster_activity_power_v16() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     proposal_dir = (
@@ -8989,6 +9028,108 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_integrated_servi
                 output.endswith(
                     "decoder_attention_decode_score_multivalue_integrated_service__"
                     "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1.md"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
+            )
+
+
+def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_activity_power() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=(
+                        "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1"
+                    ),
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_decode_score_multivalue_service_activity_power",
+                    evaluation_mode="frontier_detail",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
+                        "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1",
+                        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
+                    ],
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:2]] == [
+                "audit_decode_score_multivalue_service_activity_power",
+                "validate_runs",
+            ]
+            assert (
+                "-m npu.eval.audit_attention_decode_score_multivalue_service_activity_power"
+                in run
+            )
+            assert (
+                "--config runs/designs/npu_blocks/"
+                "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr/config.json"
+                in run
+            )
+            assert (
+                "--c1-metrics-csv runs/designs/npu_blocks/"
+                "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr/metrics.csv"
+                in run
+            )
+            assert (
+                "--equivalence-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_decode_score_multivalue_cluster_equivalence__"
+                "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1.json"
+                in run
+            )
+            assert (
+                "--integrated-service-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_decode_score_multivalue_integrated_service__"
+                "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1.json"
+                in run
+            )
+            assert (
+                "--orfs-design-config /orfs/flow/designs/nangate45/"
+                "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr/config.mk"
+                in run
+            )
+            assert "--clock-period-ns 10" in run
+            assert "--activity-dir /tmp/rtlgen_multivalue_service_c1_activity" in run
+            assert decoder_inputs["decode_score_multivalue_service_c1_source_pnr_item_id"] == (
+                "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1"
+            )
+            assert decoder_inputs["decode_score_multivalue_service_activity_power_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_decode_score_multivalue_service_activity_power__"
+                "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1.json"
+            )
+            assert decoder_inputs[
+                "decode_score_multivalue_service_activity_power_local_only_artifacts"
+            ] == ["VCD", "ODB", "SPEF"]
+            assert "direct routed component service-window energy" in decoder_inputs[
+                "decode_score_multivalue_service_activity_power_scope"
+            ]
+            assert "do not force bank3 activity" in decoder_inputs[
+                "decode_score_multivalue_service_activity_power_scope"
+            ]
+            assert "exact integrated-service c1 hash/protocol/count gates" in decoder_inputs[
+                "decode_score_multivalue_service_activity_power_promotion_gate"
+            ]
+            assert any(
+                output.endswith(
+                    "decoder_attention_decode_score_multivalue_service_activity_power__"
+                    "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1.md"
                 )
                 for output in work_item.task_request.request_payload["task"]["expected_outputs"]
             )

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,28 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
+  "source_commit_note": "Replace with the merge commit that contains this strict c1 composed-service activity-power wiring before dispatch. As of July 25, 2026, this request remains dependency-gated because the integrated-service r1 JSON and the c1 composed-service metrics row are not materialized in the repository checkout; do not dispatch until all three dependency outputs are merged/materialized.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Audit strict c1 routed composed-service activity power at 10 ns using merged/materialized c1 PNR, integrated-service r1, and shared-score multivalue cluster-equivalence evidence while reporting only direct service-window energy.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_service_activity_power",
+      "comparison_role": "strict_c1_service_activity_power_gate",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
+        "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_strict_c1_composed_service_activity_power",
+        "reason": "Require merged/materialized integrated-service r1, composed c1 PNR, and shared-score multivalue cluster-equivalence evidence before dispatch; then measure only direct routed service-window energy at 10 ns, preserve exact inherited precision, leave bank3 inactivity unforced, and withhold total-token energy."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "This request remains dependency-gated and is not ready for normal dispatch. As of July 25, 2026, the integrated-service r1 JSON and the c1 composed-service metrics row are not materialized in the repository checkout, and both must merge/materialize before dispatch even though the shared-score multivalue cluster-equivalence JSON path is already the same repo path used by related audits."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1/proposal.json
@@ -1,0 +1,95 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
+  "created_utc": "2026-07-25T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Strict c1 composed-service activity power gate for Llama7B",
+  "abstraction_layer": "decoder_attention_decode_score_multivalue_service_activity_power",
+  "hypothesis": "Once the compact integrated-service r1 probe, the merged c1 composed-service PNR row, and the shared-score multivalue cluster-equivalence evidence are all merged and materialized, a strict c1 routed audit can report only direct composed service-window energy with exact inherited precision and without forcing bank3 activity or making any total-token energy claim.",
+  "direct_comparison": {
+    "primary_question": "Does the routed c1 composed service remain physically interesting once the merged c1 PNR row is combined with strict integrated-service and cluster-equivalence gates plus evaluator-local switching evidence, while reporting only direct service-window energy?",
+    "baseline": "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1 as the authoritative composed c1 PPA row, with integrated-service r1 and shared-score multivalue cluster-equivalence evidence as strict dependency gates.",
+    "include": [
+      "strict c1 p128/b4/q4/rl2/round_robin composed-service routed row at 10 ns",
+      "merged/materialized integrated-service c1 exact hash/protocol/count evidence from l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
+      "merged/materialized shared-score multivalue cluster-equivalence evidence using the exact JSON path already consumed by related audits",
+      "direct routed component service-window dynamic and leakage energy only",
+      "bank activity reporting that preserves observed bank3 inactivity instead of forcing synthetic toggles",
+      "repo-portable JSON and Markdown outputs only, with raw VCD, ODB, SPEF, and temporary activity directories kept evaluator-local"
+    ],
+    "exclude": [
+      "do not claim total-token energy or token rankings",
+      "do not force bank3 activity or invent synthetic bank coverage",
+      "do not reopen arithmetic precision, semantic equivalence, NoC closure, HBM closure, or service-fabric PPA/energy closure",
+      "do not commit evaluator-local activity artifacts"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "total_power_mw",
+      "service_window_dynamic_energy_j",
+      "service_window_leakage_energy_j",
+      "service_window_total_energy_j",
+      "vcd_annotation_coverage",
+      "sequential_register_activity_coverage",
+      "macro_active_coverage",
+      "bank3_inactive",
+      "promotion_gate_pass"
+    ]
+  },
+  "expected_benefit": [
+    "converts the composed c1 service point from vectorless total power to a strict activity-backed component energy measurement",
+    "preserves the exact integer precision contract already proven by the merged equivalence gate",
+    "makes the scope boundary explicit by measuring only direct routed service-window energy and withholding total-token energy"
+  ],
+  "risks": [
+    "the merged c1 row may fail strict annotation or positive-power gates even after routing succeeds",
+    "bank3 may remain inactive for the reference workload, which is acceptable evidence here but limits broader service-window coverage",
+    "passing this audit still does not close service-fabric energy, NoC composition, HBM service, or total-token energy"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Audit strict c1 routed composed-service activity power at 10 ns using merged/materialized c1 PNR, integrated-service r1, and shared-score multivalue cluster-equivalence evidence while reporting only direct service-window energy.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_service_activity_power",
+      "comparison_role": "strict_c1_service_activity_power_gate",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
+        "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_strict_c1_composed_service_activity_power",
+        "reason": "Require merged/materialized integrated-service r1, composed c1 PNR, and shared-score multivalue cluster-equivalence evidence before dispatch; then measure only direct routed service-window energy at 10 ns, preserve exact inherited precision, leave bank3 inactivity unforced, and withhold total-token energy."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "This request is dependency-gated and not ready for normal dispatch. As of July 25, 2026, the repository checkout does not contain the integrated-service r1 JSON or the c1 composed-service metrics row, so both dependencies must merge/materialize before dispatch even though the shared-score multivalue cluster-equivalence JSON path is already the same repo path used by related audits."
+    }
+  ],
+  "baseline_refs": [
+    "runs/designs/npu_blocks/attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr/config.json",
+    "runs/designs/npu_blocks/attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr/metrics.csv",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_integrated_service__l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_equivalence__l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1.json",
+    "docs/proposals/prop_l1_decoder_attention_decode_score_multivalue_service_pnr_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/proposal.json",
+    "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py",
+    "tests/test_attention_decode_score_multivalue_service_activity_power.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ],
+  "remaining_abstractions_after_this_step": [
+    "This gate measures only direct routed service-window energy and is not a total-token energy claim.",
+    "Bank3 inactivity is reported as observed evidence rather than repaired with synthetic activity.",
+    "Service-fabric dynamic energy outside the direct service window remains excluded.",
+    "NoC composition, HBM service, and broader memory-system closure remain open.",
+    "The exact integer precision contract is inherited and not re-audited here."
+  ]
+}

--- a/npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py
@@ -12,7 +12,9 @@ import re
 from pathlib import Path
 from typing import Any
 
-from npu.eval.extract_fakeram_vcd_activity import extract_fakeram_vcd_activity
+from npu.eval.extract_fakeram_vcd_activity import (
+    extract_multivalue_service_fakeram_vcd_activity,
+)
 from npu.eval.extract_sequential_register_vcd_activity import (
     extract_sequential_register_vcd_activity,
 )
@@ -37,11 +39,15 @@ _MAX_FAILURE_DETAIL_BYTES = 4096
 _MODEL = "decoder_attention_decode_score_multivalue_service_activity_power_v1"
 _SCOPE = "tb/dut"
 _CASE_ID = "c1_p128_b4_rr"
+_EXPECTED_DESIGN = "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr"
+_EXPECTED_PLATFORM = "nangate45"
 _REQUIRED_FLOW_VARIANT = "decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1"
 _EXPECTED_MACRO_COUNTS = {
     "fakeram45_2048x39": 56,
     "fakeram45_64x32": 64,
 }
+_SCORE_PINS_PER_MACRO = 11 + 39 + 39 + 1 + 1
+_VALUE_PINS_PER_MACRO = 6 + 32 + 32 + 1 + 1
 _EXPECTED_REQUEST_COUNT = 48
 _EXPECTED_WIDE_RESPONSE_COUNT = 48
 _EXPECTED_RESULT_COUNT = 16
@@ -51,6 +57,13 @@ _POSTROUTE_MACRO_ACTIVITY_NAME = (
 )
 _POSTROUTE_SEQUENTIAL_ACTIVITY_NAME = (
     "attention_decode_score_multivalue_service_sequential_register_vcd_activity_v1.json"
+)
+_SCORE_ACTIVITY_RE = re.compile(
+    r"^score_bank/u_group_(\d+)_slice_(\d+)/(?:addr_in\[\d+\]|wd_in\[\d+\]|w_mask_in\[\d+\]|we_in|ce_in)$"
+)
+_VALUE_ACTIVITY_RE = re.compile(
+    r"^gen_value_macro_backend/gen_value_bank\[(\d+)\]/gen_value_lane\[(\d+)\]/u_value_mem_lane/"
+    r"(?:addr_in\[\d+\]|wd_in\[\d+\]|w_mask_in\[\d+\]|we_in|ce_in)$"
 )
 
 
@@ -156,6 +169,10 @@ def _select_c1_metric(
     for row in rows:
         if str(row.get("status", "")).strip() != "ok":
             continue
+        if str(row.get("design", "")).strip() != _EXPECTED_DESIGN:
+            continue
+        if str(row.get("platform", "")).strip() != _EXPECTED_PLATFORM:
+            continue
         params = _params(row)
         flow_variant = str(params.get("FLOW_VARIANT", "")).strip()
         if flow_variant != required_flow_variant:
@@ -176,12 +193,13 @@ def _select_c1_metric(
         matches.append(row)
     if not matches:
         raise ValueError(
-            "expected exactly one status=ok timing-feasible c1 row with FLOW_VARIANT "
-            f"{required_flow_variant}"
+            "expected exactly one status=ok timing-feasible c1 row with design "
+            f"{_EXPECTED_DESIGN}, platform {_EXPECTED_PLATFORM}, and FLOW_VARIANT {required_flow_variant}"
         )
     if len(matches) != 1:
         raise ValueError(
-            "expected exactly one status=ok timing-feasible c1 row with FLOW_VARIANT "
+            "expected exactly one status=ok timing-feasible c1 row with design "
+            f"{_EXPECTED_DESIGN}, platform {_EXPECTED_PLATFORM}, and FLOW_VARIANT "
             f"{required_flow_variant}, found {len(matches)}"
         )
     return matches[0]
@@ -380,6 +398,105 @@ def _validate_macro_manifest_counts(macro_manifest: JsonDict) -> JsonDict:
     }
 
 
+def _validate_service_macro_activity_contract(
+    macro_activity: JsonDict,
+    *,
+    macro_counts: JsonDict,
+) -> JsonDict:
+    pins = macro_activity.get("pins")
+    if not isinstance(pins, list) or not pins:
+        raise ValueError("service macro activity pins[] missing")
+
+    score_instances: set[str] = set()
+    value_instances: set[str] = set()
+    score_pin_count = 0
+    value_pin_count = 0
+    for row in pins:
+        if not isinstance(row, dict):
+            raise ValueError("service macro activity pins[] must contain objects")
+        full_name = str(row.get("full_name") or "").strip()
+        if not full_name:
+            raise ValueError("service macro activity pin full_name missing")
+        score_match = _SCORE_ACTIVITY_RE.fullmatch(full_name)
+        if score_match is not None:
+            score_pin_count += 1
+            score_instances.add(f"score_bank/u_group_{score_match.group(1)}_slice_{score_match.group(2)}")
+            continue
+        value_match = _VALUE_ACTIVITY_RE.fullmatch(full_name)
+        if value_match is not None:
+            value_pin_count += 1
+            value_instances.add(
+                "gen_value_macro_backend/gen_value_bank[{bank}]/gen_value_lane[{lane}]/u_value_mem_lane".format(
+                    bank=value_match.group(1),
+                    lane=value_match.group(2),
+                )
+            )
+            continue
+        raise ValueError(f"service macro activity contains unsupported full_name: {full_name}")
+
+    expected_score_instance_count = int(macro_counts["fakeram45_2048x39"])
+    expected_value_instance_count = int(macro_counts["fakeram45_64x32"])
+    expected_score_pin_count = expected_score_instance_count * _SCORE_PINS_PER_MACRO
+    expected_value_pin_count = expected_value_instance_count * _VALUE_PINS_PER_MACRO
+    if len(score_instances) != expected_score_instance_count or score_pin_count != expected_score_pin_count:
+        raise ValueError(
+            "service macro activity score-bank structural coverage mismatch: expected "
+            f"{expected_score_instance_count} instances / {expected_score_pin_count} pins, got "
+            f"{len(score_instances)} instances / {score_pin_count} pins"
+        )
+    if len(value_instances) != expected_value_instance_count or value_pin_count != expected_value_pin_count:
+        raise ValueError(
+            "service macro activity value-memory structural coverage mismatch: expected "
+            f"{expected_value_instance_count} instances / {expected_value_pin_count} pins, got "
+            f"{len(value_instances)} instances / {value_pin_count} pins"
+        )
+
+    structural_contract = macro_activity.get("structural_macro_contract")
+    if not isinstance(structural_contract, dict):
+        raise ValueError("service macro activity structural_macro_contract missing")
+    if str(structural_contract.get("profile") or "").strip() != "multivalue_service_c1_v1":
+        raise ValueError("service macro activity structural_macro_contract profile mismatch")
+    if int(structural_contract.get("total_assignment_count", 0)) != len(pins):
+        raise ValueError("service macro activity total_assignment_count mismatch")
+    macro_classes = structural_contract.get("macro_classes")
+    if not isinstance(macro_classes, list):
+        raise ValueError("service macro activity macro_classes missing")
+    by_name = {
+        str(row.get("macro_name") or "").strip(): row
+        for row in macro_classes
+        if isinstance(row, dict) and str(row.get("macro_name") or "").strip()
+    }
+    expected_classes = {
+        "fakeram45_2048x39": {
+            "instance_scope_prefix": "score_bank",
+            "instance_count": expected_score_instance_count,
+            "pins_per_instance": _SCORE_PINS_PER_MACRO,
+            "assignment_count": expected_score_pin_count,
+        },
+        "fakeram45_64x32": {
+            "instance_scope_prefix": "gen_value_macro_backend",
+            "instance_count": expected_value_instance_count,
+            "pins_per_instance": _VALUE_PINS_PER_MACRO,
+            "assignment_count": expected_value_pin_count,
+        },
+    }
+    for macro_name, expected in expected_classes.items():
+        row = by_name.get(macro_name)
+        if not isinstance(row, dict):
+            raise ValueError(f"service macro activity macro_classes missing {macro_name}")
+        for key, expected_value in expected.items():
+            if row.get(key) != expected_value:
+                raise ValueError(
+                    f"service macro activity {macro_name} {key} mismatch: "
+                    f"expected {expected_value!r}, got {row.get(key)!r}"
+                )
+    return {
+        "profile": "multivalue_service_c1_v1",
+        "total_assignment_count": len(pins),
+        "macro_classes": expected_classes,
+    }
+
+
 def _prepare_postroute_power_manifest(
     *,
     activity_dir: Path,
@@ -397,10 +514,14 @@ def _prepare_postroute_power_manifest(
     if not (activity_dir / _OUTPUT_SERVICE_MANIFEST_NAME).is_file():
         raise ValueError("generated service manifest missing from activity_dir")
 
-    macro_activity = extract_fakeram_vcd_activity(
+    macro_activity = extract_multivalue_service_fakeram_vcd_activity(
         vcd_path,
         source_vcd_sha256=generated_meta["vcd_sha256"],
         scope=_SCOPE,
+    )
+    macro_activity_contract = _validate_service_macro_activity_contract(
+        macro_activity,
+        macro_counts=macro_counts,
     )
     macro_activity_path = activity_dir / _POSTROUTE_MACRO_ACTIVITY_NAME
     macro_activity_path.write_text(
@@ -447,6 +568,7 @@ def _prepare_postroute_power_manifest(
         "vcd_sha256": generated_meta["vcd_sha256"],
         "cycle_count": generated_meta["cycle_count"],
         "macro_counts": macro_counts,
+        "macro_activity_contract": macro_activity_contract,
         "bank_coverage": generated_meta["bank_coverage"],
     }
 
@@ -468,6 +590,7 @@ def _strict_service_window_measurement(
     expected_vcd_sha256: str,
     expected_clock_period_ns: float,
     expected_cycle_count: int,
+    expected_macro_assignment_count: int,
 ) -> JsonDict:
     if activity_power.get("promotion_gate_pass") is not True:
         raise ValueError("postroute power promotion_gate_pass failed")
@@ -491,10 +614,16 @@ def _strict_service_window_measurement(
         raise ValueError("postroute power full_context_cycles mismatch")
     if phase.get("annotation_gate_pass") is not True:
         raise ValueError("postroute power aggregate annotation gate failed")
+    if phase.get("macro_activity_gate_pass") is not True:
+        raise ValueError("postroute power macro activity gate failed")
+    if phase.get("structural_macro_activity_gate_pass") is not True:
+        raise ValueError("postroute power structural macro activity gate failed")
     if phase.get("sequential_register_activity_gate_pass") is not True:
         raise ValueError("postroute power sequential register coverage gate failed")
     if phase.get("clock_period_gate_pass") is not True:
         raise ValueError("postroute power clock period gate failed")
+    if int(phase.get("macro_activity_assignment_count", 0)) != expected_macro_assignment_count:
+        raise ValueError("postroute power macro_activity_assignment_count mismatch")
     power = phase.get("power")
     if not isinstance(power, dict):
         raise ValueError("postroute power phase power section missing")
@@ -643,6 +772,9 @@ def build_report(
                 expected_vcd_sha256=activity_meta["vcd_sha256"],
                 expected_clock_period_ns=clock_period_ns,
                 expected_cycle_count=int(activity_meta["cycle_count"]),
+                expected_macro_assignment_count=int(
+                    activity_meta["macro_activity_contract"]["total_assignment_count"]
+                ),
             )
         except Exception as exc:
             candidate["status"] = "rejected_gate"
@@ -701,6 +833,7 @@ def build_report(
             "counts": activity_meta["macro_counts"],
             "statement": "Exact macro counts are required: 56 fakeram45_2048x39 score banks and 64 fakeram45_64x32 value-memory macros.",
         },
+        "macro_activity_contract": activity_meta["macro_activity_contract"],
         "bank3_dynamic_inactivity": {
             "inactive_banks": activity_meta["bank_coverage"]["inactive_banks"],
             "statement": (

--- a/npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py
@@ -1,0 +1,756 @@
+#!/usr/bin/env python3
+"""Audit strict c1 routed power for the multivalue integrated service."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import re
+from pathlib import Path
+from typing import Any
+
+from npu.eval.extract_fakeram_vcd_activity import extract_fakeram_vcd_activity
+from npu.eval.extract_sequential_register_vcd_activity import (
+    extract_sequential_register_vcd_activity,
+)
+from npu.eval.generate_attention_decode_score_multivalue_service_activity import (
+    _OUTPUT_MACRO_MANIFEST_NAME,
+    _OUTPUT_MANIFEST_NAME,
+    _OUTPUT_SERVICE_MANIFEST_NAME,
+    _OUTPUT_VCD_NAME,
+    generate_activity,
+)
+from npu.synth.run_postroute_vcd_power import build_report as build_power_report
+
+JsonDict = dict[str, Any]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_EVALUATOR_LOCAL_PATH_PLACEHOLDER = "<evaluator-local-path>"
+_ABSOLUTE_PATH_RE = re.compile(r"/[^\s\"'`<>|&(){}\[\]]+")
+_MAX_FAILURE_DETAIL_LINES = 16
+_MAX_FAILURE_DETAIL_LINE_CHARS = 400
+_MAX_FAILURE_DETAIL_BYTES = 4096
+
+_MODEL = "decoder_attention_decode_score_multivalue_service_activity_power_v1"
+_SCOPE = "tb/dut"
+_CASE_ID = "c1_p128_b4_rr"
+_REQUIRED_FLOW_VARIANT = "decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1"
+_EXPECTED_MACRO_COUNTS = {
+    "fakeram45_2048x39": 56,
+    "fakeram45_64x32": 64,
+}
+_EXPECTED_REQUEST_COUNT = 48
+_EXPECTED_WIDE_RESPONSE_COUNT = 48
+_EXPECTED_RESULT_COUNT = 16
+_POSTROUTE_MANIFEST_NAME = "attention_decode_score_multivalue_service_postroute_power_manifest.json"
+_POSTROUTE_MACRO_ACTIVITY_NAME = (
+    "attention_decode_score_multivalue_service_fakeram_macro_pin_vcd_activity_v1.json"
+)
+_POSTROUTE_SEQUENTIAL_ACTIVITY_NAME = (
+    "attention_decode_score_multivalue_service_sequential_register_vcd_activity_v1.json"
+)
+
+
+def _load(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected a JSON object: {path}")
+    return payload
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _portable_path(path: Path) -> str:
+    if not path.is_absolute():
+        return path.as_posix()
+    try:
+        return path.resolve().relative_to(_REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return f"{_EVALUATOR_LOCAL_PATH_PLACEHOLDER}/{path.name}"
+
+
+def _redact_path(text: str) -> str:
+    token = Path(text.rstrip(".,;:!?)]}"))
+    if token.is_absolute():
+        return _portable_path(token)
+    return text
+
+
+def _sanitize_failure_line(line: str) -> str:
+    return _ABSOLUTE_PATH_RE.sub(lambda match: _redact_path(match.group(0)), line)
+
+
+def _collect_failure_detail(lines: list[str]) -> list[str]:
+    detail = [line.strip() for line in lines if line.strip()]
+    detail = [line[:_MAX_FAILURE_DETAIL_LINE_CHARS] for line in detail[-_MAX_FAILURE_DETAIL_LINES:]]
+    while detail and sum(len(line) for line in detail) > _MAX_FAILURE_DETAIL_BYTES:
+        detail = detail[1:]
+    return detail
+
+
+def _sanitized_failure(exc: Exception) -> JsonDict:
+    lines = [_sanitize_failure_line(line).strip() for line in str(exc).splitlines()]
+    lines = [line for line in lines if line]
+    summary = lines[0][:240] if lines else f"{type(exc).__name__} failure"
+    return {
+        "error_type": type(exc).__name__,
+        "error_summary": summary,
+        "detail": _collect_failure_detail(lines),
+    }
+
+
+def _params(row: JsonDict) -> JsonDict:
+    try:
+        payload = json.loads(str(row.get("params_json", "{}")))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid params_json for PPA row {row.get('param_hash')}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"params_json is not an object for PPA row {row.get('param_hash')}")
+    return payload
+
+
+def _metric_provenance(row: JsonDict, metrics_csv: Path) -> JsonDict:
+    fields = (
+        "design",
+        "platform",
+        "config_hash",
+        "param_hash",
+        "tag",
+        "status",
+        "critical_path_ns",
+        "die_area",
+        "total_power_mw",
+        "instance_area_um2",
+        "stdcell_area_um2",
+        "stdcell_count",
+        "core_area_um2",
+        "utilization_pct",
+        "flow_elapsed_seconds",
+        "stage_elapsed_seconds",
+        "params_json",
+    )
+    return {
+        "metrics_csv": _portable_path(metrics_csv),
+        **{field: row[field] for field in fields if str(row.get(field, "")).strip()},
+    }
+
+
+def _select_c1_metric(
+    metrics_csv: Path,
+    *,
+    clock_period_ns: float,
+    required_flow_variant: str = _REQUIRED_FLOW_VARIANT,
+) -> JsonDict:
+    with metrics_csv.open(newline="", encoding="utf-8") as handle:
+        rows = [dict(row) for row in csv.DictReader(handle)]
+    matches: list[JsonDict] = []
+    for row in rows:
+        if str(row.get("status", "")).strip() != "ok":
+            continue
+        params = _params(row)
+        flow_variant = str(params.get("FLOW_VARIANT", "")).strip()
+        if flow_variant != required_flow_variant:
+            continue
+        try:
+            row_clock = float(params.get("CLOCK_PERIOD", 0.0))
+            critical_path_ns = float(row.get("critical_path_ns") or math.inf)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("selected c1 row has invalid CLOCK_PERIOD or critical_path_ns") from exc
+        if abs(row_clock - clock_period_ns) > 1e-9:
+            raise ValueError(
+                f"selected c1 row CLOCK_PERIOD mismatch: expected {clock_period_ns:g}, got {row_clock:g}"
+            )
+        if not math.isfinite(critical_path_ns) or critical_path_ns > clock_period_ns:
+            raise ValueError(
+                f"selected c1 row is not timing-feasible at {clock_period_ns:g} ns"
+            )
+        matches.append(row)
+    if not matches:
+        raise ValueError(
+            "expected exactly one status=ok timing-feasible c1 row with FLOW_VARIANT "
+            f"{required_flow_variant}"
+        )
+    if len(matches) != 1:
+        raise ValueError(
+            "expected exactly one status=ok timing-feasible c1 row with FLOW_VARIANT "
+            f"{required_flow_variant}, found {len(matches)}"
+        )
+    return matches[0]
+
+
+def _require_string_hash(payload: JsonDict, key: str, label: str) -> str:
+    value = str(payload.get(key) or "").strip()
+    if not value:
+        raise ValueError(f"{label} missing {key}")
+    return value
+
+
+def _validate_cluster_equivalence(payload: JsonDict) -> JsonDict:
+    if payload.get("equivalence_pass") is not True:
+        raise ValueError("merged cluster equivalence did not pass")
+    decision = str(payload.get("decision") or "").strip()
+    if decision != "decode_score_multivalue_cluster_equivalence_pass":
+        raise ValueError(
+            "merged cluster equivalence decision mismatch: "
+            f"expected decode_score_multivalue_cluster_equivalence_pass, got {decision or '<missing>'}"
+        )
+    return {
+        "equivalence_pass": True,
+        "decision": decision,
+        "score_tensor_hash": _require_string_hash(payload, "score_tensor_hash", "merged cluster equivalence"),
+        "final_tensor_hash": _require_string_hash(payload, "final_tensor_hash", "merged cluster equivalence"),
+        "semantic_profile": str(payload.get("semantic_profile") or "").strip() or None,
+    }
+
+
+def _validate_integrated_service(payload: JsonDict) -> JsonDict:
+    cases = payload.get("cases")
+    if not isinstance(cases, list):
+        raise ValueError("integrated-service report must contain cases[]")
+    selected = [
+        case
+        for case in cases
+        if isinstance(case, dict) and str(case.get("case_id") or "").strip() == _CASE_ID
+    ]
+    if len(selected) != 1:
+        raise ValueError(f"integrated-service report must contain exactly one {_CASE_ID} case")
+    case = selected[0]
+    if case.get("decision") != "pass":
+        raise ValueError(f"integrated-service {_CASE_ID} case did not pass")
+    config = case.get("config")
+    if not isinstance(config, dict):
+        raise ValueError("integrated-service c1 config is missing")
+    expected_config = {
+        "cluster_count": 1,
+        "packet_w": 128,
+        "banks": 4,
+        "req_queue_depth": 4,
+        "resp_queue_depth": 4,
+        "bank_queue_depth": 4,
+        "read_latency": 2,
+        "arb_mode": "round_robin",
+        "locality_burst_max": 2,
+    }
+    for key, expected in expected_config.items():
+        if config.get(key) != expected:
+            raise ValueError(
+                f"integrated-service c1 config mismatch for {key}: expected {expected!r}, got {config.get(key)!r}"
+            )
+    integrated = case.get("integrated_service")
+    if not isinstance(integrated, dict):
+        raise ValueError("integrated-service c1 section is missing")
+    if integrated.get("exact_match") is not True:
+        raise ValueError("integrated-service c1 exact_result_match gate failed")
+    for key in ("no_protocol_errors", "no_drop_duplicate_deadlock_timeout", "cycle_bound_ok"):
+        if integrated.get(key) is not True:
+            raise ValueError(f"integrated-service c1 {key} gate failed")
+    counters = integrated.get("counters")
+    if not isinstance(counters, dict):
+        raise ValueError("integrated-service c1 counters missing")
+    required_counter_keys = {
+        "request_injection_stall_cycles",
+        "arbitration_contention_cycles",
+        "bank_conflict_count",
+        "response_block_cycles",
+        "shared_result",
+        "max_occupancy",
+    }
+    missing = required_counter_keys - set(counters)
+    if missing:
+        raise ValueError(
+            "integrated-service c1 counters incomplete: " + ", ".join(sorted(missing))
+        )
+    if int(integrated.get("request_count", 0)) != _EXPECTED_REQUEST_COUNT:
+        raise ValueError("integrated-service c1 request_count mismatch")
+    if int(integrated.get("wide_response_count", 0)) != _EXPECTED_WIDE_RESPONSE_COUNT:
+        raise ValueError("integrated-service c1 wide_response_count mismatch")
+    if int(integrated.get("result_count", 0)) != _EXPECTED_RESULT_COUNT:
+        raise ValueError("integrated-service c1 result_count mismatch")
+    gates = case.get("gates")
+    if not isinstance(gates, dict) or not all(
+        bool(gates.get(key)) for key in ("hash_gate_ok", "protocol_gate_ok", "count_gate_ok")
+    ):
+        raise ValueError("integrated-service c1 gates failed")
+    egress = integrated.get("shared_result_egress")
+    if not isinstance(egress, dict) or int(egress.get("documented_initiation_interval", 0)) != 1:
+        raise ValueError("integrated-service c1 shared_result_egress contract failed")
+    summary = payload.get("summary")
+    if isinstance(summary, dict):
+        for key in ("all_hash_gates_passed", "all_protocol_gates_passed", "all_count_gates_passed"):
+            if summary.get(key) is not True:
+                raise ValueError(f"integrated-service summary {key} failed")
+    return {
+        "case_id": _CASE_ID,
+        "decision": "pass",
+        "exact_match": True,
+        "no_protocol_errors": True,
+        "no_drop_duplicate_deadlock_timeout": True,
+        "cycle_bound_ok": True,
+        "request_count": int(integrated["request_count"]),
+        "wide_response_count": int(integrated["wide_response_count"]),
+        "result_count": int(integrated["result_count"]),
+        "counters": counters,
+        "gates": {key: True for key in ("hash_gate_ok", "protocol_gate_ok", "count_gate_ok")},
+        "shared_result_egress": egress,
+        "hashes": {
+            "score_hash": _require_string_hash(integrated, "score_hash", "integrated-service c1"),
+            "final_hash": _require_string_hash(integrated, "final_hash", "integrated-service c1"),
+            "request_hash": _require_string_hash(integrated, "request_hash", "integrated-service c1"),
+            "wide_response_matrix_hash": _require_string_hash(
+                integrated, "wide_response_matrix_hash", "integrated-service c1"
+            ),
+        },
+    }
+
+
+def _validate_generated_activity_manifest(activity_manifest: JsonDict, activity_dir: Path) -> JsonDict:
+    if str(activity_manifest.get("model") or "").strip() != "attention_decode_score_multivalue_service_activity_v1":
+        raise ValueError("generated activity manifest model mismatch")
+    if str(activity_manifest.get("case_id") or "").strip() != _CASE_ID:
+        raise ValueError("generated activity manifest case_id mismatch")
+    if float(activity_manifest.get("clock_period_ns", 0.0)) != 10.0:
+        raise ValueError("generated activity manifest clock_period_ns mismatch")
+    cycle_count = int(activity_manifest.get("cycle_count", 0))
+    if cycle_count <= 0:
+        raise ValueError("generated activity manifest cycle_count must be positive")
+    counters = activity_manifest.get("request_result_protocol_counters")
+    if not isinstance(counters, dict):
+        raise ValueError("generated activity manifest request_result_protocol_counters missing")
+    if int(counters.get("request_count", 0)) != _EXPECTED_REQUEST_COUNT:
+        raise ValueError("generated activity manifest request_count mismatch")
+    if int(counters.get("wide_response_count", 0)) != _EXPECTED_WIDE_RESPONSE_COUNT:
+        raise ValueError("generated activity manifest wide_response_count mismatch")
+    if int(counters.get("result_count", 0)) != _EXPECTED_RESULT_COUNT:
+        raise ValueError("generated activity manifest result_count mismatch")
+    shared = counters.get("shared")
+    if not isinstance(shared, dict) or shared.get("protocol_error") is not False:
+        raise ValueError("generated activity manifest shared protocol contract failed")
+    bank_coverage = activity_manifest.get("value_bank_coverage")
+    if not isinstance(bank_coverage, dict):
+        raise ValueError("generated activity manifest value_bank_coverage missing")
+    if bank_coverage.get("addressed_banks_over_trace") != [0, 1, 2]:
+        raise ValueError("generated activity manifest addressed_banks_over_trace mismatch")
+    if bank_coverage.get("inactive_banks") != [3]:
+        raise ValueError("generated activity manifest inactive_banks mismatch")
+    if bank_coverage.get("inactive_reason") != "three_block_reference_workload":
+        raise ValueError("generated activity manifest inactive_reason mismatch")
+    vcd_hash = str(activity_manifest.get("hashes", {}).get("vcd_sha256") or "").strip().lower()
+    if not vcd_hash:
+        raise ValueError("generated activity manifest vcd_sha256 missing")
+    if not (activity_dir / _OUTPUT_MANIFEST_NAME).is_file():
+        raise ValueError("generated activity manifest file missing from activity_dir")
+    return {
+        "clock_period_ns": 10.0,
+        "cycle_count": cycle_count,
+        "vcd_sha256": vcd_hash,
+        "generated_manifest_sha256": _sha256_file(activity_dir / _OUTPUT_MANIFEST_NAME),
+        "generated_manifest_hashes": dict(activity_manifest.get("hashes") or {}),
+        "bank_coverage": bank_coverage,
+    }
+
+
+def _validate_macro_manifest_counts(macro_manifest: JsonDict) -> JsonDict:
+    params = macro_manifest.get("manifest_params")
+    if not isinstance(params, dict):
+        raise ValueError("macro_manifest manifest_params missing")
+    score_bank_macro_count = int(params.get("score_bank_macro_count", 0))
+    value_memory_macro_count = int(params.get("value_memory_macro_count", 0))
+    if score_bank_macro_count != _EXPECTED_MACRO_COUNTS["fakeram45_2048x39"]:
+        raise ValueError(
+            "macro_manifest score-bank macro count mismatch: expected "
+            f"{_EXPECTED_MACRO_COUNTS['fakeram45_2048x39']}, got {score_bank_macro_count}"
+        )
+    if value_memory_macro_count != _EXPECTED_MACRO_COUNTS["fakeram45_64x32"]:
+        raise ValueError(
+            "macro_manifest value-memory macro count mismatch: expected "
+            f"{_EXPECTED_MACRO_COUNTS['fakeram45_64x32']}, got {value_memory_macro_count}"
+        )
+    return {
+        "fakeram45_2048x39": score_bank_macro_count,
+        "fakeram45_64x32": value_memory_macro_count,
+    }
+
+
+def _prepare_postroute_power_manifest(
+    *,
+    activity_dir: Path,
+    activity_manifest: JsonDict,
+) -> tuple[JsonDict, Path, JsonDict]:
+    generated_meta = _validate_generated_activity_manifest(activity_manifest, activity_dir)
+    macro_counts = _validate_macro_manifest_counts(
+        _load(activity_dir / _OUTPUT_MACRO_MANIFEST_NAME)
+    )
+    vcd_path = activity_dir / _OUTPUT_VCD_NAME
+    if not vcd_path.is_file():
+        raise ValueError("generated VCD missing from activity_dir")
+    if _sha256_file(vcd_path) != generated_meta["vcd_sha256"]:
+        raise ValueError("generated VCD hash does not match the generated activity manifest")
+    if not (activity_dir / _OUTPUT_SERVICE_MANIFEST_NAME).is_file():
+        raise ValueError("generated service manifest missing from activity_dir")
+
+    macro_activity = extract_fakeram_vcd_activity(
+        vcd_path,
+        source_vcd_sha256=generated_meta["vcd_sha256"],
+        scope=_SCOPE,
+    )
+    macro_activity_path = activity_dir / _POSTROUTE_MACRO_ACTIVITY_NAME
+    macro_activity_path.write_text(
+        json.dumps(macro_activity, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    sequential_activity = extract_sequential_register_vcd_activity(
+        vcd_path,
+        source_vcd_sha256=generated_meta["vcd_sha256"],
+        scope=_SCOPE,
+    )
+    sequential_activity_path = activity_dir / _POSTROUTE_SEQUENTIAL_ACTIVITY_NAME
+    sequential_activity_path.write_text(
+        json.dumps(sequential_activity, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    adapted_manifest = {
+        "version": 1,
+        "model": "attention_decode_score_multivalue_service_postroute_activity_manifest_v1",
+        "clock_period_ns": activity_manifest["clock_period_ns"],
+        "phases": [
+            {
+                "phase": "service_window",
+                "vcd": _OUTPUT_VCD_NAME,
+                "vcd_sha256": generated_meta["vcd_sha256"],
+                "macro_activity": macro_activity_path.name,
+                "macro_activity_sha256": _sha256_file(macro_activity_path),
+                "sequential_register_activity": sequential_activity_path.name,
+                "sequential_register_activity_sha256": _sha256_file(sequential_activity_path),
+                "measured_cycles": generated_meta["cycle_count"],
+                "full_context_cycles": generated_meta["cycle_count"],
+                "requires_macro_activity": True,
+            }
+        ],
+    }
+    adapted_manifest_path = activity_dir / _POSTROUTE_MANIFEST_NAME
+    adapted_manifest_path.write_text(
+        json.dumps(adapted_manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return adapted_manifest, adapted_manifest_path, {
+        "generated_activity_manifest_sha256": generated_meta["generated_manifest_sha256"],
+        "adapted_activity_manifest_sha256": _sha256_file(adapted_manifest_path),
+        "vcd_sha256": generated_meta["vcd_sha256"],
+        "cycle_count": generated_meta["cycle_count"],
+        "macro_counts": macro_counts,
+        "bank_coverage": generated_meta["bank_coverage"],
+    }
+
+
+def _finite_positive(value: object, label: str) -> float:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be a finite positive number") from exc
+    if not math.isfinite(numeric) or numeric <= 0.0:
+        raise ValueError(f"{label} must be a finite positive number")
+    return numeric
+
+
+def _strict_service_window_measurement(
+    *,
+    activity_power: JsonDict,
+    manifest_sha256: str,
+    expected_vcd_sha256: str,
+    expected_clock_period_ns: float,
+    expected_cycle_count: int,
+) -> JsonDict:
+    if activity_power.get("promotion_gate_pass") is not True:
+        raise ValueError("postroute power promotion_gate_pass failed")
+    if activity_power.get("status") != "activity_backed":
+        raise ValueError("postroute power status is not activity_backed")
+    if abs(float(activity_power.get("clock_period_ns", 0.0)) - expected_clock_period_ns) > 1e-9:
+        raise ValueError("postroute power clock_period_ns mismatch")
+    if str(activity_power.get("source_activity_manifest_sha256") or "").strip().lower() != manifest_sha256:
+        raise ValueError("postroute power source_activity_manifest_sha256 mismatch")
+    phases = activity_power.get("phases")
+    if not isinstance(phases, list) or len(phases) != 1 or not isinstance(phases[0], dict):
+        raise ValueError("postroute power must contain exactly one service_window phase")
+    phase = phases[0]
+    if str(phase.get("phase") or "").strip() != "service_window":
+        raise ValueError("postroute power phase name mismatch")
+    if str(phase.get("vcd_sha256") or "").strip().lower() != expected_vcd_sha256:
+        raise ValueError("postroute power VCD hash mismatch")
+    if int(phase.get("measured_cycles", 0)) != expected_cycle_count:
+        raise ValueError("postroute power measured_cycles mismatch")
+    if int(phase.get("full_context_cycles", 0)) != expected_cycle_count:
+        raise ValueError("postroute power full_context_cycles mismatch")
+    if phase.get("annotation_gate_pass") is not True:
+        raise ValueError("postroute power aggregate annotation gate failed")
+    if phase.get("sequential_register_activity_gate_pass") is not True:
+        raise ValueError("postroute power sequential register coverage gate failed")
+    if phase.get("clock_period_gate_pass") is not True:
+        raise ValueError("postroute power clock period gate failed")
+    power = phase.get("power")
+    if not isinstance(power, dict):
+        raise ValueError("postroute power phase power section missing")
+    internal_w = _finite_positive(power.get("internal_w"), "internal_w")
+    switching_w = _finite_positive(power.get("switching_w"), "switching_w")
+    leakage_w = _finite_positive(power.get("leakage_w"), "leakage_w")
+    total_w = _finite_positive(power.get("total_w"), "total_w")
+    if abs((internal_w + switching_w + leakage_w) - total_w) > 1e-9:
+        raise ValueError("postroute power total_w does not match internal+switching+leakage")
+    service_window_s = expected_cycle_count * expected_clock_period_ns * 1e-9
+    dynamic_energy_j = (internal_w + switching_w) * service_window_s
+    leakage_energy_j = leakage_w * service_window_s
+    total_energy_j = dynamic_energy_j + leakage_energy_j
+    return {
+        "label": "component_service_window_energy",
+        "is_total_token_energy": False,
+        "cycle_count": expected_cycle_count,
+        "duration_s": service_window_s,
+        "power_w": {
+            "internal": internal_w,
+            "switching": switching_w,
+            "dynamic": internal_w + switching_w,
+            "leakage": leakage_w,
+            "total": total_w,
+        },
+        "energy_j": {
+            "dynamic": dynamic_energy_j,
+            "leakage": leakage_energy_j,
+            "dynamic_plus_leakage": total_energy_j,
+        },
+    }
+
+
+def _write_markdown(payload: JsonDict, path: Path) -> None:
+    best = payload.get("best") if isinstance(payload.get("best"), dict) else {}
+    service_window = (
+        best.get("component_service_window_energy")
+        if isinstance(best.get("component_service_window_energy"), dict)
+        else {}
+    )
+    composed_ppa = (
+        best.get("authoritative_composed_c1_total_ppa")
+        if isinstance(best.get("authoritative_composed_c1_total_ppa"), dict)
+        else {}
+    )
+    lines = [
+        "# Strict c1 routed service power audit",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- promotion_gate_pass: `{payload['promotion_gate_pass']}`",
+        f"- required_flow_variant: `{payload['selection_contract']['required_flow_variant']}`",
+        f"- bank3 dynamic inactivity: `{payload['bank3_dynamic_inactivity']['inactive_banks']}`",
+        f"- bank3 note: {payload['bank3_dynamic_inactivity']['statement']}",
+        "",
+        "| status | path ns | total power mW | service-window dynamic J | service-window leakage J | service-window total J |",
+        "|---|---:|---:|---:|---:|---:|",
+        "| {status} | {path_ns} | {total_power_mw} | {dynamic} | {leakage} | {total} |".format(
+            status=best.get("status"),
+            path_ns=composed_ppa.get("critical_path_ns"),
+            total_power_mw=composed_ppa.get("total_power_mw"),
+            dynamic=service_window.get("energy_j", {}).get("dynamic"),
+            leakage=service_window.get("energy_j", {}).get("leakage"),
+            total=service_window.get("energy_j", {}).get("dynamic_plus_leakage"),
+        ),
+        "",
+        "## Macro Contract",
+        "",
+        f"- `fakeram45_2048x39`: `{payload['macro_manifest_contract']['counts']['fakeram45_2048x39']}`",
+        f"- `fakeram45_64x32`: `{payload['macro_manifest_contract']['counts']['fakeram45_64x32']}`",
+    ]
+    if payload["promotion_gate_pass"] is not True:
+        failure = payload["candidates"][0].get("failure")
+        if isinstance(failure, dict):
+            lines.extend(
+                [
+                    "",
+                    "## Failure",
+                    "",
+                    f"- type: `{failure.get('error_type')}`",
+                    f"- summary: {failure.get('error_summary')}",
+                ]
+            )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_report(
+    *,
+    config: Path,
+    c1_metrics_csv: Path,
+    equivalence_json: Path,
+    integrated_service_json: Path,
+    orfs_design_config: Path,
+    clock_period_ns: float,
+    activity_dir: Path,
+    min_sequential_register_activity_coverage: float = 0.95,
+) -> JsonDict:
+    if abs(clock_period_ns - 10.0) > 1e-9:
+        raise ValueError("strict c1 routed service power audit requires a 10 ns clock")
+    cluster_equivalence = _validate_cluster_equivalence(_load(equivalence_json))
+    integrated_service = _validate_integrated_service(_load(integrated_service_json))
+    metric = _select_c1_metric(
+        c1_metrics_csv,
+        clock_period_ns=clock_period_ns,
+        required_flow_variant=_REQUIRED_FLOW_VARIANT,
+    )
+    activity_dir.mkdir(parents=True, exist_ok=True)
+    activity_manifest = generate_activity(
+        _load(config),
+        activity_dir,
+        clock_period_ns=clock_period_ns,
+    )
+    adapted_manifest, adapted_manifest_path, activity_meta = _prepare_postroute_power_manifest(
+        activity_dir=activity_dir,
+        activity_manifest=activity_manifest,
+    )
+    candidate: JsonDict = {
+        "candidate_id": f"multivalue_service_activity_{_REQUIRED_FLOW_VARIANT}",
+        "flow_variant": _REQUIRED_FLOW_VARIANT,
+        "ppa_metric": _metric_provenance(metric, c1_metrics_csv),
+    }
+    try:
+        activity_power = build_power_report(
+            manifest=adapted_manifest,
+            manifest_path=adapted_manifest_path,
+            design_config=orfs_design_config,
+            flow_variant=_REQUIRED_FLOW_VARIANT,
+            scope=_SCOPE,
+            min_vcd_coverage=0.05,
+            min_vcd_pins=32,
+            min_sequential_register_activity_coverage=min_sequential_register_activity_coverage,
+            min_macro_active_coverage=0.01,
+            min_macro_active_pins=16,
+            timeout_seconds=1800,
+        )
+    except Exception as exc:
+        candidate["status"] = "measurement_failed"
+        candidate["promotion_gate_pass"] = False
+        candidate["failure"] = _sanitized_failure(exc)
+    else:
+        candidate["activity_power"] = activity_power
+        try:
+            service_window_energy = _strict_service_window_measurement(
+                activity_power=activity_power,
+                manifest_sha256=activity_meta["adapted_activity_manifest_sha256"],
+                expected_vcd_sha256=activity_meta["vcd_sha256"],
+                expected_clock_period_ns=clock_period_ns,
+                expected_cycle_count=int(activity_meta["cycle_count"]),
+            )
+        except Exception as exc:
+            candidate["status"] = "rejected_gate"
+            candidate["promotion_gate_pass"] = False
+            candidate["failure"] = _sanitized_failure(exc)
+        else:
+            candidate["status"] = "activity_backed"
+            candidate["promotion_gate_pass"] = True
+            candidate["component_service_window_energy"] = service_window_energy
+            candidate["authoritative_composed_c1_total_ppa"] = {
+                "critical_path_ns": float(metric["critical_path_ns"]),
+                "instance_area_um2": float(metric.get("instance_area_um2") or 0.0),
+                "die_area": float(metric.get("die_area") or 0.0),
+                "total_power_mw": float(metric.get("total_power_mw") or 0.0),
+            }
+    best = candidate if candidate.get("status") == "activity_backed" else None
+    return {
+        "version": 1,
+        "model": _MODEL,
+        "decision": (
+            "activity_backed_service_power_measured"
+            if best is not None
+            else "activity_power_rejected_no_gated_candidate"
+        ),
+        "promotion_gate_pass": best is not None,
+        "candidate_count": 1,
+        "promoted_candidate_count": 1 if best is not None else 0,
+        "best_candidate_id": best["candidate_id"] if best is not None else None,
+        "best": best,
+        "candidates": [candidate],
+        "selection_contract": {
+            "case_id": _CASE_ID,
+            "required_flow_variant": _REQUIRED_FLOW_VARIANT,
+            "clock_period_ns": clock_period_ns,
+            "status": "exactly_one_status_ok_timing_feasible_row_required",
+        },
+        "source_dependencies": {
+            "service_config": _portable_path(config),
+            "c1_metrics_csv": _portable_path(c1_metrics_csv),
+            "merged_cluster_equivalence_json": _portable_path(equivalence_json),
+            "integrated_service_r1_json": _portable_path(integrated_service_json),
+            "orfs_design_config": _portable_path(orfs_design_config),
+        },
+        "dependency_contract": {
+            "cluster_equivalence": cluster_equivalence,
+            "integrated_service_c1": integrated_service,
+        },
+        "activity_contract": {
+            "generated_activity_manifest_sha256": activity_meta["generated_activity_manifest_sha256"],
+            "adapted_activity_manifest_sha256": activity_meta["adapted_activity_manifest_sha256"],
+            "vcd_sha256": activity_meta["vcd_sha256"],
+            "clock_period_ns": clock_period_ns,
+            "cycle_count": int(activity_meta["cycle_count"]),
+        },
+        "macro_manifest_contract": {
+            "counts": activity_meta["macro_counts"],
+            "statement": "Exact macro counts are required: 56 fakeram45_2048x39 score banks and 64 fakeram45_64x32 value-memory macros.",
+        },
+        "bank3_dynamic_inactivity": {
+            "inactive_banks": activity_meta["bank_coverage"]["inactive_banks"],
+            "statement": (
+                "No artificial activity was injected. Bank3 may remain dynamically inactive in this exact c1 workload; "
+                "it is not required to toggle, while leakage remains part of routed power."
+            ),
+        },
+        "precision_status": (
+            "unchanged_integer_contract_from_merged_cluster_equivalence_and_integrated_service"
+        ),
+        "remaining_abstractions": [
+            "The service-window energy is direct routed component energy for this exact c1 workload, not total token energy.",
+            "FakeRAM power uses proxy Nangate45 macro views rather than SRAM compiler signoff.",
+            "Evaluator-local VCD, ODB, and SPEF paths remain redacted from the portable output.",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--c1-metrics-csv", type=Path, required=True)
+    parser.add_argument("--equivalence-json", type=Path, required=True)
+    parser.add_argument("--integrated-service-json", type=Path, required=True)
+    parser.add_argument("--orfs-design-config", type=Path, required=True)
+    parser.add_argument("--clock-period-ns", type=float, default=10.0)
+    parser.add_argument("--activity-dir", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    parser.add_argument(
+        "--min-sequential-register-activity-coverage",
+        type=float,
+        default=0.95,
+    )
+    args = parser.parse_args()
+    payload = build_report(
+        config=args.config,
+        c1_metrics_csv=args.c1_metrics_csv,
+        equivalence_json=args.equivalence_json,
+        integrated_service_json=args.integrated_service_json,
+        orfs_design_config=args.orfs_design_config,
+        clock_period_ns=args.clock_period_ns,
+        activity_dir=args.activity_dir,
+        min_sequential_register_activity_coverage=args.min_sequential_register_activity_coverage,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_markdown(payload, args.out_md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/extract_fakeram_vcd_activity.py
+++ b/npu/eval/extract_fakeram_vcd_activity.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass
-from pathlib import Path
 import math
+from pathlib import Path
 import re
 from typing import Any
 
@@ -15,18 +15,34 @@ JsonDict = dict[str, Any]
 
 TARGET_SCOPE_PREFIX = "tb/dut"
 _TARGET_GROUP_SCOPE_RE = re.compile(r"^u_group_(\d+)_slice_(\d+)$")
+_VALUE_BANK_SCOPE_RE = re.compile(r"^gen_value_bank\[(\d+)\]$")
+_VALUE_LANE_SCOPE_RE = re.compile(r"^gen_value_lane\[(\d+)\]$")
 _VAR_RE = re.compile(r"^\$var\s+\S+\s+(\d+)\s+(\S+)\s+(.*?)\s+\$end$")
 _SCOPE_RE = re.compile(r"^\$scope\s+\S+\s+(\S+)\s+\$end$")
 _SCALAR_UPDATE_RE = re.compile(r"^([01xXzZ])(\S+)$")
 _VECTOR_UPDATE_RE = re.compile(r"^b([01xXzZ]+)\s+(\S+)$")
 
-_DEFAULT_PIN_WIDTHS = {
+_SCORE_PIN_WIDTHS = {
     "addr_in": 11,
     "wd_in": 39,
     "w_mask_in": 39,
     "we_in": 1,
     "ce_in": 1,
 }
+_VALUE_PIN_WIDTHS = {
+    "addr_in": 6,
+    "wd_in": 32,
+    "w_mask_in": 32,
+    "we_in": 1,
+    "ce_in": 1,
+}
+
+
+@dataclass(frozen=True)
+class _MacroClassSpec:
+    macro_name: str
+    pin_widths: dict[str, int]
+    instance_scope_prefix: str
 
 
 @dataclass
@@ -36,6 +52,18 @@ class _PinActivity:
     last_tick: int
     transition_count: float
     high_ticks: int
+
+
+_SCORE_MACRO_SPEC = _MacroClassSpec(
+    macro_name="fakeram45_2048x39",
+    pin_widths=_SCORE_PIN_WIDTHS,
+    instance_scope_prefix="score_bank",
+)
+_VALUE_MACRO_SPEC = _MacroClassSpec(
+    macro_name="fakeram45_64x32",
+    pin_widths=_VALUE_PIN_WIDTHS,
+    instance_scope_prefix="gen_value_macro_backend",
+)
 
 
 def _sha256_file(path: Path) -> str:
@@ -97,15 +125,12 @@ def _parse_range_indices(raw: str | None, width: int) -> list[int]:
     return expected
 
 
-def _parse_target_scope(scope_path: str, root_scope: str = TARGET_SCOPE_PREFIX) -> tuple[str, int, int] | None:
-    if scope_path == root_scope:
-        return None
-    if not scope_path.startswith(f"{root_scope}/"):
-        return None
-    remainder = scope_path[len(root_scope) + 1 :]
-    if not remainder:
-        return None
-    parts = remainder.split("/")
+def _score_scope_result(
+    parts: list[str],
+    *,
+    group_indices: tuple[int, ...],
+    slice_indices: tuple[int, ...],
+) -> tuple[str, _MacroClassSpec] | None:
     for index, part in enumerate(parts):
         if part != "score_bank":
             continue
@@ -115,11 +140,79 @@ def _parse_target_scope(scope_path: str, root_scope: str = TARGET_SCOPE_PREFIX) 
         match = _TARGET_GROUP_SCOPE_RE.fullmatch(group_scope)
         if match is None:
             continue
-        # Require the target slice to be declared directly under score_bank.
+        group_idx = int(match.group(1))
+        slice_idx = int(match.group(2))
+        if group_idx not in group_indices or slice_idx not in slice_indices:
+            continue
         if index + 2 != len(parts):
             continue
-        return (f"score_bank/{group_scope}", int(match.group(1)), int(match.group(2)))
+        return (f"score_bank/{group_scope}", _SCORE_MACRO_SPEC)
     return None
+
+
+def _value_scope_result(
+    parts: list[str],
+    *,
+    value_bank_indices: tuple[int, ...],
+    value_lane_indices: tuple[int, ...],
+) -> tuple[str, _MacroClassSpec] | None:
+    for index, part in enumerate(parts):
+        if part != "gen_value_macro_backend":
+            continue
+        if index + 3 >= len(parts):
+            return None
+        bank_scope = parts[index + 1]
+        lane_scope = parts[index + 2]
+        leaf_scope = parts[index + 3]
+        bank_match = _VALUE_BANK_SCOPE_RE.fullmatch(bank_scope)
+        lane_match = _VALUE_LANE_SCOPE_RE.fullmatch(lane_scope)
+        if bank_match is None or lane_match is None or leaf_scope != "u_value_mem_lane":
+            continue
+        bank_idx = int(bank_match.group(1))
+        lane_idx = int(lane_match.group(1))
+        if bank_idx not in value_bank_indices or lane_idx not in value_lane_indices:
+            continue
+        if index + 4 != len(parts):
+            continue
+        return (
+            f"gen_value_macro_backend/{bank_scope}/{lane_scope}/{leaf_scope}",
+            _VALUE_MACRO_SPEC,
+        )
+    return None
+
+
+def _parse_target_scope(
+    scope_path: str,
+    *,
+    root_scope: str,
+    group_indices: tuple[int, ...],
+    slice_indices: tuple[int, ...],
+    include_value_memory: bool,
+    value_bank_indices: tuple[int, ...],
+    value_lane_indices: tuple[int, ...],
+) -> tuple[str, _MacroClassSpec] | None:
+    if scope_path == root_scope:
+        return None
+    if not scope_path.startswith(f"{root_scope}/"):
+        return None
+    remainder = scope_path[len(root_scope) + 1 :]
+    if not remainder:
+        return None
+    parts = remainder.split("/")
+    score_result = _score_scope_result(
+        parts,
+        group_indices=group_indices,
+        slice_indices=slice_indices,
+    )
+    if score_result is not None:
+        return score_result
+    if not include_value_memory:
+        return None
+    return _value_scope_result(
+        parts,
+        value_bank_indices=value_bank_indices,
+        value_lane_indices=value_lane_indices,
+    )
 
 
 def _sanitize_bit(value: str) -> str:
@@ -160,31 +253,75 @@ def _value_to_tick_delta(value: str | None, tick_delta: int) -> int:
     return tick_delta
 
 
-def extract_fakeram_vcd_activity(
+def _pins_per_instance(spec: _MacroClassSpec) -> int:
+    return sum(spec.pin_widths.values())
+
+
+def _contract_rows(
+    *,
+    include_value_memory: bool,
+    group_indices: tuple[int, ...],
+    slice_indices: tuple[int, ...],
+    value_bank_indices: tuple[int, ...],
+    value_lane_indices: tuple[int, ...],
+    instance_names_by_macro: dict[str, set[str]],
+    pin_count_by_macro: dict[str, int],
+) -> tuple[list[JsonDict], int]:
+    expected: list[tuple[_MacroClassSpec, int]] = [
+        (_SCORE_MACRO_SPEC, len(group_indices) * len(slice_indices)),
+    ]
+    if include_value_memory:
+        expected.append((_VALUE_MACRO_SPEC, len(value_bank_indices) * len(value_lane_indices)))
+
+    rows: list[JsonDict] = []
+    total_assignment_count = 0
+    for spec, expected_instance_count in expected:
+        pins_per_instance = _pins_per_instance(spec)
+        expected_assignment_count = pins_per_instance * expected_instance_count
+        observed_instance_count = len(instance_names_by_macro.get(spec.macro_name, set()))
+        observed_assignment_count = pin_count_by_macro.get(spec.macro_name, 0)
+        if observed_instance_count != expected_instance_count:
+            raise ValueError(
+                f"{spec.macro_name} structural instance count mismatch: expected "
+                f"{expected_instance_count}, got {observed_instance_count}"
+            )
+        if observed_assignment_count != expected_assignment_count:
+            raise ValueError(
+                f"{spec.macro_name} structural pin count mismatch: expected "
+                f"{expected_assignment_count}, got {observed_assignment_count}"
+            )
+        total_assignment_count += observed_assignment_count
+        rows.append(
+            {
+                "macro_name": spec.macro_name,
+                "instance_scope_prefix": spec.instance_scope_prefix,
+                "instance_count": observed_instance_count,
+                "pins_per_instance": pins_per_instance,
+                "assignment_count": observed_assignment_count,
+            }
+        )
+    return rows, total_assignment_count
+
+
+def _extract_macro_vcd_activity(
     vcd_path: Path,
     *,
     source_vcd_sha256: str,
-    scope: str = TARGET_SCOPE_PREFIX,
-    pin_widths: dict[str, int] | None = None,
-    group_indices: tuple[int, ...] = tuple(range(8)),
-    slice_indices: tuple[int, ...] = tuple(range(7)),
-    expected_pin_count: int | None = None,
+    scope: str,
+    group_indices: tuple[int, ...],
+    slice_indices: tuple[int, ...],
+    expected_pin_count: int | None,
+    include_value_memory: bool,
+    value_bank_indices: tuple[int, ...],
+    value_lane_indices: tuple[int, ...],
+    target_profile: str,
 ) -> JsonDict:
     if not source_vcd_sha256:
         raise ValueError("source_vcd_sha256 is required")
-    expected = _DEFAULT_PIN_WIDTHS.copy()
-    if pin_widths is not None:
-        expected.update(pin_widths)
-        required = set(expected)
-        unexpected = set(pin_widths) - set(expected)
-        if unexpected:
-            raise ValueError(f"unexpected pin_widths keys: {', '.join(sorted(unexpected))}")
-    else:
-        required = set(expected)
-    for pin_name in required:
-        width = expected[pin_name]
-        if width <= 0:
-            raise ValueError(f"invalid width for {pin_name}: {width}")
+
+    required_pin_names = set(_SCORE_PIN_WIDTHS)
+    if include_value_memory:
+        required_pin_names.update(_VALUE_PIN_WIDTHS)
 
     vcd_text = vcd_path.read_text(encoding="utf-8", errors="replace")
     actual_hash = _sha256_file(vcd_path)
@@ -199,16 +336,15 @@ def extract_fakeram_vcd_activity(
     id_to_specs: dict[str, tuple[str, int]] = {}
     all_pin_last_values: dict[str, str | None] = {}
     full_name_specs: dict[str, tuple[str, int]] = {}
+    instance_names_by_macro: dict[str, set[str]] = {}
+    pin_count_by_macro: dict[str, int] = {}
     scope_stack: list[str] = []
 
-    # Parse VCD declarations.
     lines = vcd_text.splitlines()
     for line in lines:
         stripped = line.strip()
         if stripped == "$enddefinitions":
             break
-        if stripped == "$scope":
-            pass
         if stripped.startswith("$scope "):
             scope_match = _SCOPE_RE.match(stripped)
             if scope_match:
@@ -233,18 +369,26 @@ def extract_fakeram_vcd_activity(
         name = decl_tokens[0]
         if name.startswith("\\"):
             continue
-        if width <= 0 or name not in required:
+        if width <= 0 or name not in required_pin_names:
             continue
 
         scope_path = "/".join(scope_stack)
-        scope_result = _parse_target_scope(scope_path, root_scope=scope)
+        scope_result = _parse_target_scope(
+            scope_path,
+            root_scope=scope,
+            group_indices=group_indices,
+            slice_indices=slice_indices,
+            include_value_memory=include_value_memory,
+            value_bank_indices=value_bank_indices,
+            value_lane_indices=value_lane_indices,
+        )
         if scope_result is None:
             continue
-        full_scope, group, slice_idx = scope_result
-        if group not in group_indices or slice_idx not in slice_indices:
+        full_scope, macro_spec = scope_result
+        if name not in macro_spec.pin_widths:
             continue
 
-        expected_width = expected[name]
+        expected_width = macro_spec.pin_widths[name]
         if width != expected_width:
             raise ValueError(f"{scope_path}/{name} width mismatch: expected {expected_width}, got {width}")
 
@@ -268,19 +412,21 @@ def extract_fakeram_vcd_activity(
             leaf = full_name.rsplit("/", 1)[-1]
             return leaf.split("[", 1)[0]
 
-        # Duplicate full_name declarations should be consistent and deterministic.
         unique_full_names: list[str] = []
         for bit_index, full_name in enumerate(full_names):
             existing = full_name_specs.get(full_name)
             if existing is None:
                 full_name_specs[full_name] = (var_id, bit_index)
                 all_pin_last_values[full_name] = None
+                pin_count_by_macro[macro_spec.macro_name] = pin_count_by_macro.get(macro_spec.macro_name, 0) + 1
                 unique_full_names.append(full_name)
                 continue
             existing_var_id, existing_bit_index = existing
             if existing_var_id != var_id or existing_bit_index != bit_index:
                 raise ValueError(f"duplicate declaration for {full_name}")
-            # Exact repeated declaration: ignore as a deterministic alias.
+
+        if unique_full_names:
+            instance_names_by_macro.setdefault(macro_spec.macro_name, set()).add(full_scope)
 
         if var_id in id_to_full_names:
             existing = id_to_full_names[var_id]
@@ -288,7 +434,9 @@ def extract_fakeram_vcd_activity(
             signal_base = _signal_base(full_names[0]) if full_names else ""
             if signal_base != expected_base or len(full_names) != expected_width:
                 raise ValueError(f"duplicate id {var_id} with mismatched width/bit-count")
-            if {_signal_base(name) for name in existing} != {_signal_base(name) for name in full_names}:
+            if {_signal_base(existing_name) for existing_name in existing} != {
+                _signal_base(current_name) for current_name in full_names
+            }:
                 raise ValueError(f"duplicate id {var_id} with inconsistent target names")
             if unique_full_names:
                 id_to_full_names[var_id] = existing + tuple(unique_full_names)
@@ -297,15 +445,17 @@ def extract_fakeram_vcd_activity(
             id_to_specs[var_id] = (_signal_base(full_names[0]), len(full_names))
 
     if expected_pin_count is None:
-        expected_pin_count = sum(expected[name] for name in required) * len(group_indices) * len(slice_indices)
+        expected_pin_count = _pins_per_instance(_SCORE_MACRO_SPEC) * len(group_indices) * len(slice_indices)
+        if include_value_memory:
+            expected_pin_count += _pins_per_instance(_VALUE_MACRO_SPEC) * len(value_bank_indices) * len(
+                value_lane_indices
+            )
 
-    # Replay lines from the full file for value changes and dumpon timing.
     active_start: int | None = None
     active_end: int | None = None
     current_time = 0
     dumping = False
     state_by_pin = {name: None for name in all_pin_last_values}
-
     pin_rows: dict[str, _PinActivity] = {}
 
     for line in lines:
@@ -340,10 +490,6 @@ def extract_fakeram_vcd_activity(
             dumping = False
             break
 
-        if current_time is None:
-            continue
-
-        # Scalar update.
         scalar_update = _SCALAR_UPDATE_RE.match(stripped)
         if scalar_update is not None:
             new_value = _sanitize_bit(scalar_update.group(1))
@@ -362,19 +508,16 @@ def extract_fakeram_vcd_activity(
                 row.last_tick = current_time
             continue
 
-        # Binary/vector update.
         vector_update = _VECTOR_UPDATE_RE.match(stripped)
         if vector_update is not None:
             bits = vector_update.group(1).lower()
             var_id = vector_update.group(2)
             if var_id not in id_to_full_names:
                 continue
-            # VCD vector updates may omit leading zeros in fixed-width literals.
-            bit_values = _normalize_vector_update(bits, len(id_to_full_names[var_id]))
             full_names = id_to_full_names[var_id]
+            bit_values = _normalize_vector_update(bits, len(full_names))
             if len(bit_values) != len(full_names):
                 raise ValueError(f"vector update width mismatch for {var_id}: expected {len(full_names)}, got {len(bit_values)}")
-
             for index, full_name in enumerate(full_names):
                 state_by_pin[full_name] = bit_values[index]
                 if not dumping:
@@ -398,13 +541,12 @@ def extract_fakeram_vcd_activity(
     if active_end <= active_start:
         raise ValueError("active_end_tick must be greater than active_start_tick")
 
-    # Finish duty accounting for the final active span.
     duration = active_end - active_start
     for row in pin_rows.values():
         if row.last_value is not None:
             row.high_ticks += _value_to_tick_delta(row.last_value, active_end - row.last_tick)
 
-    pins: list[dict[str, Any]] = []
+    pins: list[JsonDict] = []
     for row in sorted(pin_rows.values(), key=lambda entry: entry.full_name):
         duty = row.high_ticks / duration
         density = row.transition_count / (duration * timescale_seconds)
@@ -424,17 +566,88 @@ def extract_fakeram_vcd_activity(
             }
         )
 
+    contract_rows, total_assignment_count = _contract_rows(
+        include_value_memory=include_value_memory,
+        group_indices=group_indices,
+        slice_indices=slice_indices,
+        value_bank_indices=value_bank_indices,
+        value_lane_indices=value_lane_indices,
+        instance_names_by_macro=instance_names_by_macro,
+        pin_count_by_macro=pin_count_by_macro,
+    )
+
     return {
         "version": 1,
         "model": "fakeram_macro_pin_vcd_activity_v1",
+        "target_profile": target_profile,
         "scope": scope,
         "source_vcd": vcd_path.name,
         "source_vcd_sha256": actual_hash,
         "timescale_seconds": timescale_seconds,
         "active_start_tick": active_start,
         "active_end_tick": active_end,
+        "structural_macro_contract": {
+            "profile": target_profile,
+            "macro_classes": contract_rows,
+            "total_assignment_count": total_assignment_count,
+        },
         "pins": pins,
     }
+
+
+def extract_fakeram_vcd_activity(
+    vcd_path: Path,
+    *,
+    source_vcd_sha256: str,
+    scope: str = TARGET_SCOPE_PREFIX,
+    pin_widths: dict[str, int] | None = None,
+    group_indices: tuple[int, ...] = tuple(range(8)),
+    slice_indices: tuple[int, ...] = tuple(range(7)),
+    expected_pin_count: int | None = None,
+) -> JsonDict:
+    if pin_widths is not None:
+        unexpected = set(pin_widths) - set(_SCORE_PIN_WIDTHS)
+        if unexpected:
+            raise ValueError(f"unexpected pin_widths keys: {', '.join(sorted(unexpected))}")
+        if dict(pin_widths) != _SCORE_PIN_WIDTHS:
+            raise ValueError("score-bank extractor requires the default fakeram45_2048x39 pin widths")
+    return _extract_macro_vcd_activity(
+        vcd_path,
+        source_vcd_sha256=source_vcd_sha256,
+        scope=scope,
+        group_indices=group_indices,
+        slice_indices=slice_indices,
+        expected_pin_count=expected_pin_count,
+        include_value_memory=False,
+        value_bank_indices=(),
+        value_lane_indices=(),
+        target_profile="score_bank_proxy_v1",
+    )
+
+
+def extract_multivalue_service_fakeram_vcd_activity(
+    vcd_path: Path,
+    *,
+    source_vcd_sha256: str,
+    scope: str = TARGET_SCOPE_PREFIX,
+    group_indices: tuple[int, ...] = tuple(range(8)),
+    slice_indices: tuple[int, ...] = tuple(range(7)),
+    value_bank_indices: tuple[int, ...] = tuple(range(4)),
+    value_lane_indices: tuple[int, ...] = tuple(range(16)),
+    expected_pin_count: int | None = None,
+) -> JsonDict:
+    return _extract_macro_vcd_activity(
+        vcd_path,
+        source_vcd_sha256=source_vcd_sha256,
+        scope=scope,
+        group_indices=group_indices,
+        slice_indices=slice_indices,
+        expected_pin_count=expected_pin_count,
+        include_value_memory=True,
+        value_bank_indices=value_bank_indices,
+        value_lane_indices=value_lane_indices,
+        target_profile="multivalue_service_c1_v1",
+    )
 
 
 def write_fakeram_vcd_activity(vcd_path: Path, *, output_path: Path, **kwargs: Any) -> JsonDict:

--- a/npu/eval/generate_attention_decode_score_multivalue_service_activity.py
+++ b/npu/eval/generate_attention_decode_score_multivalue_service_activity.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Generate a deterministic c1 integrated-service VCD and portable activity manifest."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval import probe_attention_decode_score_multivalue_integrated_service as probe  # noqa: E402
+from npu.rtlgen.gen_attention_decode_score_multivalue_service import generate as generate_service  # noqa: E402
+
+JsonDict = dict[str, Any]
+
+_DEFAULT_CLOCK_PERIOD_NS = 10.0
+_OUTPUT_VCD_NAME = "attention_decode_score_multivalue_service_activity.vcd"
+_OUTPUT_MANIFEST_NAME = "attention_decode_score_multivalue_service_activity_manifest.json"
+_OUTPUT_TOP_NAME = "top.v"
+_OUTPUT_CONFIG_NAME = "config.json"
+_OUTPUT_SERVICE_MANIFEST_NAME = "attention_decode_score_multivalue_service_manifest.json"
+_OUTPUT_MACRO_MANIFEST_NAME = "macro_manifest.json"
+_VALUE_MODEL_PATH = REPO_ROOT / "npu/sim/rtl/fakeram45_64x32_model.sv"
+_C1_CASE = next(case for case in probe.DEFAULT_CASES if str(case["case_id"]) == "c1_p128_b4_rr")
+_REQUIRED_SERVICE_FIELDS = {
+    "cluster_count": int(_C1_CASE["cluster_count"]),
+    "max_blocks": 16,
+    "packet_w": int(_C1_CASE["packet_w"]),
+    "banks": int(_C1_CASE["banks"]),
+    "req_queue_depth": int(_C1_CASE["req_queue_depth"]),
+    "resp_queue_depth": int(_C1_CASE["resp_queue_depth"]),
+    "bank_queue_depth": int(_C1_CASE["bank_queue_depth"]),
+    "read_latency": int(_C1_CASE["read_latency"]),
+    "arb_mode": str(_C1_CASE["arb_mode"]),
+    "locality_burst_max": int(_C1_CASE["locality_burst_max"]),
+    "score_scale_lanes_per_cycle": 1,
+    "value_memory_backend": "macro_banked_4x16x64x32",
+}
+
+
+def _load(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _hash_json(value: object) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _normalize_vcd(path: Path) -> None:
+    tmp_path = path.with_suffix(path.suffix + ".normalized")
+    in_date_block = False
+    date_rewritten = False
+    with path.open("r", encoding="utf-8") as src, tmp_path.open("w", encoding="utf-8") as dst:
+        for line in src:
+            if not date_rewritten and not in_date_block and line.strip() == "$date":
+                dst.write("$date\n")
+                dst.write("  deterministic_activity_capture_v1\n")
+                in_date_block = True
+                date_rewritten = True
+                continue
+            if in_date_block:
+                if line.strip() == "$end":
+                    dst.write("$end\n")
+                    in_date_block = False
+                continue
+            dst.write(line)
+    tmp_path.replace(path)
+
+
+def _normalize_config(config: JsonDict) -> JsonDict:
+    top_name = str(config.get("top_name") or "").strip()
+    if not top_name:
+        raise ValueError("config requires non-empty top_name")
+    body = config.get("attention_decode_score_multivalue_service")
+    if not isinstance(body, dict):
+        raise ValueError("config requires attention_decode_score_multivalue_service object")
+    normalized_body: JsonDict = {}
+    for key, expected in _REQUIRED_SERVICE_FIELDS.items():
+        value = body.get(key, expected)
+        if value != expected:
+            raise ValueError(f"attention_decode_score_multivalue_service.{key} must be {expected!r}")
+        normalized_body[key] = expected
+    return {"top_name": top_name, "attention_decode_score_multivalue_service": normalized_body}
+
+
+def _compile_and_run(*, sources: list[Path], timeout: int = 240) -> str:
+    with tempfile.TemporaryDirectory(prefix="multivalue-service-activity-run-") as tmp_text:
+        simv = Path(tmp_text) / "simv"
+        compiled = subprocess.run(
+            [probe._tool("iverilog"), "-g2012", "-s", "tb", "-o", str(simv), *[str(src) for src in sources]],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if compiled.returncode:
+            raise RuntimeError(f"iverilog failed:\n{compiled.stderr}")
+        run = subprocess.run([probe._tool("vvp"), str(simv)], capture_output=True, text=True, timeout=timeout)
+        if run.returncode:
+            raise RuntimeError(f"simulation failed:\n{run.stdout}\n{run.stderr}")
+        return run.stdout
+
+
+def _run_macro_integrated(config: JsonDict, out_dir: Path, *, clock_period_ns: float) -> JsonDict:
+    values = probe._shared_value_matrices()
+    with tempfile.TemporaryDirectory(prefix="multivalue-service-activity-") as tmp_text:
+        tmp = Path(tmp_text)
+        rtl_dir = tmp / "rtl"
+        tb_path = tmp / "tb.sv"
+        generate_service(json.loads(json.dumps(config)), rtl_dir)
+        top_path = rtl_dir / "top.v"
+        service_manifest_path = rtl_dir / _OUTPUT_SERVICE_MANIFEST_NAME
+        macro_manifest_path = rtl_dir / _OUTPUT_MACRO_MANIFEST_NAME
+        top_text = top_path.read_text(encoding="utf-8")
+        if "fakeram45_2048x39" not in top_text:
+            raise RuntimeError("generated RTL is missing fakeram45_2048x39 instances")
+        if "fakeram45_64x32" not in top_text:
+            raise RuntimeError("generated RTL is missing fakeram45_64x32 instances")
+        tb_text = probe._integrated_testbench(
+            top_name=str(config["top_name"]),
+            cluster_count=int(_C1_CASE["cluster_count"]),
+            values=values,
+            vcd_path=str((out_dir / _OUTPUT_VCD_NAME).resolve()),
+            vcd_dumpvars=["dut"],
+            clock_period_ns=clock_period_ns,
+        )
+        tb_path.write_text(tb_text, encoding="utf-8")
+        stdout = _compile_and_run(sources=[top_path, tb_path, _VALUE_MODEL_PATH])
+        generated_paths = {
+            _OUTPUT_CONFIG_NAME: rtl_dir / "config.json",
+            _OUTPUT_TOP_NAME: top_path,
+            _OUTPUT_SERVICE_MANIFEST_NAME: service_manifest_path,
+            _OUTPUT_MACRO_MANIFEST_NAME: macro_manifest_path,
+        }
+        for name, src in generated_paths.items():
+            (out_dir / name).write_bytes(src.read_bytes())
+
+    vcd_path = out_dir / _OUTPUT_VCD_NAME
+    if not vcd_path.is_file():
+        raise RuntimeError("simulation did not emit VCD")
+    _normalize_vcd(vcd_path)
+
+    shared_match = next(
+        (match for line in stdout.splitlines() if (match := probe._INT_SHARED_RE.fullmatch(line.strip()))),
+        None,
+    )
+    if shared_match is None:
+        raise RuntimeError("integrated shared counter line missing")
+    shared = {
+        "completion_cycle": int(shared_match.group(1)),
+        "protocol_error": bool(int(shared_match.group(2))),
+        "router_injection_stall_cycles": int(shared_match.group(3)),
+        "router_arbitration_contention_cycles": int(shared_match.group(4)),
+        "router_response_block_cycles": int(shared_match.group(5)),
+        "router_req_current_occupancy": int(shared_match.group(6)),
+        "router_req_max_occupancy": int(shared_match.group(7)),
+        "router_resp_current_occupancy": int(shared_match.group(8)),
+        "router_resp_max_occupancy": int(shared_match.group(9)),
+        "service_accepted_req_count": int(shared_match.group(10)),
+        "service_emitted_resp_count": int(shared_match.group(11)),
+        "service_bank_conflict_count": int(shared_match.group(12)),
+        "service_response_block_cycles": int(shared_match.group(13)),
+        "service_req_current_occupancy": int(shared_match.group(14)),
+        "service_req_max_occupancy": int(shared_match.group(15)),
+        "service_resp_current_occupancy": int(shared_match.group(16)),
+        "service_resp_max_occupancy": int(shared_match.group(17)),
+        "result_arbitration_contention_cycles": int(shared_match.group(18)),
+        "result_egress_block_cycles": int(shared_match.group(19)),
+        "result_back_to_back_fire_seen": bool(int(shared_match.group(20))),
+    }
+    return {
+        "score_rows": probe._parse_score_lines(stdout, probe._INT_SCORE_RE),
+        "request_rows": [
+            {
+                "cluster": int(match.group(1)),
+                "tag": int(match.group(2)),
+                "addr": int(match.group(3)),
+                "slice": int(match.group(4)),
+                "cycle": int(match.group(5)),
+            }
+            for line in stdout.splitlines()
+            if (match := probe._INT_REQ_RE.fullmatch(line.strip()))
+        ],
+        "wide_rows": [
+            {
+                "cluster": int(match.group(1)),
+                "source": int(match.group(2)),
+                "tag": int(match.group(3)),
+                "addr": int(match.group(4)),
+                "slice": int(match.group(5)),
+                "cycle": int(match.group(6)),
+                "matrix_hex": match.group(7).lower(),
+                "protocol_error": bool(int(match.group(8))),
+            }
+            for line in stdout.splitlines()
+            if (match := probe._INT_WIDE_RE.fullmatch(line.strip()))
+        ],
+        "results": probe._parse_result_lines(stdout, probe._INT_RESULT_RE),
+        "done_rows": {
+            int(match.group(1)): {
+                "cycle": int(match.group(2)),
+                "accepted": int(match.group(3)),
+                "completed": int(match.group(4)),
+            }
+            for line in stdout.splitlines()
+            if (match := probe._INT_DONE_RE.fullmatch(line.strip()))
+        },
+        "counter_rows": {
+            int(match.group(1)): {
+                "input_stall_cycles": int(match.group(2)),
+                "input_starvation_cycles": int(match.group(3)),
+                "result_egress_block_cycles": int(match.group(4)),
+                "request_count": int(match.group(5)),
+                "wide_response_count": int(match.group(6)),
+            }
+            for line in stdout.splitlines()
+            if (match := probe._INT_COUNTER_RE.fullmatch(line.strip()))
+        },
+        "shared": shared,
+        "manifest": _load(out_dir / _OUTPUT_SERVICE_MANIFEST_NAME),
+        "macro_manifest": _load(out_dir / _OUTPUT_MACRO_MANIFEST_NAME),
+        "top_sha256": _sha256_file(out_dir / _OUTPUT_TOP_NAME),
+        "clock_period_ns": clock_period_ns,
+    }
+
+
+def _assert_reference_equivalence(reference: JsonDict, candidate: JsonDict) -> None:
+    comparable = (
+        ("score rows", probe._canonical_scores(reference["score_rows"]), probe._canonical_scores(candidate["score_rows"])),
+        ("results", probe._canonical_results(reference["results"]), probe._canonical_results(candidate["results"])),
+        ("requests", probe._canonical_requests(reference["request_rows"]), probe._canonical_requests(candidate["request_rows"])),
+        ("wide responses", probe._canonical_wide(reference["wide_rows"]), probe._canonical_wide(candidate["wide_rows"])),
+        ("done rows", reference["done_rows"], candidate["done_rows"]),
+        ("per-cluster counters", reference["counter_rows"], candidate["counter_rows"]),
+        ("shared counters", reference["shared"], candidate["shared"]),
+    )
+    for label, expected, observed in comparable:
+        if observed != expected:
+            raise RuntimeError(f"macro-backed simulation diverged from reference {label}")
+
+
+def _assert_portable_manifest_strings(payload: object) -> None:
+    if isinstance(payload, dict):
+        for value in payload.values():
+            _assert_portable_manifest_strings(value)
+        return
+    if isinstance(payload, list):
+        for value in payload:
+            _assert_portable_manifest_strings(value)
+        return
+    if not isinstance(payload, str):
+        return
+    if payload.startswith("/"):
+        raise RuntimeError(f"portable manifest field contains absolute path: {payload}")
+    evaluator_root = str((REPO_ROOT / "npu/eval").resolve())
+    if evaluator_root in payload:
+        raise RuntimeError("portable manifest field contains absolute evaluator path")
+
+
+def generate_activity(config: JsonDict, out_dir: Path, *, clock_period_ns: float = _DEFAULT_CLOCK_PERIOD_NS) -> JsonDict:
+    if clock_period_ns <= 0.0:
+        raise ValueError("clock_period_ns must be > 0")
+    normalized_config = _normalize_config(config)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    values = probe._shared_value_matrices()
+    reference = probe._run_integrated(dict(_C1_CASE), values)
+    macro = _run_macro_integrated(normalized_config, out_dir, clock_period_ns=clock_period_ns)
+    _assert_reference_equivalence(reference, macro)
+
+    request_rows = probe._canonical_requests(macro["request_rows"])
+    score_rows = probe._canonical_scores(macro["score_rows"])
+    result_rows = probe._canonical_results(macro["results"])
+    wide_rows = probe._canonical_wide(macro["wide_rows"])
+    request_banks = sorted({int(row["addr"]) % int(_C1_CASE["banks"]) for row in request_rows})
+    preload_banks = sorted({int(entry["addr"]) % int(_C1_CASE["banks"]) for entry in probe._preload_entries(values)})
+    inactive_banks = sorted(set(range(int(_C1_CASE["banks"]))) - set(request_banks))
+    if "fakeram45_2048x39" not in (out_dir / _OUTPUT_TOP_NAME).read_text(encoding="utf-8"):
+        raise RuntimeError("generated top.v no longer contains fakeram45_2048x39")
+    if "fakeram45_64x32" not in (out_dir / _OUTPUT_TOP_NAME).read_text(encoding="utf-8"):
+        raise RuntimeError("generated top.v no longer contains fakeram45_64x32")
+
+    manifest = {
+        "version": 1,
+        "model": "attention_decode_score_multivalue_service_activity_v1",
+        "generator": "npu/eval/generate_attention_decode_score_multivalue_service_activity.py",
+        "case_id": str(_C1_CASE["case_id"]),
+        "artifacts": {
+            "config_json": _OUTPUT_CONFIG_NAME,
+            "top_verilog": _OUTPUT_TOP_NAME,
+            "service_manifest_json": _OUTPUT_SERVICE_MANIFEST_NAME,
+            "macro_manifest_json": _OUTPUT_MACRO_MANIFEST_NAME,
+            "vcd": _OUTPUT_VCD_NAME,
+        },
+        "hashes": {
+            "case_sha256": _hash_json(_C1_CASE),
+            "config_sha256": _hash_json(normalized_config),
+            "top_sha256": macro["top_sha256"],
+            "vcd_sha256": _sha256_file(out_dir / _OUTPUT_VCD_NAME),
+            "score_hash": _hash_json(score_rows),
+            "final_hash": _hash_json(result_rows),
+            "request_hash": _hash_json(request_rows),
+            "wide_response_matrix_hash": _hash_json(wide_rows),
+        },
+        "clock_period_ns": clock_period_ns,
+        "cycle_count": int(macro["shared"]["completion_cycle"]),
+        "request_result_protocol_counters": {
+            "request_count": len(request_rows),
+            "wide_response_count": len(wide_rows),
+            "result_count": len(result_rows),
+            "shared": dict(macro["shared"]),
+            "per_cluster": dict(macro["counter_rows"]),
+        },
+        "shared_result_egress": {
+            "architecture": macro["manifest"]["shared_result_egress"],
+            "documented_initiation_interval": macro["manifest"]["shared_result_egress_initiation_interval"],
+            "stall_semantics": macro["manifest"]["shared_result_egress_stall_semantics"],
+        },
+        "value_bank_coverage": {
+            "request_banks": request_banks,
+            "preload_banks": preload_banks,
+            "addressed_banks_over_trace": request_banks,
+            "inactive_banks": inactive_banks,
+            "inactive_reason": "three_block_reference_workload",
+        },
+        "compiled_behavioral_models": ["fakeram45_2048x39", "fakeram45_64x32"],
+        "scope": {
+            "exercised": [
+                "one deterministic c1_p128_b4_rr integrated-service command",
+                "macro-backed value-memory backend macro_banked_4x16x64x32",
+                "bounded DUT VCD from reset release through command completion",
+                "dynamic switching observed only on banks 0, 1, and 2 under the exact three-block reference workload",
+            ],
+            "remaining": [
+                "no power audit, SAIF extraction, or post-route activity processing",
+                "no non-c1 cases, no multi-cluster cases, and no alternate arbitration points",
+                "c1 dynamic power from this exact workload does not cover bank3 switching while bank3 leakage remains present in total composed PPA/power",
+            ],
+        },
+    }
+    if manifest["value_bank_coverage"]["addressed_banks_over_trace"] != [0, 1, 2]:
+        raise RuntimeError("exact c1 workload must address only banks 0, 1, and 2 over the trace")
+    if manifest["value_bank_coverage"]["inactive_banks"] != [3]:
+        raise RuntimeError("exact c1 workload must leave bank3 inactive")
+    _assert_portable_manifest_strings(manifest)
+    (out_dir / _OUTPUT_MANIFEST_NAME).write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--clock-period-ns", type=float, default=_DEFAULT_CLOCK_PERIOD_NS)
+    args = parser.parse_args()
+    generate_activity(_load(args.config), args.out_dir, clock_period_ns=args.clock_period_ns)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/probe_attention_decode_score_multivalue_integrated_service.py
+++ b/npu/eval/probe_attention_decode_score_multivalue_integrated_service.py
@@ -743,7 +743,17 @@ endmodule
 """
 
 
-def _integrated_testbench(*, top_name: str, cluster_count: int, values: list[list[list[list[int]]]]) -> str:
+def _integrated_testbench(
+    *,
+    top_name: str,
+    cluster_count: int,
+    values: list[list[list[list[int]]]],
+    vcd_path: str | None = None,
+    vcd_dumpvars: list[str] | None = None,
+    clock_period_ns: float = 10.0,
+) -> str:
+    if clock_period_ns <= 0.0:
+        raise ValueError("clock_period_ns must be > 0")
     total_beats = 3 * 128
     source_w = max(1, (cluster_count - 1).bit_length())
     entries = _preload_entries(values)
@@ -828,7 +838,8 @@ def _integrated_testbench(*, top_name: str, cluster_count: int, values: list[lis
         )
         per_cluster_done.append(f"done[{cluster}]")
 
-    return f"""`timescale 1ns/1ps
+    clock_stmt = "  always #5 clk = ~clk;" if clock_period_ns == 10.0 else f"  always #{clock_period_ns / 2.0:g} clk = ~clk;"
+    tb = f"""`timescale 1ns/1ps
 {_FAKERAM_MODEL}
 module tb;
   localparam integer CLUSTERS = {cluster_count};
@@ -928,7 +939,7 @@ module tb;
   reg [319:0] blocked_value_q;
 {chr(10).join(per_cluster_decl)}
 
-  always #5 clk = ~clk;
+{clock_stmt}
 
   {top_name} dut (
     .clk(clk),
@@ -1154,6 +1165,25 @@ module tb;
   end
 endmodule
 """
+    if vcd_path is None:
+        return tb
+    dumpvars = vcd_dumpvars or ["dut"]
+    dump_lines = "\n".join(f"    $dumpvars(0, {target});" for target in dumpvars)
+    vcd_block = f"""
+
+  initial begin
+    $dumpfile({json.dumps(vcd_path)});
+{dump_lines}
+    $dumpoff;
+    @(posedge rst_n);
+    $dumpon;
+    wait ({' && '.join(per_cluster_done)});
+    @(posedge clk);
+    $dumpoff;
+  end
+"""
+    prefix, suffix = tb.rsplit("\nendmodule\n", 1)
+    return f"{prefix}{vcd_block}\nendmodule\n{suffix}"
 
 
 def _compile_and_run(*, sources: list[Path], top: str = "tb", timeout: int = 180) -> str:

--- a/tests/test_attention_decode_score_multivalue_service_activity_power.py
+++ b/tests/test_attention_decode_score_multivalue_service_activity_power.py
@@ -1,0 +1,401 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+import sys
+from unittest import mock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval import audit_attention_decode_score_multivalue_service_activity_power as audit
+
+
+def _config(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_macro_activity",
+                "attention_decode_score_multivalue_service": {
+                    "cluster_count": 1,
+                    "max_blocks": 16,
+                    "packet_w": 128,
+                    "banks": 4,
+                    "req_queue_depth": 4,
+                    "resp_queue_depth": 4,
+                    "bank_queue_depth": 4,
+                    "read_latency": 2,
+                    "arb_mode": "round_robin",
+                    "locality_burst_max": 2,
+                    "score_scale_lanes_per_cycle": 1,
+                    "value_memory_backend": "macro_banked_4x16x64x32",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_metrics(path: Path, rows: list[dict[str, str]]) -> None:
+    fields = [
+        "design",
+        "platform",
+        "config_hash",
+        "param_hash",
+        "tag",
+        "status",
+        "critical_path_ns",
+        "die_area",
+        "total_power_mw",
+        "instance_area_um2",
+        "params_json",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _ok_metric(*, param_hash: str = "p1", flow_variant: str = audit._REQUIRED_FLOW_VARIANT) -> dict[str, str]:
+    return {
+        "design": "service",
+        "platform": "nangate45",
+        "config_hash": "cfg1",
+        "param_hash": param_hash,
+        "tag": "die3000",
+        "status": "ok",
+        "critical_path_ns": "9.2",
+        "die_area": "9000000",
+        "total_power_mw": "12.75",
+        "instance_area_um2": "3300000",
+        "params_json": json.dumps({"CLOCK_PERIOD": 10, "FLOW_VARIANT": flow_variant}),
+    }
+
+
+def _cluster_equivalence(path: Path, *, passed: bool = True) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "decision": "decode_score_multivalue_cluster_equivalence_pass",
+                "equivalence_pass": passed,
+                "score_tensor_hash": "score-hash",
+                "final_tensor_hash": "final-hash",
+                "semantic_profile": "shared_score_integer_contract",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _integrated_service(path: Path, *, exact_match: bool = True, include_counters: bool = True) -> None:
+    counters = {
+        "request_injection_stall_cycles": 0,
+        "arbitration_contention_cycles": 1,
+        "bank_conflict_count": 2,
+        "response_block_cycles": {"router": 0, "service": 0},
+        "shared_result": {"arbitration_contention_cycles": 1, "egress_block_cycles": 1},
+        "max_occupancy": {"router_req": 1, "router_resp": 1, "service_req": 1, "service_resp": 1},
+    }
+    if not include_counters:
+        counters.pop("max_occupancy")
+    path.write_text(
+        json.dumps(
+            {
+                "summary": {
+                    "all_hash_gates_passed": True,
+                    "all_protocol_gates_passed": True,
+                    "all_count_gates_passed": True,
+                },
+                "cases": [
+                    {
+                        "case_id": "c1_p128_b4_rr",
+                        "decision": "pass",
+                        "config": {
+                            "cluster_count": 1,
+                            "packet_w": 128,
+                            "banks": 4,
+                            "req_queue_depth": 4,
+                            "resp_queue_depth": 4,
+                            "bank_queue_depth": 4,
+                            "read_latency": 2,
+                            "arb_mode": "round_robin",
+                            "locality_burst_max": 2,
+                        },
+                        "integrated_service": {
+                            "exact_match": exact_match,
+                            "no_protocol_errors": True,
+                            "no_drop_duplicate_deadlock_timeout": True,
+                            "cycle_bound_ok": True,
+                            "request_count": 48,
+                            "wide_response_count": 48,
+                            "result_count": 16,
+                            "score_hash": "score-hash",
+                            "final_hash": "final-hash",
+                            "request_hash": "request-hash",
+                            "wide_response_matrix_hash": "wide-hash",
+                            "counters": counters,
+                            "shared_result_egress": {"documented_initiation_interval": 1},
+                        },
+                        "gates": {
+                            "hash_gate_ok": True,
+                            "protocol_gate_ok": True,
+                            "count_gate_ok": True,
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _generated_activity_manifest() -> dict:
+    return {
+        "model": "attention_decode_score_multivalue_service_activity_v1",
+        "case_id": "c1_p128_b4_rr",
+        "clock_period_ns": 10.0,
+        "cycle_count": 321,
+        "request_result_protocol_counters": {
+            "request_count": 48,
+            "wide_response_count": 48,
+            "result_count": 16,
+            "shared": {"protocol_error": False},
+        },
+        "value_bank_coverage": {
+            "addressed_banks_over_trace": [0, 1, 2],
+            "inactive_banks": [3],
+            "inactive_reason": "three_block_reference_workload",
+        },
+        "hashes": {"vcd_sha256": "vcd-hash"},
+    }
+
+
+def _adapted_manifest(tmp_path: Path) -> tuple[dict, Path, dict]:
+    manifest = {
+        "clock_period_ns": 10.0,
+        "phases": [
+            {
+                "phase": "service_window",
+                "vcd": "attention_decode_score_multivalue_service_activity.vcd",
+                "vcd_sha256": "vcd-hash",
+                "macro_activity": "service_macro_activity.json",
+                "macro_activity_sha256": "macro-sidecar-hash",
+                "sequential_register_activity": "service_seq_activity.json",
+                "sequential_register_activity_sha256": "seq-sidecar-hash",
+                "measured_cycles": 321,
+                "full_context_cycles": 321,
+                "requires_macro_activity": True,
+            }
+        ],
+    }
+    manifest_path = tmp_path / "attention_decode_score_multivalue_service_postroute_power_manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return manifest, manifest_path, {
+        "generated_activity_manifest_sha256": "generated-manifest-hash",
+        "adapted_activity_manifest_sha256": audit._sha256_file(manifest_path),
+        "vcd_sha256": "vcd-hash",
+        "cycle_count": 321,
+        "macro_counts": {"fakeram45_2048x39": 56, "fakeram45_64x32": 64},
+        "bank_coverage": {"inactive_banks": [3]},
+    }
+
+
+def _power_report(*, manifest_sha256: str, with_abs_path: bool = False) -> dict:
+    phase = {
+        "phase": "service_window",
+        "vcd": "/tmp/private/activity.vcd" if with_abs_path else "attention_decode_score_multivalue_service_activity.vcd",
+        "vcd_sha256": "vcd-hash",
+        "measured_cycles": 321,
+        "full_context_cycles": 321,
+        "annotation_gate_pass": True,
+        "sequential_register_activity_gate_pass": True,
+        "clock_period_gate_pass": True,
+        "power": {
+            "internal_w": 0.10,
+            "switching_w": 0.20,
+            "leakage_w": 0.05,
+            "total_w": 0.35,
+        },
+    }
+    return {
+        "model": "postroute_phase_vcd_power_v1",
+        "status": "activity_backed",
+        "promotion_gate_pass": True,
+        "clock_period_ns": 10.0,
+        "source_activity_manifest": "<evaluator-local-path>/attention_decode_score_multivalue_service_postroute_power_manifest.json",
+        "source_activity_manifest_sha256": manifest_sha256,
+        "phases": [phase],
+    }
+
+
+def test_select_c1_metric_rejects_ambiguity_and_flow_mismatch(tmp_path: Path) -> None:
+    metrics = tmp_path / "metrics.csv"
+    _write_metrics(metrics, [_ok_metric(flow_variant="wrong_variant")])
+    with pytest.raises(ValueError, match="expected exactly one"):
+        audit._select_c1_metric(metrics, clock_period_ns=10.0)
+
+    _write_metrics(metrics, [_ok_metric(param_hash="p1"), _ok_metric(param_hash="p2")])
+    with pytest.raises(ValueError, match="found 2"):
+        audit._select_c1_metric(metrics, clock_period_ns=10.0)
+
+
+def test_dependency_gates_reject_weak_equivalence_or_protocol(tmp_path: Path) -> None:
+    equivalence = tmp_path / "equivalence.json"
+    _cluster_equivalence(equivalence, passed=False)
+    with pytest.raises(ValueError, match="merged cluster equivalence did not pass"):
+        audit._validate_cluster_equivalence(audit._load(equivalence))
+
+    integrated = tmp_path / "integrated.json"
+    _integrated_service(integrated, exact_match=False)
+    with pytest.raises(ValueError, match="exact_result_match gate failed"):
+        audit._validate_integrated_service(audit._load(integrated))
+
+    _integrated_service(integrated, include_counters=False)
+    with pytest.raises(ValueError, match="counters incomplete"):
+        audit._validate_integrated_service(audit._load(integrated))
+
+
+def test_validate_generated_activity_manifest_and_macro_counts(tmp_path: Path) -> None:
+    activity_manifest_path = tmp_path / audit._OUTPUT_MANIFEST_NAME
+    activity_manifest_path.write_text(
+        json.dumps(_generated_activity_manifest(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    macro_manifest = {
+        "manifest_params": {
+            "score_bank_macro_count": 56,
+            "value_memory_macro_count": 64,
+        }
+    }
+    assert audit._validate_generated_activity_manifest(_generated_activity_manifest(), tmp_path)[
+        "cycle_count"
+    ] == 321
+    assert audit._validate_macro_manifest_counts(macro_manifest) == {
+        "fakeram45_2048x39": 56,
+        "fakeram45_64x32": 64,
+    }
+    macro_manifest["manifest_params"]["value_memory_macro_count"] = 63
+    with pytest.raises(ValueError, match="value-memory macro count mismatch"):
+        audit._validate_macro_manifest_counts(macro_manifest)
+
+
+def test_build_report_success_keeps_paths_portable_and_writes_markdown(tmp_path: Path) -> None:
+    config = tmp_path / "config.json"
+    _config(config)
+    metrics = tmp_path / "metrics.csv"
+    _write_metrics(metrics, [_ok_metric()])
+    equivalence = tmp_path / "equivalence.json"
+    _cluster_equivalence(equivalence)
+    integrated = tmp_path / "integrated.json"
+    _integrated_service(integrated)
+    adapted_manifest, manifest_path, adapted_meta = _adapted_manifest(tmp_path)
+
+    with mock.patch.object(audit, "generate_activity", return_value=_generated_activity_manifest()), mock.patch.object(
+        audit,
+        "_prepare_postroute_power_manifest",
+        return_value=(adapted_manifest, manifest_path, adapted_meta),
+    ), mock.patch.object(
+        audit,
+        "build_power_report",
+        return_value=_power_report(manifest_sha256=adapted_meta["adapted_activity_manifest_sha256"], with_abs_path=False),
+    ):
+        payload = audit.build_report(
+            config=config,
+            c1_metrics_csv=metrics,
+            equivalence_json=equivalence,
+            integrated_service_json=integrated,
+            orfs_design_config=Path("/orfs/flow/designs/nangate45/service/config.mk"),
+            clock_period_ns=10.0,
+            activity_dir=tmp_path / "activity",
+        )
+
+    assert payload["decision"] == "activity_backed_service_power_measured"
+    assert payload["promotion_gate_pass"] is True
+    best = payload["best"]
+    assert best["status"] == "activity_backed"
+    assert best["authoritative_composed_c1_total_ppa"]["total_power_mw"] == 12.75
+    assert best["component_service_window_energy"]["energy_j"]["dynamic"] == pytest.approx(0.30 * 321e-9 * 10.0)
+    assert best["component_service_window_energy"]["energy_j"]["leakage"] == pytest.approx(0.05 * 321e-9 * 10.0)
+    assert payload["bank3_dynamic_inactivity"]["inactive_banks"] == [3]
+    assert "/tmp/" not in json.dumps(payload, sort_keys=True)
+    assert "/orfs/" not in json.dumps(payload, sort_keys=True)
+
+    markdown_path = tmp_path / "report.md"
+    audit._write_markdown(payload, markdown_path)
+    markdown = markdown_path.read_text(encoding="utf-8")
+    assert "bank3 dynamic inactivity" in markdown
+    assert "service-window dynamic J" in markdown
+
+
+def test_build_report_marks_openroad_failure_as_measurement_failed(tmp_path: Path) -> None:
+    config = tmp_path / "config.json"
+    _config(config)
+    metrics = tmp_path / "metrics.csv"
+    _write_metrics(metrics, [_ok_metric()])
+    equivalence = tmp_path / "equivalence.json"
+    _cluster_equivalence(equivalence)
+    integrated = tmp_path / "integrated.json"
+    _integrated_service(integrated)
+    adapted_manifest, manifest_path, adapted_meta = _adapted_manifest(tmp_path)
+
+    with mock.patch.object(audit, "generate_activity", return_value=_generated_activity_manifest()), mock.patch.object(
+        audit,
+        "_prepare_postroute_power_manifest",
+        return_value=(adapted_manifest, manifest_path, adapted_meta),
+    ), mock.patch.object(
+        audit,
+        "build_power_report",
+        side_effect=RuntimeError("/orfs/private/run/6_final.odb failed after /tmp/work/vcd"),
+    ):
+        payload = audit.build_report(
+            config=config,
+            c1_metrics_csv=metrics,
+            equivalence_json=equivalence,
+            integrated_service_json=integrated,
+            orfs_design_config=Path("/orfs/flow/designs/nangate45/service/config.mk"),
+            clock_period_ns=10.0,
+            activity_dir=tmp_path / "activity",
+        )
+
+    assert payload["promotion_gate_pass"] is False
+    assert payload["candidates"][0]["status"] == "measurement_failed"
+    assert "/orfs/" not in json.dumps(payload["candidates"][0], sort_keys=True)
+    assert "/tmp/" not in json.dumps(payload["candidates"][0], sort_keys=True)
+
+
+def test_build_report_rejects_non_positive_power_components(tmp_path: Path) -> None:
+    config = tmp_path / "config.json"
+    _config(config)
+    metrics = tmp_path / "metrics.csv"
+    _write_metrics(metrics, [_ok_metric()])
+    equivalence = tmp_path / "equivalence.json"
+    _cluster_equivalence(equivalence)
+    integrated = tmp_path / "integrated.json"
+    _integrated_service(integrated)
+    adapted_manifest, manifest_path, adapted_meta = _adapted_manifest(tmp_path)
+    bad_report = _power_report(manifest_sha256=adapted_meta["adapted_activity_manifest_sha256"])
+    bad_report["phases"][0]["power"]["leakage_w"] = 0.0
+    bad_report["phases"][0]["power"]["total_w"] = 0.30
+
+    with mock.patch.object(audit, "generate_activity", return_value=_generated_activity_manifest()), mock.patch.object(
+        audit,
+        "_prepare_postroute_power_manifest",
+        return_value=(adapted_manifest, manifest_path, adapted_meta),
+    ), mock.patch.object(audit, "build_power_report", return_value=bad_report):
+        payload = audit.build_report(
+            config=config,
+            c1_metrics_csv=metrics,
+            equivalence_json=equivalence,
+            integrated_service_json=integrated,
+            orfs_design_config=Path("/orfs/flow/designs/nangate45/service/config.mk"),
+            clock_period_ns=10.0,
+            activity_dir=tmp_path / "activity",
+        )
+
+    assert payload["promotion_gate_pass"] is False
+    assert payload["candidates"][0]["status"] == "rejected_gate"
+    assert "finite positive number" in payload["candidates"][0]["failure"]["error_summary"]

--- a/tests/test_attention_decode_score_multivalue_service_activity_power.py
+++ b/tests/test_attention_decode_score_multivalue_service_activity_power.py
@@ -62,8 +62,8 @@ def _write_metrics(path: Path, rows: list[dict[str, str]]) -> None:
 
 def _ok_metric(*, param_hash: str = "p1", flow_variant: str = audit._REQUIRED_FLOW_VARIANT) -> dict[str, str]:
     return {
-        "design": "service",
-        "platform": "nangate45",
+        "design": audit._EXPECTED_DESIGN,
+        "platform": audit._EXPECTED_PLATFORM,
         "config_hash": "cfg1",
         "param_hash": param_hash,
         "tag": "die3000",
@@ -200,6 +200,24 @@ def _adapted_manifest(tmp_path: Path) -> tuple[dict, Path, dict]:
         "vcd_sha256": "vcd-hash",
         "cycle_count": 321,
         "macro_counts": {"fakeram45_2048x39": 56, "fakeram45_64x32": 64},
+        "macro_activity_contract": {
+            "profile": "multivalue_service_c1_v1",
+            "total_assignment_count": 9704,
+            "macro_classes": {
+                "fakeram45_2048x39": {
+                    "instance_scope_prefix": "score_bank",
+                    "instance_count": 56,
+                    "pins_per_instance": 91,
+                    "assignment_count": 5096,
+                },
+                "fakeram45_64x32": {
+                    "instance_scope_prefix": "gen_value_macro_backend",
+                    "instance_count": 64,
+                    "pins_per_instance": 72,
+                    "assignment_count": 4608,
+                },
+            },
+        },
         "bank_coverage": {"inactive_banks": [3]},
     }
 
@@ -212,8 +230,11 @@ def _power_report(*, manifest_sha256: str, with_abs_path: bool = False) -> dict:
         "measured_cycles": 321,
         "full_context_cycles": 321,
         "annotation_gate_pass": True,
+        "macro_activity_gate_pass": True,
+        "structural_macro_activity_gate_pass": True,
         "sequential_register_activity_gate_pass": True,
         "clock_period_gate_pass": True,
+        "macro_activity_assignment_count": 9704,
         "power": {
             "internal_w": 0.10,
             "switching_w": 0.20,
@@ -240,6 +261,12 @@ def test_select_c1_metric_rejects_ambiguity_and_flow_mismatch(tmp_path: Path) ->
 
     _write_metrics(metrics, [_ok_metric(param_hash="p1"), _ok_metric(param_hash="p2")])
     with pytest.raises(ValueError, match="found 2"):
+        audit._select_c1_metric(metrics, clock_period_ns=10.0)
+
+    wrong_design = _ok_metric()
+    wrong_design["design"] = "other_design"
+    _write_metrics(metrics, [wrong_design])
+    with pytest.raises(ValueError, match="design"):
         audit._select_c1_metric(metrics, clock_period_ns=10.0)
 
 

--- a/tests/test_extract_fakeram_vcd_activity.py
+++ b/tests/test_extract_fakeram_vcd_activity.py
@@ -4,15 +4,39 @@
 from __future__ import annotations
 
 import hashlib
+import shutil
 from pathlib import Path
+import sys
 
 import pytest
 
-from npu.eval.extract_fakeram_vcd_activity import extract_fakeram_vcd_activity
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval.extract_fakeram_vcd_activity import (
+    extract_fakeram_vcd_activity,
+    extract_multivalue_service_fakeram_vcd_activity,
+)
+from npu.eval.generate_attention_decode_score_multivalue_service_activity import (
+    _REQUIRED_SERVICE_FIELDS,
+    generate_activity,
+)
 
 
 def _write_vcd(path: Path, body: str) -> None:
     path.write_text(body, encoding="utf-8")
+
+
+def _iverilog_available() -> bool:
+    return bool(shutil.which("iverilog") and shutil.which("vvp"))
+
+
+def _service_config() -> dict[str, object]:
+    return {
+        "top_name": "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_macro_activity",
+        "attention_decode_score_multivalue_service": dict(_REQUIRED_SERVICE_FIELDS),
+    }
 
 
 def _mini_vcd() -> str:
@@ -259,3 +283,117 @@ def test_extract_fakeram_activity_rejects_inconsistent_duplicate_full_name(tmp_p
             slice_indices=(0,),
             expected_pin_count=91,
         )
+
+
+def test_extract_multivalue_service_activity_tracks_both_macro_classes(tmp_path: Path) -> None:
+    vcd_path = tmp_path / "service_macro.vcd"
+    _write_vcd(
+        vcd_path,
+        "\n".join(
+            [
+                "$timescale",
+                "1ns/1ps",
+                "$end",
+                "$scope module tb $end",
+                "$scope module dut $end",
+                "$scope module wrapper $end",
+                "$scope module score_bank $end",
+                "$scope module u_group_0_slice_0 $end",
+                "$var reg 11 a addr_in [10:0] $end",
+                "$var reg 39 b wd_in [38:0] $end",
+                "$var reg 39 c w_mask_in [38:0] $end",
+                "$var reg 1 d we_in $end",
+                "$var reg 1 e ce_in $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$scope begin gen_value_macro_backend $end",
+                "$scope begin gen_value_bank[0] $end",
+                "$scope begin gen_value_lane[0] $end",
+                "$scope module u_value_mem_lane $end",
+                "$var reg 6 f addr_in [5:0] $end",
+                "$var reg 32 g wd_in [31:0] $end",
+                "$var reg 32 h w_mask_in [31:0] $end",
+                "$var reg 1 i we_in $end",
+                "$var reg 1 j ce_in $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$enddefinitions",
+                "#0",
+                f"b{'0'*11} a",
+                f"b{'0'*39} b",
+                f"b{'0'*39} c",
+                "0d",
+                "1e",
+                f"b{'0'*6} f",
+                f"b{'0'*32} g",
+                f"b{'0'*32} h",
+                "0i",
+                "0j",
+                "#10",
+                "$dumpon",
+                "#20",
+                f"b{'1' + '0'*10} a",
+                "1d",
+                f"b{'1' + '0'*5} f",
+                "1j",
+                "#40",
+                "0d",
+                "0j",
+                "#50",
+                "$dumpoff",
+            ]
+        ),
+    )
+    payload = extract_multivalue_service_fakeram_vcd_activity(
+        vcd_path,
+        source_vcd_sha256=hashlib.sha256(vcd_path.read_bytes()).hexdigest(),
+        scope="tb/dut",
+        group_indices=(0,),
+        slice_indices=(0,),
+        value_bank_indices=(0,),
+        value_lane_indices=(0,),
+        expected_pin_count=163,
+    )
+
+    assert payload["target_profile"] == "multivalue_service_c1_v1"
+    assert len(payload["pins"]) == 163
+    by_name = {row["full_name"]: row for row in payload["pins"]}
+    assert "score_bank/u_group_0_slice_0/we_in" in by_name
+    assert "gen_value_macro_backend/gen_value_bank[0]/gen_value_lane[0]/u_value_mem_lane/ce_in" in by_name
+    contract = payload["structural_macro_contract"]
+    assert contract["total_assignment_count"] == 163
+    classes = {row["macro_name"]: row for row in contract["macro_classes"]}
+    assert classes["fakeram45_2048x39"]["assignment_count"] == 91
+    assert classes["fakeram45_64x32"]["assignment_count"] == 72
+
+
+@pytest.mark.skipif(not _iverilog_available(), reason="iverilog/vvp unavailable")
+def test_extract_multivalue_service_activity_real_generated_vcd_sidecar(tmp_path: Path) -> None:
+    activity_dir = tmp_path / "activity"
+    manifest = generate_activity(_service_config(), activity_dir)
+    vcd_path = activity_dir / manifest["artifacts"]["vcd"]
+    payload = extract_multivalue_service_fakeram_vcd_activity(
+        vcd_path,
+        source_vcd_sha256=manifest["hashes"]["vcd_sha256"],
+        scope="tb/dut",
+    )
+
+    assert payload["source_vcd"] == vcd_path.name
+    assert payload["source_vcd_sha256"] == manifest["hashes"]["vcd_sha256"]
+    assert payload["target_profile"] == "multivalue_service_c1_v1"
+    assert len(payload["pins"]) == 9704
+    classes = {row["macro_name"]: row for row in payload["structural_macro_contract"]["macro_classes"]}
+    assert classes["fakeram45_2048x39"]["instance_count"] == 56
+    assert classes["fakeram45_2048x39"]["assignment_count"] == 5096
+    assert classes["fakeram45_64x32"]["instance_count"] == 64
+    assert classes["fakeram45_64x32"]["assignment_count"] == 4608
+    assert payload["structural_macro_contract"]["total_assignment_count"] == 9704
+    full_names = {row["full_name"] for row in payload["pins"]}
+    assert "score_bank/u_group_7_slice_6/ce_in" in full_names
+    assert (
+        "gen_value_macro_backend/gen_value_bank[3]/gen_value_lane[15]/u_value_mem_lane/ce_in"
+        in full_names
+    )

--- a/tests/test_generate_attention_decode_score_multivalue_service_activity.py
+++ b/tests/test_generate_attention_decode_score_multivalue_service_activity.py
@@ -1,0 +1,112 @@
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import npu.eval.probe_attention_decode_score_multivalue_integrated_service as probe_module
+from npu.eval.generate_attention_decode_score_multivalue_service_activity import (
+    _OUTPUT_MANIFEST_NAME,
+    _OUTPUT_TOP_NAME,
+    _OUTPUT_VCD_NAME,
+    _REQUIRED_SERVICE_FIELDS,
+    _normalize_config,
+)
+
+
+def _iverilog_available() -> bool:
+    return bool(shutil.which("iverilog") and shutil.which("vvp"))
+
+
+def _config() -> dict[str, object]:
+    return {
+        "top_name": "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_macro_activity",
+        "attention_decode_score_multivalue_service": dict(_REQUIRED_SERVICE_FIELDS),
+    }
+
+
+def test_normalize_config_requires_macro_backed_c1() -> None:
+    normalized = _normalize_config(_config())
+    assert normalized["top_name"] == "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_macro_activity"
+    assert normalized["attention_decode_score_multivalue_service"] == _REQUIRED_SERVICE_FIELDS
+
+
+def test_integrated_testbench_default_clock_text_and_8ns_override() -> None:
+    values = probe_module._shared_value_matrices()
+    default_tb = probe_module._integrated_testbench(
+        top_name="demo",
+        cluster_count=1,
+        values=values,
+    )
+    fast_tb = probe_module._integrated_testbench(
+        top_name="demo",
+        cluster_count=1,
+        values=values,
+        clock_period_ns=8.0,
+    )
+    assert "  always #5 clk = ~clk;" in default_tb
+    assert "always #4 clk = ~clk;" in fast_tb
+    assert "always #4 clk = ~clk;" not in default_tb
+
+
+def test_activity_generator_source_has_no_artificial_macro_touch() -> None:
+    source = (REPO_ROOT / "npu/eval/generate_attention_decode_score_multivalue_service_activity.py").read_text(
+        encoding="utf-8"
+    )
+    assert "_inject_bank3_trace_touch" not in source
+    assert "force dut" not in source
+    assert "release dut" not in source
+    assert "post-completion trace touch" not in source
+
+
+@pytest.mark.skipif(not _iverilog_available(), reason="iverilog/vvp unavailable")
+def test_generate_service_activity_is_deterministic(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(_config(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    out_a = tmp_path / "run_a"
+    out_b = tmp_path / "run_b"
+    script = REPO_ROOT / "npu/eval/generate_attention_decode_score_multivalue_service_activity.py"
+    for out_dir in (out_a, out_b):
+        run = subprocess.run(
+            [sys.executable, str(script), "--config", str(config_path), "--out-dir", str(out_dir)],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=240,
+        )
+        assert run.returncode == 0, f"generator failed:\nstdout:\n{run.stdout}\nstderr:\n{run.stderr}"
+
+    manifest_a = json.loads((out_a / _OUTPUT_MANIFEST_NAME).read_text(encoding="utf-8"))
+    manifest_b = json.loads((out_b / _OUTPUT_MANIFEST_NAME).read_text(encoding="utf-8"))
+    assert manifest_a == manifest_b
+    assert manifest_a["cycle_count"] > 0
+    assert manifest_a["clock_period_ns"] == 10.0
+    assert manifest_a["request_result_protocol_counters"]["request_count"] == 48
+    assert manifest_a["request_result_protocol_counters"]["wide_response_count"] == 48
+    assert manifest_a["request_result_protocol_counters"]["result_count"] == 16
+    assert manifest_a["request_result_protocol_counters"]["shared"]["protocol_error"] is False
+    assert manifest_a["value_bank_coverage"]["addressed_banks_over_trace"] == [0, 1, 2]
+    assert manifest_a["value_bank_coverage"]["request_banks"] == [0, 1, 2]
+    assert manifest_a["value_bank_coverage"]["inactive_banks"] == [3]
+    assert manifest_a["value_bank_coverage"]["inactive_reason"] == "three_block_reference_workload"
+    assert manifest_a["compiled_behavioral_models"] == ["fakeram45_2048x39", "fakeram45_64x32"]
+    assert manifest_a["artifacts"]["vcd"] == _OUTPUT_VCD_NAME
+    assert not manifest_a["artifacts"]["vcd"].startswith("/")
+    assert str(REPO_ROOT / "npu/eval") not in json.dumps(manifest_a, sort_keys=True)
+    assert "bank3 switching" in " ".join(manifest_a["scope"]["remaining"])
+
+    top_text = (out_a / _OUTPUT_TOP_NAME).read_text(encoding="utf-8")
+    assert "fakeram45_2048x39" in top_text
+    assert "fakeram45_64x32" in top_text
+
+    vcd_a = (out_a / _OUTPUT_VCD_NAME).read_bytes()
+    vcd_b = (out_b / _OUTPUT_VCD_NAME).read_bytes()
+    assert vcd_a == vcd_b
+    assert manifest_a["hashes"]["vcd_sha256"] == manifest_b["hashes"]["vcd_sha256"]


### PR DESCRIPTION
## Summary
- generate deterministic macro-backed c1 integrated-service VCD activity without artificial bank toggles
- annotate all 56 score-bank and 64 value-memory FakeRAM macros, with strict structural assignment gates
- audit exact c1 routed service-window power after equivalence, integrated-service, and PNR dependencies
- add a dependency-gated L2 remote-evaluator request; this does not claim total-token energy

## Validation
- `251 passed` across extractor, service activity/audit, cluster compatibility, and L2 generator tests
- `python scripts/validate_runs.py --skip_eval_queue`
- `python -m py_compile` for changed Python entry points
- `git diff --check origin/master...HEAD`

## Dispatch state
The new activity-power item must remain blocked until integrated-service r1 and c1 composed-service PNR are merged/materialized. The existing service r1 item remains the single remote-evaluator prerequisite; no duplicate job is introduced.
