### PR TITLE
Add measured multivalue service frontier

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -54,6 +54,15 @@ _MULTIVALUE_INTEGRATED_SERVICE_BASE_ITEM = (
 _MULTIVALUE_INTEGRATED_SERVICE_DEFAULT_ITEM = (
     "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1"
 )
+_MULTIVALUE_CLUSTER_FRONTIER_BASE_ITEM = (
+    "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1"
+)
+_MULTIVALUE_CLUSTER_FRONTIER_DEFAULT_ITEM = (
+    "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1"
+)
+_MULTIVALUE_SERVICE_ACTIVITY_POWER_DEFAULT_ITEM = (
+    "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1"
+)
 _MULTIVALUE_SERVICE_C1_PNR_ITEM = (
     "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1"
 )
@@ -124,6 +133,14 @@ def _gqa_evidence_version_for_consumer(item_id: str) -> str:
     return "v2" if revision >= 2 else "v1"
 
 
+def _item_version_retry_rank(candidate: str) -> tuple[int, int]:
+    version_match = _VERSION_SUFFIX_RE.search(_retry_base(candidate))
+    version = int(version_match.group(1)) if version_match else 1
+    retry_match = _RETRY_SUFFIX_RE.search(candidate)
+    retry = int(retry_match.group(0)[2:]) if retry_match else 0
+    return version, retry
+
+
 def _cluster_activity_power_revision(item_id: str) -> int:
     match = _VERSION_SUFFIX_RE.search(_retry_base(item_id))
     return int(match.group(1)) if match else 1
@@ -183,6 +200,34 @@ def _multivalue_integrated_service_item_for_consumer(
         return int(match.group(0)[2:])
 
     return max(candidate_item_ids, key=_rank)
+
+
+def _multivalue_cluster_frontier_item_for_consumer(
+    *, depends_on_item_ids: list[str] | None
+) -> str:
+    prefix = _MULTIVALUE_CLUSTER_FRONTIER_BASE_ITEM
+    candidate_item_ids = [
+        str(dep).strip()
+        for dep in (depends_on_item_ids or [])
+        if str(dep).strip() == prefix or str(dep).strip().startswith(f"{prefix}_r")
+    ]
+    if not candidate_item_ids:
+        return _MULTIVALUE_CLUSTER_FRONTIER_DEFAULT_ITEM
+    return max(candidate_item_ids, key=_item_version_retry_rank)
+
+
+def _multivalue_service_activity_power_item_for_consumer(
+    *, depends_on_item_ids: list[str] | None
+) -> str:
+    prefix = "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_"
+    candidate_item_ids = [
+        str(dep).strip()
+        for dep in (depends_on_item_ids or [])
+        if str(dep).strip().startswith(prefix)
+    ]
+    if not candidate_item_ids:
+        return _MULTIVALUE_SERVICE_ACTIVITY_POWER_DEFAULT_ITEM
+    return max(candidate_item_ids, key=_item_version_retry_rank)
 
 
 def _proposal_dir(repo_root: Path, proposal_path: str | None) -> Path | None:
@@ -7396,6 +7441,62 @@ def _decoder_attention_decode_score_multivalue_service_activity_power_evidence(
     }
 
 
+def _decoder_attention_decode_score_multivalue_service_measured_frontier_evidence(
+    *, item_id: str, depends_on_item_ids: list[str] | None = None
+) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    prior_cluster_frontier_item = _multivalue_cluster_frontier_item_for_consumer(
+        depends_on_item_ids=depends_on_item_ids
+    )
+    prior_cluster_frontier = (
+        f"{base}/decoder_attention_decode_score_multivalue_cluster_frontier__"
+        f"{prior_cluster_frontier_item}.json"
+    )
+    service_activity_power_item = _multivalue_service_activity_power_item_for_consumer(
+        depends_on_item_ids=depends_on_item_ids
+    )
+    service_activity_power = (
+        f"{base}/decoder_attention_decode_score_multivalue_service_activity_power__"
+        f"{service_activity_power_item}.json"
+    )
+    out = f"{base}/decoder_attention_decode_score_multivalue_service_measured_frontier__{item_id}.json"
+    report = f"{base}/decoder_attention_decode_score_multivalue_service_measured_frontier__{item_id}.md"
+    return {
+        "inputs": {
+            "decode_score_multivalue_service_measured_frontier_prior_cluster_frontier": (
+                prior_cluster_frontier
+            ),
+            "decode_score_multivalue_service_measured_frontier_service_activity_power": (
+                service_activity_power
+            ),
+            "decode_score_multivalue_service_measured_frontier_out": out,
+            "decode_score_multivalue_service_measured_frontier_report": report,
+            "decode_score_multivalue_service_measured_frontier_scope": (
+                "Replace the prior shared-score multivalue cluster frontier area/energy proxy with the "
+                "measured composed-service c1 anchor only. Keep c2+ service points blocked/unpromoted, "
+                "scale the direct routed microkernel service-window activity explicitly into the "
+                "Llama7B context, preserve the exact integer precision contract unchanged, do not claim "
+                "total-token energy, and leave broader SRAM, NoC, HBM, producer, and dense energy "
+                "outside this measured-service frontier."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decode_score_multivalue_service_measured_frontier",
+                "run": (
+                    "python3 -m npu.eval.audit_attention_decode_score_multivalue_service_measured_frontier "
+                    f"--prior-cluster-frontier-json {prior_cluster_frontier} "
+                    f"--service-activity-power-json {service_activity_power} "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            }
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_decode_score_multivalue_gqa_group_frontier_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     evidence_version = _gqa_evidence_version_for_consumer(item_id)
@@ -11057,6 +11158,7 @@ def _build_payload(
         "decoder_attention_decode_score_multivalue_cluster_activity_power",
         "decoder_attention_decode_score_multivalue_integrated_service",
         "decoder_attention_decode_score_multivalue_service_activity_power",
+        "decoder_attention_decode_score_multivalue_service_measured_frontier",
         "decoder_attention_decode_score_multivalue_gqa_group_activity_power",
         "decoder_attention_decode_score_tile_frontier",
         "decoder_attention_decode_score_local_cluster_frontier",
@@ -11325,6 +11427,11 @@ def _build_payload(
             )
         elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_service_activity_power":
             decoder_evidence = _decoder_attention_decode_score_multivalue_service_activity_power_evidence(
+                item_id=item_id,
+                depends_on_item_ids=depends_on_item_ids,
+            )
+        elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_service_measured_frontier":
+            decoder_evidence = _decoder_attention_decode_score_multivalue_service_measured_frontier_evidence(
                 item_id=item_id,
                 depends_on_item_ids=depends_on_item_ids,
             )

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -8477,9 +8477,11 @@ def test_service_measured_frontier_request_manifests_remain_dependency_gated() -
         assert "July 25, 2026" in item["notes"]
         assert "only c1 is a measured composed-service anchor" in item["notes"]
         assert "c2+ remain blocked/unpromoted" in item["notes"]
-        assert "scale the direct routed microkernel activity explicitly to the Llama7B context" in item[
-            "expected_result"
-        ]["reason"]
+        expected_reason = item["expected_result"]["reason"]
+        assert "24-active-context-token" in expected_reason
+        assert "ceil(sequence_length / 24)" in expected_reason
+        assert "final partial window" in expected_reason
+        assert "128 tokens labeled only as capacity" in expected_reason
         assert "c2+ blocked/unpromoted" in item["expected_result"]["reason"]
         assert "exact integer precision unchanged" in item["expected_result"]["reason"]
         assert "broader SRAM/NoC/HBM/producer/dense energy remains outside" in item[

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -8440,6 +8440,53 @@ def test_service_activity_power_request_manifests_remain_dependency_gated() -> N
         assert "bank3 inactivity unforced" in item["expected_result"]["reason"]
 
 
+def test_service_measured_frontier_request_manifests_remain_dependency_gated() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    proposal_dir = (
+        repo_root
+        / "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1"
+    )
+    expected_depends = {
+        "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
+        "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
+    }
+
+    for manifest_name, items_key in (
+        ("proposal.json", "required_evaluations"),
+        ("evaluation_requests.json", "requested_items"),
+    ):
+        manifest = json.loads((proposal_dir / manifest_name).read_text(encoding="utf-8"))
+        if manifest_name == "evaluation_requests.json":
+            note = manifest["source_commit_note"]
+            assert "Replace with the merge commit" in note
+            assert "July 25, 2026" in note
+            assert "pending implementation/dependency merge" in note
+            assert "only c1 is a measured composed-service anchor" in note
+            assert "c2+ remain blocked/unpromoted" in note
+        item = manifest[items_key][0]
+        assert (
+            item["item_id"]
+            == "l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1"
+        )
+        assert set(item["depends_on_item_ids"]) == expected_depends
+        assert item["requires_merged_inputs"] is True
+        assert item["requires_materialized_refs"] is True
+        assert item["status"] == "pending_implementation_merge"
+        assert "dependency-gated" in item["notes"]
+        assert "pending implementation/dependency merge" in item["notes"]
+        assert "July 25, 2026" in item["notes"]
+        assert "only c1 is a measured composed-service anchor" in item["notes"]
+        assert "c2+ remain blocked/unpromoted" in item["notes"]
+        assert "scale the direct routed microkernel activity explicitly to the Llama7B context" in item[
+            "expected_result"
+        ]["reason"]
+        assert "c2+ blocked/unpromoted" in item["expected_result"]["reason"]
+        assert "exact integer precision unchanged" in item["expected_result"]["reason"]
+        assert "broader SRAM/NoC/HBM/producer/dense energy remains outside" in item[
+            "expected_result"
+        ]["reason"]
+
+
 def test_gqa_folded_activity_request_manifests_require_cluster_activity_power_v16() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     proposal_dir = (
@@ -9171,6 +9218,103 @@ def test_generate_l2_campaign_task_cluster_frontier_uses_cluster_activity_v1_dep
                 "decoder_attention_decode_score_multivalue_cluster_activity_power__"
                 "l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1.json"
                 in run
+            )
+
+
+def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_measured_frontier() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=(
+                        "l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1"
+                    ),
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_decode_score_multivalue_service_measured_frontier",
+                    evaluation_mode="frontier_recost",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
+                        "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
+                    ],
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands[:2]] == [
+                "audit_decode_score_multivalue_service_measured_frontier",
+                "validate_runs",
+            ]
+            assert (
+                "-m npu.eval.audit_attention_decode_score_multivalue_service_measured_frontier"
+                in run
+            )
+            assert (
+                "--prior-cluster-frontier-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_decode_score_multivalue_cluster_frontier__"
+                "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1.json"
+                in run
+            )
+            assert (
+                "--service-activity-power-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_decode_score_multivalue_service_activity_power__"
+                "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1.json"
+                in run
+            )
+            assert decoder_inputs[
+                "decode_score_multivalue_service_measured_frontier_prior_cluster_frontier"
+            ].endswith(
+                "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1.json"
+            )
+            assert decoder_inputs[
+                "decode_score_multivalue_service_measured_frontier_service_activity_power"
+            ].endswith(
+                "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1.json"
+            )
+            assert "Replace the prior shared-score multivalue cluster frontier area/energy proxy" in (
+                decoder_inputs["decode_score_multivalue_service_measured_frontier_scope"]
+            )
+            assert "Keep c2+ service points blocked/unpromoted" in decoder_inputs[
+                "decode_score_multivalue_service_measured_frontier_scope"
+            ]
+            assert "direct routed microkernel service-window activity explicitly into the Llama7B context" in (
+                decoder_inputs["decode_score_multivalue_service_measured_frontier_scope"]
+            )
+            assert "exact integer precision contract unchanged" in decoder_inputs[
+                "decode_score_multivalue_service_measured_frontier_scope"
+            ]
+            assert "do not claim total-token energy" in decoder_inputs[
+                "decode_score_multivalue_service_measured_frontier_scope"
+            ]
+            assert "broader SRAM, NoC, HBM, producer, and dense energy outside" in decoder_inputs[
+                "decode_score_multivalue_service_measured_frontier_scope"
+            ]
+            assert decoder_inputs["decode_score_multivalue_service_measured_frontier_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_decode_score_multivalue_service_measured_frontier__"
+                "l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1.json"
+            )
+            assert any(
+                output.endswith(
+                    "decoder_attention_decode_score_multivalue_service_measured_frontier__"
+                    "l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1.md"
+                )
+                for output in work_item.task_request.request_payload["task"]["expected_outputs"]
             )
 
 

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/evaluation_requests.json
@@ -48,7 +48,7 @@
       },
       "expected_result": {
         "direction": "recast_shared_score_multivalue_cluster_frontier",
-        "reason": "Use deterministic integrated-service completion ratios from compact r1 evidence, once merged/materialized, to scale activity-backed full-context per-wave cluster service cycles for c1/c2/c4/c8/c16/c32, while preserving strict activity-backed power requirements, withholding total-token energy, and explicitly limiting the calibration to the probe's 128-context, 128-value-dimension, no-HBM, no-service-fabric-PPA/energy scope."
+        "reason": "Use deterministic integrated-service completion ratios from compact r1 evidence, once merged/materialized, to scale activity-backed full-context per-wave cluster service cycles for c1/c2/c4/c8/c16/c32, while preserving strict activity-backed power requirements, withholding total-token energy, and explicitly limiting the calibration to the probe's exercised 3 blocks x 8 context entries = 24 active context tokens, 128-token maximum capacity, 128-value-dimension, no-HBM, no-service-fabric-PPA/energy scope."
       },
       "status": "pending_implementation_merge",
       "notes": "This revision remains dependency-gated and is not ready for normal dispatch. As of July 24, 2026, integrated-service compact r1 evidence is READY but not yet materialized, activity-power v16 remains pending, and both inputs must merge/materialize before dispatch."

--- a/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/proposal.json
@@ -95,7 +95,7 @@
       },
       "expected_result": {
         "direction": "recast_shared_score_multivalue_cluster_frontier",
-        "reason": "Use deterministic integrated-service completion ratios from compact r1 evidence, once merged/materialized, to scale activity-backed full-context per-wave cluster service cycles for c1/c2/c4/c8/c16/c32, while preserving strict activity-backed power requirements, withholding total-token energy, and explicitly limiting the calibration to the probe's 128-context, 128-value-dimension, no-HBM, no-service-fabric-PPA/energy scope."
+        "reason": "Use deterministic integrated-service completion ratios from compact r1 evidence, once merged/materialized, to scale activity-backed full-context per-wave cluster service cycles for c1/c2/c4/c8/c16/c32, while preserving strict activity-backed power requirements, withholding total-token energy, and explicitly limiting the calibration to the probe's exercised 3 blocks x 8 context entries = 24 active context tokens, 128-token maximum capacity, 128-value-dimension, no-HBM, no-service-fabric-PPA/energy scope."
       },
       "status": "pending_implementation_merge",
       "notes": "This revision consumes the compact integrated-service r1 evidence path rather than reusing no-stall cycles directly, but as of July 24, 2026 it remains dependency-gated and is not ready for normal dispatch: integrated-service compact r1 is READY but not yet materialized, activity-power v16 remains pending, and both inputs must merge/materialize before dispatch."
@@ -118,7 +118,7 @@
     "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/evaluation_requests.json"
   ],
   "remaining_abstractions_after_this_step": [
-    "Integrated-service completion ratios calibrate only latency and service-window duration from a bounded 128-context/128-value-dimension microkernel probe.",
+    "Integrated-service completion ratios calibrate only latency and service-window duration from a bounded microkernel probe exercising 3 blocks x 8 context entries = 24 active context tokens at 128-value dimension; 128 tokens is maximum capacity, not the measured active context.",
     "Value-memory composition is still external to this cluster-level recost and must be closed separately.",
     "NoC composition remains open; this frontier does not include full transport contention or routing-energy closure.",
     "HBM service remains open; this recost is not a full memory-system closure.",

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1/evaluation_requests.json
@@ -5,7 +5,7 @@
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1",
       "task_type": "l2_campaign",
-      "objective": "Replace the prior shared-score multivalue cluster frontier area/energy proxy with the measured composed-service c1 anchor, scaling only the direct routed microkernel activity into the Llama7B context while keeping c2+ blocked/unpromoted.",
+      "objective": "Replace the prior shared-score multivalue cluster frontier area/energy proxy with the measured composed-service c1 anchor, scaling the direct routed 24-active-context-token microkernel activity into the Llama7B context while keeping the 128-token capacity distinct and c2+ blocked/unpromoted.",
       "evaluation_mode": "frontier_recost",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_service_measured_frontier",
       "comparison_role": "measured_c1_service_frontier_anchor_replacement",
@@ -18,7 +18,7 @@
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "replace_multivalue_cluster_area_energy_with_measured_c1_service_anchor",
-        "reason": "Replace rather than add the old cluster area/energy proxy, use only the measured composed-service c1 anchor, scale the direct routed microkernel activity explicitly to the Llama7B context, keep c2+ blocked/unpromoted, preserve exact integer precision unchanged, and withhold any total-token energy claim while broader SRAM/NoC/HBM/producer/dense energy remains outside."
+        "reason": "Replace rather than add the old cluster area/energy proxy, use only the measured composed-service c1 anchor, scale the direct routed 24-active-context-token window with ceil(sequence_length / 24), conservatively charge the final partial window, keep 128 tokens labeled only as capacity, keep c2+ blocked/unpromoted, preserve exact integer precision unchanged, and withhold any total-token energy claim while broader SRAM/NoC/HBM/producer/dense energy remains outside."
       },
       "status": "pending_implementation_merge",
       "notes": "This request remains dependency-gated and pending implementation/dependency merge. As of July 25, 2026, only c1 is a measured composed-service anchor, c2+ remain blocked/unpromoted, and the measured-service frontier audit CLI plus both dependency artifacts must merge/materialize before normal dispatch."

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1",
+  "source_commit_note": "Replace with the merge commit that contains this measured c1 service-frontier wiring before dispatch. As of July 25, 2026, this request remains pending implementation/dependency merge because only c1 is a measured composed-service anchor, c2+ remain blocked/unpromoted, and the measured-service frontier audit CLI plus both dependency artifacts are not all merged/materialized.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Replace the prior shared-score multivalue cluster frontier area/energy proxy with the measured composed-service c1 anchor, scaling only the direct routed microkernel activity into the Llama7B context while keeping c2+ blocked/unpromoted.",
+      "evaluation_mode": "frontier_recost",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_service_measured_frontier",
+      "comparison_role": "measured_c1_service_frontier_anchor_replacement",
+      "paired_baseline_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
+        "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "replace_multivalue_cluster_area_energy_with_measured_c1_service_anchor",
+        "reason": "Replace rather than add the old cluster area/energy proxy, use only the measured composed-service c1 anchor, scale the direct routed microkernel activity explicitly to the Llama7B context, keep c2+ blocked/unpromoted, preserve exact integer precision unchanged, and withhold any total-token energy claim while broader SRAM/NoC/HBM/producer/dense energy remains outside."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "This request remains dependency-gated and pending implementation/dependency merge. As of July 25, 2026, only c1 is a measured composed-service anchor, c2+ remain blocked/unpromoted, and the measured-service frontier audit CLI plus both dependency artifacts must merge/materialize before normal dispatch."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1/proposal.json
@@ -8,13 +8,13 @@
   "abstraction_layer": "decoder_attention_decode_score_multivalue_service_measured_frontier",
   "hypothesis": "Once the service-aware shared-score multivalue cluster frontier r1 and the strict c1 composed-service activity-power audit are both merged/materialized, the Llama7B frontier can replace rather than add the old cluster area/energy proxy with a measured composed-service c1 anchor while keeping c2+ blocked/unpromoted, preserving exact integer precision, and keeping broader system energy outside.",
   "direct_comparison": {
-    "primary_question": "How does the shared-score multivalue Llama7B frontier change when the prior cluster area/energy proxy is replaced with the measured composed-service c1 anchor and only the direct routed microkernel activity is scaled into the Llama7B context?",
+    "primary_question": "How does the shared-score multivalue Llama7B frontier change when the prior cluster area/energy proxy is replaced with the measured composed-service c1 anchor and the direct routed 24-active-context-token microkernel activity is scaled into the Llama7B context while 128 tokens remains explicitly a capacity bound?",
     "baseline": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
     "include": [
       "only c1 as the measured composed-service anchor",
       "the prior service-aware shared-score multivalue cluster frontier structure from l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
       "strict c1 direct routed service-window activity from l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
-      "explicit scaling from the routed microkernel measurement into the Llama7B context",
+      "explicit ceil(sequence_length / 24) scaling from the routed 24-active-context-token microkernel measurement into the Llama7B context, with the final partial window conservatively charged",
       "exact integer precision unchanged from the inherited equivalence-backed frontier contract",
       "repo-portable JSON and Markdown outputs only from an evidence-only evaluator"
     ],
@@ -49,7 +49,7 @@
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1",
       "task_type": "l2_campaign",
-      "objective": "Replace the prior shared-score multivalue cluster frontier area/energy proxy with the measured composed-service c1 anchor, scaling only the direct routed microkernel activity into the Llama7B context while keeping c2+ blocked/unpromoted.",
+      "objective": "Replace the prior shared-score multivalue cluster frontier area/energy proxy with the measured composed-service c1 anchor, scaling the direct routed 24-active-context-token microkernel activity into the Llama7B context while keeping the 128-token capacity distinct and c2+ blocked/unpromoted.",
       "evaluation_mode": "frontier_recost",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_service_measured_frontier",
       "comparison_role": "measured_c1_service_frontier_anchor_replacement",
@@ -62,7 +62,7 @@
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "replace_multivalue_cluster_area_energy_with_measured_c1_service_anchor",
-        "reason": "Use only the measured composed-service c1 anchor to replace the old cluster area/energy proxy, scale the direct routed microkernel activity explicitly to the Llama7B context, keep c2+ blocked/unpromoted, preserve exact integer precision unchanged, and withhold any total-token energy claim while broader SRAM/NoC/HBM/producer/dense energy remains outside."
+        "reason": "Use only the measured composed-service c1 anchor to replace the old cluster area/energy proxy, scale the direct routed 24-active-context-token window with ceil(sequence_length / 24), conservatively charge the final partial window, keep 128 tokens labeled only as capacity, keep c2+ blocked/unpromoted, preserve exact integer precision unchanged, and withhold any total-token energy claim while broader SRAM/NoC/HBM/producer/dense energy remains outside."
       },
       "status": "pending_implementation_merge",
       "notes": "This request remains dependency-gated and pending implementation/dependency merge. As of July 25, 2026, only c1 is a measured composed-service anchor, c2+ remain blocked/unpromoted, and the measured-service frontier audit CLI plus both dependency artifacts must merge/materialize before normal dispatch."
@@ -80,7 +80,7 @@
   ],
   "remaining_abstractions_after_this_step": [
     "Only c1 is measured; c2 and higher service points remain blocked/unpromoted.",
-    "The direct routed microkernel activity is scaled into the Llama7B context, not remeasured at full system scope.",
+    "The direct routed microkernel activity covers 24 active context tokens, while 128 tokens is only the measured service capacity. Dynamic energy is scaled with ceil(sequence_length / 24), conservatively charging the final partial window, rather than remeasured at full system scope.",
     "This is not a total-token energy claim.",
     "Broader SRAM, NoC, HBM, producer, and dense energy remain outside this frontier replacement.",
     "The exact integer precision contract is inherited unchanged rather than reopened here."

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1/proposal.json
@@ -1,0 +1,88 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1",
+  "created_utc": "2026-07-25T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Measured c1 composed-service frontier replacement for multivalue Llama7B",
+  "abstraction_layer": "decoder_attention_decode_score_multivalue_service_measured_frontier",
+  "hypothesis": "Once the service-aware shared-score multivalue cluster frontier r1 and the strict c1 composed-service activity-power audit are both merged/materialized, the Llama7B frontier can replace rather than add the old cluster area/energy proxy with a measured composed-service c1 anchor while keeping c2+ blocked/unpromoted, preserving exact integer precision, and keeping broader system energy outside.",
+  "direct_comparison": {
+    "primary_question": "How does the shared-score multivalue Llama7B frontier change when the prior cluster area/energy proxy is replaced with the measured composed-service c1 anchor and only the direct routed microkernel activity is scaled into the Llama7B context?",
+    "baseline": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
+    "include": [
+      "only c1 as the measured composed-service anchor",
+      "the prior service-aware shared-score multivalue cluster frontier structure from l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
+      "strict c1 direct routed service-window activity from l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
+      "explicit scaling from the routed microkernel measurement into the Llama7B context",
+      "exact integer precision unchanged from the inherited equivalence-backed frontier contract",
+      "repo-portable JSON and Markdown outputs only from an evidence-only evaluator"
+    ],
+    "exclude": [
+      "do not add the measured c1 anchor on top of the old cluster area/energy proxy; replace it",
+      "do not promote c2 or higher service points; they remain blocked/unpromoted without their own measured anchors",
+      "do not claim total-token energy",
+      "do not include broader SRAM, NoC, HBM, producer, or dense energy"
+    ],
+    "metrics": [
+      "cluster_count",
+      "latency_us",
+      "token_throughput_per_s",
+      "service_window_total_energy_j",
+      "measured_anchor_kind",
+      "precision_contract_status",
+      "c2plus_status"
+    ]
+  },
+  "expected_benefit": [
+    "replaces the old cluster area/energy proxy with a measured composed-service c1 anchor instead of layering a second energy term on top",
+    "keeps the measured-service substitution explicit and limited to the routed microkernel activity scaled into the Llama7B context",
+    "preserves the exact integer precision contract while leaving broader energy closure work outside"
+  ],
+  "risks": [
+    "a c1-only measured anchor may worsen the retained frontier relative to the prior cluster proxy",
+    "c2 and higher service points remain blocked/unpromoted until they have their own measured anchors",
+    "this frontier replacement still excludes broader SRAM, NoC, HBM, producer, and dense energy, so it is not a total-token energy result",
+    "the request remains pending implementation/dependency merge until the new audit CLI and both dependency artifacts are merged/materialized"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Replace the prior shared-score multivalue cluster frontier area/energy proxy with the measured composed-service c1 anchor, scaling only the direct routed microkernel activity into the Llama7B context while keeping c2+ blocked/unpromoted.",
+      "evaluation_mode": "frontier_recost",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_service_measured_frontier",
+      "comparison_role": "measured_c1_service_frontier_anchor_replacement",
+      "paired_baseline_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
+        "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "replace_multivalue_cluster_area_energy_with_measured_c1_service_anchor",
+        "reason": "Use only the measured composed-service c1 anchor to replace the old cluster area/energy proxy, scale the direct routed microkernel activity explicitly to the Llama7B context, keep c2+ blocked/unpromoted, preserve exact integer precision unchanged, and withhold any total-token energy claim while broader SRAM/NoC/HBM/producer/dense energy remains outside."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "This request remains dependency-gated and pending implementation/dependency merge. As of July 25, 2026, only c1 is a measured composed-service anchor, c2+ remain blocked/unpromoted, and the measured-service frontier audit CLI plus both dependency artifacts must merge/materialize before normal dispatch."
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_frontier__l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_activity_power__l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1.json",
+    "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1/proposal.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/audit_attention_decode_score_multivalue_service_measured_frontier.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ],
+  "remaining_abstractions_after_this_step": [
+    "Only c1 is measured; c2 and higher service points remain blocked/unpromoted.",
+    "The direct routed microkernel activity is scaled into the Llama7B context, not remeasured at full system scope.",
+    "This is not a total-token energy claim.",
+    "Broader SRAM, NoC, HBM, producer, and dense energy remain outside this frontier replacement.",
+    "The exact integer precision contract is inherited unchanged rather than reopened here."
+  ]
+}

--- a/npu/eval/audit_attention_decode_score_multivalue_cluster_frontier.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_cluster_frontier.py
@@ -9,6 +9,9 @@ import math
 from pathlib import Path
 from typing import Any
 
+from npu.eval.probe_attention_decode_score_multivalue_integrated_service import (
+    _workload_contract as _expected_workload_contract,
+)
 
 JsonDict = dict[str, Any]
 
@@ -39,7 +42,7 @@ _EXPECTED_SERVICE_CASE_IDS = {
 }
 _SERVICE_CALIBRATION_LIMITATIONS = [
     (
-        "Integrated-service calibration comes from a 128-context, 128-value-dimension "
+        "Integrated-service calibration comes from a 24-active-context/128-capacity/128-value-dimension "
         "shared-score microkernel probe rather than full decoder sequence composition."
     ),
     "HBM/DRAM service is excluded from the integrated-service calibration.",
@@ -157,6 +160,7 @@ def _validated_activity_best(activity_report: JsonDict) -> JsonDict:
 def _service_ratio_cases(
     service_report: JsonDict, cluster_counts: list[int]
 ) -> tuple[dict[int, JsonDict], JsonDict]:
+    expected_workload = _expected_workload_contract()
     if service_report.get("model") != _EXPECTED_INTEGRATED_SERVICE_MODEL:
         raise ValueError("integrated-service report has an unexpected model")
     if service_report.get("decision") != _EXPECTED_INTEGRATED_SERVICE_DECISION:
@@ -164,6 +168,8 @@ def _service_ratio_cases(
     diagnosis = service_report.get("diagnosis")
     if not isinstance(diagnosis, dict) or diagnosis.get("decision") != _EXPECTED_INTEGRATED_SERVICE_DIAGNOSIS:
         raise ValueError("integrated-service report has an unexpected diagnosis")
+    if service_report.get("workload_contract") != expected_workload:
+        raise ValueError("integrated-service report workload contract mismatch")
     cases = service_report.get("cases")
     if not isinstance(cases, list) or not cases:
         raise ValueError("integrated-service report lacks cases")
@@ -239,8 +245,7 @@ def _service_ratio_cases(
         "ratio_definition": "integrated_service.completion_cycle / baseline_no_stall.completion_cycle",
         "scaled_target": "activity-backed full-context per-wave cluster service cycles",
         "probe_contract": {
-            "microkernel_context_tokens": 128,
-            "microkernel_value_dim": 128,
+            **expected_workload,
             "consumed_case_ids": [
                 _EXPECTED_SERVICE_CASE_IDS[count] for count in sorted(requested)
             ],
@@ -547,8 +552,8 @@ def build_report(
         "remaining_abstractions": [
             (
                 "On-chip shared value-service latency is calibrated from deterministic c1/c2/c4/c8/c16/c32 "
-                "integrated-service ratios, but the calibration is still a 128-context/128-value-dimension "
-                "microkernel proxy rather than full decoder memory-system composition."
+                "integrated-service ratios, but the calibration is still a 24-active-context/128-capacity/"
+                "128-value-dimension microkernel proxy rather than full decoder memory-system composition."
             ),
             (
                 "Producer, Q/K/V transport, NoC, off-cluster value memory, HBM/DRAM, "

--- a/npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py
@@ -25,6 +25,10 @@ from npu.eval.generate_attention_decode_score_multivalue_service_activity import
     _OUTPUT_VCD_NAME,
     generate_activity,
 )
+from npu.eval.probe_attention_decode_score_multivalue_integrated_service import (
+    _workload_contract as _expected_workload_contract,
+    _workload_expected_counts,
+)
 from npu.synth.run_postroute_vcd_power import build_report as build_power_report
 
 JsonDict = dict[str, Any]
@@ -48,9 +52,6 @@ _EXPECTED_MACRO_COUNTS = {
 }
 _SCORE_PINS_PER_MACRO = 11 + 39 + 39 + 1 + 1
 _VALUE_PINS_PER_MACRO = 6 + 32 + 32 + 1 + 1
-_EXPECTED_REQUEST_COUNT = 48
-_EXPECTED_WIDE_RESPONSE_COUNT = 48
-_EXPECTED_RESULT_COUNT = 16
 _POSTROUTE_MANIFEST_NAME = "attention_decode_score_multivalue_service_postroute_power_manifest.json"
 _POSTROUTE_MACRO_ACTIVITY_NAME = (
     "attention_decode_score_multivalue_service_fakeram_macro_pin_vcd_activity_v1.json"
@@ -231,6 +232,10 @@ def _validate_cluster_equivalence(payload: JsonDict) -> JsonDict:
 
 
 def _validate_integrated_service(payload: JsonDict) -> JsonDict:
+    expected_workload = _expected_workload_contract()
+    expected_counts = _workload_expected_counts(expected_workload)
+    if payload.get("workload_contract") != expected_workload:
+        raise ValueError("integrated-service workload contract mismatch")
     cases = payload.get("cases")
     if not isinstance(cases, list):
         raise ValueError("integrated-service report must contain cases[]")
@@ -287,11 +292,11 @@ def _validate_integrated_service(payload: JsonDict) -> JsonDict:
         raise ValueError(
             "integrated-service c1 counters incomplete: " + ", ".join(sorted(missing))
         )
-    if int(integrated.get("request_count", 0)) != _EXPECTED_REQUEST_COUNT:
+    if int(integrated.get("request_count", 0)) != int(expected_counts["request_count"]):
         raise ValueError("integrated-service c1 request_count mismatch")
-    if int(integrated.get("wide_response_count", 0)) != _EXPECTED_WIDE_RESPONSE_COUNT:
+    if int(integrated.get("wide_response_count", 0)) != int(expected_counts["wide_response_count"]):
         raise ValueError("integrated-service c1 wide_response_count mismatch")
-    if int(integrated.get("result_count", 0)) != _EXPECTED_RESULT_COUNT:
+    if int(integrated.get("result_count", 0)) != int(expected_counts["result_count"]):
         raise ValueError("integrated-service c1 result_count mismatch")
     gates = case.get("gates")
     if not isinstance(gates, dict) or not all(
@@ -308,6 +313,7 @@ def _validate_integrated_service(payload: JsonDict) -> JsonDict:
                 raise ValueError(f"integrated-service summary {key} failed")
     return {
         "case_id": _CASE_ID,
+        "config": dict(config),
         "decision": "pass",
         "exact_match": True,
         "no_protocol_errors": True,
@@ -319,6 +325,7 @@ def _validate_integrated_service(payload: JsonDict) -> JsonDict:
         "counters": counters,
         "gates": {key: True for key in ("hash_gate_ok", "protocol_gate_ok", "count_gate_ok")},
         "shared_result_egress": egress,
+        "workload_contract": expected_workload,
         "hashes": {
             "score_hash": _require_string_hash(integrated, "score_hash", "integrated-service c1"),
             "final_hash": _require_string_hash(integrated, "final_hash", "integrated-service c1"),
@@ -331,10 +338,14 @@ def _validate_integrated_service(payload: JsonDict) -> JsonDict:
 
 
 def _validate_generated_activity_manifest(activity_manifest: JsonDict, activity_dir: Path) -> JsonDict:
+    expected_workload = _expected_workload_contract()
+    expected_counts = _workload_expected_counts(expected_workload)
     if str(activity_manifest.get("model") or "").strip() != "attention_decode_score_multivalue_service_activity_v1":
         raise ValueError("generated activity manifest model mismatch")
     if str(activity_manifest.get("case_id") or "").strip() != _CASE_ID:
         raise ValueError("generated activity manifest case_id mismatch")
+    if activity_manifest.get("workload_contract") != expected_workload:
+        raise ValueError("generated activity manifest workload contract mismatch")
     if float(activity_manifest.get("clock_period_ns", 0.0)) != 10.0:
         raise ValueError("generated activity manifest clock_period_ns mismatch")
     cycle_count = int(activity_manifest.get("cycle_count", 0))
@@ -343,11 +354,11 @@ def _validate_generated_activity_manifest(activity_manifest: JsonDict, activity_
     counters = activity_manifest.get("request_result_protocol_counters")
     if not isinstance(counters, dict):
         raise ValueError("generated activity manifest request_result_protocol_counters missing")
-    if int(counters.get("request_count", 0)) != _EXPECTED_REQUEST_COUNT:
+    if int(counters.get("request_count", 0)) != int(expected_counts["request_count"]):
         raise ValueError("generated activity manifest request_count mismatch")
-    if int(counters.get("wide_response_count", 0)) != _EXPECTED_WIDE_RESPONSE_COUNT:
+    if int(counters.get("wide_response_count", 0)) != int(expected_counts["wide_response_count"]):
         raise ValueError("generated activity manifest wide_response_count mismatch")
-    if int(counters.get("result_count", 0)) != _EXPECTED_RESULT_COUNT:
+    if int(counters.get("result_count", 0)) != int(expected_counts["result_count"]):
         raise ValueError("generated activity manifest result_count mismatch")
     shared = counters.get("shared")
     if not isinstance(shared, dict) or shared.get("protocol_error") is not False:
@@ -373,6 +384,7 @@ def _validate_generated_activity_manifest(activity_manifest: JsonDict, activity_
         "generated_manifest_sha256": _sha256_file(activity_dir / _OUTPUT_MANIFEST_NAME),
         "generated_manifest_hashes": dict(activity_manifest.get("hashes") or {}),
         "bank_coverage": bank_coverage,
+        "workload_contract": expected_workload,
     }
 
 
@@ -791,6 +803,20 @@ def build_report(
                 "total_power_mw": float(metric.get("total_power_mw") or 0.0),
             }
     best = candidate if candidate.get("status") == "activity_backed" else None
+    if activity_meta["workload_contract"] != integrated_service["workload_contract"]:
+        raise ValueError("generated activity workload contract does not match integrated-service c1")
+    generated_hashes = activity_meta["generated_manifest_hashes"]
+    integrated_hashes = integrated_service["hashes"]
+    for generated_key, integrated_key in (
+        ("score_hash", "score_hash"),
+        ("final_hash", "final_hash"),
+        ("request_hash", "request_hash"),
+        ("wide_response_matrix_hash", "wide_response_matrix_hash"),
+    ):
+        if str(generated_hashes.get(generated_key) or "").strip() != str(integrated_hashes[integrated_key]).strip():
+            raise ValueError(
+                f"generated activity {generated_key} does not match integrated-service c1 {integrated_key}"
+            )
     return {
         "version": 1,
         "model": _MODEL,
@@ -828,6 +854,7 @@ def build_report(
             "vcd_sha256": activity_meta["vcd_sha256"],
             "clock_period_ns": clock_period_ns,
             "cycle_count": int(activity_meta["cycle_count"]),
+            "workload_contract": activity_meta["workload_contract"],
         },
         "macro_manifest_contract": {
             "counts": activity_meta["macro_counts"],

--- a/npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py
@@ -752,6 +752,20 @@ def build_report(
         activity_dir=activity_dir,
         activity_manifest=activity_manifest,
     )
+    if activity_meta["workload_contract"] != integrated_service["workload_contract"]:
+        raise ValueError("generated activity workload contract does not match integrated-service c1")
+    generated_hashes = activity_meta["generated_manifest_hashes"]
+    integrated_hashes = integrated_service["hashes"]
+    for generated_key, integrated_key in (
+        ("score_hash", "score_hash"),
+        ("final_hash", "final_hash"),
+        ("request_hash", "request_hash"),
+        ("wide_response_matrix_hash", "wide_response_matrix_hash"),
+    ):
+        if str(generated_hashes.get(generated_key) or "").strip() != str(integrated_hashes[integrated_key]).strip():
+            raise ValueError(
+                f"generated activity {generated_key} does not match integrated-service c1 {integrated_key}"
+            )
     candidate: JsonDict = {
         "candidate_id": f"multivalue_service_activity_{_REQUIRED_FLOW_VARIANT}",
         "flow_variant": _REQUIRED_FLOW_VARIANT,
@@ -803,20 +817,6 @@ def build_report(
                 "total_power_mw": float(metric.get("total_power_mw") or 0.0),
             }
     best = candidate if candidate.get("status") == "activity_backed" else None
-    if activity_meta["workload_contract"] != integrated_service["workload_contract"]:
-        raise ValueError("generated activity workload contract does not match integrated-service c1")
-    generated_hashes = activity_meta["generated_manifest_hashes"]
-    integrated_hashes = integrated_service["hashes"]
-    for generated_key, integrated_key in (
-        ("score_hash", "score_hash"),
-        ("final_hash", "final_hash"),
-        ("request_hash", "request_hash"),
-        ("wide_response_matrix_hash", "wide_response_matrix_hash"),
-    ):
-        if str(generated_hashes.get(generated_key) or "").strip() != str(integrated_hashes[integrated_key]).strip():
-            raise ValueError(
-                f"generated activity {generated_key} does not match integrated-service c1 {integrated_key}"
-            )
     return {
         "version": 1,
         "model": _MODEL,

--- a/npu/eval/audit_attention_decode_score_multivalue_service_measured_frontier.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_service_measured_frontier.py
@@ -54,6 +54,7 @@ _EXPECTED_KV_HEADS = 4
 _EXPECTED_LAYERS = 32
 _EXPECTED_SERVICE_CLOCK_NS = 10.0
 _EXPECTED_MICROKERNEL_CONTEXT_TOKENS = 128
+_EXPECTED_ACTIVE_CONTEXT_TOKENS = 24
 
 
 def _load(path: Path) -> JsonDict:
@@ -111,22 +112,45 @@ def _string(value: Any, label: str) -> str:
     return text
 
 
-def _source_schedule(frontier: JsonDict, frontier_path: Path) -> tuple[JsonDict, str]:
-    schedule = frontier.get("source_schedule")
+def _resolved_path(path_value: str, base_path: Path) -> Path:
+    path = Path(path_value)
+    if not path.is_absolute():
+        path = base_path.parent / path
+    return path.resolve()
+
+
+def _extract_schedule(payload: JsonDict, label: str) -> JsonDict:
+    schedule = payload.get("source_schedule")
     if isinstance(schedule, dict):
-        return schedule, _portable_path(frontier_path)
-    inputs = frontier.get("inputs")
-    linked = inputs.get("prior_frontier_json") if isinstance(inputs, dict) else None
-    if not isinstance(linked, str) or not linked.strip():
-        raise ValueError("prior frontier lacks source_schedule and a prior_frontier_json linkage")
-    linked_path = Path(linked)
-    if not linked_path.is_absolute():
-        linked_path = Path.cwd() / linked_path
-    linked_payload = _load(linked_path)
-    schedule = linked_payload.get("source_schedule")
-    if not isinstance(schedule, dict):
-        raise ValueError(f"linked prior frontier lacks source_schedule: {linked}")
-    return schedule, _portable_path(linked_path)
+        return schedule
+    if "hidden_size" in payload and "attention_heads" in payload and "sequence_length" in payload:
+        return payload
+    raise ValueError(f"{label} lacks source_schedule")
+
+
+def _source_schedule(frontier: JsonDict, frontier_path: Path) -> tuple[JsonDict, str]:
+    visited = {frontier_path.resolve()}
+    current_payload = frontier
+    current_path = frontier_path.resolve()
+    for _ in range(8):
+        inputs = current_payload.get("inputs")
+        if isinstance(inputs, dict):
+            source_schedule_json = inputs.get("source_schedule_json")
+            if isinstance(source_schedule_json, str) and source_schedule_json.strip():
+                source_path = _resolved_path(source_schedule_json, current_path)
+                return _extract_schedule(_load(source_path), "linked source_schedule_json"), _portable_path(source_path)
+        schedule = current_payload.get("source_schedule")
+        if isinstance(schedule, dict):
+            return schedule, _portable_path(current_path)
+        linked = inputs.get("prior_frontier_json") if isinstance(inputs, dict) else None
+        if not isinstance(linked, str) or not linked.strip():
+            raise ValueError("prior frontier lacks inputs.source_schedule_json and a recursive prior_frontier_json chain")
+        current_path = _resolved_path(linked, current_path)
+        if current_path in visited:
+            raise ValueError("prior frontier source_schedule resolution encountered a cycle")
+        visited.add(current_path)
+        current_payload = _load(current_path)
+    raise ValueError("prior frontier source_schedule resolution exceeded the maximum recursion depth")
 
 
 def _validate_optional_item_id(payload: JsonDict, expected: str, label: str) -> None:
@@ -174,7 +198,7 @@ def _validated_prior_frontier(
         raise ValueError("prior frontier kv_heads mismatch")
     if _positive_int(schedule_contract.get("layers"), "prior layers") != _EXPECTED_LAYERS:
         raise ValueError("prior frontier layers mismatch")
-    _positive_int(schedule_contract.get("sequence_length"), "prior sequence_length")
+    sequence_length = _positive_int(schedule_contract.get("sequence_length"), "prior sequence_length")
     if schedule_contract.get("sequence_sharding_supported") is not False:
         raise ValueError("prior frontier must keep sequence_sharding_supported=false")
     dense_qkv_tile = prior.get("dense_qkv_tile")
@@ -207,35 +231,49 @@ def _validated_prior_frontier(
     c1_row = c1_rows[0]
     if _string(c1_row.get("service_calibration_case_id"), "prior c1 service_calibration_case_id") != _EXPECTED_CASE_ID:
         raise ValueError("prior frontier c1 service_calibration_case_id mismatch")
-    if _positive_int(
+    _positive_int(
         c1_row.get("service_calibration_microkernel_integrated_completion_cycle"),
         "prior c1 service_calibration_microkernel_integrated_completion_cycle",
-    ) <= 0:
-        raise ValueError("prior frontier c1 microkernel integrated completion cycle must be positive")
+    )
     if _positive_int(c1_row.get("cluster_waves_per_layer"), "prior c1 cluster_waves_per_layer") != _EXPECTED_HEADS:
         raise ValueError("prior frontier c1 cluster_waves_per_layer mismatch")
     if _positive_int(c1_row.get("head_commands_per_layer"), "prior c1 head_commands_per_layer") != _EXPECTED_HEADS:
         raise ValueError("prior frontier c1 head_commands_per_layer mismatch")
-    if _positive_int(
+    _positive_int(
         c1_row.get("service_no_stall_full_context_cycles_per_wave"),
         "prior c1 service_no_stall_full_context_cycles_per_wave",
-    ) <= 0:
-        raise ValueError("prior frontier c1 no-stall full-context cycles must be positive")
-    if _positive_int(
+    )
+    _positive_int(
         c1_row.get("service_calibrated_full_context_cycles_per_wave"),
         "prior c1 service_calibrated_full_context_cycles_per_wave",
-    ) <= 0:
-        raise ValueError("prior frontier c1 calibrated full-context cycles must be positive")
-    if _positive_int(c1_row.get("fixed_cycles"), "prior c1 fixed_cycles") < 0:
-        raise ValueError("prior frontier c1 fixed_cycles must be nonnegative")
+    )
+    _nonnegative_int(c1_row.get("fixed_cycles"), "prior c1 fixed_cycles")
     _positive(c1_row.get("clock_ns"), "prior c1 clock_ns")
     schedule, schedule_source = _source_schedule(prior, prior_frontier_json)
+    if _positive_int(schedule.get("hidden_size"), "resolved schedule hidden_size") != _positive_int(
+        schedule_contract.get("hidden_size"), "prior contract hidden_size"
+    ):
+        raise ValueError("resolved schedule hidden_size mismatch vs prior schedule_contract")
+    if _positive_int(schedule.get("attention_heads"), "resolved schedule attention_heads") != _positive_int(
+        schedule_contract.get("attention_heads"), "prior contract attention_heads"
+    ):
+        raise ValueError("resolved schedule attention_heads mismatch vs prior schedule_contract")
+    if _positive_int(schedule.get("kv_heads"), "resolved schedule kv_heads") != _positive_int(
+        schedule_contract.get("kv_heads"), "prior contract kv_heads"
+    ):
+        raise ValueError("resolved schedule kv_heads mismatch vs prior schedule_contract")
+    if _positive_int(schedule.get("layers"), "resolved schedule layers") != _positive_int(
+        schedule_contract.get("layers"), "prior contract layers"
+    ):
+        raise ValueError("resolved schedule layers mismatch vs prior schedule_contract")
+    if _positive_int(schedule.get("sequence_length"), "resolved schedule sequence_length") != sequence_length:
+        raise ValueError("resolved schedule sequence_length mismatch vs prior schedule_contract")
     return schedule, schedule_source, dense_qkv_tile, c1_row, rows, precision
 
 
 def _validated_service_activity(
     service_report: JsonDict, prior_precision: JsonDict
-) -> tuple[JsonDict, JsonDict, JsonDict, JsonDict, JsonDict]:
+) -> tuple[JsonDict, JsonDict, JsonDict, JsonDict, JsonDict, JsonDict, JsonDict]:
     if _string(service_report.get("model"), "service activity-power model") != _EXPECTED_SERVICE_MODEL:
         raise ValueError("service activity-power report has an unexpected model")
     if _string(service_report.get("decision"), "service activity-power decision") != _EXPECTED_SERVICE_DECISION:
@@ -250,8 +288,14 @@ def _validated_service_activity(
     best = service_report.get("best")
     if not isinstance(best, dict):
         raise ValueError("service activity-power report lacks best")
+    if _string(service_report.get("best_candidate_id"), "service best_candidate_id") != _string(
+        best.get("candidate_id"), "service best candidate_id"
+    ):
+        raise ValueError("service best_candidate_id mismatch")
     if _string(best.get("status"), "service best status") != "activity_backed":
         raise ValueError("service best is not activity_backed")
+    if best.get("promotion_gate_pass") is not True:
+        raise ValueError("service best promotion_gate_pass failed")
     if _string(best.get("flow_variant"), "service best flow_variant") != _EXPECTED_SERVICE_FLOW_VARIANT:
         raise ValueError("service best flow_variant mismatch")
     metric = best.get("ppa_metric")
@@ -329,6 +373,19 @@ def _validated_service_activity(
         raise ValueError("service report lacks activity_contract")
     if abs(_positive(activity_contract.get("clock_period_ns"), "service activity_contract clock_period_ns") - _EXPECTED_SERVICE_CLOCK_NS) > 1e-9:
         raise ValueError("service activity clock_period_ns mismatch")
+    workload_contract = service_report.get("activity_workload_contract")
+    if not isinstance(workload_contract, dict):
+        raise ValueError("service report lacks activity_workload_contract")
+    if _positive_int(
+        workload_contract.get("active_context_tokens"),
+        "service activity_workload_contract active_context_tokens",
+    ) != _EXPECTED_ACTIVE_CONTEXT_TOKENS:
+        raise ValueError("service activity_workload_contract active_context_tokens mismatch")
+    if _positive_int(
+        workload_contract.get("measured_context_capacity_tokens"),
+        "service activity_workload_contract measured_context_capacity_tokens",
+    ) != _EXPECTED_MICROKERNEL_CONTEXT_TOKENS:
+        raise ValueError("service activity_workload_contract measured_context_capacity_tokens mismatch")
     bank3 = service_report.get("bank3_dynamic_inactivity")
     if not isinstance(bank3, dict):
         raise ValueError("service report lacks bank3_dynamic_inactivity")
@@ -360,7 +417,14 @@ def _validated_service_activity(
         raise ValueError("service window lacks energy_j")
     _positive(energy_j.get("dynamic"), "service window dynamic energy")
     _positive(energy_j.get("leakage"), "service window leakage energy")
-    _positive(energy_j.get("dynamic_plus_leakage"), "service window total energy")
+    if not math.isclose(
+        _positive(energy_j.get("dynamic"), "service window dynamic energy")
+        + _positive(energy_j.get("leakage"), "service window leakage energy"),
+        _positive(energy_j.get("dynamic_plus_leakage"), "service window total energy"),
+        rel_tol=0.0,
+        abs_tol=1e-18,
+    ):
+        raise ValueError("service window total energy does not match dynamic+leakage")
     dependency_contract = service_report.get("dependency_contract")
     if not isinstance(dependency_contract, dict):
         raise ValueError("service report lacks dependency_contract")
@@ -393,15 +457,16 @@ def _validated_service_activity(
     hashes = integrated_service.get("hashes")
     if not isinstance(hashes, dict):
         raise ValueError("service integrated_service_c1 lacks hashes")
-    if _string(hashes.get("score_hash"), "service integrated_service_c1 score_hash") != _string(
-        prior_precision.get("score_tensor_hash"), "prior precision score_tensor_hash"
-    ):
-        raise ValueError("service integrated_service_c1 score_hash mismatch")
-    if _string(hashes.get("final_hash"), "service integrated_service_c1 final_hash") != _string(
-        prior_precision.get("final_tensor_hash"), "prior precision final_tensor_hash"
-    ):
-        raise ValueError("service integrated_service_c1 final_hash mismatch")
-    return best, authoritative, service_window, activity_contract, macro_activity_contract
+    integrated_hashes = {
+        "score_hash": _string(hashes.get("score_hash"), "service integrated_service_c1 score_hash"),
+        "final_hash": _string(hashes.get("final_hash"), "service integrated_service_c1 final_hash"),
+        "request_hash": _string(hashes.get("request_hash"), "service integrated_service_c1 request_hash"),
+        "wide_response_matrix_hash": _string(
+            hashes.get("wide_response_matrix_hash"),
+            "service integrated_service_c1 wide_response_matrix_hash",
+        ),
+    }
+    return best, authoritative, service_window, activity_contract, workload_contract, macro_activity_contract, integrated_hashes
 
 
 def _recompute_dense_tiles(
@@ -461,10 +526,6 @@ def _measured_row(
     kv_heads = _positive_int(schedule.get("kv_heads"), "schedule kv_heads")
     layers = _positive_int(schedule.get("layers"), "schedule layers")
     sequence_length = _positive_int(schedule.get("sequence_length"), "schedule sequence_length")
-    microkernel_context_tokens = _EXPECTED_MICROKERNEL_CONTEXT_TOKENS
-    if sequence_length % microkernel_context_tokens != 0:
-        raise ValueError("sequence_length must be divisible by microkernel_context_tokens")
-    context_tile_count = sequence_length // microkernel_context_tokens
     prior_microkernel_cycle = _positive_int(
         prior_c1_row.get("service_calibration_microkernel_integrated_completion_cycle"),
         "prior c1 service_calibration_microkernel_integrated_completion_cycle",
@@ -502,13 +563,18 @@ def _measured_row(
     prior_clock_ns = _positive(prior_c1_row.get("clock_ns"), "prior c1 clock_ns")
     clock_ns = max(prior_clock_ns, _EXPECTED_SERVICE_CLOCK_NS)
     latency_us = total_cycles * clock_ns / 1000.0 if total_cycles is not None else None
-    timing_feasible = _positive(authoritative_service_ppa.get("critical_path_ns"), "authoritative service critical_path_ns") <= _EXPECTED_SERVICE_CLOCK_NS
+    timing_feasible = _positive(authoritative_service_ppa.get("critical_path_ns"), "authoritative service critical_path_ns") <= clock_ns
 
     microkernel_duration_s = _positive(service_window.get("duration_s"), "service window duration_s")
     service_duration_s = service_cycles_per_wave * clock_ns * 1.0e-9
     dynamic_j = _positive(service_window.get("energy_j", {}).get("dynamic"), "service window dynamic energy")
     leakage_j = _positive(service_window.get("energy_j", {}).get("leakage"), "service window leakage energy")
-    full_context_dynamic_per_head_j = dynamic_j * context_tile_count
+    active_context_tokens = _EXPECTED_ACTIVE_CONTEXT_TOKENS
+    measured_context_capacity_tokens = _EXPECTED_MICROKERNEL_CONTEXT_TOKENS
+    full_measured_window_count = math.ceil(sequence_length / active_context_tokens)
+    full_measured_window_count_exact = sequence_length // active_context_tokens
+    final_partial_tokens = sequence_length % active_context_tokens
+    full_context_dynamic_per_head_j = dynamic_j * full_measured_window_count
     full_context_leakage_per_head_j = leakage_j * (service_duration_s / microkernel_duration_s)
     full_context_component_per_head_j = full_context_dynamic_per_head_j + full_context_leakage_per_head_j
     full_token_commands = heads * layers
@@ -572,7 +638,12 @@ def _measured_row(
             "The 16KiB service value store remains counted inside the service instance area as a "
             "command-working-set macro component, and broader schedule shared/tile SRAM remains separately charged."
         ),
-        "context_tile_count": context_tile_count,
+        "measured_window_active_context_tokens": active_context_tokens,
+        "measured_window_context_capacity_tokens": measured_context_capacity_tokens,
+        "full_measured_window_count": full_measured_window_count,
+        "full_measured_window_count_exact": full_measured_window_count_exact,
+        "final_partial_tokens": final_partial_tokens,
+        "final_partial_window_conservatively_charged_as_full_measured_window": final_partial_tokens > 0,
         "service_window_duration_s": microkernel_duration_s,
         "full_context_service_duration_s_per_head_command": service_duration_s,
         "service_window_dynamic_energy_j": dynamic_j,
@@ -623,7 +694,15 @@ def build_report(
         prior,
         prior_cluster_frontier_json,
     )
-    best, authoritative_service_ppa, service_window, activity_contract, macro_activity_contract = _validated_service_activity(
+    (
+        best,
+        authoritative_service_ppa,
+        service_window,
+        activity_contract,
+        workload_contract,
+        macro_activity_contract,
+        integrated_hashes,
+    ) = _validated_service_activity(
         service,
         prior_precision,
     )
@@ -634,6 +713,8 @@ def build_report(
         authoritative_service_ppa=authoritative_service_ppa,
         service_window=service_window,
     )
+    if not measured["compute_budget_area_fit"] or not measured["timing_feasible"]:
+        raise ValueError("recomputed c1 measured anchor is not feasible for promotion")
     blocked_rows = [
         _blocked_row(row)
         for row in sorted(prior_rows, key=lambda item: _positive_int(item.get("cluster_count"), "prior row cluster_count"))
@@ -670,16 +751,22 @@ def build_report(
             "layers": _positive_int(schedule.get("layers"), "schedule layers"),
             "sequence_length": _positive_int(schedule.get("sequence_length"), "schedule sequence_length"),
             "microkernel_context_tokens": _EXPECTED_MICROKERNEL_CONTEXT_TOKENS,
-            "context_tile_count": measured["context_tile_count"],
+            "measured_window_active_context_tokens": measured["measured_window_active_context_tokens"],
+            "measured_window_context_capacity_tokens": measured["measured_window_context_capacity_tokens"],
+            "full_measured_window_count": measured["full_measured_window_count"],
+            "full_measured_window_count_exact": measured["full_measured_window_count_exact"],
+            "final_partial_tokens": measured["final_partial_tokens"],
             "full_head_commands_per_token": _EXPECTED_HEADS * _EXPECTED_LAYERS,
         },
         "selected_service_activity_candidate": {
             "candidate_id": _string(best.get("candidate_id"), "service best candidate_id"),
             "flow_variant": _string(best.get("flow_variant"), "service best flow_variant"),
+            "integrated_service_hashes": integrated_hashes,
             "activity_contract": {
                 "clock_period_ns": _positive(activity_contract.get("clock_period_ns"), "service activity clock_period_ns"),
                 "cycle_count": _positive_int(activity_contract.get("cycle_count"), "service activity cycle_count"),
             },
+            "activity_workload_contract": workload_contract,
             "macro_activity_contract": macro_activity_contract,
         },
         "precision": {

--- a/npu/eval/audit_attention_decode_score_multivalue_service_measured_frontier.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_service_measured_frontier.py
@@ -1,0 +1,771 @@
+#!/usr/bin/env python3
+"""Compose a strict c1 measured-service frontier anchor for Llama7B decode."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_EVALUATOR_LOCAL_PATH_PLACEHOLDER = "<evaluator-local-path>"
+
+_MODEL = "decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1"
+_EXPECTED_PRIOR_MODEL = "decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1"
+_EXPECTED_PRIOR_DECISION = "shared_score_multivalue_cluster_measured_component_frontier_promoted"
+_EXPECTED_PRIOR_PROMOTION = "component_frontier_promoted_full_architecture_promotion_blocked"
+_EXPECTED_PRIOR_ITEM_ID = "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1"
+_EXPECTED_PRIOR_PRECISION_STATUS = "unchanged_integer_contract_from_merged_multivalue_equivalence"
+_EXPECTED_PRIOR_PRECISION_DECISION = "decode_score_multivalue_cluster_equivalence_pass"
+
+_EXPECTED_SERVICE_MODEL = "decoder_attention_decode_score_multivalue_service_activity_power_v1"
+_EXPECTED_SERVICE_DECISION = "activity_backed_service_power_measured"
+_EXPECTED_SERVICE_PRECISION_STATUS = (
+    "unchanged_integer_contract_from_merged_cluster_equivalence_and_integrated_service"
+)
+_EXPECTED_SERVICE_FLOW_VARIANT = "decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1"
+_EXPECTED_SERVICE_DESIGN = "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr"
+_EXPECTED_SERVICE_PLATFORM = "nangate45"
+_EXPECTED_SERVICE_MACRO_COUNTS = {
+    "fakeram45_2048x39": 56,
+    "fakeram45_64x32": 64,
+}
+_EXPECTED_SERVICE_MACRO_PROFILE = "multivalue_service_c1_v1"
+_EXPECTED_CASE_ID = "c1_p128_b4_rr"
+_EXPECTED_SERVICE_CONFIG = {
+    "cluster_count": 1,
+    "packet_w": 128,
+    "banks": 4,
+    "req_queue_depth": 4,
+    "resp_queue_depth": 4,
+    "bank_queue_depth": 4,
+    "read_latency": 2,
+    "arb_mode": "round_robin",
+    "locality_burst_max": 2,
+}
+_EXPECTED_HIDDEN = 4096
+_EXPECTED_HEADS = 32
+_EXPECTED_KV_HEADS = 4
+_EXPECTED_LAYERS = 32
+_EXPECTED_SERVICE_CLOCK_NS = 10.0
+_EXPECTED_MICROKERNEL_CONTEXT_TOKENS = 128
+
+
+def _load(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return payload
+
+
+def _portable_path(path: Path) -> str:
+    if not path.is_absolute():
+        return path.as_posix()
+    try:
+        return path.resolve().relative_to(_REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return f"{_EVALUATOR_LOCAL_PATH_PLACEHOLDER}/{path.name}"
+
+
+def _positive(value: Any, label: str) -> float:
+    result = float(value)
+    if not math.isfinite(result) or result <= 0.0:
+        raise ValueError(f"{label} must be finite and positive")
+    return result
+
+
+def _nonnegative(value: Any, label: str) -> float:
+    result = float(value)
+    if not math.isfinite(result) or result < 0.0:
+        raise ValueError(f"{label} must be finite and nonnegative")
+    return result
+
+
+def _positive_int(value: Any, label: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{label} must be a positive integer")
+    numeric = float(value)
+    if not math.isfinite(numeric) or numeric <= 0.0 or not numeric.is_integer():
+        raise ValueError(f"{label} must be a positive integer")
+    return int(numeric)
+
+
+def _nonnegative_int(value: Any, label: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{label} must be a nonnegative integer")
+    numeric = float(value)
+    if not math.isfinite(numeric) or numeric < 0.0 or not numeric.is_integer():
+        raise ValueError(f"{label} must be a nonnegative integer")
+    return int(numeric)
+
+
+def _string(value: Any, label: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{label} must be a non-empty string")
+    return text
+
+
+def _source_schedule(frontier: JsonDict, frontier_path: Path) -> tuple[JsonDict, str]:
+    schedule = frontier.get("source_schedule")
+    if isinstance(schedule, dict):
+        return schedule, _portable_path(frontier_path)
+    inputs = frontier.get("inputs")
+    linked = inputs.get("prior_frontier_json") if isinstance(inputs, dict) else None
+    if not isinstance(linked, str) or not linked.strip():
+        raise ValueError("prior frontier lacks source_schedule and a prior_frontier_json linkage")
+    linked_path = Path(linked)
+    if not linked_path.is_absolute():
+        linked_path = Path.cwd() / linked_path
+    linked_payload = _load(linked_path)
+    schedule = linked_payload.get("source_schedule")
+    if not isinstance(schedule, dict):
+        raise ValueError(f"linked prior frontier lacks source_schedule: {linked}")
+    return schedule, _portable_path(linked_path)
+
+
+def _validate_optional_item_id(payload: JsonDict, expected: str, label: str) -> None:
+    for key in ("item_id", "report_item_id", "promotion_item_id"):
+        value = payload.get(key)
+        if value is None:
+            continue
+        if _string(value, f"{label} {key}") != expected:
+            raise ValueError(f"{label} {key} mismatch: expected {expected}")
+        break
+
+
+def _validated_prior_frontier(
+    prior: JsonDict, prior_frontier_json: Path
+) -> tuple[JsonDict, str, JsonDict, JsonDict, list[JsonDict], JsonDict]:
+    if _string(prior.get("model"), "prior frontier model") != _EXPECTED_PRIOR_MODEL:
+        raise ValueError("prior frontier has an unexpected model")
+    if _string(prior.get("decision"), "prior frontier decision") != _EXPECTED_PRIOR_DECISION:
+        raise ValueError("prior frontier has an unexpected decision")
+    if _string(prior.get("promotion_status"), "prior frontier promotion_status") != _EXPECTED_PRIOR_PROMOTION:
+        raise ValueError("prior frontier has an unexpected promotion_status")
+    _validate_optional_item_id(prior, _EXPECTED_PRIOR_ITEM_ID, "prior frontier")
+    precision = prior.get("precision")
+    if not isinstance(precision, dict):
+        raise ValueError("prior frontier lacks precision evidence")
+    if precision.get("equivalence_pass") is not True:
+        raise ValueError("prior frontier precision equivalence did not pass")
+    if _string(precision.get("status"), "prior frontier precision status") != _EXPECTED_PRIOR_PRECISION_STATUS:
+        raise ValueError("prior frontier precision status mismatch")
+    if _string(precision.get("decision"), "prior frontier precision decision") != _EXPECTED_PRIOR_PRECISION_DECISION:
+        raise ValueError("prior frontier precision decision mismatch")
+    if (
+        _string(precision.get("quality_change"), "prior frontier quality_change")
+        != "none_exact_integer_semantics_preserved"
+    ):
+        raise ValueError("prior frontier quality_change mismatch")
+    schedule_contract = prior.get("schedule_contract")
+    if not isinstance(schedule_contract, dict):
+        raise ValueError("prior frontier lacks schedule_contract")
+    if _positive_int(schedule_contract.get("hidden_size"), "prior hidden_size") != _EXPECTED_HIDDEN:
+        raise ValueError("prior frontier hidden_size mismatch")
+    if _positive_int(schedule_contract.get("attention_heads"), "prior attention_heads") != _EXPECTED_HEADS:
+        raise ValueError("prior frontier attention_heads mismatch")
+    if _positive_int(schedule_contract.get("kv_heads"), "prior kv_heads") != _EXPECTED_KV_HEADS:
+        raise ValueError("prior frontier kv_heads mismatch")
+    if _positive_int(schedule_contract.get("layers"), "prior layers") != _EXPECTED_LAYERS:
+        raise ValueError("prior frontier layers mismatch")
+    _positive_int(schedule_contract.get("sequence_length"), "prior sequence_length")
+    if schedule_contract.get("sequence_sharding_supported") is not False:
+        raise ValueError("prior frontier must keep sequence_sharding_supported=false")
+    dense_qkv_tile = prior.get("dense_qkv_tile")
+    if not isinstance(dense_qkv_tile, dict):
+        raise ValueError("prior frontier lacks dense_qkv_tile evidence")
+    _positive(dense_qkv_tile.get("area_um2"), "dense_qkv_tile area_um2")
+    _positive(dense_qkv_tile.get("effective_macs_per_cycle"), "dense_qkv_tile effective_macs_per_cycle")
+    calibration = prior.get("service_cycle_calibration")
+    if not isinstance(calibration, dict):
+        raise ValueError("prior frontier lacks service_cycle_calibration")
+    probe_contract = calibration.get("probe_contract")
+    if not isinstance(probe_contract, dict):
+        raise ValueError("prior frontier lacks service probe_contract")
+    microkernel_context_tokens = _positive_int(
+        probe_contract.get("microkernel_context_tokens"),
+        "prior frontier microkernel_context_tokens",
+    )
+    if microkernel_context_tokens != _EXPECTED_MICROKERNEL_CONTEXT_TOKENS:
+        raise ValueError("prior frontier microkernel_context_tokens mismatch")
+    rows = [row for row in prior.get("rows", []) if isinstance(row, dict)]
+    if not rows:
+        raise ValueError("prior frontier has no rows")
+    c1_rows = [
+        row
+        for row in rows
+        if _positive_int(row.get("cluster_count"), "prior frontier cluster_count") == 1
+    ]
+    if len(c1_rows) != 1:
+        raise ValueError("prior frontier must contain exactly one c1 row")
+    c1_row = c1_rows[0]
+    if _string(c1_row.get("service_calibration_case_id"), "prior c1 service_calibration_case_id") != _EXPECTED_CASE_ID:
+        raise ValueError("prior frontier c1 service_calibration_case_id mismatch")
+    if _positive_int(
+        c1_row.get("service_calibration_microkernel_integrated_completion_cycle"),
+        "prior c1 service_calibration_microkernel_integrated_completion_cycle",
+    ) <= 0:
+        raise ValueError("prior frontier c1 microkernel integrated completion cycle must be positive")
+    if _positive_int(c1_row.get("cluster_waves_per_layer"), "prior c1 cluster_waves_per_layer") != _EXPECTED_HEADS:
+        raise ValueError("prior frontier c1 cluster_waves_per_layer mismatch")
+    if _positive_int(c1_row.get("head_commands_per_layer"), "prior c1 head_commands_per_layer") != _EXPECTED_HEADS:
+        raise ValueError("prior frontier c1 head_commands_per_layer mismatch")
+    if _positive_int(
+        c1_row.get("service_no_stall_full_context_cycles_per_wave"),
+        "prior c1 service_no_stall_full_context_cycles_per_wave",
+    ) <= 0:
+        raise ValueError("prior frontier c1 no-stall full-context cycles must be positive")
+    if _positive_int(
+        c1_row.get("service_calibrated_full_context_cycles_per_wave"),
+        "prior c1 service_calibrated_full_context_cycles_per_wave",
+    ) <= 0:
+        raise ValueError("prior frontier c1 calibrated full-context cycles must be positive")
+    if _positive_int(c1_row.get("fixed_cycles"), "prior c1 fixed_cycles") < 0:
+        raise ValueError("prior frontier c1 fixed_cycles must be nonnegative")
+    _positive(c1_row.get("clock_ns"), "prior c1 clock_ns")
+    schedule, schedule_source = _source_schedule(prior, prior_frontier_json)
+    return schedule, schedule_source, dense_qkv_tile, c1_row, rows, precision
+
+
+def _validated_service_activity(
+    service_report: JsonDict, prior_precision: JsonDict
+) -> tuple[JsonDict, JsonDict, JsonDict, JsonDict, JsonDict]:
+    if _string(service_report.get("model"), "service activity-power model") != _EXPECTED_SERVICE_MODEL:
+        raise ValueError("service activity-power report has an unexpected model")
+    if _string(service_report.get("decision"), "service activity-power decision") != _EXPECTED_SERVICE_DECISION:
+        raise ValueError("service activity-power report has an unexpected decision")
+    if service_report.get("promotion_gate_pass") is not True:
+        raise ValueError("service activity-power promotion gate did not pass")
+    if (
+        _string(service_report.get("precision_status"), "service activity-power precision_status")
+        != _EXPECTED_SERVICE_PRECISION_STATUS
+    ):
+        raise ValueError("service activity-power precision_status mismatch")
+    best = service_report.get("best")
+    if not isinstance(best, dict):
+        raise ValueError("service activity-power report lacks best")
+    if _string(best.get("status"), "service best status") != "activity_backed":
+        raise ValueError("service best is not activity_backed")
+    if _string(best.get("flow_variant"), "service best flow_variant") != _EXPECTED_SERVICE_FLOW_VARIANT:
+        raise ValueError("service best flow_variant mismatch")
+    metric = best.get("ppa_metric")
+    if not isinstance(metric, dict):
+        raise ValueError("service best lacks ppa_metric")
+    if _string(metric.get("design"), "service best design") != _EXPECTED_SERVICE_DESIGN:
+        raise ValueError("service best design mismatch")
+    if _string(metric.get("platform"), "service best platform") != _EXPECTED_SERVICE_PLATFORM:
+        raise ValueError("service best platform mismatch")
+    params_json = json.loads(_string(metric.get("params_json"), "service best params_json"))
+    if not isinstance(params_json, dict):
+        raise ValueError("service best params_json is not an object")
+    if _string(params_json.get("FLOW_VARIANT"), "service best FLOW_VARIANT") != _EXPECTED_SERVICE_FLOW_VARIANT:
+        raise ValueError("service best FLOW_VARIANT mismatch")
+    if abs(_positive(params_json.get("CLOCK_PERIOD"), "service best CLOCK_PERIOD") - _EXPECTED_SERVICE_CLOCK_NS) > 1e-9:
+        raise ValueError("service best CLOCK_PERIOD mismatch")
+    if _positive(metric.get("critical_path_ns"), "service best critical_path_ns") > _EXPECTED_SERVICE_CLOCK_NS:
+        raise ValueError("service best is not timing-feasible at 10 ns")
+    authoritative = best.get("authoritative_composed_c1_total_ppa")
+    if not isinstance(authoritative, dict):
+        raise ValueError("service best lacks authoritative_composed_c1_total_ppa")
+    if _positive(authoritative.get("critical_path_ns"), "authoritative service critical_path_ns") > _EXPECTED_SERVICE_CLOCK_NS:
+        raise ValueError("authoritative composed c1 total instance is not timing-feasible at 10 ns")
+    if not math.isclose(
+        _positive(authoritative.get("instance_area_um2"), "authoritative service instance_area_um2"),
+        _positive(metric.get("instance_area_um2"), "service best instance_area_um2"),
+        rel_tol=0.0,
+        abs_tol=1e-9,
+    ):
+        raise ValueError("authoritative composed c1 total instance area mismatches service best ppa_metric")
+    if not math.isclose(
+        _positive(authoritative.get("critical_path_ns"), "authoritative service critical_path_ns"),
+        _positive(metric.get("critical_path_ns"), "service best critical_path_ns"),
+        rel_tol=0.0,
+        abs_tol=1e-9,
+    ):
+        raise ValueError("authoritative composed c1 timing mismatches service best ppa_metric")
+    counts = service_report.get("macro_manifest_contract")
+    if not isinstance(counts, dict) or not isinstance(counts.get("counts"), dict):
+        raise ValueError("service report lacks macro_manifest_contract counts")
+    macro_counts = counts["counts"]
+    if macro_counts != _EXPECTED_SERVICE_MACRO_COUNTS:
+        raise ValueError("service macro count contract mismatch")
+    macro_activity_contract = service_report.get("macro_activity_contract")
+    if not isinstance(macro_activity_contract, dict):
+        raise ValueError("service report lacks macro_activity_contract")
+    if _string(macro_activity_contract.get("profile"), "service macro_activity profile") != _EXPECTED_SERVICE_MACRO_PROFILE:
+        raise ValueError("service macro_activity profile mismatch")
+    macro_classes = macro_activity_contract.get("macro_classes")
+    if not isinstance(macro_classes, dict):
+        raise ValueError("service macro_activity_contract lacks macro_classes")
+    if set(macro_classes) != set(_EXPECTED_SERVICE_MACRO_COUNTS):
+        raise ValueError("service macro_activity_contract macro_classes mismatch")
+    assignment_total = 0
+    for macro_name, expected_count in _EXPECTED_SERVICE_MACRO_COUNTS.items():
+        payload = macro_classes.get(macro_name)
+        if not isinstance(payload, dict):
+            raise ValueError(f"service macro_activity_contract missing {macro_name}")
+        instance_count = _positive_int(payload.get("instance_count"), f"{macro_name} instance_count")
+        pins_per_instance = _positive_int(payload.get("pins_per_instance"), f"{macro_name} pins_per_instance")
+        assignment_count = _positive_int(payload.get("assignment_count"), f"{macro_name} assignment_count")
+        _string(payload.get("instance_scope_prefix"), f"{macro_name} instance_scope_prefix")
+        if instance_count != expected_count:
+            raise ValueError(f"service macro_activity_contract {macro_name} instance_count mismatch")
+        if assignment_count != instance_count * pins_per_instance:
+            raise ValueError(f"service macro_activity_contract {macro_name} assignment_count mismatch")
+        assignment_total += assignment_count
+    if _positive_int(
+        macro_activity_contract.get("total_assignment_count"),
+        "service macro_activity total_assignment_count",
+    ) != assignment_total:
+        raise ValueError("service macro_activity total_assignment_count mismatch")
+    activity_contract = service_report.get("activity_contract")
+    if not isinstance(activity_contract, dict):
+        raise ValueError("service report lacks activity_contract")
+    if abs(_positive(activity_contract.get("clock_period_ns"), "service activity_contract clock_period_ns") - _EXPECTED_SERVICE_CLOCK_NS) > 1e-9:
+        raise ValueError("service activity clock_period_ns mismatch")
+    bank3 = service_report.get("bank3_dynamic_inactivity")
+    if not isinstance(bank3, dict):
+        raise ValueError("service report lacks bank3_dynamic_inactivity")
+    if bank3.get("inactive_banks") != [3]:
+        raise ValueError("service report must keep bank3 inactive")
+    bank3_statement = _string(bank3.get("statement"), "service bank3 statement")
+    if "No artificial activity was injected" not in bank3_statement or "not required to toggle" not in bank3_statement:
+        raise ValueError("service report bank3 inactivity must be explicitly unforced")
+    service_window = best.get("component_service_window_energy")
+    if not isinstance(service_window, dict):
+        raise ValueError("service best lacks component_service_window_energy")
+    if _string(service_window.get("label"), "service component_service_window_energy label") != "component_service_window_energy":
+        raise ValueError("service component_service_window_energy label mismatch")
+    if service_window.get("is_total_token_energy") is not False:
+        raise ValueError("service component_service_window_energy must not be total-token energy")
+    service_cycle_count = _positive_int(service_window.get("cycle_count"), "service window cycle_count")
+    if service_cycle_count != _positive_int(activity_contract.get("cycle_count"), "service activity cycle_count"):
+        raise ValueError("service window cycle_count does not match activity_contract cycle_count")
+    expected_duration_s = service_cycle_count * _EXPECTED_SERVICE_CLOCK_NS * 1.0e-9
+    if not math.isclose(
+        _positive(service_window.get("duration_s"), "service window duration_s"),
+        expected_duration_s,
+        rel_tol=0.0,
+        abs_tol=1e-18,
+    ):
+        raise ValueError("service window duration_s mismatch")
+    energy_j = service_window.get("energy_j")
+    if not isinstance(energy_j, dict):
+        raise ValueError("service window lacks energy_j")
+    _positive(energy_j.get("dynamic"), "service window dynamic energy")
+    _positive(energy_j.get("leakage"), "service window leakage energy")
+    _positive(energy_j.get("dynamic_plus_leakage"), "service window total energy")
+    dependency_contract = service_report.get("dependency_contract")
+    if not isinstance(dependency_contract, dict):
+        raise ValueError("service report lacks dependency_contract")
+    cluster_equivalence = dependency_contract.get("cluster_equivalence")
+    if not isinstance(cluster_equivalence, dict):
+        raise ValueError("service dependency_contract lacks cluster_equivalence")
+    if cluster_equivalence.get("equivalence_pass") is not True:
+        raise ValueError("service cluster equivalence did not pass")
+    if _string(cluster_equivalence.get("decision"), "service cluster equivalence decision") != _EXPECTED_PRIOR_PRECISION_DECISION:
+        raise ValueError("service cluster equivalence decision mismatch")
+    for field in ("score_tensor_hash", "final_tensor_hash"):
+        if _string(cluster_equivalence.get(field), f"service cluster equivalence {field}") != _string(
+            prior_precision.get(field), f"prior precision {field}"
+        ):
+            raise ValueError(f"service cluster equivalence {field} mismatch")
+    integrated_service = dependency_contract.get("integrated_service_c1")
+    if not isinstance(integrated_service, dict):
+        raise ValueError("service dependency_contract lacks integrated_service_c1")
+    if _string(integrated_service.get("case_id"), "service integrated_service_c1 case_id") != _EXPECTED_CASE_ID:
+        raise ValueError("service integrated_service_c1 case_id mismatch")
+    if _string(integrated_service.get("decision"), "service integrated_service_c1 decision") != "pass":
+        raise ValueError("service integrated_service_c1 decision mismatch")
+    for key, expected in _EXPECTED_SERVICE_CONFIG.items():
+        config_value = integrated_service.get("config", {}).get(key) if isinstance(integrated_service.get("config"), dict) else None
+        if config_value is not None and config_value != expected:
+            raise ValueError(f"service integrated_service_c1 config mismatch for {key}")
+    for key in ("exact_match", "no_protocol_errors", "no_drop_duplicate_deadlock_timeout", "cycle_bound_ok"):
+        if integrated_service.get(key) is not True:
+            raise ValueError(f"service integrated_service_c1 {key} gate failed")
+    hashes = integrated_service.get("hashes")
+    if not isinstance(hashes, dict):
+        raise ValueError("service integrated_service_c1 lacks hashes")
+    if _string(hashes.get("score_hash"), "service integrated_service_c1 score_hash") != _string(
+        prior_precision.get("score_tensor_hash"), "prior precision score_tensor_hash"
+    ):
+        raise ValueError("service integrated_service_c1 score_hash mismatch")
+    if _string(hashes.get("final_hash"), "service integrated_service_c1 final_hash") != _string(
+        prior_precision.get("final_tensor_hash"), "prior precision final_tensor_hash"
+    ):
+        raise ValueError("service integrated_service_c1 final_hash mismatch")
+    return best, authoritative, service_window, activity_contract, macro_activity_contract
+
+
+def _recompute_dense_tiles(
+    *,
+    schedule: JsonDict,
+    dense_qkv_tile: JsonDict,
+    service_area_um2: float,
+) -> tuple[int, int, int, float, float, float, bool]:
+    hidden = _positive_int(schedule.get("hidden_size"), "schedule hidden_size")
+    heads = _positive_int(schedule.get("attention_heads"), "schedule attention_heads")
+    kv_heads = _positive_int(schedule.get("kv_heads"), "schedule kv_heads")
+    head_dim = hidden // heads
+    dense_area_um2 = _positive(dense_qkv_tile.get("area_um2"), "dense_qkv_tile area_um2")
+    budget_um2 = _positive(schedule.get("compute_budget_um2"), "schedule compute_budget_um2")
+    logic_area_used_um2 = _nonnegative(schedule.get("logic_area_used_um2"), "schedule logic_area_used_um2")
+    compute_area_um2 = _nonnegative(schedule.get("compute_area_um2"), "schedule compute_area_um2")
+    retained_noncompute_logic_um2 = logic_area_used_um2 - compute_area_um2
+    if retained_noncompute_logic_um2 < 0.0:
+        raise ValueError("schedule retained noncompute logic area must be nonnegative")
+    qkv_useful_limit = hidden // 8 + 2 * kv_heads * head_dim // 8
+    dense_count = min(
+        qkv_useful_limit,
+        max(0, math.floor((budget_um2 - retained_noncompute_logic_um2 - service_area_um2) / dense_area_um2)),
+    )
+    logic_area_um2 = retained_noncompute_logic_um2 + service_area_um2 + dense_count * dense_area_um2
+    area_fit = dense_count > 0 and logic_area_um2 <= budget_um2 + 1e-9
+    shared_sram_um2 = _nonnegative(
+        schedule.get("measured_shared_sram_used_area_um2", 0.0),
+        "schedule measured_shared_sram_used_area_um2",
+    )
+    tile_sram_um2 = _nonnegative(
+        schedule.get("measured_tile_local_sram_area_um2", 0.0),
+        "schedule measured_tile_local_sram_area_um2",
+    )
+    embodied_area_um2 = logic_area_um2 + shared_sram_um2 + tile_sram_um2
+    return (
+        dense_count,
+        qkv_useful_limit,
+        retained_noncompute_logic_um2,
+        logic_area_um2,
+        shared_sram_um2,
+        tile_sram_um2,
+        area_fit,
+    )
+
+
+def _measured_row(
+    *,
+    schedule: JsonDict,
+    dense_qkv_tile: JsonDict,
+    prior_c1_row: JsonDict,
+    authoritative_service_ppa: JsonDict,
+    service_window: JsonDict,
+) -> JsonDict:
+    hidden = _positive_int(schedule.get("hidden_size"), "schedule hidden_size")
+    heads = _positive_int(schedule.get("attention_heads"), "schedule attention_heads")
+    kv_heads = _positive_int(schedule.get("kv_heads"), "schedule kv_heads")
+    layers = _positive_int(schedule.get("layers"), "schedule layers")
+    sequence_length = _positive_int(schedule.get("sequence_length"), "schedule sequence_length")
+    microkernel_context_tokens = _EXPECTED_MICROKERNEL_CONTEXT_TOKENS
+    if sequence_length % microkernel_context_tokens != 0:
+        raise ValueError("sequence_length must be divisible by microkernel_context_tokens")
+    context_tile_count = sequence_length // microkernel_context_tokens
+    prior_microkernel_cycle = _positive_int(
+        prior_c1_row.get("service_calibration_microkernel_integrated_completion_cycle"),
+        "prior c1 service_calibration_microkernel_integrated_completion_cycle",
+    )
+    measured_cycle_count = _positive_int(service_window.get("cycle_count"), "service window cycle_count")
+    if measured_cycle_count != prior_microkernel_cycle:
+        raise ValueError("service VCD microkernel cycle_count does not match prior c1 calibration cycle")
+    service_area_um2 = _positive(authoritative_service_ppa.get("instance_area_um2"), "authoritative service area")
+    (
+        dense_count,
+        qkv_useful_limit,
+        retained_noncompute_logic_um2,
+        logic_area_um2,
+        shared_sram_um2,
+        tile_sram_um2,
+        area_fit,
+    ) = _recompute_dense_tiles(
+        schedule=schedule,
+        dense_qkv_tile=dense_qkv_tile,
+        service_area_um2=service_area_um2,
+    )
+    dense_macs = _positive(dense_qkv_tile.get("effective_macs_per_cycle"), "dense_qkv_tile effective_macs_per_cycle")
+    head_dim = hidden // heads
+    qkv_work = hidden**2 + 2 * hidden * kv_heads * head_dim
+    qkv_cycles = math.ceil(qkv_work / (dense_count * dense_macs)) if dense_count else None
+    cluster_waves_per_layer = _positive_int(prior_c1_row.get("cluster_waves_per_layer"), "prior c1 cluster_waves_per_layer")
+    service_cycles_per_wave = _positive_int(
+        prior_c1_row.get("service_calibrated_full_context_cycles_per_wave"),
+        "prior c1 service_calibrated_full_context_cycles_per_wave",
+    )
+    attention_cycles = cluster_waves_per_layer * service_cycles_per_wave
+    fixed_cycles = _nonnegative_int(prior_c1_row.get("fixed_cycles"), "prior c1 fixed_cycles")
+    layer_cycles = qkv_cycles + attention_cycles + fixed_cycles if qkv_cycles is not None else None
+    total_cycles = layer_cycles * layers if layer_cycles is not None else None
+    prior_clock_ns = _positive(prior_c1_row.get("clock_ns"), "prior c1 clock_ns")
+    clock_ns = max(prior_clock_ns, _EXPECTED_SERVICE_CLOCK_NS)
+    latency_us = total_cycles * clock_ns / 1000.0 if total_cycles is not None else None
+    timing_feasible = _positive(authoritative_service_ppa.get("critical_path_ns"), "authoritative service critical_path_ns") <= _EXPECTED_SERVICE_CLOCK_NS
+
+    microkernel_duration_s = _positive(service_window.get("duration_s"), "service window duration_s")
+    service_duration_s = service_cycles_per_wave * clock_ns * 1.0e-9
+    dynamic_j = _positive(service_window.get("energy_j", {}).get("dynamic"), "service window dynamic energy")
+    leakage_j = _positive(service_window.get("energy_j", {}).get("leakage"), "service window leakage energy")
+    full_context_dynamic_per_head_j = dynamic_j * context_tile_count
+    full_context_leakage_per_head_j = leakage_j * (service_duration_s / microkernel_duration_s)
+    full_context_component_per_head_j = full_context_dynamic_per_head_j + full_context_leakage_per_head_j
+    full_token_commands = heads * layers
+    component_dynamic_j = full_context_dynamic_per_head_j * full_token_commands
+    component_leakage_j = full_context_leakage_per_head_j * full_token_commands
+    component_total_j = full_context_component_per_head_j * full_token_commands
+    prior_cluster_area_mm2 = _positive(prior_c1_row.get("cluster_area_mm2"), "prior c1 cluster_area_mm2")
+
+    return {
+        "candidate_id": "decode_score_multivalue_service_measured_c1",
+        "source_prior_candidate_id": _string(prior_c1_row.get("candidate_id"), "prior c1 candidate_id"),
+        "cluster_count": 1,
+        "status": "directly_measured_c1_anchor",
+        "promoted": True,
+        "rankable_as_measured": True,
+        "measurement_scope": "strict_c1_activity_backed_microkernel_scaled_composed_service_anchor",
+        "service_calibration_case_id": _EXPECTED_CASE_ID,
+        "service_calibration_microkernel_integrated_completion_cycle": prior_microkernel_cycle,
+        "service_activity_microkernel_cycle_count": measured_cycle_count,
+        "service_no_stall_full_context_cycles_per_wave": _positive_int(
+            prior_c1_row.get("service_no_stall_full_context_cycles_per_wave"),
+            "prior c1 service_no_stall_full_context_cycles_per_wave",
+        ),
+        "service_calibrated_full_context_cycles_per_wave": service_cycles_per_wave,
+        "service_cycle_source": "preserved_from_prior_c1_full_context_calibration",
+        "cluster_waves_per_layer": cluster_waves_per_layer,
+        "head_commands_per_layer": _positive_int(prior_c1_row.get("head_commands_per_layer"), "prior c1 head_commands_per_layer"),
+        "dense_qkv_tile_count": dense_count,
+        "dense_qkv_useful_parallelism_limit": qkv_useful_limit,
+        "qkv_cycles": qkv_cycles,
+        "attention_cycles": attention_cycles,
+        "fixed_cycles": fixed_cycles,
+        "layer_cycles": layer_cycles,
+        "total_cycles": total_cycles,
+        "prior_clock_ns": prior_clock_ns,
+        "measured_service_clock_ns": _EXPECTED_SERVICE_CLOCK_NS,
+        "clock_ns": clock_ns,
+        "latency_us": round(latency_us, 6) if latency_us is not None else None,
+        "token_throughput_per_s": round(1.0e6 / latency_us, 12) if latency_us else None,
+        "prior_cluster_area_mm2": round(prior_cluster_area_mm2, 9),
+        "authoritative_composed_service_area_mm2": round(service_area_um2 / 1.0e6, 9),
+        "area_replacement_delta_mm2": round(service_area_um2 / 1.0e6 - prior_cluster_area_mm2, 9),
+        "dense_qkv_area_mm2": round(dense_count * _positive(dense_qkv_tile.get("area_um2"), "dense_qkv_tile area_um2") / 1.0e6, 9),
+        "retained_noncompute_logic_area_mm2": round(retained_noncompute_logic_um2 / 1.0e6, 9),
+        "logic_area_mm2": round(logic_area_um2 / 1.0e6, 9),
+        "existing_shared_sram_area_mm2": round(shared_sram_um2 / 1.0e6, 9),
+        "existing_tile_local_sram_area_mm2": round(tile_sram_um2 / 1.0e6, 9),
+        "embodied_logic_plus_existing_shared_tile_sram_area_mm2": round(
+            (logic_area_um2 + shared_sram_um2 + tile_sram_um2) / 1.0e6,
+            9,
+        ),
+        "compute_budget_slack_mm2": round(
+            (_positive(schedule.get("compute_budget_um2"), "schedule compute_budget_um2") - logic_area_um2)
+            / 1.0e6,
+            9,
+        ),
+        "compute_budget_area_fit": area_fit,
+        "timing_feasible": timing_feasible,
+        "area_replacement_provenance": (
+            "Authoritative composed c1 total instance area replaces the prior c1 cluster total instance area. "
+            "The 16KiB service value store remains counted inside the service instance area as a "
+            "command-working-set macro component, and broader schedule shared/tile SRAM remains separately charged."
+        ),
+        "context_tile_count": context_tile_count,
+        "service_window_duration_s": microkernel_duration_s,
+        "full_context_service_duration_s_per_head_command": service_duration_s,
+        "service_window_dynamic_energy_j": dynamic_j,
+        "service_window_leakage_energy_j": leakage_j,
+        "full_context_dynamic_energy_j_per_head_command": full_context_dynamic_per_head_j,
+        "full_context_leakage_energy_j_per_head_command": full_context_leakage_per_head_j,
+        "service_component_dynamic_energy_mj_per_token": component_dynamic_j * 1.0e3,
+        "service_component_leakage_energy_mj_per_token": component_leakage_j * 1.0e3,
+        "service_component_energy_mj_per_token": component_total_j * 1.0e3,
+        "energy_status": (
+            "activity_backed_microkernel_scaled_composed_service_component_estimate_"
+            "not_direct_total_token_energy"
+        ),
+        "direct_total_token_energy": False,
+        "energy_scope_exclusions": [
+            "legacy cluster dynamic energy is excluded",
+            "HBM/DRAM energy is excluded",
+            "broader SRAM and NoC energy are excluded",
+            "producer and dense QKV activity energy are excluded",
+        ],
+    }
+
+
+def _blocked_row(row: JsonDict) -> JsonDict:
+    return {
+        "candidate_id": f"{_string(row.get('candidate_id'), 'prior row candidate_id')}_blocked_pending_measured_service",
+        "source_prior_candidate_id": _string(row.get("candidate_id"), "prior row candidate_id"),
+        "cluster_count": _positive_int(row.get("cluster_count"), "prior row cluster_count"),
+        "status": "blocked_unpromoted_pending_equivalent_composed_physical_activity_evidence",
+        "promoted": False,
+        "rankable_as_measured": False,
+        "measurement_scope": "not_measured",
+        "blocker": (
+            "Only the directly measured c1 composed physical/activity anchor is promoted. "
+            "Equivalent composed physical area and activity-backed service evidence is still required for c2+."
+        ),
+    }
+
+
+def build_report(
+    *,
+    prior_cluster_frontier_json: Path,
+    service_activity_power_json: Path,
+) -> JsonDict:
+    prior = _load(prior_cluster_frontier_json)
+    service = _load(service_activity_power_json)
+    schedule, schedule_source, dense_qkv_tile, prior_c1_row, prior_rows, prior_precision = _validated_prior_frontier(
+        prior,
+        prior_cluster_frontier_json,
+    )
+    best, authoritative_service_ppa, service_window, activity_contract, macro_activity_contract = _validated_service_activity(
+        service,
+        prior_precision,
+    )
+    measured = _measured_row(
+        schedule=schedule,
+        dense_qkv_tile=dense_qkv_tile,
+        prior_c1_row=prior_c1_row,
+        authoritative_service_ppa=authoritative_service_ppa,
+        service_window=service_window,
+    )
+    blocked_rows = [
+        _blocked_row(row)
+        for row in sorted(prior_rows, key=lambda item: _positive_int(item.get("cluster_count"), "prior row cluster_count"))
+        if _positive_int(row.get("cluster_count"), "prior row cluster_count") > 1
+    ]
+    return {
+        "version": 1,
+        "model": _MODEL,
+        "decision": "strict_c1_measured_service_anchor_promoted_c2plus_blocked",
+        "inputs": {
+            "prior_cluster_frontier_json": _portable_path(prior_cluster_frontier_json),
+            "service_activity_power_json": _portable_path(service_activity_power_json),
+            "source_schedule_json": schedule_source,
+        },
+        "prior_cluster_frontier_contract": {
+            "model": _EXPECTED_PRIOR_MODEL,
+            "decision": _EXPECTED_PRIOR_DECISION,
+            "promotion_status": _EXPECTED_PRIOR_PROMOTION,
+            "expected_item_id_if_present": _EXPECTED_PRIOR_ITEM_ID,
+        },
+        "service_activity_power_contract": {
+            "model": _EXPECTED_SERVICE_MODEL,
+            "decision": _EXPECTED_SERVICE_DECISION,
+            "promotion_gate_pass": True,
+            "required_flow_variant": _EXPECTED_SERVICE_FLOW_VARIANT,
+            "required_design": _EXPECTED_SERVICE_DESIGN,
+            "required_platform": _EXPECTED_SERVICE_PLATFORM,
+            "required_clock_period_ns": _EXPECTED_SERVICE_CLOCK_NS,
+        },
+        "schedule_contract": {
+            "hidden_size": _positive_int(schedule.get("hidden_size"), "schedule hidden_size"),
+            "attention_heads": _positive_int(schedule.get("attention_heads"), "schedule attention_heads"),
+            "kv_heads": _positive_int(schedule.get("kv_heads"), "schedule kv_heads"),
+            "layers": _positive_int(schedule.get("layers"), "schedule layers"),
+            "sequence_length": _positive_int(schedule.get("sequence_length"), "schedule sequence_length"),
+            "microkernel_context_tokens": _EXPECTED_MICROKERNEL_CONTEXT_TOKENS,
+            "context_tile_count": measured["context_tile_count"],
+            "full_head_commands_per_token": _EXPECTED_HEADS * _EXPECTED_LAYERS,
+        },
+        "selected_service_activity_candidate": {
+            "candidate_id": _string(best.get("candidate_id"), "service best candidate_id"),
+            "flow_variant": _string(best.get("flow_variant"), "service best flow_variant"),
+            "activity_contract": {
+                "clock_period_ns": _positive(activity_contract.get("clock_period_ns"), "service activity clock_period_ns"),
+                "cycle_count": _positive_int(activity_contract.get("cycle_count"), "service activity cycle_count"),
+            },
+            "macro_activity_contract": macro_activity_contract,
+        },
+        "precision": {
+            "status": _EXPECTED_SERVICE_PRECISION_STATUS,
+            "decision": _EXPECTED_PRIOR_PRECISION_DECISION,
+            "score_tensor_hash": _string(prior_precision.get("score_tensor_hash"), "prior precision score_tensor_hash"),
+            "final_tensor_hash": _string(prior_precision.get("final_tensor_hash"), "prior precision final_tensor_hash"),
+            "quality_change": "none_exact_integer_semantics_preserved",
+        },
+        "rows": [measured, *blocked_rows],
+        "promoted_rows": [measured],
+        "blocked_rows": blocked_rows,
+        "best_measured_anchor": measured,
+        "promotion_status": (
+            "strict_c1_measured_anchor_promoted_c2plus_unpromoted_pending_equivalent_"
+            "composed_physical_activity_evidence"
+        ),
+        "remaining_abstractions": [
+            "This report promotes only the directly measured c1 composed service anchor.",
+            "The activity-backed energy is a microkernel-scaled composed-service component estimate, not direct total-token energy.",
+            "HBM/DRAM, broader SRAM/NoC, producer, and dense-QKV activity energy remain outside this report.",
+            "The 16KiB service value store remains counted inside the service instance area, while broader schedule SRAM remains separately charged.",
+            "c2+ rows remain blocked until equivalent composed physical/activity evidence exists for those cluster counts.",
+        ],
+    }
+
+
+def _write_markdown(payload: JsonDict, path: Path) -> None:
+    anchor = payload["best_measured_anchor"]
+    lines = [
+        "# Llama7B strict c1 measured-service frontier",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- promoted anchor: `{anchor['candidate_id']}`",
+        f"- clock ns: `{anchor['clock_ns']}`",
+        f"- latency us: `{anchor['latency_us']}`",
+        f"- dense QKV tiles: `{anchor['dense_qkv_tile_count']}`",
+        (
+            "- area replacement: prior cluster `{prior}` mm2 -> composed service `{new}` mm2".format(
+                prior=anchor["prior_cluster_area_mm2"],
+                new=anchor["authoritative_composed_service_area_mm2"],
+            )
+        ),
+        (
+            "- service component energy: `{total}` mJ/token "
+            "(dynamic `{dynamic}`, leakage `{leakage}`)".format(
+                total=anchor["service_component_energy_mj_per_token"],
+                dynamic=anchor["service_component_dynamic_energy_mj_per_token"],
+                leakage=anchor["service_component_leakage_energy_mj_per_token"],
+            )
+        ),
+        "- total-token energy: `not directly measured here`",
+        "",
+        "| candidate | clusters | status | promoted | rankable | latency us | area mm2 | service component mJ/token |",
+        "|---|---:|---|---|---|---:|---:|---:|",
+    ]
+    for row in payload["rows"]:
+        area = row.get("embodied_logic_plus_existing_shared_tile_sram_area_mm2")
+        energy = row.get("service_component_energy_mj_per_token")
+        lines.append(
+            f"| {row['candidate_id']} | {row['cluster_count']} | {row['status']} | "
+            f"{row['promoted']} | {row['rankable_as_measured']} | {row.get('latency_us')} | "
+            f"{area if area is not None else 'blocked'} | {energy if energy is not None else 'blocked'} |"
+        )
+    lines.extend(["", "## Remaining Abstractions", ""])
+    lines.extend(f"- {item}" for item in payload["remaining_abstractions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--prior-cluster-frontier-json", type=Path, required=True)
+    parser.add_argument("--service-activity-power-json", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_report(
+        prior_cluster_frontier_json=args.prior_cluster_frontier_json,
+        service_activity_power_json=args.service_activity_power_json,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_markdown(payload, args.out_md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/audit_attention_decode_score_multivalue_service_measured_frontier.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_service_measured_frontier.py
@@ -53,8 +53,14 @@ _EXPECTED_HEADS = 32
 _EXPECTED_KV_HEADS = 4
 _EXPECTED_LAYERS = 32
 _EXPECTED_SERVICE_CLOCK_NS = 10.0
-_EXPECTED_MICROKERNEL_CONTEXT_TOKENS = 128
-_EXPECTED_ACTIVE_CONTEXT_TOKENS = 24
+_EXPECTED_WORKLOAD_CONTRACT = {
+    "command_block_count": 3,
+    "context_tokens_per_block": 8,
+    "active_context_tokens": 24,
+    "max_blocks": 16,
+    "max_context_capacity_tokens": 128,
+    "value_dim": 128,
+}
 
 
 def _load(path: Path) -> JsonDict:
@@ -126,6 +132,18 @@ def _extract_schedule(payload: JsonDict, label: str) -> JsonDict:
     if "hidden_size" in payload and "attention_heads" in payload and "sequence_length" in payload:
         return payload
     raise ValueError(f"{label} lacks source_schedule")
+
+
+def _validated_workload_contract(payload: Any, label: str) -> JsonDict:
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must be an object")
+    validated: JsonDict = {}
+    for key, expected in _EXPECTED_WORKLOAD_CONTRACT.items():
+        value = _positive_int(payload.get(key), f"{label} {key}")
+        if value != expected:
+            raise ValueError(f"{label} {key} mismatch: expected {expected}, got {value}")
+        validated[key] = value
+    return validated
 
 
 def _source_schedule(frontier: JsonDict, frontier_path: Path) -> tuple[JsonDict, str]:
@@ -212,12 +230,7 @@ def _validated_prior_frontier(
     probe_contract = calibration.get("probe_contract")
     if not isinstance(probe_contract, dict):
         raise ValueError("prior frontier lacks service probe_contract")
-    microkernel_context_tokens = _positive_int(
-        probe_contract.get("microkernel_context_tokens"),
-        "prior frontier microkernel_context_tokens",
-    )
-    if microkernel_context_tokens != _EXPECTED_MICROKERNEL_CONTEXT_TOKENS:
-        raise ValueError("prior frontier microkernel_context_tokens mismatch")
+    workload_contract = _validated_workload_contract(probe_contract, "prior frontier probe_contract")
     rows = [row for row in prior.get("rows", []) if isinstance(row, dict)]
     if not rows:
         raise ValueError("prior frontier has no rows")
@@ -268,11 +281,13 @@ def _validated_prior_frontier(
         raise ValueError("resolved schedule layers mismatch vs prior schedule_contract")
     if _positive_int(schedule.get("sequence_length"), "resolved schedule sequence_length") != sequence_length:
         raise ValueError("resolved schedule sequence_length mismatch vs prior schedule_contract")
-    return schedule, schedule_source, dense_qkv_tile, c1_row, rows, precision
+    return schedule, schedule_source, dense_qkv_tile, c1_row, rows, precision, workload_contract
 
 
 def _validated_service_activity(
-    service_report: JsonDict, prior_precision: JsonDict
+    service_report: JsonDict,
+    prior_precision: JsonDict,
+    prior_workload_contract: JsonDict,
 ) -> tuple[JsonDict, JsonDict, JsonDict, JsonDict, JsonDict, JsonDict, JsonDict]:
     if _string(service_report.get("model"), "service activity-power model") != _EXPECTED_SERVICE_MODEL:
         raise ValueError("service activity-power report has an unexpected model")
@@ -373,19 +388,12 @@ def _validated_service_activity(
         raise ValueError("service report lacks activity_contract")
     if abs(_positive(activity_contract.get("clock_period_ns"), "service activity_contract clock_period_ns") - _EXPECTED_SERVICE_CLOCK_NS) > 1e-9:
         raise ValueError("service activity clock_period_ns mismatch")
-    workload_contract = service_report.get("activity_workload_contract")
-    if not isinstance(workload_contract, dict):
-        raise ValueError("service report lacks activity_workload_contract")
-    if _positive_int(
-        workload_contract.get("active_context_tokens"),
-        "service activity_workload_contract active_context_tokens",
-    ) != _EXPECTED_ACTIVE_CONTEXT_TOKENS:
-        raise ValueError("service activity_workload_contract active_context_tokens mismatch")
-    if _positive_int(
-        workload_contract.get("measured_context_capacity_tokens"),
-        "service activity_workload_contract measured_context_capacity_tokens",
-    ) != _EXPECTED_MICROKERNEL_CONTEXT_TOKENS:
-        raise ValueError("service activity_workload_contract measured_context_capacity_tokens mismatch")
+    workload_contract = _validated_workload_contract(
+        activity_contract.get("workload_contract"),
+        "service activity_contract workload_contract",
+    )
+    if workload_contract != prior_workload_contract:
+        raise ValueError("service activity_contract workload_contract mismatch vs prior probe_contract")
     bank3 = service_report.get("bank3_dynamic_inactivity")
     if not isinstance(bank3, dict):
         raise ValueError("service report lacks bank3_dynamic_inactivity")
@@ -447,10 +455,19 @@ def _validated_service_activity(
         raise ValueError("service integrated_service_c1 case_id mismatch")
     if _string(integrated_service.get("decision"), "service integrated_service_c1 decision") != "pass":
         raise ValueError("service integrated_service_c1 decision mismatch")
+    config = integrated_service.get("config")
+    if not isinstance(config, dict):
+        raise ValueError("service integrated_service_c1 config is missing")
     for key, expected in _EXPECTED_SERVICE_CONFIG.items():
-        config_value = integrated_service.get("config", {}).get(key) if isinstance(integrated_service.get("config"), dict) else None
-        if config_value is not None and config_value != expected:
+        config_value = config.get(key)
+        if config_value != expected:
             raise ValueError(f"service integrated_service_c1 config mismatch for {key}")
+    integrated_workload_contract = _validated_workload_contract(
+        integrated_service.get("workload_contract"),
+        "service integrated_service_c1 workload_contract",
+    )
+    if integrated_workload_contract != workload_contract:
+        raise ValueError("service integrated_service_c1 workload_contract mismatch vs activity workload_contract")
     for key in ("exact_match", "no_protocol_errors", "no_drop_duplicate_deadlock_timeout", "cycle_bound_ok"):
         if integrated_service.get(key) is not True:
             raise ValueError(f"service integrated_service_c1 {key} gate failed")
@@ -520,6 +537,7 @@ def _measured_row(
     prior_c1_row: JsonDict,
     authoritative_service_ppa: JsonDict,
     service_window: JsonDict,
+    workload_contract: JsonDict,
 ) -> JsonDict:
     hidden = _positive_int(schedule.get("hidden_size"), "schedule hidden_size")
     heads = _positive_int(schedule.get("attention_heads"), "schedule attention_heads")
@@ -569,8 +587,14 @@ def _measured_row(
     service_duration_s = service_cycles_per_wave * clock_ns * 1.0e-9
     dynamic_j = _positive(service_window.get("energy_j", {}).get("dynamic"), "service window dynamic energy")
     leakage_j = _positive(service_window.get("energy_j", {}).get("leakage"), "service window leakage energy")
-    active_context_tokens = _EXPECTED_ACTIVE_CONTEXT_TOKENS
-    measured_context_capacity_tokens = _EXPECTED_MICROKERNEL_CONTEXT_TOKENS
+    active_context_tokens = _positive_int(
+        workload_contract.get("active_context_tokens"),
+        "workload_contract active_context_tokens",
+    )
+    measured_context_capacity_tokens = _positive_int(
+        workload_contract.get("max_context_capacity_tokens"),
+        "workload_contract max_context_capacity_tokens",
+    )
     full_measured_window_count = math.ceil(sequence_length / active_context_tokens)
     full_measured_window_count_exact = sequence_length // active_context_tokens
     final_partial_tokens = sequence_length % active_context_tokens
@@ -690,7 +714,15 @@ def build_report(
 ) -> JsonDict:
     prior = _load(prior_cluster_frontier_json)
     service = _load(service_activity_power_json)
-    schedule, schedule_source, dense_qkv_tile, prior_c1_row, prior_rows, prior_precision = _validated_prior_frontier(
+    (
+        schedule,
+        schedule_source,
+        dense_qkv_tile,
+        prior_c1_row,
+        prior_rows,
+        prior_precision,
+        workload_contract,
+    ) = _validated_prior_frontier(
         prior,
         prior_cluster_frontier_json,
     )
@@ -705,6 +737,7 @@ def build_report(
     ) = _validated_service_activity(
         service,
         prior_precision,
+        workload_contract,
     )
     measured = _measured_row(
         schedule=schedule,
@@ -712,6 +745,7 @@ def build_report(
         prior_c1_row=prior_c1_row,
         authoritative_service_ppa=authoritative_service_ppa,
         service_window=service_window,
+        workload_contract=workload_contract,
     )
     if not measured["compute_budget_area_fit"] or not measured["timing_feasible"]:
         raise ValueError("recomputed c1 measured anchor is not feasible for promotion")
@@ -750,7 +784,7 @@ def build_report(
             "kv_heads": _positive_int(schedule.get("kv_heads"), "schedule kv_heads"),
             "layers": _positive_int(schedule.get("layers"), "schedule layers"),
             "sequence_length": _positive_int(schedule.get("sequence_length"), "schedule sequence_length"),
-            "microkernel_context_tokens": _EXPECTED_MICROKERNEL_CONTEXT_TOKENS,
+            "workload_contract": dict(workload_contract),
             "measured_window_active_context_tokens": measured["measured_window_active_context_tokens"],
             "measured_window_context_capacity_tokens": measured["measured_window_context_capacity_tokens"],
             "full_measured_window_count": measured["full_measured_window_count"],

--- a/npu/eval/generate_attention_decode_score_multivalue_service_activity.py
+++ b/npu/eval/generate_attention_decode_score_multivalue_service_activity.py
@@ -32,7 +32,7 @@ _VALUE_MODEL_PATH = REPO_ROOT / "npu/sim/rtl/fakeram45_64x32_model.sv"
 _C1_CASE = next(case for case in probe.DEFAULT_CASES if str(case["case_id"]) == "c1_p128_b4_rr")
 _REQUIRED_SERVICE_FIELDS = {
     "cluster_count": int(_C1_CASE["cluster_count"]),
-    "max_blocks": 16,
+    "max_blocks": int(probe._workload_contract()["max_blocks"]),
     "packet_w": int(_C1_CASE["packet_w"]),
     "banks": int(_C1_CASE["banks"]),
     "req_queue_depth": int(_C1_CASE["req_queue_depth"]),
@@ -274,6 +274,8 @@ def generate_activity(config: JsonDict, out_dir: Path, *, clock_period_ns: float
     normalized_config = _normalize_config(config)
     out_dir.mkdir(parents=True, exist_ok=True)
     values = probe._shared_value_matrices()
+    workload_contract = probe._workload_contract()
+    expected_counts = probe._workload_expected_counts(workload_contract)
     reference = probe._run_integrated(dict(_C1_CASE), values)
     macro = _run_macro_integrated(normalized_config, out_dir, clock_period_ns=clock_period_ns)
     _assert_reference_equivalence(reference, macro)
@@ -282,6 +284,14 @@ def generate_activity(config: JsonDict, out_dir: Path, *, clock_period_ns: float
     score_rows = probe._canonical_scores(macro["score_rows"])
     result_rows = probe._canonical_results(macro["results"])
     wide_rows = probe._canonical_wide(macro["wide_rows"])
+    if len(score_rows) != int(expected_counts["score_row_count"]):
+        raise RuntimeError("generated activity score rows do not match the workload contract")
+    if len(request_rows) != int(expected_counts["request_count"]):
+        raise RuntimeError("generated activity request rows do not match the workload contract")
+    if len(wide_rows) != int(expected_counts["wide_response_count"]):
+        raise RuntimeError("generated activity wide-response rows do not match the workload contract")
+    if len(result_rows) != int(expected_counts["result_count"]):
+        raise RuntimeError("generated activity result rows do not match the workload contract")
     request_banks = sorted({int(row["addr"]) % int(_C1_CASE["banks"]) for row in request_rows})
     preload_banks = sorted({int(entry["addr"]) % int(_C1_CASE["banks"]) for entry in probe._preload_entries(values)})
     inactive_banks = sorted(set(range(int(_C1_CASE["banks"]))) - set(request_banks))
@@ -295,6 +305,7 @@ def generate_activity(config: JsonDict, out_dir: Path, *, clock_period_ns: float
         "model": "attention_decode_score_multivalue_service_activity_v1",
         "generator": "npu/eval/generate_attention_decode_score_multivalue_service_activity.py",
         "case_id": str(_C1_CASE["case_id"]),
+        "workload_contract": workload_contract,
         "artifacts": {
             "config_json": _OUTPUT_CONFIG_NAME,
             "top_verilog": _OUTPUT_TOP_NAME,
@@ -339,6 +350,7 @@ def generate_activity(config: JsonDict, out_dir: Path, *, clock_period_ns: float
                 "one deterministic c1_p128_b4_rr integrated-service command",
                 "macro-backed value-memory backend macro_banked_4x16x64x32",
                 "bounded DUT VCD from reset release through command completion",
+                "active workload contract is 3 blocks x 8 context tokens = 24 active context tokens at value_dim=128",
                 "dynamic switching observed only on banks 0, 1, and 2 under the exact three-block reference workload",
             ],
             "remaining": [

--- a/npu/eval/probe_attention_decode_score_multivalue_integrated_service.py
+++ b/npu/eval/probe_attention_decode_score_multivalue_integrated_service.py
@@ -396,6 +396,8 @@ def _shared_value_matrices() -> list[list[list[list[int]]]]:
 
 
 def _cluster_beats(cluster_index: int, *, head_dim: int = 128) -> list[list[tuple[int, list[int]]]]:
+    workload = _workload_contract()
+    beat_count = int(head_dim)
     return [
         [
             (
@@ -405,9 +407,9 @@ def _cluster_beats(cluster_index: int, *, head_dim: int = 128) -> list[list[tupl
                     for lane in range(8)
                 ],
             )
-            for beat in range(head_dim)
+            for beat in range(beat_count)
         ]
-        for block in range(3)
+        for block in range(int(workload["command_block_count"]))
     ]
 
 
@@ -416,16 +418,18 @@ def _raw_scores(block: list[tuple[int, list[int]]]) -> list[int]:
 
 
 def _cluster_expected(cluster_index: int, values: list[list[list[list[int]]]]) -> JsonDict:
-    beats = _cluster_beats(cluster_index)
+    workload = _workload_contract()
+    expected_counts = _workload_expected_counts(workload)
+    beats = _cluster_beats(cluster_index, head_dim=int(workload["value_dim"]))
     score_rows = [list(requantize_score_row(_raw_scores(block), multiplier=1, shift=0)) for block in beats]
     results: list[JsonDict] = []
-    for value_slice in range(16):
+    for value_slice in range(int(expected_counts["result_count"])):
         stats = two_pass_stats(score_rows, [values[block][value_slice] for block in range(len(values))])
         results.append(
             {
                 "cluster": cluster_index,
                 "slice": value_slice,
-                "last": value_slice == 15,
+                "last": value_slice == int(expected_counts["result_count"]) - 1,
                 "command_id": 0x4A21 + cluster_index,
                 "global_max": stats.max_score,
                 "exp_sum": stats.exp_sum,
@@ -436,7 +440,7 @@ def _cluster_expected(cluster_index: int, values: list[list[list[list[int]]]]) -
     response_records = []
     tag = 0
     for block in range(len(values)):
-        for value_slice in range(16):
+        for value_slice in range(int(expected_counts["result_count"])):
             matrix_hex = f"{_pack([lane for row in values[block][value_slice] for lane in row], 8):0128x}"
             request_records.append(
                 {
@@ -467,9 +471,10 @@ def _cluster_expected(cluster_index: int, values: list[list[list[list[int]]]]) -
 
 
 def _preload_entries(values: list[list[list[list[int]]]]) -> list[JsonDict]:
+    expected_counts = _workload_expected_counts()
     entries = []
     for block in range(len(values)):
-        for value_slice in range(16):
+        for value_slice in range(int(expected_counts["result_count"])):
             matrix_hex = f"{_pack([lane for row in values[block][value_slice] for lane in row], 8):0128x}"
             entries.append(
                 {
@@ -495,12 +500,80 @@ def _cluster_config(top_name: str) -> JsonDict:
     }
 
 
+def _workload_contract() -> JsonDict:
+    values = _shared_value_matrices()
+    if not values:
+        raise ValueError("shared_value_matrices must provide at least one command block")
+    command_block_count = len(values)
+    value_slices = len(values[0])
+    if value_slices < 1:
+        raise ValueError("shared_value_matrices must provide at least one value slice")
+    context_tokens_per_block = len(values[0][0])
+    if context_tokens_per_block < 1:
+        raise ValueError("shared_value_matrices must provide at least one context row per slice")
+    lanes_per_row = len(values[0][0][0])
+    if lanes_per_row < 1:
+        raise ValueError("shared_value_matrices must provide at least one lane per row")
+    for block_index, block in enumerate(values):
+        if len(block) != value_slices:
+            raise ValueError(
+                f"shared_value_matrices block {block_index} value_slices mismatch: "
+                f"expected {value_slices}, got {len(block)}"
+            )
+        for slice_index, matrix in enumerate(block):
+            if len(matrix) != context_tokens_per_block:
+                raise ValueError(
+                    f"shared_value_matrices block {block_index} slice {slice_index} "
+                    f"context_tokens_per_block mismatch: expected {context_tokens_per_block}, got {len(matrix)}"
+                )
+            for row_index, row in enumerate(matrix):
+                if len(row) != lanes_per_row:
+                    raise ValueError(
+                        f"shared_value_matrices block {block_index} slice {slice_index} row {row_index} "
+                        f"lane width mismatch: expected {lanes_per_row}, got {len(row)}"
+                    )
+    cluster_config = _cluster_config("workload_contract")["attention_decode_score_multivalue_cluster"]
+    if int(cluster_config["array_n"]) != context_tokens_per_block:
+        raise ValueError("cluster array_n does not match the exercised context_tokens_per_block")
+    if int(cluster_config["value_slices"]) != value_slices:
+        raise ValueError("cluster value_slices do not match the exercised value slices")
+    max_blocks = int(cluster_config["max_blocks"])
+    value_dim = value_slices * lanes_per_row
+    return {
+        "command_block_count": command_block_count,
+        "context_tokens_per_block": context_tokens_per_block,
+        "active_context_tokens": command_block_count * context_tokens_per_block,
+        "max_blocks": max_blocks,
+        "max_context_capacity_tokens": max_blocks * context_tokens_per_block,
+        "value_dim": value_dim,
+    }
+
+
+def _workload_expected_counts(contract: JsonDict | None = None) -> JsonDict:
+    workload = dict(contract or _workload_contract())
+    command_block_count = int(workload["command_block_count"])
+    context_tokens_per_block = int(workload["context_tokens_per_block"])
+    value_dim = int(workload["value_dim"])
+    if value_dim % context_tokens_per_block != 0:
+        raise ValueError("value_dim must be divisible by context_tokens_per_block")
+    result_count = value_dim // context_tokens_per_block
+    return {
+        "score_row_count": command_block_count,
+        "request_count": command_block_count * result_count,
+        "wide_response_count": command_block_count * result_count,
+        "result_count": result_count,
+        "preload_entry_count": command_block_count * result_count,
+        "input_beat_count": command_block_count * value_dim,
+    }
+
+
 def _service_config(case: JsonDict, top_name: str) -> JsonDict:
+    workload = _workload_contract()
     return {
         "top_name": top_name,
         "attention_decode_score_multivalue_service": {
             "cluster_count": int(case["cluster_count"]),
-            "max_blocks": 16,
+            "max_blocks": int(workload["max_blocks"]),
             "packet_w": int(case["packet_w"]),
             "banks": int(case["banks"]),
             "req_queue_depth": int(case["req_queue_depth"]),
@@ -515,11 +588,18 @@ def _service_config(case: JsonDict, top_name: str) -> JsonDict:
 
 
 def _baseline_testbench(*, top_name: str, cluster_count: int, values: list[list[list[list[int]]]]) -> str:
-    total_beats = 3 * 128
+    workload = _workload_contract()
+    expected_counts = _workload_expected_counts(workload)
+    if len(values) != int(workload["command_block_count"]):
+        raise ValueError("baseline workload values do not match command_block_count")
+    total_beats = int(expected_counts["input_beat_count"])
+    result_count = int(expected_counts["result_count"])
     value_init = "\n".join(
-        f"    value_mem[{addr * 16 + value_slice}] = 512'h{entry['matrix_hex']};"
-        for addr in range(3)
-        for value_slice, entry in enumerate(_preload_entries(values)[addr * 16 : (addr + 1) * 16])
+        f"    value_mem[{addr * result_count + value_slice}] = 512'h{entry['matrix_hex']};"
+        for addr in range(int(workload["command_block_count"]))
+        for value_slice, entry in enumerate(
+            _preload_entries(values)[addr * result_count : (addr + 1) * result_count]
+        )
     )
     per_cluster_decl: list[str] = []
     per_cluster_mem_init: list[str] = []
@@ -527,7 +607,10 @@ def _baseline_testbench(*, top_name: str, cluster_count: int, values: list[list[
     per_cluster_seq: list[str] = []
     per_cluster_log: list[str] = []
     per_cluster_done: list[str] = []
-    last_indices = {127, 255, 383}
+    last_indices = {
+        ((block_index + 1) * int(workload["value_dim"])) - 1
+        for block_index in range(int(workload["command_block_count"]))
+    }
 
     for cluster in range(cluster_count):
         beats = [beat for block in _cluster_beats(cluster) for beat in block]
@@ -577,7 +660,7 @@ def _baseline_testbench(*, top_name: str, cluster_count: int, values: list[list[
           value_response_valid[{cluster}] <= 1'b1;
           value_response_addr[(14*{cluster}) +: 14] <= pending_addr_{cluster};
           value_response_slice[(4*{cluster}) +: 4] <= pending_slice_{cluster};
-          value_response_matrix[(512*{cluster}) +: 512] <= value_mem[(pending_addr_{cluster} * 16) + pending_slice_{cluster}];
+          value_response_matrix[(512*{cluster}) +: 512] <= value_mem[(pending_addr_{cluster} * {result_count}) + pending_slice_{cluster}];
         end else begin
           pending_delay_{cluster} <= pending_delay_{cluster} - 1;
         end
@@ -670,7 +753,7 @@ module tb;
   wire [CLUSTERS*32-1:0] cluster_completed_count;
   wire [CLUSTERS*32-1:0] cluster_cycle_count;
   wire [CLUSTERS-1:0] cluster_protocol_error;
-  reg [511:0] value_mem [0:(3*16)-1];
+  reg [511:0] value_mem [0:({int(workload['command_block_count'])}*{result_count})-1];
   reg [CLUSTERS-1:0] command_sent;
   reg [CLUSTERS-1:0] value_pending;
   reg [CLUSTERS-1:0] done;
@@ -731,7 +814,7 @@ module tb;
     cluster_command_score_shift = {{(CLUSTERS*6){{1'b0}}}};
     for (idx = 0; idx < CLUSTERS; idx = idx + 1) begin
       cluster_command_id[(16*idx) +: 16] = 16'h4a21 + idx[15:0];
-      cluster_command_block_count[(15*idx) +: 15] = 15'd3;
+      cluster_command_block_count[(15*idx) +: 15] = 15'd{int(workload['command_block_count'])};
       cluster_command_score_multiplier[(32*idx) +: 32] = 32'd1;
       cluster_command_score_shift[(6*idx) +: 6] = 6'd0;
     end
@@ -754,9 +837,15 @@ def _integrated_testbench(
 ) -> str:
     if clock_period_ns <= 0.0:
         raise ValueError("clock_period_ns must be > 0")
-    total_beats = 3 * 128
+    workload = _workload_contract()
+    expected_counts = _workload_expected_counts(workload)
+    if len(values) != int(workload["command_block_count"]):
+        raise ValueError("integrated workload values do not match command_block_count")
+    total_beats = int(expected_counts["input_beat_count"])
     source_w = max(1, (cluster_count - 1).bit_length())
     entries = _preload_entries(values)
+    if len(entries) != int(expected_counts["preload_entry_count"]):
+        raise ValueError("integrated workload preload entries do not match the derived contract")
     preload_init = "\n".join(
         f"    preload_addr_mem[{idx}] = 14'd{entry['addr']}; preload_slice_mem[{idx}] = 4'd{entry['slice']}; preload_matrix_mem[{idx}] = 512'h{entry['matrix_hex']};"
         for idx, entry in enumerate(entries)
@@ -767,7 +856,10 @@ def _integrated_testbench(
     per_cluster_seq: list[str] = []
     per_cluster_log: list[str] = []
     per_cluster_done: list[str] = []
-    last_indices = {127, 255, 383}
+    last_indices = {
+        ((block_index + 1) * int(workload["value_dim"])) - 1
+        for block_index in range(int(workload["command_block_count"]))
+    }
 
     for cluster in range(cluster_count):
         beats = [beat for block in _cluster_beats(cluster) for beat in block]
@@ -1155,7 +1247,7 @@ module tb;
     cluster_command_score_shift = {{(CLUSTERS*6){{1'b0}}}};
     for (idx = 0; idx < CLUSTERS; idx = idx + 1) begin
       cluster_command_id[(16*idx) +: 16] = 16'h4a21 + idx[15:0];
-      cluster_command_block_count[(15*idx) +: 15] = 15'd3;
+      cluster_command_block_count[(15*idx) +: 15] = 15'd{int(workload['command_block_count'])};
       cluster_command_score_multiplier[(32*idx) +: 32] = 32'd1;
       cluster_command_score_shift[(6*idx) +: 6] = 6'd0;
     end
@@ -1443,6 +1535,7 @@ def _canonical_wide(rows: list[JsonDict]) -> list[JsonDict]:
 
 def _summarize_case(case: JsonDict, baseline: JsonDict, integrated: JsonDict, source_refs: JsonDict) -> JsonDict:
     cluster_count = int(case["cluster_count"])
+    expected_counts = _workload_expected_counts()
     values = _shared_value_matrices()
     expected_clusters = [_cluster_expected(cluster, values) for cluster in range(cluster_count)]
     expected_scores = [
@@ -1472,12 +1565,12 @@ def _summarize_case(case: JsonDict, baseline: JsonDict, integrated: JsonDict, so
     )
 
     counts_ok = (
-        len(baseline_results) == 16 * cluster_count
-        and len(integrated_results) == 16 * cluster_count
-        and len(integrated_requests) == 48 * cluster_count
-        and len(integrated_wide) == 48 * cluster_count
-        and integrated["shared"]["service_accepted_req_count"] == 48 * cluster_count
-        and integrated["shared"]["service_emitted_resp_count"] == 48 * cluster_count
+        len(baseline_results) == int(expected_counts["result_count"]) * cluster_count
+        and len(integrated_results) == int(expected_counts["result_count"]) * cluster_count
+        and len(integrated_requests) == int(expected_counts["request_count"]) * cluster_count
+        and len(integrated_wide) == int(expected_counts["wide_response_count"]) * cluster_count
+        and integrated["shared"]["service_accepted_req_count"] == int(expected_counts["request_count"]) * cluster_count
+        and integrated["shared"]["service_emitted_resp_count"] == int(expected_counts["wide_response_count"]) * cluster_count
     )
     exact_match = (
         baseline_scores == expected_score_rows
@@ -1738,6 +1831,7 @@ def build_report(
         raise ValueError("config must provide non-empty cases list")
     cases = [_validate_case(row if isinstance(row, dict) else {}) for row in case_rows]
 
+    workload_contract = _workload_contract()
     values = _shared_value_matrices()
     preload_entries = _preload_entries(values)
     shared_preload_identity = {
@@ -1786,6 +1880,7 @@ def build_report(
             "max_pretty_json_bytes": COMPACT_REPORT_MAX_BYTES,
             "max_pretty_json_lines": COMPACT_REPORT_MAX_LINES,
         },
+        "workload_contract": workload_contract,
         "source_identities": {
             "repo_commit": _git_head(),
             "tool_versions": {
@@ -1854,6 +1949,9 @@ def validate_report(payload: JsonDict) -> None:
         "max_pretty_json_lines": COMPACT_REPORT_MAX_LINES,
     }:
         raise ValueError("report compactness contract mismatch")
+    workload_contract = payload.get("workload_contract")
+    if workload_contract != _workload_contract():
+        raise ValueError("report workload_contract mismatch")
     source = payload.get("source_identities")
     if not isinstance(source, dict) or not source.get("repo_commit"):
         raise ValueError("report lacks source identities")
@@ -1865,7 +1963,10 @@ def validate_report(payload: JsonDict) -> None:
     shared_preload = generated_artifacts.get("shared_preload")
     if not isinstance(shared_preload, dict):
         raise ValueError("report lacks shared preload identity")
-    if int(shared_preload.get("entry_count", 0)) != 48 or shared_preload.get("payload_elided") is not True:
+    if (
+        int(shared_preload.get("entry_count", 0)) != _workload_expected_counts()["preload_entry_count"]
+        or shared_preload.get("payload_elided") is not True
+    ):
         raise ValueError("shared preload identity is incomplete")
     manifest_rows = generated_artifacts.get("generated_manifests")
     if not isinstance(manifest_rows, list) or not manifest_rows:
@@ -2002,6 +2103,12 @@ def _build_markdown(report: JsonDict) -> str:
         f"- selected_scale_point_note: {selected_scale_point['selection_basis']}",
         f"- gates: `hash={summary['all_hash_gates_passed']}` `protocol={summary['all_protocol_gates_passed']}` `count={summary['all_count_gates_passed']}`",
         f"- compact_report_shape: `{contract['shape']}`",
+        (
+            "- workload_contract: "
+            f"`active_context_tokens={report['workload_contract']['active_context_tokens']}` "
+            f"`max_context_capacity_tokens={report['workload_contract']['max_context_capacity_tokens']}` "
+            f"`value_dim={report['workload_contract']['value_dim']}`"
+        ),
         (
             f"- compact_report_size: `{pretty_json_bytes} bytes / {pretty_json_lines} lines` "
             f"(gate <= {contract['max_pretty_json_bytes']} bytes / {contract['max_pretty_json_lines']} lines)"

--- a/tests/test_attention_decode_score_multivalue_cluster_frontier.py
+++ b/tests/test_attention_decode_score_multivalue_cluster_frontier.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from npu.eval.audit_attention_decode_score_multivalue_cluster_frontier import build_report
+from npu.eval.probe_attention_decode_score_multivalue_integrated_service import _workload_contract
 
 
 def _write(path: Path, payload: dict) -> Path:
@@ -60,6 +61,7 @@ def _service_report(tmp_path: Path) -> Path:
             "model": "llm_decoder_attention_decode_score_multivalue_integrated_service_probe_v1",
             "decision": "pass",
             "diagnosis": {"decision": "multivalue_integrated_service_probe_passed"},
+            "workload_contract": _workload_contract(),
             "cases": cases,
         },
     )
@@ -165,8 +167,9 @@ def test_recost_uses_full_head_commands_activity_energy_and_linked_schedule(tmp_
         "fill": 200,
         "replay": 100,
     }
-    assert report["service_cycle_calibration"]["probe_contract"]["microkernel_context_tokens"] == 128
-    assert report["service_cycle_calibration"]["probe_contract"]["microkernel_value_dim"] == 128
+    assert report["service_cycle_calibration"]["probe_contract"]["active_context_tokens"] == 24
+    assert report["service_cycle_calibration"]["probe_contract"]["max_context_capacity_tokens"] == 128
+    assert report["service_cycle_calibration"]["probe_contract"]["value_dim"] == 128
     assert rows[1]["cluster_waves_per_layer"] == 32
     assert rows[32]["cluster_waves_per_layer"] == 1
     assert rows[32]["service_completion_ratio"] == pytest.approx(2.0)
@@ -429,3 +432,18 @@ def test_recost_does_not_substitute_microkernel_completion_cycles_for_full_conte
     ]
     assert row["attention_cycles"] == 600
     assert row["attention_cycles"] > row["service_no_stall_full_context_cycles_per_wave"]
+
+
+def test_recost_rejects_integrated_service_workload_contract_mismatch(tmp_path: Path) -> None:
+    prior, activity, service = _inputs(tmp_path)
+    payload = json.loads(service.read_text(encoding="utf-8"))
+    payload["workload_contract"]["active_context_tokens"] = 128
+    service.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="workload contract mismatch"):
+        build_report(
+            prior_frontier_json=prior,
+            activity_power_json=activity,
+            integrated_service_json=service,
+            cluster_counts=[1],
+        )

--- a/tests/test_attention_decode_score_multivalue_integrated_service.py
+++ b/tests/test_attention_decode_score_multivalue_integrated_service.py
@@ -16,6 +16,8 @@ from npu.eval.probe_attention_decode_score_multivalue_integrated_service import 
     COMPACT_REPORT_MAX_LINES,
     DEFAULT_CASES,
     REPORT_EXCLUSIONS,
+    _workload_contract,
+    _workload_expected_counts,
     _selected_scale_point,
     build_report,
     validate_report,
@@ -322,11 +324,15 @@ def test_integrated_service_report_retains_linkage_and_summary() -> None:
     assert report["summary"]["all_hash_gates_passed"] is True
     assert report["summary"]["all_protocol_gates_passed"] is True
     assert report["summary"]["all_count_gates_passed"] is True
+    assert report["workload_contract"] == _workload_contract()
     assert report["selected_scale_point"]["arch_id"] == "decode_score_multivalue_integrated_service"
     assert report["selected_scale_point"]["case_id"] == "linkage"
     assert "not a performance or architectural ranking" in report["selected_scale_point"]["selection_basis"]
     assert report["report_contract"]["shape"] == "deduplicated_shared_artifact_identities_v1"
-    assert report["source_identities"]["generated_artifacts"]["shared_preload"]["entry_count"] == 48
+    assert (
+        report["source_identities"]["generated_artifacts"]["shared_preload"]["entry_count"]
+        == _workload_expected_counts()["preload_entry_count"]
+    )
     case = report["cases"][0]
     assert "generated_manifests" not in case
     assert "preload" not in case
@@ -513,6 +519,83 @@ def test_integrated_service_report_compact_size_gate_with_large_manifests(
         row["result_beats_per_command"] == 16
         for row in report["source_identities"]["generated_artifacts"]["generated_manifests"]
     )
+
+
+def test_integrated_service_report_workload_contract_rejects_128_as_active_context() -> None:
+    report = {
+        "version": 1,
+        "model": "llm_decoder_attention_decode_score_multivalue_integrated_service_probe_v1",
+        "decision": "pass",
+        "diagnosis": {"decision": "multivalue_integrated_service_probe_passed"},
+        "exclusions": REPORT_EXCLUSIONS,
+        "report_contract": {
+            "shape": "deduplicated_shared_artifact_identities_v1",
+            "max_pretty_json_bytes": COMPACT_REPORT_MAX_BYTES,
+            "max_pretty_json_lines": COMPACT_REPORT_MAX_LINES,
+        },
+        "workload_contract": {
+            **_workload_contract(),
+            "active_context_tokens": 128,
+        },
+        "source_identities": {
+            "repo_commit": "deadbeef",
+            "generated_artifacts": {
+                "shared_preload": {
+                    "artifact_id": "shared_preload_v1",
+                    "entry_count": _workload_expected_counts()["preload_entry_count"],
+                    "payload_elided": True,
+                },
+                "generated_manifests": [{"artifact_id": "m1", "result_beats_per_command": 16}],
+                "generated_tops": [{"artifact_id": "t1"}],
+            },
+        },
+        "selected_scale_point": {
+            "selection_role": "representative_largest_available_scale_point",
+            "selection_basis": "coverage representative only, not a performance or architectural ranking.",
+            "case_id": "c1",
+        },
+        "summary": {
+            "validated_case_count": 1,
+            "all_hash_gates_passed": True,
+            "all_protocol_gates_passed": True,
+            "all_count_gates_passed": True,
+        },
+        "cases": [
+            {
+                "case_id": "c1",
+                "decision": "pass",
+                "source_refs": {
+                    "shared_preload": "shared_preload_v1",
+                    "baseline_manifest": "m1",
+                    "integrated_manifest": "m1",
+                    "baseline_top": "t1",
+                    "integrated_top": "t1",
+                },
+                "baseline_no_stall": {"completion_cycle": 1},
+                "integrated_service": {
+                    "completion_cycle": 1,
+                    "service_penalty_cycles": 0,
+                    "exact_match": True,
+                    "no_protocol_errors": True,
+                    "no_drop_duplicate_deadlock_timeout": True,
+                    "cycle_bound_ok": True,
+                    "counters": {
+                        "request_injection_stall_cycles": 0,
+                        "arbitration_contention_cycles": 0,
+                        "bank_conflict_count": 0,
+                        "response_block_cycles": {"router": 0, "service": 0},
+                        "shared_result": {"arbitration_contention_cycles": 0, "egress_block_cycles": 0},
+                        "max_occupancy": {"router_req": 0, "router_resp": 0, "service_req": 0, "service_resp": 0},
+                    },
+                    "shared_result_egress": {"documented_initiation_interval": 1},
+                },
+                "gates": {"hash_gate_ok": True, "protocol_gate_ok": True, "count_gate_ok": True},
+            }
+        ],
+    }
+
+    with pytest.raises(ValueError, match="workload_contract mismatch"):
+        validate_report(report)
 
 
 def test_integrated_service_selected_scale_point_is_nominal_not_worst_penalty() -> None:

--- a/tests/test_attention_decode_score_multivalue_service_activity_power.py
+++ b/tests/test_attention_decode_score_multivalue_service_activity_power.py
@@ -13,6 +13,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from npu.eval import audit_attention_decode_score_multivalue_service_activity_power as audit
+from npu.eval.probe_attention_decode_score_multivalue_integrated_service import _workload_contract
 
 
 def _config(path: Path) -> None:
@@ -105,6 +106,7 @@ def _integrated_service(path: Path, *, exact_match: bool = True, include_counter
     path.write_text(
         json.dumps(
             {
+                "workload_contract": _workload_contract(),
                 "summary": {
                     "all_hash_gates_passed": True,
                     "all_protocol_gates_passed": True,
@@ -157,6 +159,7 @@ def _generated_activity_manifest() -> dict:
     return {
         "model": "attention_decode_score_multivalue_service_activity_v1",
         "case_id": "c1_p128_b4_rr",
+        "workload_contract": _workload_contract(),
         "clock_period_ns": 10.0,
         "cycle_count": 321,
         "request_result_protocol_counters": {
@@ -170,7 +173,13 @@ def _generated_activity_manifest() -> dict:
             "inactive_banks": [3],
             "inactive_reason": "three_block_reference_workload",
         },
-        "hashes": {"vcd_sha256": "vcd-hash"},
+        "hashes": {
+            "vcd_sha256": "vcd-hash",
+            "score_hash": "score-hash",
+            "final_hash": "final-hash",
+            "request_hash": "request-hash",
+            "wide_response_matrix_hash": "wide-hash",
+        },
     }
 
 
@@ -199,6 +208,14 @@ def _adapted_manifest(tmp_path: Path) -> tuple[dict, Path, dict]:
         "adapted_activity_manifest_sha256": audit._sha256_file(manifest_path),
         "vcd_sha256": "vcd-hash",
         "cycle_count": 321,
+        "generated_manifest_hashes": {
+            "vcd_sha256": "vcd-hash",
+            "score_hash": "score-hash",
+            "final_hash": "final-hash",
+            "request_hash": "request-hash",
+            "wide_response_matrix_hash": "wide-hash",
+        },
+        "workload_contract": _workload_contract(),
         "macro_counts": {"fakeram45_2048x39": 56, "fakeram45_64x32": 64},
         "macro_activity_contract": {
             "profile": "multivalue_service_c1_v1",
@@ -348,6 +365,8 @@ def test_build_report_success_keeps_paths_portable_and_writes_markdown(tmp_path:
     assert best["component_service_window_energy"]["energy_j"]["dynamic"] == pytest.approx(0.30 * 321e-9 * 10.0)
     assert best["component_service_window_energy"]["energy_j"]["leakage"] == pytest.approx(0.05 * 321e-9 * 10.0)
     assert payload["bank3_dynamic_inactivity"]["inactive_banks"] == [3]
+    assert payload["dependency_contract"]["integrated_service_c1"]["config"]["cluster_count"] == 1
+    assert payload["activity_contract"]["workload_contract"] == _workload_contract()
     assert "/tmp/" not in json.dumps(payload, sort_keys=True)
     assert "/orfs/" not in json.dumps(payload, sort_keys=True)
 
@@ -426,3 +445,86 @@ def test_build_report_rejects_non_positive_power_components(tmp_path: Path) -> N
     assert payload["promotion_gate_pass"] is False
     assert payload["candidates"][0]["status"] == "rejected_gate"
     assert "finite positive number" in payload["candidates"][0]["failure"]["error_summary"]
+
+
+def test_validate_generated_activity_manifest_rejects_128_as_active_context(tmp_path: Path) -> None:
+    payload = _generated_activity_manifest()
+    payload["workload_contract"]["active_context_tokens"] = 128
+    (tmp_path / audit._OUTPUT_MANIFEST_NAME).write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="workload contract mismatch"):
+        audit._validate_generated_activity_manifest(payload, tmp_path)
+
+
+def test_build_report_rejects_generated_activity_hash_mismatch(tmp_path: Path) -> None:
+    config = tmp_path / "config.json"
+    _config(config)
+    metrics = tmp_path / "metrics.csv"
+    _write_metrics(metrics, [_ok_metric()])
+    equivalence = tmp_path / "equivalence.json"
+    _cluster_equivalence(equivalence)
+    integrated = tmp_path / "integrated.json"
+    _integrated_service(integrated)
+    adapted_manifest, manifest_path, adapted_meta = _adapted_manifest(tmp_path)
+    generated = _generated_activity_manifest()
+    generated["hashes"]["request_hash"] = "wrong-request-hash"
+
+    with mock.patch.object(audit, "generate_activity", return_value=generated), mock.patch.object(
+        audit,
+        "_prepare_postroute_power_manifest",
+        return_value=(adapted_manifest, manifest_path, adapted_meta | {"generated_manifest_hashes": generated["hashes"], "workload_contract": _workload_contract()}),
+    ), mock.patch.object(
+        audit,
+        "build_power_report",
+        return_value=_power_report(manifest_sha256=adapted_meta["adapted_activity_manifest_sha256"], with_abs_path=False),
+    ):
+        with pytest.raises(ValueError, match="generated activity request_hash does not match integrated-service c1 request_hash"):
+            audit.build_report(
+                config=config,
+                c1_metrics_csv=metrics,
+                equivalence_json=equivalence,
+                integrated_service_json=integrated,
+                orfs_design_config=Path("/orfs/flow/designs/nangate45/service/config.mk"),
+                clock_period_ns=10.0,
+                activity_dir=tmp_path / "activity",
+            )
+
+
+def test_build_report_does_not_compare_integrated_hashes_to_cluster_equivalence_hashes(tmp_path: Path) -> None:
+    config = tmp_path / "config.json"
+    _config(config)
+    metrics = tmp_path / "metrics.csv"
+    _write_metrics(metrics, [_ok_metric()])
+    equivalence = tmp_path / "equivalence.json"
+    _cluster_equivalence(equivalence)
+    eq_payload = json.loads(equivalence.read_text(encoding="utf-8"))
+    eq_payload["score_tensor_hash"] = "different-score-hash"
+    eq_payload["final_tensor_hash"] = "different-final-hash"
+    equivalence.write_text(json.dumps(eq_payload), encoding="utf-8")
+    integrated = tmp_path / "integrated.json"
+    _integrated_service(integrated)
+    adapted_manifest, manifest_path, adapted_meta = _adapted_manifest(tmp_path)
+
+    with mock.patch.object(audit, "generate_activity", return_value=_generated_activity_manifest()), mock.patch.object(
+        audit,
+        "_prepare_postroute_power_manifest",
+        return_value=(adapted_manifest, manifest_path, adapted_meta | {"workload_contract": _workload_contract()}),
+    ), mock.patch.object(
+        audit,
+        "build_power_report",
+        return_value=_power_report(manifest_sha256=adapted_meta["adapted_activity_manifest_sha256"], with_abs_path=False),
+    ):
+        payload = audit.build_report(
+            config=config,
+            c1_metrics_csv=metrics,
+            equivalence_json=equivalence,
+            integrated_service_json=integrated,
+            orfs_design_config=Path("/orfs/flow/designs/nangate45/service/config.mk"),
+            clock_period_ns=10.0,
+            activity_dir=tmp_path / "activity",
+        )
+
+    assert payload["promotion_gate_pass"] is True

--- a/tests/test_attention_decode_score_multivalue_service_activity_power.py
+++ b/tests/test_attention_decode_score_multivalue_service_activity_power.py
@@ -480,7 +480,7 @@ def test_build_report_rejects_generated_activity_hash_mismatch(tmp_path: Path) -
         audit,
         "build_power_report",
         return_value=_power_report(manifest_sha256=adapted_meta["adapted_activity_manifest_sha256"], with_abs_path=False),
-    ):
+    ) as build_power_report_mock:
         with pytest.raises(ValueError, match="generated activity request_hash does not match integrated-service c1 request_hash"):
             audit.build_report(
                 config=config,
@@ -491,6 +491,7 @@ def test_build_report_rejects_generated_activity_hash_mismatch(tmp_path: Path) -
                 clock_period_ns=10.0,
                 activity_dir=tmp_path / "activity",
             )
+    build_power_report_mock.assert_not_called()
 
 
 def test_build_report_does_not_compare_integrated_hashes_to_cluster_equivalence_hashes(tmp_path: Path) -> None:

--- a/tests/test_attention_decode_score_multivalue_service_measured_frontier.py
+++ b/tests/test_attention_decode_score_multivalue_service_measured_frontier.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval.audit_attention_decode_score_multivalue_service_measured_frontier import (
+    build_report,
+)
+
+
+def _write(path: Path, payload: dict) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _source_schedule(tmp_path: Path, *, sequence_length: int = 131072) -> Path:
+    return _write(
+        tmp_path / "source_schedule.json",
+        {
+            "source_schedule": {
+                "hidden_size": 4096,
+                "attention_heads": 32,
+                "kv_heads": 4,
+                "sequence_length": sequence_length,
+                "clock_ns": 6.0,
+                "layers": 32,
+                "compute_budget_um2": 12_000_000,
+                "logic_area_used_um2": 4_000_000,
+                "compute_area_um2": 3_000_000,
+                "measured_shared_sram_used_area_um2": 2_000_000,
+                "measured_tile_local_sram_area_um2": 1_000_000,
+                "command_dispatch_cycles": 2,
+                "kv_write_cycles": 10,
+            }
+        },
+    )
+
+
+def _prior_frontier(tmp_path: Path, *, sequence_length: int = 131072) -> Path:
+    source = _source_schedule(tmp_path, sequence_length=sequence_length)
+    rows = [
+        {
+            "candidate_id": "decode_score_multivalue_cluster_c1",
+            "cluster_count": 1,
+            "head_commands_per_layer": 32,
+            "cluster_waves_per_layer": 32,
+            "service_no_stall_full_context_cycles_per_wave": 320,
+            "service_calibrated_full_context_cycles_per_wave": 400,
+            "service_calibration_case_id": "c1_p128_b4_rr",
+            "service_calibration_microkernel_no_stall_completion_cycle": 128,
+            "service_calibration_microkernel_integrated_completion_cycle": 160,
+            "dense_qkv_tile_count": 3,
+            "dense_qkv_useful_parallelism_limit": 640,
+            "qkv_cycles": 683,
+            "attention_cycles": 12800,
+            "fixed_cycles": 12,
+            "layer_cycles": 13495,
+            "total_cycles": 431840,
+            "clock_ns": 8.0,
+            "latency_us": 3454.72,
+            "token_throughput_per_s": 289.459,
+            "cluster_area_mm2": 2.0,
+            "dense_qkv_area_mm2": 6.0,
+            "retained_noncompute_logic_area_mm2": 1.0,
+            "compute_budget_slack_mm2": 3.0,
+            "logic_area_mm2": 9.0,
+            "embodied_logic_plus_shared_sram_area_mm2": 12.0,
+            "compute_budget_area_fit": True,
+            "timing_feasible": True,
+            "attention_cluster_dynamic_energy_mj_per_token": 1.0,
+            "attention_cluster_service_window_leakage_energy_mj_per_token": 0.1,
+            "attention_cluster_modeled_service_energy_mj_per_token": 1.1,
+            "energy_lower_bound_component_estimate": True,
+            "energy_status": "activity_backed_cluster_dynamic_plus_service_window_leakage_lower_bound_component_estimate_total_token_energy_incomplete",
+        },
+        {
+            "candidate_id": "decode_score_multivalue_cluster_c2",
+            "cluster_count": 2,
+            "head_commands_per_layer": 32,
+            "cluster_waves_per_layer": 16,
+            "service_no_stall_full_context_cycles_per_wave": 320,
+            "service_calibrated_full_context_cycles_per_wave": 440,
+            "service_calibration_case_id": "c2_p128_b4_rr",
+            "service_calibration_microkernel_no_stall_completion_cycle": 128,
+            "service_calibration_microkernel_integrated_completion_cycle": 176,
+            "dense_qkv_tile_count": 3,
+            "dense_qkv_useful_parallelism_limit": 640,
+            "qkv_cycles": 683,
+            "attention_cycles": 7040,
+            "fixed_cycles": 12,
+            "layer_cycles": 7735,
+            "total_cycles": 247520,
+            "clock_ns": 8.0,
+            "latency_us": 1980.16,
+            "token_throughput_per_s": 505.0,
+            "cluster_area_mm2": 4.0,
+            "dense_qkv_area_mm2": 6.0,
+            "retained_noncompute_logic_area_mm2": 1.0,
+            "compute_budget_slack_mm2": 1.0,
+            "logic_area_mm2": 11.0,
+            "embodied_logic_plus_shared_sram_area_mm2": 14.0,
+            "compute_budget_area_fit": True,
+            "timing_feasible": True,
+            "attention_cluster_dynamic_energy_mj_per_token": 1.0,
+            "attention_cluster_service_window_leakage_energy_mj_per_token": 0.2,
+            "attention_cluster_modeled_service_energy_mj_per_token": 1.2,
+            "energy_lower_bound_component_estimate": True,
+            "energy_status": "activity_backed_cluster_dynamic_plus_service_window_leakage_lower_bound_component_estimate_total_token_energy_incomplete",
+        },
+    ]
+    return _write(
+        tmp_path / "prior_frontier.json",
+        {
+            "model": "decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
+            "decision": "shared_score_multivalue_cluster_measured_component_frontier_promoted",
+            "promotion_status": "component_frontier_promoted_full_architecture_promotion_blocked",
+            "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
+            "inputs": {"prior_frontier_json": str(source)},
+            "schedule_contract": {
+                "hidden_size": 4096,
+                "attention_heads": 32,
+                "kv_heads": 4,
+                "head_dim": 128,
+                "sequence_length": sequence_length,
+                "layers": 32,
+                "full_head_commands_per_layer": 32,
+                "full_head_command_cycles_no_stall_baseline": 320,
+                "full_head_phase_cycles_no_stall_baseline": {"fill": 200, "replay": 120},
+                "sequence_sharding_supported": False,
+            },
+            "service_cycle_calibration": {
+                "probe_contract": {
+                    "microkernel_context_tokens": 128,
+                    "microkernel_value_dim": 128,
+                    "consumed_case_ids": ["c1_p128_b4_rr", "c2_p128_b4_rr"],
+                    "resource_policy": {
+                        "packet_w": 128,
+                        "banks": 4,
+                        "req_queue_depth": 4,
+                        "resp_queue_depth": 4,
+                        "bank_queue_depth": 4,
+                        "read_latency": 2,
+                        "arb_mode": "round_robin",
+                        "locality_burst_max": 2,
+                    },
+                }
+            },
+            "dense_qkv_tile": {"area_um2": 2_000_000, "effective_macs_per_cycle": 10240.0},
+            "precision": {
+                "status": "unchanged_integer_contract_from_merged_multivalue_equivalence",
+                "equivalence_pass": True,
+                "decision": "decode_score_multivalue_cluster_equivalence_pass",
+                "score_tensor_hash": "score-hash",
+                "final_tensor_hash": "final-hash",
+                "quality_change": "none_exact_integer_semantics_preserved",
+            },
+            "rows": rows,
+        },
+    )
+
+
+def _service_activity_power(tmp_path: Path) -> Path:
+    return _write(
+        tmp_path / "service_activity_power.json",
+        {
+            "model": "decoder_attention_decode_score_multivalue_service_activity_power_v1",
+            "decision": "activity_backed_service_power_measured",
+            "promotion_gate_pass": True,
+            "precision_status": "unchanged_integer_contract_from_merged_cluster_equivalence_and_integrated_service",
+            "best_candidate_id": "multivalue_service_activity_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1",
+            "best": {
+                "candidate_id": "multivalue_service_activity_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1",
+                "flow_variant": "decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1",
+                "status": "activity_backed",
+                "ppa_metric": {
+                    "design": "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr",
+                    "platform": "nangate45",
+                    "param_hash": "p1",
+                    "config_hash": "cfg1",
+                    "tag": "die3000",
+                    "status": "ok",
+                    "critical_path_ns": "9.2",
+                    "instance_area_um2": "3000000",
+                    "params_json": json.dumps(
+                        {
+                            "CLOCK_PERIOD": 10,
+                            "FLOW_VARIANT": "decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1",
+                        }
+                    ),
+                },
+                "component_service_window_energy": {
+                    "label": "component_service_window_energy",
+                    "is_total_token_energy": False,
+                    "cycle_count": 160,
+                    "duration_s": 1.6e-6,
+                    "energy_j": {
+                        "dynamic": 4.8e-7,
+                        "leakage": 8.0e-8,
+                        "dynamic_plus_leakage": 5.6e-7,
+                    },
+                },
+                "authoritative_composed_c1_total_ppa": {
+                    "critical_path_ns": 9.2,
+                    "instance_area_um2": 3_000_000,
+                    "die_area": 9_000_000,
+                    "total_power_mw": 12.75,
+                },
+            },
+            "dependency_contract": {
+                "cluster_equivalence": {
+                    "equivalence_pass": True,
+                    "decision": "decode_score_multivalue_cluster_equivalence_pass",
+                    "score_tensor_hash": "score-hash",
+                    "final_tensor_hash": "final-hash",
+                },
+                "integrated_service_c1": {
+                    "case_id": "c1_p128_b4_rr",
+                    "decision": "pass",
+                    "exact_match": True,
+                    "no_protocol_errors": True,
+                    "no_drop_duplicate_deadlock_timeout": True,
+                    "cycle_bound_ok": True,
+                    "hashes": {
+                        "score_hash": "score-hash",
+                        "final_hash": "final-hash",
+                        "request_hash": "request-hash",
+                        "wide_response_matrix_hash": "wide-hash",
+                    },
+                },
+            },
+            "activity_contract": {
+                "clock_period_ns": 10.0,
+                "cycle_count": 160,
+            },
+            "macro_manifest_contract": {
+                "counts": {"fakeram45_2048x39": 56, "fakeram45_64x32": 64},
+            },
+            "macro_activity_contract": {
+                "profile": "multivalue_service_c1_v1",
+                "total_assignment_count": 9704,
+                "macro_classes": {
+                    "fakeram45_2048x39": {
+                        "instance_scope_prefix": "score_bank",
+                        "instance_count": 56,
+                        "pins_per_instance": 91,
+                        "assignment_count": 5096,
+                    },
+                    "fakeram45_64x32": {
+                        "instance_scope_prefix": "gen_value_macro_backend",
+                        "instance_count": 64,
+                        "pins_per_instance": 72,
+                        "assignment_count": 4608,
+                    },
+                },
+            },
+            "bank3_dynamic_inactivity": {
+                "inactive_banks": [3],
+                "statement": (
+                    "No artificial activity was injected. Bank3 may remain dynamically inactive in this exact c1 "
+                    "workload; it is not required to toggle, while leakage remains part of routed power."
+                ),
+            },
+        },
+    )
+
+
+def test_build_report_success_recomputes_latency_area_and_component_energy(tmp_path: Path) -> None:
+    prior = _prior_frontier(tmp_path)
+    service = _service_activity_power(tmp_path)
+
+    payload = build_report(
+        prior_cluster_frontier_json=prior,
+        service_activity_power_json=service,
+    )
+
+    assert payload["decision"] == "strict_c1_measured_service_anchor_promoted_c2plus_blocked"
+    assert payload["schedule_contract"]["context_tile_count"] == 1024
+    assert len(payload["promoted_rows"]) == 1
+    row = payload["best_measured_anchor"]
+    assert row["cluster_count"] == 1
+    assert row["clock_ns"] == 10.0
+    assert row["dense_qkv_tile_count"] == 4
+    assert row["qkv_cycles"] == 512
+    assert row["attention_cycles"] == 12800
+    assert row["layer_cycles"] == 13324
+    assert row["total_cycles"] == 426368
+    assert row["latency_us"] == pytest.approx(4263.68)
+    assert row["logic_area_mm2"] == pytest.approx(12.0)
+    assert row["embodied_logic_plus_existing_shared_tile_sram_area_mm2"] == pytest.approx(15.0)
+    assert row["compute_budget_slack_mm2"] == pytest.approx(0.0)
+    assert row["prior_cluster_area_mm2"] == pytest.approx(2.0)
+    assert row["authoritative_composed_service_area_mm2"] == pytest.approx(3.0)
+    assert "16KiB service value store" in row["area_replacement_provenance"]
+    assert row["service_component_dynamic_energy_mj_per_token"] == pytest.approx(503.31648)
+    assert row["service_component_leakage_energy_mj_per_token"] == pytest.approx(0.2048)
+    assert row["service_component_energy_mj_per_token"] == pytest.approx(503.52128)
+    assert row["direct_total_token_energy"] is False
+
+
+def test_build_report_prevents_old_cluster_and_service_area_double_count(tmp_path: Path) -> None:
+    prior = _prior_frontier(tmp_path)
+    service = _service_activity_power(tmp_path)
+
+    payload = build_report(
+        prior_cluster_frontier_json=prior,
+        service_activity_power_json=service,
+    )
+
+    row = payload["best_measured_anchor"]
+    assert row["dense_qkv_tile_count"] == 4
+    assert row["logic_area_mm2"] == pytest.approx(12.0)
+    assert row["area_replacement_delta_mm2"] == pytest.approx(1.0)
+
+
+def test_build_report_rejects_cycle_mismatch(tmp_path: Path) -> None:
+    prior = _prior_frontier(tmp_path)
+    service = _service_activity_power(tmp_path)
+    payload = json.loads(service.read_text(encoding="utf-8"))
+    payload["activity_contract"]["cycle_count"] = 161
+    payload["best"]["component_service_window_energy"]["cycle_count"] = 161
+    payload["best"]["component_service_window_energy"]["duration_s"] = 1.61e-6
+    service.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="microkernel cycle_count"):
+        build_report(
+            prior_cluster_frontier_json=prior,
+            service_activity_power_json=service,
+        )
+
+
+def test_build_report_rejects_structural_macro_gate_failure(tmp_path: Path) -> None:
+    prior = _prior_frontier(tmp_path)
+    service = _service_activity_power(tmp_path)
+    payload = json.loads(service.read_text(encoding="utf-8"))
+    payload["macro_activity_contract"]["macro_classes"]["fakeram45_64x32"]["assignment_count"] = 4607
+    service.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="assignment_count mismatch"):
+        build_report(
+            prior_cluster_frontier_json=prior,
+            service_activity_power_json=service,
+        )
+
+
+def test_build_report_rejects_precision_gate_mismatch(tmp_path: Path) -> None:
+    prior = _prior_frontier(tmp_path)
+    service = _service_activity_power(tmp_path)
+    payload = json.loads(service.read_text(encoding="utf-8"))
+    payload["dependency_contract"]["cluster_equivalence"]["final_tensor_hash"] = "wrong-hash"
+    service.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="final_tensor_hash mismatch"):
+        build_report(
+            prior_cluster_frontier_json=prior,
+            service_activity_power_json=service,
+        )
+
+
+def test_build_report_rejects_non_divisible_sequence(tmp_path: Path) -> None:
+    prior = _prior_frontier(tmp_path, sequence_length=131000)
+    service = _service_activity_power(tmp_path)
+
+    with pytest.raises(ValueError, match="divisible by microkernel_context_tokens"):
+        build_report(
+            prior_cluster_frontier_json=prior,
+            service_activity_power_json=service,
+        )
+
+
+def test_build_report_keeps_c2_blocked_unpromoted(tmp_path: Path) -> None:
+    prior = _prior_frontier(tmp_path)
+    service = _service_activity_power(tmp_path)
+
+    payload = build_report(
+        prior_cluster_frontier_json=prior,
+        service_activity_power_json=service,
+    )
+
+    assert len(payload["rows"]) == 2
+    blocked = payload["blocked_rows"]
+    assert len(blocked) == 1
+    assert blocked[0]["cluster_count"] == 2
+    assert blocked[0]["promoted"] is False
+    assert blocked[0]["rankable_as_measured"] is False
+    assert "pending_equivalent_composed_physical_activity_evidence" in blocked[0]["status"]

--- a/tests/test_attention_decode_score_multivalue_service_measured_frontier.py
+++ b/tests/test_attention_decode_score_multivalue_service_measured_frontier.py
@@ -45,6 +45,14 @@ def _source_schedule(tmp_path: Path, *, sequence_length: int = 131072) -> Path:
 
 def _prior_frontier(tmp_path: Path, *, sequence_length: int = 131072) -> Path:
     source = _source_schedule(tmp_path, sequence_length=sequence_length)
+    linked_prior = _write(
+        tmp_path / "linked_local_cluster_frontier.json",
+        {
+            "inputs": {
+                "source_schedule_json": str(source),
+            }
+        },
+    )
     rows = [
         {
             "candidate_id": "decode_score_multivalue_cluster_c1",
@@ -122,7 +130,7 @@ def _prior_frontier(tmp_path: Path, *, sequence_length: int = 131072) -> Path:
             "decision": "shared_score_multivalue_cluster_measured_component_frontier_promoted",
             "promotion_status": "component_frontier_promoted_full_architecture_promotion_blocked",
             "item_id": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
-            "inputs": {"prior_frontier_json": str(source)},
+            "inputs": {"prior_frontier_json": str(linked_prior)},
             "schedule_contract": {
                 "hidden_size": 4096,
                 "attention_heads": 32,
@@ -179,6 +187,7 @@ def _service_activity_power(tmp_path: Path) -> Path:
                 "candidate_id": "multivalue_service_activity_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1",
                 "flow_variant": "decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1",
                 "status": "activity_backed",
+                "promotion_gate_pass": True,
                 "ppa_metric": {
                     "design": "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr",
                     "platform": "nangate45",
@@ -228,8 +237,8 @@ def _service_activity_power(tmp_path: Path) -> Path:
                     "no_drop_duplicate_deadlock_timeout": True,
                     "cycle_bound_ok": True,
                     "hashes": {
-                        "score_hash": "score-hash",
-                        "final_hash": "final-hash",
+                        "score_hash": "integrated-c1-score-hash",
+                        "final_hash": "integrated-c1-final-hash",
                         "request_hash": "request-hash",
                         "wide_response_matrix_hash": "wide-hash",
                     },
@@ -238,6 +247,12 @@ def _service_activity_power(tmp_path: Path) -> Path:
             "activity_contract": {
                 "clock_period_ns": 10.0,
                 "cycle_count": 160,
+            },
+            "activity_workload_contract": {
+                "active_context_tokens": 24,
+                "measured_context_capacity_tokens": 128,
+                "score_hash": "activity-workload-score-hash",
+                "final_hash": "activity-workload-final-hash",
             },
             "macro_manifest_contract": {
                 "counts": {"fakeram45_2048x39": 56, "fakeram45_64x32": 64},
@@ -281,7 +296,7 @@ def test_build_report_success_recomputes_latency_area_and_component_energy(tmp_p
     )
 
     assert payload["decision"] == "strict_c1_measured_service_anchor_promoted_c2plus_blocked"
-    assert payload["schedule_contract"]["context_tile_count"] == 1024
+    assert payload["inputs"]["source_schedule_json"].endswith("source_schedule.json")
     assert len(payload["promoted_rows"]) == 1
     row = payload["best_measured_anchor"]
     assert row["cluster_count"] == 1
@@ -298,10 +313,18 @@ def test_build_report_success_recomputes_latency_area_and_component_energy(tmp_p
     assert row["prior_cluster_area_mm2"] == pytest.approx(2.0)
     assert row["authoritative_composed_service_area_mm2"] == pytest.approx(3.0)
     assert "16KiB service value store" in row["area_replacement_provenance"]
-    assert row["service_component_dynamic_energy_mj_per_token"] == pytest.approx(503.31648)
+    assert row["service_component_dynamic_energy_mj_per_token"] == pytest.approx(2684.68224)
     assert row["service_component_leakage_energy_mj_per_token"] == pytest.approx(0.2048)
-    assert row["service_component_energy_mj_per_token"] == pytest.approx(503.52128)
+    assert row["service_component_energy_mj_per_token"] == pytest.approx(2684.88704)
     assert row["direct_total_token_energy"] is False
+    assert row["full_measured_window_count"] == 5462
+    assert row["full_measured_window_count_exact"] == 5461
+    assert row["final_partial_tokens"] == 8
+    assert row["final_partial_window_conservatively_charged_as_full_measured_window"] is True
+    assert (
+        payload["selected_service_activity_candidate"]["integrated_service_hashes"]["score_hash"]
+        == "integrated-c1-score-hash"
+    )
 
 
 def test_build_report_prevents_old_cluster_and_service_area_double_count(tmp_path: Path) -> None:
@@ -317,6 +340,26 @@ def test_build_report_prevents_old_cluster_and_service_area_double_count(tmp_pat
     assert row["dense_qkv_tile_count"] == 4
     assert row["logic_area_mm2"] == pytest.approx(12.0)
     assert row["area_replacement_delta_mm2"] == pytest.approx(1.0)
+
+
+def test_build_report_accepts_distinct_integrated_hash_domain(tmp_path: Path) -> None:
+    prior = _prior_frontier(tmp_path)
+    service = _service_activity_power(tmp_path)
+
+    payload = build_report(
+        prior_cluster_frontier_json=prior,
+        service_activity_power_json=service,
+    )
+
+    assert payload["precision"]["score_tensor_hash"] == "score-hash"
+    assert (
+        payload["selected_service_activity_candidate"]["integrated_service_hashes"]["score_hash"]
+        == "integrated-c1-score-hash"
+    )
+    assert (
+        payload["selected_service_activity_candidate"]["integrated_service_hashes"]["final_hash"]
+        == "integrated-c1-final-hash"
+    )
 
 
 def test_build_report_rejects_cycle_mismatch(tmp_path: Path) -> None:
@@ -363,11 +406,35 @@ def test_build_report_rejects_precision_gate_mismatch(tmp_path: Path) -> None:
         )
 
 
-def test_build_report_rejects_non_divisible_sequence(tmp_path: Path) -> None:
+def test_build_report_uses_24_token_measured_window_ceil_and_partial_charge(tmp_path: Path) -> None:
     prior = _prior_frontier(tmp_path, sequence_length=131000)
     service = _service_activity_power(tmp_path)
 
-    with pytest.raises(ValueError, match="divisible by microkernel_context_tokens"):
+    payload = build_report(
+        prior_cluster_frontier_json=prior,
+        service_activity_power_json=service,
+    )
+
+    row = payload["best_measured_anchor"]
+    assert row["full_measured_window_count"] == 5459
+    assert row["full_measured_window_count_exact"] == 5458
+    assert row["final_partial_tokens"] == 8
+    assert row["final_partial_window_conservatively_charged_as_full_measured_window"] is True
+    assert row["service_component_dynamic_energy_mj_per_token"] == pytest.approx(2683.20768)
+
+
+def test_build_report_rejects_recomputed_infeasible_c1(tmp_path: Path) -> None:
+    prior = _prior_frontier(tmp_path)
+    prior_payload = json.loads(prior.read_text(encoding="utf-8"))
+    linked_prior = Path(prior_payload["inputs"]["prior_frontier_json"])
+    linked_payload = json.loads(linked_prior.read_text(encoding="utf-8"))
+    source = Path(linked_payload["inputs"]["source_schedule_json"])
+    source_payload = json.loads(source.read_text(encoding="utf-8"))
+    source_payload["source_schedule"]["compute_budget_um2"] = 3_500_000
+    source.write_text(json.dumps(source_payload), encoding="utf-8")
+    service = _service_activity_power(tmp_path)
+
+    with pytest.raises(ValueError, match="not feasible for promotion"):
         build_report(
             prior_cluster_frontier_json=prior,
             service_activity_power_json=service,

--- a/tests/test_attention_decode_score_multivalue_service_measured_frontier.py
+++ b/tests/test_attention_decode_score_multivalue_service_measured_frontier.py
@@ -43,6 +43,17 @@ def _source_schedule(tmp_path: Path, *, sequence_length: int = 131072) -> Path:
     )
 
 
+def _workload_contract() -> dict:
+    return {
+        "command_block_count": 3,
+        "context_tokens_per_block": 8,
+        "active_context_tokens": 24,
+        "max_blocks": 16,
+        "max_context_capacity_tokens": 128,
+        "value_dim": 128,
+    }
+
+
 def _prior_frontier(tmp_path: Path, *, sequence_length: int = 131072) -> Path:
     source = _source_schedule(tmp_path, sequence_length=sequence_length)
     linked_prior = _write(
@@ -145,8 +156,7 @@ def _prior_frontier(tmp_path: Path, *, sequence_length: int = 131072) -> Path:
             },
             "service_cycle_calibration": {
                 "probe_contract": {
-                    "microkernel_context_tokens": 128,
-                    "microkernel_value_dim": 128,
+                    **_workload_contract(),
                     "consumed_case_ids": ["c1_p128_b4_rr", "c2_p128_b4_rr"],
                     "resource_policy": {
                         "packet_w": 128,
@@ -231,6 +241,18 @@ def _service_activity_power(tmp_path: Path) -> Path:
                 },
                 "integrated_service_c1": {
                     "case_id": "c1_p128_b4_rr",
+                    "config": {
+                        "cluster_count": 1,
+                        "packet_w": 128,
+                        "banks": 4,
+                        "req_queue_depth": 4,
+                        "resp_queue_depth": 4,
+                        "bank_queue_depth": 4,
+                        "read_latency": 2,
+                        "arb_mode": "round_robin",
+                        "locality_burst_max": 2,
+                    },
+                    "workload_contract": _workload_contract(),
                     "decision": "pass",
                     "exact_match": True,
                     "no_protocol_errors": True,
@@ -247,12 +269,7 @@ def _service_activity_power(tmp_path: Path) -> Path:
             "activity_contract": {
                 "clock_period_ns": 10.0,
                 "cycle_count": 160,
-            },
-            "activity_workload_contract": {
-                "active_context_tokens": 24,
-                "measured_context_capacity_tokens": 128,
-                "score_hash": "activity-workload-score-hash",
-                "final_hash": "activity-workload-final-hash",
+                "workload_contract": _workload_contract(),
             },
             "macro_manifest_contract": {
                 "counts": {"fakeram45_2048x39": 56, "fakeram45_64x32": 64},
@@ -297,6 +314,7 @@ def test_build_report_success_recomputes_latency_area_and_component_energy(tmp_p
 
     assert payload["decision"] == "strict_c1_measured_service_anchor_promoted_c2plus_blocked"
     assert payload["inputs"]["source_schedule_json"].endswith("source_schedule.json")
+    assert payload["schedule_contract"]["workload_contract"] == _workload_contract()
     assert len(payload["promoted_rows"]) == 1
     row = payload["best_measured_anchor"]
     assert row["cluster_count"] == 1
@@ -324,6 +342,10 @@ def test_build_report_success_recomputes_latency_area_and_component_energy(tmp_p
     assert (
         payload["selected_service_activity_candidate"]["integrated_service_hashes"]["score_hash"]
         == "integrated-c1-score-hash"
+    )
+    assert (
+        payload["selected_service_activity_candidate"]["activity_workload_contract"]
+        == _workload_contract()
     )
 
 
@@ -400,6 +422,20 @@ def test_build_report_rejects_precision_gate_mismatch(tmp_path: Path) -> None:
     service.write_text(json.dumps(payload), encoding="utf-8")
 
     with pytest.raises(ValueError, match="final_tensor_hash mismatch"):
+        build_report(
+            prior_cluster_frontier_json=prior,
+            service_activity_power_json=service,
+        )
+
+
+def test_build_report_rejects_workload_contract_schema_drift(tmp_path: Path) -> None:
+    prior = _prior_frontier(tmp_path)
+    service = _service_activity_power(tmp_path)
+    payload = json.loads(service.read_text(encoding="utf-8"))
+    payload["activity_contract"]["workload_contract"]["active_context_tokens"] = 25
+    service.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="workload_contract"):
         build_report(
             prior_cluster_frontier_json=prior,
             service_activity_power_json=service,

--- a/tests/test_generate_attention_decode_score_multivalue_service_activity.py
+++ b/tests/test_generate_attention_decode_score_multivalue_service_activity.py
@@ -18,6 +18,7 @@ from npu.eval.generate_attention_decode_score_multivalue_service_activity import
     _REQUIRED_SERVICE_FIELDS,
     _normalize_config,
 )
+from npu.eval.probe_attention_decode_score_multivalue_integrated_service import _workload_contract
 
 
 def _iverilog_available() -> bool:
@@ -35,6 +36,7 @@ def test_normalize_config_requires_macro_backed_c1() -> None:
     normalized = _normalize_config(_config())
     assert normalized["top_name"] == "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_macro_activity"
     assert normalized["attention_decode_score_multivalue_service"] == _REQUIRED_SERVICE_FIELDS
+    assert normalized["attention_decode_score_multivalue_service"]["max_blocks"] == _workload_contract()["max_blocks"]
 
 
 def test_integrated_testbench_default_clock_text_and_8ns_override() -> None:
@@ -53,6 +55,7 @@ def test_integrated_testbench_default_clock_text_and_8ns_override() -> None:
     assert "  always #5 clk = ~clk;" in default_tb
     assert "always #4 clk = ~clk;" in fast_tb
     assert "always #4 clk = ~clk;" not in default_tb
+    assert "cluster_command_block_count[(15*idx) +: 15] = 15'd3;" in default_tb
 
 
 def test_activity_generator_source_has_no_artificial_macro_touch() -> None:
@@ -86,6 +89,9 @@ def test_generate_service_activity_is_deterministic(tmp_path: Path) -> None:
     manifest_a = json.loads((out_a / _OUTPUT_MANIFEST_NAME).read_text(encoding="utf-8"))
     manifest_b = json.loads((out_b / _OUTPUT_MANIFEST_NAME).read_text(encoding="utf-8"))
     assert manifest_a == manifest_b
+    assert manifest_a["workload_contract"] == _workload_contract()
+    assert manifest_a["workload_contract"]["active_context_tokens"] == 24
+    assert manifest_a["workload_contract"]["max_context_capacity_tokens"] == 128
     assert manifest_a["cycle_count"] > 0
     assert manifest_a["clock_period_ns"] == 10.0
     assert manifest_a["request_result_protocol_counters"]["request_count"] == 48
@@ -101,6 +107,7 @@ def test_generate_service_activity_is_deterministic(tmp_path: Path) -> None:
     assert not manifest_a["artifacts"]["vcd"].startswith("/")
     assert str(REPO_ROOT / "npu/eval") not in json.dumps(manifest_a, sort_keys=True)
     assert "bank3 switching" in " ".join(manifest_a["scope"]["remaining"])
+    assert "24 active context tokens" in " ".join(manifest_a["scope"]["exercised"])
 
     top_text = (out_a / _OUTPUT_TOP_NAME).read_text(encoding="utf-8")
     assert "fakeram45_2048x39" in top_text


### PR DESCRIPTION
## Summary
- add a strict measured c1 multivalue-service frontier evaluator and L2 control-plane wiring
- propagate and validate the integrated-service workload contract and generated activity hashes before physical power analysis
- correct the measured workload from a falsely implied 128 active context tokens to 24 active tokens (3 blocks x 8), while retaining 128 only as capacity
- scale the Llama7B context with `ceil(sequence_length / 24)`, conservatively charging the final partial window

## Why
The prior cluster frontier used proxy area/energy and ambiguous workload scope. This change replaces, rather than adds to, the old c1 cluster area/energy with the measured composed-service anchor. It keeps c2+ unpromoted and does not claim total-token energy while SRAM, NoC, HBM, producer, and dense energy remain outside the measurement.

## Validation
- 308 focused integrated-service/activity/frontier/control-plane tests passed
- 19 campaign workflow tests passed
- `scripts/validate_runs.py` passed
- changed Python files compile cleanly
- direct 14-case integrated-service probe passed locally; compact report is 67,742 bytes / 1,704 lines