### PR TITLE
Add strict c2 multivalue service measurement

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -60,14 +60,29 @@ _MULTIVALUE_CLUSTER_FRONTIER_BASE_ITEM = (
 _MULTIVALUE_CLUSTER_FRONTIER_DEFAULT_ITEM = (
     "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1"
 )
-_MULTIVALUE_SERVICE_ACTIVITY_POWER_DEFAULT_ITEM = (
+_MULTIVALUE_SERVICE_C1_ACTIVITY_POWER_DEFAULT_ITEM = (
     "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1"
+)
+_MULTIVALUE_SERVICE_C2_ACTIVITY_POWER_DEFAULT_ITEM = (
+    "l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1"
 )
 _MULTIVALUE_SERVICE_C1_PNR_ITEM = (
     "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1"
 )
+_MULTIVALUE_SERVICE_C2_PNR_ITEM = (
+    "l1_decoder_attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_pnr_v1"
+)
 _MULTIVALUE_SERVICE_C1_DESIGN = (
     "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr"
+)
+_MULTIVALUE_SERVICE_C2_DESIGN = (
+    "attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr"
+)
+_MULTIVALUE_SERVICE_MEASURED_FRONTIER_C1_ONLY_DEFAULT_ITEM = (
+    "l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1"
+)
+_MULTIVALUE_SERVICE_MEASURED_FRONTIER_C1_C2_DEFAULT_ITEM = (
+    "l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v2"
 )
 
 
@@ -217,16 +232,23 @@ def _multivalue_cluster_frontier_item_for_consumer(
 
 
 def _multivalue_service_activity_power_item_for_consumer(
-    *, depends_on_item_ids: list[str] | None
+    *, depends_on_item_ids: list[str] | None, cluster_count: int = 1
 ) -> str:
-    prefix = "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_"
+    prefix = (
+        "l2_decoder_attention_decode_score_multivalue_service_"
+        f"c{cluster_count}_activity_power_llama7b_"
+    )
     candidate_item_ids = [
         str(dep).strip()
         for dep in (depends_on_item_ids or [])
         if str(dep).strip().startswith(prefix)
     ]
     if not candidate_item_ids:
-        return _MULTIVALUE_SERVICE_ACTIVITY_POWER_DEFAULT_ITEM
+        return (
+            _MULTIVALUE_SERVICE_C1_ACTIVITY_POWER_DEFAULT_ITEM
+            if cluster_count == 1
+            else _MULTIVALUE_SERVICE_C2_ACTIVITY_POWER_DEFAULT_ITEM
+        )
     return max(candidate_item_ids, key=_item_version_retry_rank)
 
 
@@ -7376,7 +7398,9 @@ def _decoder_attention_decode_score_multivalue_service_activity_power_evidence(
     *, item_id: str, depends_on_item_ids: list[str] | None = None
 ) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
-    design = _MULTIVALUE_SERVICE_C1_DESIGN
+    is_c2 = "service_c2_activity_power" in item_id
+    case_id = "c2_p128_b4_rr" if is_c2 else "c1_p128_b4_rr"
+    design = _MULTIVALUE_SERVICE_C2_DESIGN if is_c2 else _MULTIVALUE_SERVICE_C1_DESIGN
     config = f"runs/designs/npu_blocks/{design}/config.json"
     metrics_csv = f"runs/designs/npu_blocks/{design}/metrics.csv"
     equivalence_json = (
@@ -7391,32 +7415,51 @@ def _decoder_attention_decode_score_multivalue_service_activity_power_evidence(
         f"{integrated_service_item}.json"
     )
     orfs_design_config = f"/orfs/flow/designs/nangate45/{design}/config.mk"
-    activity_dir = "/tmp/rtlgen_multivalue_service_c1_activity"
+    activity_dir = f"/tmp/rtlgen_multivalue_service_{case_id.split('_', 1)[0]}_activity"
     out = f"{base}/decoder_attention_decode_score_multivalue_service_activity_power__{item_id}.json"
     report = f"{base}/decoder_attention_decode_score_multivalue_service_activity_power__{item_id}.md"
+    pnr_item = _MULTIVALUE_SERVICE_C2_PNR_ITEM if is_c2 else _MULTIVALUE_SERVICE_C1_PNR_ITEM
+    config_key_prefix = f"decode_score_multivalue_service_{case_id.split('_', 1)[0]}"
+    scope = (
+        "Audit strict c2 routed composed-service activity power after merged/materialized "
+        "integrated-service c2, c2 PNR, and shared-score multivalue cluster-equivalence evidence. "
+        "Measure only direct routed whole-service window energy, inherit the exact integer precision "
+        "contract from the merged equivalence proof, require complete relevant FakeRAM macro-class "
+        "annotation, keep VCD/ODB/SPEF evaluator-local, and do not claim total-token energy."
+        if is_c2
+        else (
+            "Audit strict c1 routed composed-service activity power after merged/materialized "
+            "integrated-service, c1 PNR, and shared-score multivalue cluster-equivalence evidence. "
+            "Measure only direct routed component service-window energy, inherit the exact integer "
+            "precision contract from the merged equivalence proof, do not force bank3 activity, keep "
+            "VCD/ODB/SPEF evaluator-local, and do not claim total-token energy."
+        )
+    )
+    promotion_gate = (
+        "Promotion requires a timing-feasible 10 ns c2 routed row, exact integrated-service c2 "
+        "hash/protocol/count gates, validation that the c2 activity cycle count matches case "
+        "c2_p128_b4_rr, complete relevant FakeRAM macro-class annotation, finite positive routed "
+        "power, and direct whole-service-window measurement rather than compositional token-energy accounting."
+        if is_c2
+        else (
+            "Promotion requires a timing-feasible 10 ns c1 routed row, exact integrated-service c1 "
+            "hash/protocol/count gates, explicit annotation coverage, finite positive routed power, "
+            "and a direct service-window measurement rather than compositional token-energy accounting."
+        )
+    )
     return {
         "inputs": {
-            "decode_score_multivalue_service_c1_config": config,
-            "decode_score_multivalue_service_c1_pnr_metrics_csv": metrics_csv,
-            "decode_score_multivalue_service_c1_source_pnr_item_id": _MULTIVALUE_SERVICE_C1_PNR_ITEM,
-            "decode_score_multivalue_service_c1_equivalence_json": equivalence_json,
-            "decode_score_multivalue_service_c1_integrated_service_json": integrated_service_json,
-            "decode_score_multivalue_service_c1_orfs_design_config": orfs_design_config,
-            "decode_score_multivalue_service_c1_activity_dir": activity_dir,
+            f"{config_key_prefix}_config": config,
+            f"{config_key_prefix}_pnr_metrics_csv": metrics_csv,
+            f"{config_key_prefix}_source_pnr_item_id": pnr_item,
+            f"{config_key_prefix}_equivalence_json": equivalence_json,
+            f"{config_key_prefix}_integrated_service_json": integrated_service_json,
+            f"{config_key_prefix}_orfs_design_config": orfs_design_config,
+            f"{config_key_prefix}_activity_dir": activity_dir,
             "decode_score_multivalue_service_activity_power_out": out,
             "decode_score_multivalue_service_activity_power_report": report,
-            "decode_score_multivalue_service_activity_power_scope": (
-                "Audit strict c1 routed composed-service activity power after merged/materialized "
-                "integrated-service, c1 PNR, and shared-score multivalue cluster-equivalence evidence. "
-                "Measure only direct routed component service-window energy, inherit the exact integer "
-                "precision contract from the merged equivalence proof, do not force bank3 activity, keep "
-                "VCD/ODB/SPEF evaluator-local, and do not claim total-token energy."
-            ),
-            "decode_score_multivalue_service_activity_power_promotion_gate": (
-                "Promotion requires a timing-feasible 10 ns c1 routed row, exact integrated-service c1 "
-                "hash/protocol/count gates, explicit annotation coverage, finite positive routed power, "
-                "and a direct service-window measurement rather than compositional token-energy accounting."
-            ),
+            "decode_score_multivalue_service_activity_power_scope": scope,
+            "decode_score_multivalue_service_activity_power_promotion_gate": promotion_gate,
             "decode_score_multivalue_service_activity_power_local_only_artifacts": ["VCD", "ODB", "SPEF"],
         },
         "commands": [
@@ -7425,14 +7468,18 @@ def _decoder_attention_decode_score_multivalue_service_activity_power_evidence(
                 "run": (
                     "python3 -m npu.eval.audit_attention_decode_score_multivalue_service_activity_power "
                     f"--config {config} "
-                    f"--c1-metrics-csv {metrics_csv} "
-                    f"--equivalence-json {equivalence_json} "
-                    f"--integrated-service-json {integrated_service_json} "
-                    f"--orfs-design-config {orfs_design_config} "
-                    "--clock-period-ns 10 "
-                    f"--activity-dir {activity_dir} "
-                    f"--out {out} "
-                    f"--out-md {report}"
+                    + (
+                        f"--metrics-csv {metrics_csv} --case-id {case_id} "
+                        if is_c2
+                        else f"--c1-metrics-csv {metrics_csv} "
+                    )
+                    + f"--equivalence-json {equivalence_json} "
+                    + f"--integrated-service-json {integrated_service_json} "
+                    + f"--orfs-design-config {orfs_design_config} "
+                    + "--clock-period-ns 10 "
+                    + f"--activity-dir {activity_dir} "
+                    + f"--out {out} "
+                    + f"--out-md {report}"
                 ),
             }
         ],
@@ -7445,6 +7492,7 @@ def _decoder_attention_decode_score_multivalue_service_measured_frontier_evidenc
     *, item_id: str, depends_on_item_ids: list[str] | None = None
 ) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    c2_enabled = "llama7b_v2" in item_id
     prior_cluster_frontier_item = _multivalue_cluster_frontier_item_for_consumer(
         depends_on_item_ids=depends_on_item_ids
     )
@@ -7452,44 +7500,77 @@ def _decoder_attention_decode_score_multivalue_service_measured_frontier_evidenc
         f"{base}/decoder_attention_decode_score_multivalue_cluster_frontier__"
         f"{prior_cluster_frontier_item}.json"
     )
-    service_activity_power_item = _multivalue_service_activity_power_item_for_consumer(
-        depends_on_item_ids=depends_on_item_ids
+    service_activity_power_item_c1 = _multivalue_service_activity_power_item_for_consumer(
+        depends_on_item_ids=depends_on_item_ids,
+        cluster_count=1,
     )
-    service_activity_power = (
+    service_activity_power_c1 = (
         f"{base}/decoder_attention_decode_score_multivalue_service_activity_power__"
-        f"{service_activity_power_item}.json"
+        f"{service_activity_power_item_c1}.json"
+    )
+    service_activity_power_item_c2 = (
+        _multivalue_service_activity_power_item_for_consumer(
+            depends_on_item_ids=depends_on_item_ids,
+            cluster_count=2,
+        )
+        if c2_enabled
+        else None
+    )
+    service_activity_power_c2 = (
+        f"{base}/decoder_attention_decode_score_multivalue_service_activity_power__"
+        f"{service_activity_power_item_c2}.json"
+        if service_activity_power_item_c2
+        else None
     )
     out = f"{base}/decoder_attention_decode_score_multivalue_service_measured_frontier__{item_id}.json"
     report = f"{base}/decoder_attention_decode_score_multivalue_service_measured_frontier__{item_id}.md"
+    scope = (
+        "Replace the prior shared-score multivalue cluster frontier area/energy proxy with measured "
+        "composed-service c1 and c2 anchors only. Compare c1 and c2 using measured latency/area/dynamic/"
+        "leakage, scale whole-service measured windows with ceil(sequence_length / 24) and then "
+        "cluster_waves_per_layer * layers instead of heads * layers, preserve the exact integer "
+        "precision contract unchanged, do not claim total-token energy, and leave broader SRAM, "
+        "NoC, HBM, producer, and dense energy outside while c3+ remain blocked/unpromoted."
+        if c2_enabled
+        else (
+            "Replace the prior shared-score multivalue cluster frontier area/energy proxy with the "
+            "measured composed-service c1 anchor only. Keep c2+ service points blocked/unpromoted, "
+            "scale the direct routed microkernel service-window activity explicitly into the "
+            "Llama7B context, preserve the exact integer precision contract unchanged, do not claim "
+            "total-token energy, and leave broader SRAM, NoC, HBM, producer, and dense energy "
+            "outside this measured-service frontier."
+        )
+    )
+    command = (
+        "python3 -m npu.eval.audit_attention_decode_score_multivalue_service_measured_frontier "
+        f"--prior-cluster-frontier-json {prior_cluster_frontier} "
+        f"--service-activity-power-json {service_activity_power_c1} "
+        + (
+            f"--service-activity-power-json {service_activity_power_c2} "
+            if c2_enabled and service_activity_power_c2 is not None
+            else ""
+        )
+        + f"--out {out} --out-md {report}"
+    )
     return {
         "inputs": {
             "decode_score_multivalue_service_measured_frontier_prior_cluster_frontier": (
                 prior_cluster_frontier
             ),
-            "decode_score_multivalue_service_measured_frontier_service_activity_power": (
-                service_activity_power
-            ),
+            "decode_score_multivalue_service_measured_frontier_service_activity_power": service_activity_power_c1,
+            "decode_score_multivalue_service_measured_frontier_service_activity_powers": [
+                value
+                for value in (service_activity_power_c1, service_activity_power_c2)
+                if value is not None
+            ],
             "decode_score_multivalue_service_measured_frontier_out": out,
             "decode_score_multivalue_service_measured_frontier_report": report,
-            "decode_score_multivalue_service_measured_frontier_scope": (
-                "Replace the prior shared-score multivalue cluster frontier area/energy proxy with the "
-                "measured composed-service c1 anchor only. Keep c2+ service points blocked/unpromoted, "
-                "scale the direct routed microkernel service-window activity explicitly into the "
-                "Llama7B context, preserve the exact integer precision contract unchanged, do not claim "
-                "total-token energy, and leave broader SRAM, NoC, HBM, producer, and dense energy "
-                "outside this measured-service frontier."
-            ),
+            "decode_score_multivalue_service_measured_frontier_scope": scope,
         },
         "commands": [
             {
                 "name": "audit_decode_score_multivalue_service_measured_frontier",
-                "run": (
-                    "python3 -m npu.eval.audit_attention_decode_score_multivalue_service_measured_frontier "
-                    f"--prior-cluster-frontier-json {prior_cluster_frontier} "
-                    f"--service-activity-power-json {service_activity_power} "
-                    f"--out {out} "
-                    f"--out-md {report}"
-                ),
+                "run": command,
             }
         ],
         "expected_outputs": [out, report],

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -8489,6 +8489,78 @@ def test_service_measured_frontier_request_manifests_remain_dependency_gated() -
         ]["reason"]
 
 
+def test_service_c2_activity_power_request_manifests_remain_dependency_gated() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    proposal_dir = (
+        repo_root
+        / "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1"
+    )
+    expected_depends = {
+        "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
+        "l1_decoder_attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_pnr_v1",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
+    }
+
+    for manifest_name, items_key in (
+        ("proposal.json", "required_evaluations"),
+        ("evaluation_requests.json", "requested_items"),
+    ):
+        manifest = json.loads((proposal_dir / manifest_name).read_text(encoding="utf-8"))
+        if manifest_name == "evaluation_requests.json":
+            note = manifest["source_commit_note"]
+            assert "Sunday, July 26, 2026" in note
+            assert "dependency-gated" in note
+            assert "c2 composed-service metrics row" in note
+        item = manifest[items_key][0]
+        assert (
+            item["item_id"]
+            == "l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1"
+        )
+        assert set(item["depends_on_item_ids"]) == expected_depends
+        assert item["requires_merged_inputs"] is True
+        assert item["requires_materialized_refs"] is True
+        assert item["status"] == "pending_implementation_merge"
+        assert "Sunday, July 26, 2026" in item["notes"]
+        assert "cycle 8863" in item["expected_result"]["reason"]
+        assert "FakeRAM macro-class annotation" in item["expected_result"]["reason"]
+
+
+def test_service_measured_frontier_v2_request_manifests_remain_dependency_gated() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    proposal_dir = (
+        repo_root
+        / "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v2"
+    )
+    expected_depends = {
+        "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
+        "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
+        "l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1",
+    }
+
+    for manifest_name, items_key in (
+        ("proposal.json", "required_evaluations"),
+        ("evaluation_requests.json", "requested_items"),
+    ):
+        manifest = json.loads((proposal_dir / manifest_name).read_text(encoding="utf-8"))
+        if manifest_name == "evaluation_requests.json":
+            note = manifest["source_commit_note"]
+            assert "Sunday, July 26, 2026" in note
+            assert "c3+ remain blocked/unpromoted" in note
+        item = manifest[items_key][0]
+        assert (
+            item["item_id"]
+            == "l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v2"
+        )
+        assert set(item["depends_on_item_ids"]) == expected_depends
+        assert item["requires_merged_inputs"] is True
+        assert item["requires_materialized_refs"] is True
+        assert item["status"] == "pending_implementation_merge"
+        assert "Sunday, July 26, 2026" in item["notes"]
+        assert "cluster_waves_per_layer * layers" in item["expected_result"]["reason"]
+        assert "instead of heads * layers" in item["expected_result"]["reason"]
+        assert "c3+ blocked/unpromoted" in item["notes"]
+
+
 def test_gqa_folded_activity_request_manifests_require_cluster_activity_power_v16() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     proposal_dir = (
@@ -9184,6 +9256,61 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_activity
             )
 
 
+def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_c2_activity_power() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=(
+                        "l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1"
+                    ),
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_decode_score_multivalue_service_activity_power",
+                    evaluation_mode="frontier_detail",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
+                        "l1_decoder_attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_pnr_v1",
+                        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
+                    ],
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            run = work_item.task_request.request_payload["task"]["commands"][0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert "--config runs/designs/npu_blocks/attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr/config.json" in run
+            assert "--metrics-csv runs/designs/npu_blocks/attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr/metrics.csv" in run
+            assert "--case-id c2_p128_b4_rr" in run
+            assert "--activity-dir /tmp/rtlgen_multivalue_service_c2_activity" in run
+            assert decoder_inputs["decode_score_multivalue_service_c2_source_pnr_item_id"] == (
+                "l1_decoder_attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_pnr_v1"
+            )
+            assert "cycle count matches case c2_p128_b4_rr" in decoder_inputs[
+                "decode_score_multivalue_service_activity_power_promotion_gate"
+            ]
+            assert "FakeRAM macro-class annotation" in decoder_inputs[
+                "decode_score_multivalue_service_activity_power_scope"
+            ]
+            assert decoder_inputs["decode_score_multivalue_service_activity_power_local_only_artifacts"] == [
+                "VCD",
+                "ODB",
+                "SPEF",
+            ]
+
+
 def test_generate_l2_campaign_task_cluster_frontier_uses_cluster_activity_v1_dependency() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"
@@ -9318,6 +9445,68 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_measured
                 )
                 for output in work_item.task_request.request_payload["task"]["expected_outputs"]
             )
+
+
+def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_measured_frontier_v2() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=(
+                        "l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v2"
+                    ),
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_decode_score_multivalue_service_measured_frontier",
+                    evaluation_mode="frontier_recost",
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
+                        "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
+                        "l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1",
+                    ],
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            run = work_item.task_request.request_payload["task"]["commands"][0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert run.count("--service-activity-power-json ") == 2
+            assert (
+                "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1.json"
+                in run
+            )
+            assert (
+                "l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1.json"
+                in run
+            )
+            assert decoder_inputs[
+                "decode_score_multivalue_service_measured_frontier_service_activity_powers"
+            ] == [
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_decode_score_multivalue_service_activity_power__"
+                "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1.json",
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_decode_score_multivalue_service_activity_power__"
+                "l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1.json",
+            ]
+            assert "cluster_waves_per_layer * layers" in decoder_inputs[
+                "decode_score_multivalue_service_measured_frontier_scope"
+            ]
+            assert "instead of heads" in decoder_inputs[
+                "decode_score_multivalue_service_measured_frontier_scope"
+            ]
 
 
 def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_group_frontier() -> None:

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,28 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1",
+  "source_commit_note": "Replace with the merge commit that contains this strict c2 composed-service activity-power wiring before dispatch. As of Sunday, July 26, 2026, this request remains dependency-gated because the integrated-service r1 JSON and the c2 composed-service metrics row are not both materialized in the repository checkout; do not dispatch until all three dependency outputs are merged/materialized.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Audit strict c2 routed composed-service activity power at 10 ns using merged/materialized c2 PNR, integrated-service r1, and shared-score multivalue cluster-equivalence evidence while reporting only direct whole-service window energy.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_service_activity_power",
+      "comparison_role": "strict_c2_service_activity_power_gate",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_pnr_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
+        "l1_decoder_attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_pnr_v1",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_strict_c2_composed_service_activity_power",
+        "reason": "Require merged/materialized integrated-service r1, composed c2 PNR, and shared-score multivalue cluster-equivalence evidence before dispatch; then measure only direct routed whole-service window energy at 10 ns, preserve exact inherited precision, validate c2_p128_b4_rr cycle 8863 and hashes before physical power build, require complete relevant FakeRAM macro-class annotation, and withhold total-token energy."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "This request remains dependency-gated and is not ready for normal dispatch. As of Sunday, July 26, 2026, the integrated-service r1 JSON and the c2 composed-service metrics row are not both materialized in the repository checkout, and both must merge/materialize before dispatch even though the shared-score multivalue cluster-equivalence JSON path is already the same repo path used by related audits."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1/proposal.json
@@ -1,0 +1,94 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1",
+  "created_utc": "2026-07-26T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Strict c2 composed-service activity power gate for Llama7B",
+  "abstraction_layer": "decoder_attention_decode_score_multivalue_service_activity_power",
+  "hypothesis": "Once the compact integrated-service r1 probe, the merged c2 composed-service PNR row, and the shared-score multivalue cluster-equivalence evidence are all merged and materialized, a strict c2 routed audit can report only direct whole-service window energy with exact inherited precision, exact c2 cycle/hash gating, complete relevant FakeRAM annotation, and no total-token energy claim.",
+  "direct_comparison": {
+    "primary_question": "Does the routed c2 composed service remain physically interesting once the merged c2 PNR row is combined with strict integrated-service c2 and cluster-equivalence gates plus evaluator-local switching evidence, while reporting only direct whole-service window energy?",
+    "baseline": "l1_decoder_attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_pnr_v1 as the authoritative composed c2 PPA row, with integrated-service r1 and shared-score multivalue cluster-equivalence evidence as strict dependency gates.",
+    "include": [
+      "strict c2 p128/b4/q4/rl2/round_robin composed-service routed row at 10 ns",
+      "merged/materialized integrated-service c2 exact hash/protocol/count evidence from l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
+      "validation that the c2 activity cycle count matches case c2_p128_b4_rr and integrated completion cycle 8863",
+      "merged/materialized shared-score multivalue cluster-equivalence evidence using the exact JSON path already consumed by related audits",
+      "direct routed whole-service window dynamic and leakage energy only",
+      "complete relevant FakeRAM macro-class annotation for the c2 composed service",
+      "repo-portable JSON and Markdown outputs only, with raw VCD, ODB, SPEF, and temporary activity directories kept evaluator-local"
+    ],
+    "exclude": [
+      "do not claim total-token energy or token rankings",
+      "do not reopen arithmetic precision, semantic equivalence, NoC closure, HBM closure, or service-fabric PPA/energy closure",
+      "do not commit evaluator-local activity artifacts"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "total_power_mw",
+      "service_window_dynamic_energy_j",
+      "service_window_leakage_energy_j",
+      "service_window_total_energy_j",
+      "vcd_annotation_coverage",
+      "sequential_register_activity_coverage",
+      "macro_active_coverage",
+      "promotion_gate_pass"
+    ]
+  },
+  "expected_benefit": [
+    "converts the composed c2 service point from vectorless total power to a strict activity-backed whole-service component energy measurement",
+    "preserves the exact integer precision contract already proven by the merged equivalence gate",
+    "makes the scope boundary explicit by measuring only direct routed whole-service window energy and withholding total-token energy"
+  ],
+  "risks": [
+    "the merged c2 row may fail strict annotation or positive-power gates even after routing succeeds",
+    "the c2 measured service point could still lose on area or timing despite closing the activity path",
+    "passing this audit still does not close service-fabric energy, NoC composition, HBM service, or total-token energy"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Audit strict c2 routed composed-service activity power at 10 ns using merged/materialized c2 PNR, integrated-service r1, and shared-score multivalue cluster-equivalence evidence while reporting only direct whole-service window energy.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_service_activity_power",
+      "comparison_role": "strict_c2_service_activity_power_gate",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_pnr_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
+        "l1_decoder_attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_pnr_v1",
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_strict_c2_composed_service_activity_power",
+        "reason": "Require merged/materialized integrated-service r1, composed c2 PNR, and shared-score multivalue cluster-equivalence evidence before dispatch; then measure only direct routed whole-service window energy at 10 ns, preserve exact inherited precision, validate c2_p128_b4_rr cycle 8863 and hashes before physical power build, require complete relevant FakeRAM macro-class annotation, and withhold total-token energy."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "This request remains dependency-gated and is not ready for normal dispatch. As of Sunday, July 26, 2026, the integrated-service r1 JSON and the c2 composed-service metrics row are not both materialized in the repository checkout, and both must merge/materialize before dispatch even though the shared-score multivalue cluster-equivalence JSON path is already the same repo path used by related audits."
+    }
+  ],
+  "baseline_refs": [
+    "runs/designs/npu_blocks/attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr/config.json",
+    "runs/designs/npu_blocks/attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr/metrics.csv",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_integrated_service__l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_equivalence__l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1.json",
+    "docs/proposals/prop_l1_decoder_attention_decode_score_multivalue_service_pnr_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/proposal.json",
+    "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py",
+    "tests/test_attention_decode_score_multivalue_service_activity_power.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ],
+  "remaining_abstractions_after_this_step": [
+    "This gate measures only direct routed whole-service window energy and is not a total-token energy claim.",
+    "FakeRAM power still uses proxy Nangate45 macro views rather than SRAM compiler signoff.",
+    "Service-fabric dynamic energy outside the direct service window remains excluded.",
+    "NoC composition, HBM service, and broader memory-system closure remain open.",
+    "The exact integer precision contract is inherited and not re-audited here."
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v2/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v2/evaluation_requests.json
@@ -1,0 +1,28 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v2",
+  "source_commit_note": "Replace with the merge commit that contains this measured c1/c2 service-frontier wiring before dispatch. As of Sunday, July 26, 2026, this request remains pending implementation/dependency merge because measured c1/c2 anchors, the revised frontier audit CLI, and the dependency artifacts are not all merged/materialized, and c3+ remain blocked/unpromoted.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v2",
+      "task_type": "l2_campaign",
+      "objective": "Replace the prior shared-score multivalue cluster frontier area/energy proxy with measured composed-service c1 and c2 anchors, scaling whole-service measured windows with ceil(sequence_length / 24) and cluster waves while keeping the 128-token capacity distinct and c3+ blocked/unpromoted.",
+      "evaluation_mode": "frontier_recost",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_service_measured_frontier",
+      "comparison_role": "measured_c1_c2_service_frontier_anchor_replacement",
+      "paired_baseline_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
+        "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
+        "l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "replace_multivalue_cluster_area_energy_with_measured_c1_c2_service_anchors",
+        "reason": "Replace rather than add the old cluster area/energy proxy, use measured composed-service c1 and c2 anchors only, scale the direct routed 24-active-context-token window with ceil(sequence_length / 24), conservatively charge the final partial window, keep 128 tokens labeled only as capacity, account c2 as a whole two-cluster service window scaled by cluster_waves_per_layer * layers instead of heads * layers, preserve exact integer precision unchanged, and withhold any total-token energy claim while broader SRAM/NoC/HBM/producer/dense energy remains outside."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "This request remains dependency-gated and pending implementation/dependency merge. As of Sunday, July 26, 2026, the measured-service frontier revision, the strict c2 activity-power artifact, and the dependency artifacts must all merge/materialize before normal dispatch; c3+ blocked/unpromoted."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v2/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v2/proposal.json
@@ -1,0 +1,94 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v2",
+  "created_utc": "2026-07-26T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Measured c1/c2 composed-service frontier replacement for multivalue Llama7B",
+  "abstraction_layer": "decoder_attention_decode_score_multivalue_service_measured_frontier",
+  "hypothesis": "Once the service-aware shared-score multivalue cluster frontier r1 and the strict c1 and c2 composed-service activity-power audits are all merged/materialized, the Llama7B frontier can replace rather than add the old cluster area/energy proxy with measured composed-service c1 and c2 anchors while keeping c3+ blocked, preserving exact integer precision, and keeping broader system energy outside.",
+  "direct_comparison": {
+    "primary_question": "How does the shared-score multivalue Llama7B frontier change when the prior cluster area/energy proxy is replaced with measured composed-service c1 and c2 anchors, scaling whole-service measured windows with ceil(sequence_length / 24) and cluster waves instead of multiplying c2 by heads?",
+    "baseline": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
+    "include": [
+      "measured composed-service c1 and c2 anchors only",
+      "the prior service-aware shared-score multivalue cluster frontier structure from l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
+      "strict c1 direct routed service-window activity from l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
+      "strict c2 direct routed whole-service window activity from l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1",
+      "explicit ceil(sequence_length / 24) scaling from the routed 24-active-context-token microkernel measurement into the Llama7B context, with the final partial window conservatively charged",
+      "whole-service energy accounting for c2 using cluster_waves_per_layer * layers rather than heads * layers",
+      "exact integer precision unchanged from the inherited equivalence-backed frontier contract",
+      "repo-portable JSON and Markdown outputs only from an evidence-only evaluator"
+    ],
+    "exclude": [
+      "do not add measured anchors on top of the old cluster area/energy proxy; replace it",
+      "do not promote c3 or higher service points; they remain blocked/unpromoted without their own measured anchors",
+      "do not claim total-token energy",
+      "do not include broader SRAM, NoC, HBM, producer, or dense energy"
+    ],
+    "metrics": [
+      "cluster_count",
+      "latency_us",
+      "token_throughput_per_s",
+      "service_component_dynamic_energy_mj_per_token",
+      "service_component_leakage_energy_mj_per_token",
+      "measured_anchor_kind",
+      "precision_contract_status",
+      "c3plus_status"
+    ]
+  },
+  "expected_benefit": [
+    "replaces the old cluster area/energy proxy with measured composed-service anchors instead of layering a second energy term on top",
+    "makes the c2 accounting explicit so the whole two-cluster service window is scaled by measured windows and service waves instead of being double counted as if it were per head",
+    "preserves the exact integer precision contract while leaving broader energy closure work outside"
+  ],
+  "risks": [
+    "the c2 measured anchor may still lose on area or timing relative to the prior proxy frontier",
+    "c3 and higher service points remain blocked/unpromoted until they have their own measured anchors",
+    "this frontier replacement still excludes broader SRAM, NoC, HBM, producer, and dense energy, so it is not a total-token energy result"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v2",
+      "task_type": "l2_campaign",
+      "objective": "Replace the prior shared-score multivalue cluster frontier area/energy proxy with measured composed-service c1 and c2 anchors, scaling whole-service measured windows with ceil(sequence_length / 24) and cluster waves while keeping the 128-token capacity distinct and c3+ blocked/unpromoted.",
+      "evaluation_mode": "frontier_recost",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_service_measured_frontier",
+      "comparison_role": "measured_c1_c2_service_frontier_anchor_replacement",
+      "paired_baseline_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
+        "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
+        "l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "replace_multivalue_cluster_area_energy_with_measured_c1_c2_service_anchors",
+        "reason": "Replace rather than add the old cluster area/energy proxy, use measured composed-service c1 and c2 anchors only, scale the direct routed 24-active-context-token window with ceil(sequence_length / 24), conservatively charge the final partial window, keep 128 tokens labeled only as capacity, account c2 as a whole two-cluster service window scaled by cluster_waves_per_layer * layers instead of heads * layers, preserve exact integer precision unchanged, and withhold any total-token energy claim while broader SRAM/NoC/HBM/producer/dense energy remains outside."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "This request remains dependency-gated and pending implementation/dependency merge. As of Sunday, July 26, 2026, the measured-service frontier revision, the strict c2 activity-power artifact, and the dependency artifacts must all merge/materialize before normal dispatch; c3+ blocked/unpromoted."
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_frontier__l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_activity_power__l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_activity_power__l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1.json",
+    "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1/proposal.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/audit_attention_decode_score_multivalue_service_measured_frontier.py",
+    "control_plane/control_plane/services/l2_task_generator.py",
+    "tests/test_attention_decode_score_multivalue_service_measured_frontier.py"
+  ],
+  "remaining_abstractions_after_this_step": [
+    "Only c1 and c2 are measured; c3 and higher service points remain blocked/unpromoted.",
+    "The direct routed microkernel activity covers 24 active context tokens, while 128 tokens is only the measured service capacity. Whole-service energy is scaled with ceil(sequence_length / 24) and cluster_waves_per_layer * layers, conservatively charging the final partial window, rather than remeasured at full system scope.",
+    "This is not a total-token energy claim.",
+    "Broader SRAM, NoC, HBM, producer, and dense energy remain outside this frontier replacement.",
+    "The exact integer precision contract is inherited unchanged rather than reopened here."
+  ]
+}

--- a/npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+from dataclasses import dataclass
 import hashlib
 import json
 import math
@@ -42,16 +43,10 @@ _MAX_FAILURE_DETAIL_BYTES = 4096
 
 _MODEL = "decoder_attention_decode_score_multivalue_service_activity_power_v1"
 _SCOPE = "tb/dut"
-_CASE_ID = "c1_p128_b4_rr"
-_EXPECTED_DESIGN = "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr"
 _EXPECTED_PLATFORM = "nangate45"
-_REQUIRED_FLOW_VARIANT = "decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1"
-_EXPECTED_MACRO_COUNTS = {
-    "fakeram45_2048x39": 56,
-    "fakeram45_64x32": 64,
-}
 _SCORE_PINS_PER_MACRO = 11 + 39 + 39 + 1 + 1
 _VALUE_PINS_PER_MACRO = 6 + 32 + 32 + 1 + 1
+_EXPECTED_MACRO_ACTIVITY_PROFILE = "multivalue_service_c1_v1"
 _POSTROUTE_MANIFEST_NAME = "attention_decode_score_multivalue_service_postroute_power_manifest.json"
 _POSTROUTE_MACRO_ACTIVITY_NAME = (
     "attention_decode_score_multivalue_service_fakeram_macro_pin_vcd_activity_v1.json"
@@ -66,6 +61,47 @@ _VALUE_ACTIVITY_RE = re.compile(
     r"^gen_value_macro_backend/gen_value_bank\[(\d+)\]/gen_value_lane\[(\d+)\]/u_value_mem_lane/"
     r"(?:addr_in\[\d+\]|wd_in\[\d+\]|w_mask_in\[\d+\]|we_in|ce_in)$"
 )
+
+
+@dataclass(frozen=True)
+class _ServiceCaseContract:
+    case_id: str
+    cluster_count: int
+    design: str
+    flow_variant: str
+    macro_counts: dict[str, int]
+    dependency_key: str
+    authoritative_ppa_key: str
+
+
+_SERVICE_CASES = {
+    "c1_p128_b4_rr": _ServiceCaseContract(
+        case_id="c1_p128_b4_rr",
+        cluster_count=1,
+        design="attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr",
+        flow_variant="decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1",
+        macro_counts={"fakeram45_2048x39": 56, "fakeram45_64x32": 64},
+        dependency_key="integrated_service_c1",
+        authoritative_ppa_key="authoritative_composed_c1_total_ppa",
+    ),
+    "c2_p128_b4_rr": _ServiceCaseContract(
+        case_id="c2_p128_b4_rr",
+        cluster_count=2,
+        design="attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr",
+        flow_variant="decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_3700_v1",
+        macro_counts={"fakeram45_2048x39": 112, "fakeram45_64x32": 64},
+        dependency_key="integrated_service_c2",
+        authoritative_ppa_key="authoritative_composed_c2_total_ppa",
+    ),
+}
+_CASE_ID = _SERVICE_CASES["c1_p128_b4_rr"].case_id
+_EXPECTED_DESIGN = _SERVICE_CASES["c1_p128_b4_rr"].design
+_REQUIRED_FLOW_VARIANT = _SERVICE_CASES["c1_p128_b4_rr"].flow_variant
+_EXPECTED_MACRO_COUNTS = dict(_SERVICE_CASES["c1_p128_b4_rr"].macro_counts)
+
+
+def _case_label(case_contract: _ServiceCaseContract) -> str:
+    return "c1" if case_contract.case_id == "c1_p128_b4_rr" else case_contract.case_id
 
 
 def _load(path: Path) -> JsonDict:
@@ -122,6 +158,37 @@ def _sanitized_failure(exc: Exception) -> JsonDict:
     }
 
 
+def _service_case_contract(
+    *,
+    case_id: str | None = None,
+    cluster_count: int | None = None,
+) -> _ServiceCaseContract:
+    if case_id is not None:
+        contract = _SERVICE_CASES.get(str(case_id).strip())
+        if contract is None:
+            raise ValueError(f"unsupported service activity case_id: {case_id}")
+        return contract
+    if cluster_count is None:
+        raise ValueError("service activity case selection requires case_id or cluster_count")
+    for contract in _SERVICE_CASES.values():
+        if contract.cluster_count == int(cluster_count):
+            return contract
+    raise ValueError(f"unsupported service activity cluster_count: {cluster_count}")
+
+
+def _case_from_config(config: JsonDict, *, explicit_case_id: str | None = None) -> _ServiceCaseContract:
+    body = config.get("attention_decode_score_multivalue_service")
+    if not isinstance(body, dict):
+        raise ValueError("config requires attention_decode_score_multivalue_service object")
+    contract = _service_case_contract(
+        case_id=explicit_case_id,
+        cluster_count=int(body.get("cluster_count", 0)),
+    )
+    if int(body.get("cluster_count", 0)) != contract.cluster_count:
+        raise ValueError("service config cluster_count does not match the selected case")
+    return contract
+
+
 def _params(row: JsonDict) -> JsonDict:
     try:
         payload = json.loads(str(row.get("params_json", "{}")))
@@ -158,11 +225,11 @@ def _metric_provenance(row: JsonDict, metrics_csv: Path) -> JsonDict:
     }
 
 
-def _select_c1_metric(
+def _select_metric(
     metrics_csv: Path,
     *,
+    case_contract: _ServiceCaseContract,
     clock_period_ns: float,
-    required_flow_variant: str = _REQUIRED_FLOW_VARIANT,
 ) -> JsonDict:
     with metrics_csv.open(newline="", encoding="utf-8") as handle:
         rows = [dict(row) for row in csv.DictReader(handle)]
@@ -170,13 +237,13 @@ def _select_c1_metric(
     for row in rows:
         if str(row.get("status", "")).strip() != "ok":
             continue
-        if str(row.get("design", "")).strip() != _EXPECTED_DESIGN:
+        if str(row.get("design", "")).strip() != case_contract.design:
             continue
         if str(row.get("platform", "")).strip() != _EXPECTED_PLATFORM:
             continue
         params = _params(row)
         flow_variant = str(params.get("FLOW_VARIANT", "")).strip()
-        if flow_variant != required_flow_variant:
+        if flow_variant != case_contract.flow_variant:
             continue
         try:
             row_clock = float(params.get("CLOCK_PERIOD", 0.0))
@@ -185,25 +252,33 @@ def _select_c1_metric(
             raise ValueError("selected c1 row has invalid CLOCK_PERIOD or critical_path_ns") from exc
         if abs(row_clock - clock_period_ns) > 1e-9:
             raise ValueError(
-                f"selected c1 row CLOCK_PERIOD mismatch: expected {clock_period_ns:g}, got {row_clock:g}"
+                f"selected {case_contract.case_id} row CLOCK_PERIOD mismatch: expected {clock_period_ns:g}, got {row_clock:g}"
             )
         if not math.isfinite(critical_path_ns) or critical_path_ns > clock_period_ns:
             raise ValueError(
-                f"selected c1 row is not timing-feasible at {clock_period_ns:g} ns"
+                f"selected {case_contract.case_id} row is not timing-feasible at {clock_period_ns:g} ns"
             )
         matches.append(row)
     if not matches:
         raise ValueError(
-            "expected exactly one status=ok timing-feasible c1 row with design "
-            f"{_EXPECTED_DESIGN}, platform {_EXPECTED_PLATFORM}, and FLOW_VARIANT {required_flow_variant}"
+            "expected exactly one status=ok timing-feasible row with design "
+            f"{case_contract.design}, platform {_EXPECTED_PLATFORM}, and FLOW_VARIANT {case_contract.flow_variant}"
         )
     if len(matches) != 1:
         raise ValueError(
-            "expected exactly one status=ok timing-feasible c1 row with design "
-            f"{_EXPECTED_DESIGN}, platform {_EXPECTED_PLATFORM}, and FLOW_VARIANT "
-            f"{required_flow_variant}, found {len(matches)}"
+            "expected exactly one status=ok timing-feasible row with design "
+            f"{case_contract.design}, platform {_EXPECTED_PLATFORM}, and FLOW_VARIANT "
+            f"{case_contract.flow_variant}, found {len(matches)}"
         )
     return matches[0]
+
+
+def _select_c1_metric(metrics_csv: Path, *, clock_period_ns: float) -> JsonDict:
+    return _select_metric(
+        metrics_csv,
+        case_contract=_SERVICE_CASES["c1_p128_b4_rr"],
+        clock_period_ns=clock_period_ns,
+    )
 
 
 def _require_string_hash(payload: JsonDict, key: str, label: str) -> str:
@@ -231,7 +306,11 @@ def _validate_cluster_equivalence(payload: JsonDict) -> JsonDict:
     }
 
 
-def _validate_integrated_service(payload: JsonDict) -> JsonDict:
+def _validate_integrated_service(
+    payload: JsonDict,
+    *,
+    case_contract: _ServiceCaseContract = _SERVICE_CASES["c1_p128_b4_rr"],
+) -> JsonDict:
     expected_workload = _expected_workload_contract()
     expected_counts = _workload_expected_counts(expected_workload)
     if payload.get("workload_contract") != expected_workload:
@@ -242,18 +321,18 @@ def _validate_integrated_service(payload: JsonDict) -> JsonDict:
     selected = [
         case
         for case in cases
-        if isinstance(case, dict) and str(case.get("case_id") or "").strip() == _CASE_ID
+        if isinstance(case, dict) and str(case.get("case_id") or "").strip() == case_contract.case_id
     ]
     if len(selected) != 1:
-        raise ValueError(f"integrated-service report must contain exactly one {_CASE_ID} case")
+        raise ValueError(f"integrated-service report must contain exactly one {case_contract.case_id} case")
     case = selected[0]
     if case.get("decision") != "pass":
-        raise ValueError(f"integrated-service {_CASE_ID} case did not pass")
+        raise ValueError(f"integrated-service {case_contract.case_id} case did not pass")
     config = case.get("config")
     if not isinstance(config, dict):
-        raise ValueError("integrated-service c1 config is missing")
+        raise ValueError(f"integrated-service {case_contract.case_id} config is missing")
     expected_config = {
-        "cluster_count": 1,
+        "cluster_count": case_contract.cluster_count,
         "packet_w": 128,
         "banks": 4,
         "req_queue_depth": 4,
@@ -266,19 +345,19 @@ def _validate_integrated_service(payload: JsonDict) -> JsonDict:
     for key, expected in expected_config.items():
         if config.get(key) != expected:
             raise ValueError(
-                f"integrated-service c1 config mismatch for {key}: expected {expected!r}, got {config.get(key)!r}"
+                f"integrated-service {case_contract.case_id} config mismatch for {key}: expected {expected!r}, got {config.get(key)!r}"
             )
     integrated = case.get("integrated_service")
     if not isinstance(integrated, dict):
-        raise ValueError("integrated-service c1 section is missing")
+        raise ValueError(f"integrated-service {case_contract.case_id} section is missing")
     if integrated.get("exact_match") is not True:
-        raise ValueError("integrated-service c1 exact_result_match gate failed")
+        raise ValueError(f"integrated-service {case_contract.case_id} exact_result_match gate failed")
     for key in ("no_protocol_errors", "no_drop_duplicate_deadlock_timeout", "cycle_bound_ok"):
         if integrated.get(key) is not True:
-            raise ValueError(f"integrated-service c1 {key} gate failed")
+            raise ValueError(f"integrated-service {case_contract.case_id} {key} gate failed")
     counters = integrated.get("counters")
     if not isinstance(counters, dict):
-        raise ValueError("integrated-service c1 counters missing")
+        raise ValueError(f"integrated-service {case_contract.case_id} counters missing")
     required_counter_keys = {
         "request_injection_stall_cycles",
         "arbitration_contention_cycles",
@@ -290,29 +369,29 @@ def _validate_integrated_service(payload: JsonDict) -> JsonDict:
     missing = required_counter_keys - set(counters)
     if missing:
         raise ValueError(
-            "integrated-service c1 counters incomplete: " + ", ".join(sorted(missing))
+            f"integrated-service {case_contract.case_id} counters incomplete: " + ", ".join(sorted(missing))
         )
     if int(integrated.get("request_count", 0)) != int(expected_counts["request_count"]):
-        raise ValueError("integrated-service c1 request_count mismatch")
+        raise ValueError(f"integrated-service {case_contract.case_id} request_count mismatch")
     if int(integrated.get("wide_response_count", 0)) != int(expected_counts["wide_response_count"]):
-        raise ValueError("integrated-service c1 wide_response_count mismatch")
+        raise ValueError(f"integrated-service {case_contract.case_id} wide_response_count mismatch")
     if int(integrated.get("result_count", 0)) != int(expected_counts["result_count"]):
-        raise ValueError("integrated-service c1 result_count mismatch")
+        raise ValueError(f"integrated-service {case_contract.case_id} result_count mismatch")
     gates = case.get("gates")
     if not isinstance(gates, dict) or not all(
         bool(gates.get(key)) for key in ("hash_gate_ok", "protocol_gate_ok", "count_gate_ok")
     ):
-        raise ValueError("integrated-service c1 gates failed")
+        raise ValueError(f"integrated-service {case_contract.case_id} gates failed")
     egress = integrated.get("shared_result_egress")
     if not isinstance(egress, dict) or int(egress.get("documented_initiation_interval", 0)) != 1:
-        raise ValueError("integrated-service c1 shared_result_egress contract failed")
+        raise ValueError(f"integrated-service {case_contract.case_id} shared_result_egress contract failed")
     summary = payload.get("summary")
     if isinstance(summary, dict):
         for key in ("all_hash_gates_passed", "all_protocol_gates_passed", "all_count_gates_passed"):
             if summary.get(key) is not True:
                 raise ValueError(f"integrated-service summary {key} failed")
     return {
-        "case_id": _CASE_ID,
+        "case_id": case_contract.case_id,
         "config": dict(config),
         "decision": "pass",
         "exact_match": True,
@@ -327,22 +406,27 @@ def _validate_integrated_service(payload: JsonDict) -> JsonDict:
         "shared_result_egress": egress,
         "workload_contract": expected_workload,
         "hashes": {
-            "score_hash": _require_string_hash(integrated, "score_hash", "integrated-service c1"),
-            "final_hash": _require_string_hash(integrated, "final_hash", "integrated-service c1"),
-            "request_hash": _require_string_hash(integrated, "request_hash", "integrated-service c1"),
+            "score_hash": _require_string_hash(integrated, "score_hash", f"integrated-service {case_contract.case_id}"),
+            "final_hash": _require_string_hash(integrated, "final_hash", f"integrated-service {case_contract.case_id}"),
+            "request_hash": _require_string_hash(integrated, "request_hash", f"integrated-service {case_contract.case_id}"),
             "wide_response_matrix_hash": _require_string_hash(
-                integrated, "wide_response_matrix_hash", "integrated-service c1"
+                integrated, "wide_response_matrix_hash", f"integrated-service {case_contract.case_id}"
             ),
         },
     }
 
 
-def _validate_generated_activity_manifest(activity_manifest: JsonDict, activity_dir: Path) -> JsonDict:
+def _validate_generated_activity_manifest(
+    activity_manifest: JsonDict,
+    activity_dir: Path,
+    *,
+    case_contract: _ServiceCaseContract = _SERVICE_CASES["c1_p128_b4_rr"],
+) -> JsonDict:
     expected_workload = _expected_workload_contract()
     expected_counts = _workload_expected_counts(expected_workload)
     if str(activity_manifest.get("model") or "").strip() != "attention_decode_score_multivalue_service_activity_v1":
         raise ValueError("generated activity manifest model mismatch")
-    if str(activity_manifest.get("case_id") or "").strip() != _CASE_ID:
+    if str(activity_manifest.get("case_id") or "").strip() != case_contract.case_id:
         raise ValueError("generated activity manifest case_id mismatch")
     if activity_manifest.get("workload_contract") != expected_workload:
         raise ValueError("generated activity manifest workload contract mismatch")
@@ -366,12 +450,17 @@ def _validate_generated_activity_manifest(activity_manifest: JsonDict, activity_
     bank_coverage = activity_manifest.get("value_bank_coverage")
     if not isinstance(bank_coverage, dict):
         raise ValueError("generated activity manifest value_bank_coverage missing")
-    if bank_coverage.get("addressed_banks_over_trace") != [0, 1, 2]:
-        raise ValueError("generated activity manifest addressed_banks_over_trace mismatch")
-    if bank_coverage.get("inactive_banks") != [3]:
-        raise ValueError("generated activity manifest inactive_banks mismatch")
+    if not isinstance(bank_coverage.get("addressed_banks_over_trace"), list):
+        raise ValueError("generated activity manifest addressed_banks_over_trace missing")
+    if not isinstance(bank_coverage.get("inactive_banks"), list):
+        raise ValueError("generated activity manifest inactive_banks missing")
     if bank_coverage.get("inactive_reason") != "three_block_reference_workload":
         raise ValueError("generated activity manifest inactive_reason mismatch")
+    if case_contract.case_id == "c1_p128_b4_rr":
+        if bank_coverage.get("addressed_banks_over_trace") != [0, 1, 2]:
+            raise ValueError("generated activity manifest addressed_banks_over_trace mismatch")
+        if bank_coverage.get("inactive_banks") != [3]:
+            raise ValueError("generated activity manifest inactive_banks mismatch")
     vcd_hash = str(activity_manifest.get("hashes", {}).get("vcd_sha256") or "").strip().lower()
     if not vcd_hash:
         raise ValueError("generated activity manifest vcd_sha256 missing")
@@ -388,21 +477,25 @@ def _validate_generated_activity_manifest(activity_manifest: JsonDict, activity_
     }
 
 
-def _validate_macro_manifest_counts(macro_manifest: JsonDict) -> JsonDict:
+def _validate_macro_manifest_counts(
+    macro_manifest: JsonDict,
+    *,
+    case_contract: _ServiceCaseContract = _SERVICE_CASES["c1_p128_b4_rr"],
+) -> JsonDict:
     params = macro_manifest.get("manifest_params")
     if not isinstance(params, dict):
         raise ValueError("macro_manifest manifest_params missing")
     score_bank_macro_count = int(params.get("score_bank_macro_count", 0))
     value_memory_macro_count = int(params.get("value_memory_macro_count", 0))
-    if score_bank_macro_count != _EXPECTED_MACRO_COUNTS["fakeram45_2048x39"]:
+    if score_bank_macro_count != case_contract.macro_counts["fakeram45_2048x39"]:
         raise ValueError(
             "macro_manifest score-bank macro count mismatch: expected "
-            f"{_EXPECTED_MACRO_COUNTS['fakeram45_2048x39']}, got {score_bank_macro_count}"
+            f"{case_contract.macro_counts['fakeram45_2048x39']}, got {score_bank_macro_count}"
         )
-    if value_memory_macro_count != _EXPECTED_MACRO_COUNTS["fakeram45_64x32"]:
+    if value_memory_macro_count != case_contract.macro_counts["fakeram45_64x32"]:
         raise ValueError(
             "macro_manifest value-memory macro count mismatch: expected "
-            f"{_EXPECTED_MACRO_COUNTS['fakeram45_64x32']}, got {value_memory_macro_count}"
+            f"{case_contract.macro_counts['fakeram45_64x32']}, got {value_memory_macro_count}"
         )
     return {
         "fakeram45_2048x39": score_bank_macro_count,
@@ -466,7 +559,7 @@ def _validate_service_macro_activity_contract(
     structural_contract = macro_activity.get("structural_macro_contract")
     if not isinstance(structural_contract, dict):
         raise ValueError("service macro activity structural_macro_contract missing")
-    if str(structural_contract.get("profile") or "").strip() != "multivalue_service_c1_v1":
+    if str(structural_contract.get("profile") or "").strip() != _EXPECTED_MACRO_ACTIVITY_PROFILE:
         raise ValueError("service macro activity structural_macro_contract profile mismatch")
     if int(structural_contract.get("total_assignment_count", 0)) != len(pins):
         raise ValueError("service macro activity total_assignment_count mismatch")
@@ -503,7 +596,7 @@ def _validate_service_macro_activity_contract(
                     f"expected {expected_value!r}, got {row.get(key)!r}"
                 )
     return {
-        "profile": "multivalue_service_c1_v1",
+        "profile": _EXPECTED_MACRO_ACTIVITY_PROFILE,
         "total_assignment_count": len(pins),
         "macro_classes": expected_classes,
     }
@@ -513,10 +606,16 @@ def _prepare_postroute_power_manifest(
     *,
     activity_dir: Path,
     activity_manifest: JsonDict,
+    case_contract: _ServiceCaseContract,
 ) -> tuple[JsonDict, Path, JsonDict]:
-    generated_meta = _validate_generated_activity_manifest(activity_manifest, activity_dir)
+    generated_meta = _validate_generated_activity_manifest(
+        activity_manifest,
+        activity_dir,
+        case_contract=case_contract,
+    )
     macro_counts = _validate_macro_manifest_counts(
-        _load(activity_dir / _OUTPUT_MACRO_MANIFEST_NAME)
+        _load(activity_dir / _OUTPUT_MACRO_MANIFEST_NAME),
+        case_contract=case_contract,
     )
     vcd_path = activity_dir / _OUTPUT_VCD_NAME
     if not vcd_path.is_file():
@@ -677,16 +776,18 @@ def _write_markdown(payload: JsonDict, path: Path) -> None:
         else {}
     )
     composed_ppa = (
-        best.get("authoritative_composed_c1_total_ppa")
-        if isinstance(best.get("authoritative_composed_c1_total_ppa"), dict)
+        best.get("authoritative_composed_total_ppa")
+        if isinstance(best.get("authoritative_composed_total_ppa"), dict)
         else {}
     )
+    selection_contract = payload.get("selection_contract", {})
+    case_id = selection_contract.get("case_id", "service_case")
     lines = [
-        "# Strict c1 routed service power audit",
+        f"# Strict {case_id} routed service power audit",
         "",
         f"- decision: `{payload['decision']}`",
         f"- promotion_gate_pass: `{payload['promotion_gate_pass']}`",
-        f"- required_flow_variant: `{payload['selection_contract']['required_flow_variant']}`",
+        f"- required_flow_variant: `{selection_contract.get('required_flow_variant')}`",
         f"- bank3 dynamic inactivity: `{payload['bank3_dynamic_inactivity']['inactive_banks']}`",
         f"- bank3 note: {payload['bank3_dynamic_inactivity']['statement']}",
         "",
@@ -725,35 +826,49 @@ def _write_markdown(payload: JsonDict, path: Path) -> None:
 def build_report(
     *,
     config: Path,
-    c1_metrics_csv: Path,
+    c1_metrics_csv: Path | None = None,
+    metrics_csv: Path | None = None,
     equivalence_json: Path,
     integrated_service_json: Path,
     orfs_design_config: Path,
     clock_period_ns: float,
     activity_dir: Path,
     min_sequential_register_activity_coverage: float = 0.95,
+    case_id: str | None = None,
 ) -> JsonDict:
     if abs(clock_period_ns - 10.0) > 1e-9:
-        raise ValueError("strict c1 routed service power audit requires a 10 ns clock")
+        raise ValueError("strict routed service power audit requires a 10 ns clock")
+    config_payload = _load(config)
+    case_contract = _case_from_config(config_payload, explicit_case_id=case_id)
+    selected_metrics_csv = metrics_csv or c1_metrics_csv
+    if selected_metrics_csv is None:
+        raise ValueError("metrics_csv is required")
     cluster_equivalence = _validate_cluster_equivalence(_load(equivalence_json))
-    integrated_service = _validate_integrated_service(_load(integrated_service_json))
-    metric = _select_c1_metric(
-        c1_metrics_csv,
+    integrated_service = _validate_integrated_service(
+        _load(integrated_service_json),
+        case_contract=case_contract,
+    )
+    metric = _select_metric(
+        selected_metrics_csv,
+        case_contract=case_contract,
         clock_period_ns=clock_period_ns,
-        required_flow_variant=_REQUIRED_FLOW_VARIANT,
     )
     activity_dir.mkdir(parents=True, exist_ok=True)
     activity_manifest = generate_activity(
-        _load(config),
+        config_payload,
         activity_dir,
         clock_period_ns=clock_period_ns,
+        case_id=case_contract.case_id,
     )
     adapted_manifest, adapted_manifest_path, activity_meta = _prepare_postroute_power_manifest(
         activity_dir=activity_dir,
         activity_manifest=activity_manifest,
+        case_contract=case_contract,
     )
     if activity_meta["workload_contract"] != integrated_service["workload_contract"]:
-        raise ValueError("generated activity workload contract does not match integrated-service c1")
+        raise ValueError(
+            f"generated activity workload contract does not match integrated-service {case_contract.case_id}"
+        )
     generated_hashes = activity_meta["generated_manifest_hashes"]
     integrated_hashes = integrated_service["hashes"]
     for generated_key, integrated_key in (
@@ -764,19 +879,19 @@ def build_report(
     ):
         if str(generated_hashes.get(generated_key) or "").strip() != str(integrated_hashes[integrated_key]).strip():
             raise ValueError(
-                f"generated activity {generated_key} does not match integrated-service c1 {integrated_key}"
+                f"generated activity {generated_key} does not match integrated-service {_case_label(case_contract)} {integrated_key}"
             )
     candidate: JsonDict = {
-        "candidate_id": f"multivalue_service_activity_{_REQUIRED_FLOW_VARIANT}",
-        "flow_variant": _REQUIRED_FLOW_VARIANT,
-        "ppa_metric": _metric_provenance(metric, c1_metrics_csv),
+        "candidate_id": f"multivalue_service_activity_{case_contract.flow_variant}",
+        "flow_variant": case_contract.flow_variant,
+        "ppa_metric": _metric_provenance(metric, selected_metrics_csv),
     }
     try:
         activity_power = build_power_report(
             manifest=adapted_manifest,
             manifest_path=adapted_manifest_path,
             design_config=orfs_design_config,
-            flow_variant=_REQUIRED_FLOW_VARIANT,
+            flow_variant=case_contract.flow_variant,
             scope=_SCOPE,
             min_vcd_coverage=0.05,
             min_vcd_pins=32,
@@ -810,13 +925,27 @@ def build_report(
             candidate["status"] = "activity_backed"
             candidate["promotion_gate_pass"] = True
             candidate["component_service_window_energy"] = service_window_energy
-            candidate["authoritative_composed_c1_total_ppa"] = {
+            authoritative_ppa = {
                 "critical_path_ns": float(metric["critical_path_ns"]),
                 "instance_area_um2": float(metric.get("instance_area_um2") or 0.0),
                 "die_area": float(metric.get("die_area") or 0.0),
                 "total_power_mw": float(metric.get("total_power_mw") or 0.0),
             }
+            candidate["authoritative_composed_total_ppa"] = authoritative_ppa
+            candidate[case_contract.authoritative_ppa_key] = dict(authoritative_ppa)
     best = candidate if candidate.get("status") == "activity_backed" else None
+    inactive_banks = activity_meta["bank_coverage"]["inactive_banks"]
+    if case_contract.case_id == "c1_p128_b4_rr":
+        inactivity_statement = (
+            "No artificial activity was injected. Bank3 may remain dynamically inactive in this exact c1 workload; "
+            "it is not required to toggle, while leakage remains part of routed power."
+        )
+    else:
+        inactivity_statement = (
+            "No artificial activity was injected. Banks "
+            f"{inactive_banks} may remain dynamically inactive in this exact {case_contract.case_id} workload; "
+            "they are not required to toggle, while leakage remains part of routed power."
+        )
     return {
         "version": 1,
         "model": _MODEL,
@@ -832,21 +961,22 @@ def build_report(
         "best": best,
         "candidates": [candidate],
         "selection_contract": {
-            "case_id": _CASE_ID,
-            "required_flow_variant": _REQUIRED_FLOW_VARIANT,
+            "case_id": case_contract.case_id,
+            "cluster_count": case_contract.cluster_count,
+            "required_flow_variant": case_contract.flow_variant,
             "clock_period_ns": clock_period_ns,
             "status": "exactly_one_status_ok_timing_feasible_row_required",
         },
         "source_dependencies": {
             "service_config": _portable_path(config),
-            "c1_metrics_csv": _portable_path(c1_metrics_csv),
+            "metrics_csv": _portable_path(selected_metrics_csv),
             "merged_cluster_equivalence_json": _portable_path(equivalence_json),
             "integrated_service_r1_json": _portable_path(integrated_service_json),
             "orfs_design_config": _portable_path(orfs_design_config),
         },
         "dependency_contract": {
             "cluster_equivalence": cluster_equivalence,
-            "integrated_service_c1": integrated_service,
+            case_contract.dependency_key: integrated_service,
         },
         "activity_contract": {
             "generated_activity_manifest_sha256": activity_meta["generated_activity_manifest_sha256"],
@@ -858,21 +988,25 @@ def build_report(
         },
         "macro_manifest_contract": {
             "counts": activity_meta["macro_counts"],
-            "statement": "Exact macro counts are required: 56 fakeram45_2048x39 score banks and 64 fakeram45_64x32 value-memory macros.",
+            "statement": (
+                "Exact macro counts are required: "
+                f"{activity_meta['macro_counts']['fakeram45_2048x39']} fakeram45_2048x39 score banks and "
+                f"{activity_meta['macro_counts']['fakeram45_64x32']} fakeram45_64x32 value-memory macros."
+            ),
         },
         "macro_activity_contract": activity_meta["macro_activity_contract"],
         "bank3_dynamic_inactivity": {
-            "inactive_banks": activity_meta["bank_coverage"]["inactive_banks"],
-            "statement": (
-                "No artificial activity was injected. Bank3 may remain dynamically inactive in this exact c1 workload; "
-                "it is not required to toggle, while leakage remains part of routed power."
-            ),
+            "inactive_banks": inactive_banks,
+            "statement": inactivity_statement,
         },
         "precision_status": (
             "unchanged_integer_contract_from_merged_cluster_equivalence_and_integrated_service"
         ),
         "remaining_abstractions": [
-            "The service-window energy is direct routed component energy for this exact c1 workload, not total token energy.",
+            (
+                f"The service-window energy is direct routed component energy for this exact "
+                f"{case_contract.case_id} workload, not total token energy."
+            ),
             "FakeRAM power uses proxy Nangate45 macro views rather than SRAM compiler signoff.",
             "Evaluator-local VCD, ODB, and SPEF paths remain redacted from the portable output.",
         ],
@@ -882,7 +1016,8 @@ def build_report(
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--config", type=Path, required=True)
-    parser.add_argument("--c1-metrics-csv", type=Path, required=True)
+    parser.add_argument("--c1-metrics-csv", type=Path)
+    parser.add_argument("--metrics-csv", type=Path)
     parser.add_argument("--equivalence-json", type=Path, required=True)
     parser.add_argument("--integrated-service-json", type=Path, required=True)
     parser.add_argument("--orfs-design-config", type=Path, required=True)
@@ -890,6 +1025,7 @@ def main() -> int:
     parser.add_argument("--activity-dir", type=Path, required=True)
     parser.add_argument("--out", type=Path, required=True)
     parser.add_argument("--out-md", type=Path, required=True)
+    parser.add_argument("--case-id", type=str)
     parser.add_argument(
         "--min-sequential-register-activity-coverage",
         type=float,
@@ -899,12 +1035,14 @@ def main() -> int:
     payload = build_report(
         config=args.config,
         c1_metrics_csv=args.c1_metrics_csv,
+        metrics_csv=args.metrics_csv,
         equivalence_json=args.equivalence_json,
         integrated_service_json=args.integrated_service_json,
         orfs_design_config=args.orfs_design_config,
         clock_period_ns=args.clock_period_ns,
         activity_dir=args.activity_dir,
         min_sequential_register_activity_coverage=args.min_sequential_register_activity_coverage,
+        case_id=args.case_id,
     )
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Audit strict c1 routed power for the multivalue integrated service."""
+"""Audit strict c1/c2 routed power for the multivalue integrated service."""
 
 from __future__ import annotations
 
@@ -46,7 +46,6 @@ _SCOPE = "tb/dut"
 _EXPECTED_PLATFORM = "nangate45"
 _SCORE_PINS_PER_MACRO = 11 + 39 + 39 + 1 + 1
 _VALUE_PINS_PER_MACRO = 6 + 32 + 32 + 1 + 1
-_EXPECTED_MACRO_ACTIVITY_PROFILE = "multivalue_service_c1_v1"
 _POSTROUTE_MANIFEST_NAME = "attention_decode_score_multivalue_service_postroute_power_manifest.json"
 _POSTROUTE_MACRO_ACTIVITY_NAME = (
     "attention_decode_score_multivalue_service_fakeram_macro_pin_vcd_activity_v1.json"
@@ -55,7 +54,8 @@ _POSTROUTE_SEQUENTIAL_ACTIVITY_NAME = (
     "attention_decode_score_multivalue_service_sequential_register_vcd_activity_v1.json"
 )
 _SCORE_ACTIVITY_RE = re.compile(
-    r"^score_bank/u_group_(\d+)_slice_(\d+)/(?:addr_in\[\d+\]|wd_in\[\d+\]|w_mask_in\[\d+\]|we_in|ce_in)$"
+    r"^(?P<instance>(?:[^/]+/)*score_bank/u_group_(\d+)_slice_(\d+))/"
+    r"(?:addr_in\[\d+\]|wd_in\[\d+\]|w_mask_in\[\d+\]|we_in|ce_in)$"
 )
 _VALUE_ACTIVITY_RE = re.compile(
     r"^gen_value_macro_backend/gen_value_bank\[(\d+)\]/gen_value_lane\[(\d+)\]/u_value_mem_lane/"
@@ -102,6 +102,17 @@ _EXPECTED_MACRO_COUNTS = dict(_SERVICE_CASES["c1_p128_b4_rr"].macro_counts)
 
 def _case_label(case_contract: _ServiceCaseContract) -> str:
     return "c1" if case_contract.case_id == "c1_p128_b4_rr" else case_contract.case_id
+
+
+def _macro_activity_profile(case_contract: _ServiceCaseContract) -> str:
+    return f"multivalue_service_{case_contract.case_id.split('_', 1)[0]}_v1"
+
+
+def _scaled_expected_counts(*, cluster_count: int) -> JsonDict:
+    expected_counts = dict(_workload_expected_counts(_expected_workload_contract()))
+    for key in ("request_count", "wide_response_count", "result_count"):
+        expected_counts[key] = int(expected_counts[key]) * int(cluster_count)
+    return expected_counts
 
 
 def _load(path: Path) -> JsonDict:
@@ -249,7 +260,9 @@ def _select_metric(
             row_clock = float(params.get("CLOCK_PERIOD", 0.0))
             critical_path_ns = float(row.get("critical_path_ns") or math.inf)
         except (TypeError, ValueError) as exc:
-            raise ValueError("selected c1 row has invalid CLOCK_PERIOD or critical_path_ns") from exc
+            raise ValueError(
+                f"selected {case_contract.case_id} row has invalid CLOCK_PERIOD or critical_path_ns"
+            ) from exc
         if abs(row_clock - clock_period_ns) > 1e-9:
             raise ValueError(
                 f"selected {case_contract.case_id} row CLOCK_PERIOD mismatch: expected {clock_period_ns:g}, got {row_clock:g}"
@@ -312,7 +325,7 @@ def _validate_integrated_service(
     case_contract: _ServiceCaseContract = _SERVICE_CASES["c1_p128_b4_rr"],
 ) -> JsonDict:
     expected_workload = _expected_workload_contract()
-    expected_counts = _workload_expected_counts(expected_workload)
+    expected_counts = _scaled_expected_counts(cluster_count=case_contract.cluster_count)
     if payload.get("workload_contract") != expected_workload:
         raise ValueError("integrated-service workload contract mismatch")
     cases = payload.get("cases")
@@ -423,7 +436,7 @@ def _validate_generated_activity_manifest(
     case_contract: _ServiceCaseContract = _SERVICE_CASES["c1_p128_b4_rr"],
 ) -> JsonDict:
     expected_workload = _expected_workload_contract()
-    expected_counts = _workload_expected_counts(expected_workload)
+    expected_counts = _scaled_expected_counts(cluster_count=case_contract.cluster_count)
     if str(activity_manifest.get("model") or "").strip() != "attention_decode_score_multivalue_service_activity_v1":
         raise ValueError("generated activity manifest model mismatch")
     if str(activity_manifest.get("case_id") or "").strip() != case_contract.case_id:
@@ -507,6 +520,7 @@ def _validate_service_macro_activity_contract(
     macro_activity: JsonDict,
     *,
     macro_counts: JsonDict,
+    case_contract: _ServiceCaseContract,
 ) -> JsonDict:
     pins = macro_activity.get("pins")
     if not isinstance(pins, list) or not pins:
@@ -525,7 +539,7 @@ def _validate_service_macro_activity_contract(
         score_match = _SCORE_ACTIVITY_RE.fullmatch(full_name)
         if score_match is not None:
             score_pin_count += 1
-            score_instances.add(f"score_bank/u_group_{score_match.group(1)}_slice_{score_match.group(2)}")
+            score_instances.add(str(score_match.group("instance")))
             continue
         value_match = _VALUE_ACTIVITY_RE.fullmatch(full_name)
         if value_match is not None:
@@ -559,7 +573,7 @@ def _validate_service_macro_activity_contract(
     structural_contract = macro_activity.get("structural_macro_contract")
     if not isinstance(structural_contract, dict):
         raise ValueError("service macro activity structural_macro_contract missing")
-    if str(structural_contract.get("profile") or "").strip() != _EXPECTED_MACRO_ACTIVITY_PROFILE:
+    if str(structural_contract.get("profile") or "").strip() != _macro_activity_profile(case_contract):
         raise ValueError("service macro activity structural_macro_contract profile mismatch")
     if int(structural_contract.get("total_assignment_count", 0)) != len(pins):
         raise ValueError("service macro activity total_assignment_count mismatch")
@@ -596,7 +610,7 @@ def _validate_service_macro_activity_contract(
                     f"expected {expected_value!r}, got {row.get(key)!r}"
                 )
     return {
-        "profile": _EXPECTED_MACRO_ACTIVITY_PROFILE,
+        "profile": _macro_activity_profile(case_contract),
         "total_assignment_count": len(pins),
         "macro_classes": expected_classes,
     }
@@ -629,10 +643,13 @@ def _prepare_postroute_power_manifest(
         vcd_path,
         source_vcd_sha256=generated_meta["vcd_sha256"],
         scope=_SCOPE,
+        cluster_count=case_contract.cluster_count,
+        case_id=case_contract.case_id,
     )
     macro_activity_contract = _validate_service_macro_activity_contract(
         macro_activity,
         macro_counts=macro_counts,
+        case_contract=case_contract,
     )
     macro_activity_path = activity_dir / _POSTROUTE_MACRO_ACTIVITY_NAME
     macro_activity_path.write_text(

--- a/npu/eval/audit_attention_decode_score_multivalue_service_measured_frontier.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_service_measured_frontier.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Compose a strict c1 measured-service frontier anchor for Llama7B decode."""
+"""Compose strict measured-service frontier anchors for Llama7B decode."""
 
 from __future__ import annotations
 
@@ -28,26 +28,8 @@ _EXPECTED_SERVICE_DECISION = "activity_backed_service_power_measured"
 _EXPECTED_SERVICE_PRECISION_STATUS = (
     "unchanged_integer_contract_from_merged_cluster_equivalence_and_integrated_service"
 )
-_EXPECTED_SERVICE_FLOW_VARIANT = "decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1"
-_EXPECTED_SERVICE_DESIGN = "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr"
 _EXPECTED_SERVICE_PLATFORM = "nangate45"
-_EXPECTED_SERVICE_MACRO_COUNTS = {
-    "fakeram45_2048x39": 56,
-    "fakeram45_64x32": 64,
-}
 _EXPECTED_SERVICE_MACRO_PROFILE = "multivalue_service_c1_v1"
-_EXPECTED_CASE_ID = "c1_p128_b4_rr"
-_EXPECTED_SERVICE_CONFIG = {
-    "cluster_count": 1,
-    "packet_w": 128,
-    "banks": 4,
-    "req_queue_depth": 4,
-    "resp_queue_depth": 4,
-    "bank_queue_depth": 4,
-    "read_latency": 2,
-    "arb_mode": "round_robin",
-    "locality_burst_max": 2,
-}
 _EXPECTED_HIDDEN = 4096
 _EXPECTED_HEADS = 32
 _EXPECTED_KV_HEADS = 4
@@ -60,6 +42,24 @@ _EXPECTED_WORKLOAD_CONTRACT = {
     "max_blocks": 16,
     "max_context_capacity_tokens": 128,
     "value_dim": 128,
+}
+_SERVICE_CASES = {
+    "c1_p128_b4_rr": {
+        "cluster_count": 1,
+        "flow_variant": "decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1",
+        "design": "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr",
+        "macro_counts": {"fakeram45_2048x39": 56, "fakeram45_64x32": 64},
+        "dependency_key": "integrated_service_c1",
+        "authoritative_key": "authoritative_composed_c1_total_ppa",
+    },
+    "c2_p128_b4_rr": {
+        "cluster_count": 2,
+        "flow_variant": "decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_3700_v1",
+        "design": "attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr",
+        "macro_counts": {"fakeram45_2048x39": 112, "fakeram45_64x32": 64},
+        "dependency_key": "integrated_service_c2",
+        "authoritative_key": "authoritative_composed_c2_total_ppa",
+    },
 }
 
 
@@ -181,9 +181,16 @@ def _validate_optional_item_id(payload: JsonDict, expected: str, label: str) -> 
         break
 
 
+def _service_case(case_id: str) -> JsonDict:
+    contract = _SERVICE_CASES.get(str(case_id).strip())
+    if contract is None:
+        raise ValueError(f"unsupported measured-service case_id: {case_id}")
+    return dict(contract)
+
+
 def _validated_prior_frontier(
     prior: JsonDict, prior_frontier_json: Path
-) -> tuple[JsonDict, str, JsonDict, JsonDict, list[JsonDict], JsonDict]:
+) -> tuple[JsonDict, str, JsonDict, dict[int, JsonDict], list[JsonDict], JsonDict, JsonDict]:
     if _string(prior.get("model"), "prior frontier model") != _EXPECTED_PRIOR_MODEL:
         raise ValueError("prior frontier has an unexpected model")
     if _string(prior.get("decision"), "prior frontier decision") != _EXPECTED_PRIOR_DECISION:
@@ -234,34 +241,46 @@ def _validated_prior_frontier(
     rows = [row for row in prior.get("rows", []) if isinstance(row, dict)]
     if not rows:
         raise ValueError("prior frontier has no rows")
-    c1_rows = [
-        row
-        for row in rows
-        if _positive_int(row.get("cluster_count"), "prior frontier cluster_count") == 1
-    ]
-    if len(c1_rows) != 1:
+    prior_rows_by_cluster: dict[int, JsonDict] = {}
+    for row in rows:
+        cluster_count = _positive_int(row.get("cluster_count"), "prior frontier cluster_count")
+        if cluster_count in prior_rows_by_cluster:
+            raise ValueError(f"prior frontier has multiple c{cluster_count} rows")
+        prior_rows_by_cluster[cluster_count] = row
+        expected_case_id = f"c{cluster_count}_p128_b4_rr"
+        if _string(
+            row.get("service_calibration_case_id"),
+            f"prior c{cluster_count} service_calibration_case_id",
+        ) != expected_case_id:
+            raise ValueError(f"prior frontier c{cluster_count} service_calibration_case_id mismatch")
+        _positive_int(
+            row.get("service_calibration_microkernel_integrated_completion_cycle"),
+            f"prior c{cluster_count} service_calibration_microkernel_integrated_completion_cycle",
+        )
+        if _positive_int(
+            row.get("head_commands_per_layer"),
+            f"prior c{cluster_count} head_commands_per_layer",
+        ) != _EXPECTED_HEADS:
+            raise ValueError(f"prior frontier c{cluster_count} head_commands_per_layer mismatch")
+        _positive_int(
+            row.get("cluster_waves_per_layer"),
+            f"prior c{cluster_count} cluster_waves_per_layer",
+        )
+        _positive_int(
+            row.get("service_no_stall_full_context_cycles_per_wave"),
+            f"prior c{cluster_count} service_no_stall_full_context_cycles_per_wave",
+        )
+        _positive_int(
+            row.get("service_calibrated_full_context_cycles_per_wave"),
+            f"prior c{cluster_count} service_calibrated_full_context_cycles_per_wave",
+        )
+        _nonnegative_int(row.get("fixed_cycles"), f"prior c{cluster_count} fixed_cycles")
+        _positive(row.get("clock_ns"), f"prior c{cluster_count} clock_ns")
+    if 1 not in prior_rows_by_cluster:
         raise ValueError("prior frontier must contain exactly one c1 row")
-    c1_row = c1_rows[0]
-    if _string(c1_row.get("service_calibration_case_id"), "prior c1 service_calibration_case_id") != _EXPECTED_CASE_ID:
-        raise ValueError("prior frontier c1 service_calibration_case_id mismatch")
-    _positive_int(
-        c1_row.get("service_calibration_microkernel_integrated_completion_cycle"),
-        "prior c1 service_calibration_microkernel_integrated_completion_cycle",
-    )
+    c1_row = prior_rows_by_cluster[1]
     if _positive_int(c1_row.get("cluster_waves_per_layer"), "prior c1 cluster_waves_per_layer") != _EXPECTED_HEADS:
         raise ValueError("prior frontier c1 cluster_waves_per_layer mismatch")
-    if _positive_int(c1_row.get("head_commands_per_layer"), "prior c1 head_commands_per_layer") != _EXPECTED_HEADS:
-        raise ValueError("prior frontier c1 head_commands_per_layer mismatch")
-    _positive_int(
-        c1_row.get("service_no_stall_full_context_cycles_per_wave"),
-        "prior c1 service_no_stall_full_context_cycles_per_wave",
-    )
-    _positive_int(
-        c1_row.get("service_calibrated_full_context_cycles_per_wave"),
-        "prior c1 service_calibrated_full_context_cycles_per_wave",
-    )
-    _nonnegative_int(c1_row.get("fixed_cycles"), "prior c1 fixed_cycles")
-    _positive(c1_row.get("clock_ns"), "prior c1 clock_ns")
     schedule, schedule_source = _source_schedule(prior, prior_frontier_json)
     if _positive_int(schedule.get("hidden_size"), "resolved schedule hidden_size") != _positive_int(
         schedule_contract.get("hidden_size"), "prior contract hidden_size"
@@ -281,14 +300,22 @@ def _validated_prior_frontier(
         raise ValueError("resolved schedule layers mismatch vs prior schedule_contract")
     if _positive_int(schedule.get("sequence_length"), "resolved schedule sequence_length") != sequence_length:
         raise ValueError("resolved schedule sequence_length mismatch vs prior schedule_contract")
-    return schedule, schedule_source, dense_qkv_tile, c1_row, rows, precision, workload_contract
+    return (
+        schedule,
+        schedule_source,
+        dense_qkv_tile,
+        prior_rows_by_cluster,
+        sorted(rows, key=lambda row: _positive_int(row.get("cluster_count"), "prior row cluster_count")),
+        precision,
+        workload_contract,
+    )
 
 
 def _validated_service_activity(
     service_report: JsonDict,
     prior_precision: JsonDict,
     prior_workload_contract: JsonDict,
-) -> tuple[JsonDict, JsonDict, JsonDict, JsonDict, JsonDict, JsonDict, JsonDict]:
+) -> JsonDict:
     if _string(service_report.get("model"), "service activity-power model") != _EXPECTED_SERVICE_MODEL:
         raise ValueError("service activity-power report has an unexpected model")
     if _string(service_report.get("decision"), "service activity-power decision") != _EXPECTED_SERVICE_DECISION:
@@ -300,6 +327,16 @@ def _validated_service_activity(
         != _EXPECTED_SERVICE_PRECISION_STATUS
     ):
         raise ValueError("service activity-power precision_status mismatch")
+    selection_contract = service_report.get("selection_contract")
+    if not isinstance(selection_contract, dict):
+        raise ValueError("service activity-power report lacks selection_contract")
+    case_id = _string(selection_contract.get("case_id"), "service selection_contract case_id")
+    case_contract = _service_case(case_id)
+    if _positive_int(
+        selection_contract.get("cluster_count"),
+        "service selection_contract cluster_count",
+    ) != int(case_contract["cluster_count"]):
+        raise ValueError("service selection_contract cluster_count mismatch")
     best = service_report.get("best")
     if not isinstance(best, dict):
         raise ValueError("service activity-power report lacks best")
@@ -311,48 +348,49 @@ def _validated_service_activity(
         raise ValueError("service best is not activity_backed")
     if best.get("promotion_gate_pass") is not True:
         raise ValueError("service best promotion_gate_pass failed")
-    if _string(best.get("flow_variant"), "service best flow_variant") != _EXPECTED_SERVICE_FLOW_VARIANT:
+    if _string(best.get("flow_variant"), "service best flow_variant") != case_contract["flow_variant"]:
         raise ValueError("service best flow_variant mismatch")
     metric = best.get("ppa_metric")
     if not isinstance(metric, dict):
         raise ValueError("service best lacks ppa_metric")
-    if _string(metric.get("design"), "service best design") != _EXPECTED_SERVICE_DESIGN:
+    if _string(metric.get("design"), "service best design") != case_contract["design"]:
         raise ValueError("service best design mismatch")
     if _string(metric.get("platform"), "service best platform") != _EXPECTED_SERVICE_PLATFORM:
         raise ValueError("service best platform mismatch")
     params_json = json.loads(_string(metric.get("params_json"), "service best params_json"))
     if not isinstance(params_json, dict):
         raise ValueError("service best params_json is not an object")
-    if _string(params_json.get("FLOW_VARIANT"), "service best FLOW_VARIANT") != _EXPECTED_SERVICE_FLOW_VARIANT:
+    if _string(params_json.get("FLOW_VARIANT"), "service best FLOW_VARIANT") != case_contract["flow_variant"]:
         raise ValueError("service best FLOW_VARIANT mismatch")
     if abs(_positive(params_json.get("CLOCK_PERIOD"), "service best CLOCK_PERIOD") - _EXPECTED_SERVICE_CLOCK_NS) > 1e-9:
         raise ValueError("service best CLOCK_PERIOD mismatch")
     if _positive(metric.get("critical_path_ns"), "service best critical_path_ns") > _EXPECTED_SERVICE_CLOCK_NS:
         raise ValueError("service best is not timing-feasible at 10 ns")
-    authoritative = best.get("authoritative_composed_c1_total_ppa")
+    authoritative = best.get("authoritative_composed_total_ppa")
     if not isinstance(authoritative, dict):
-        raise ValueError("service best lacks authoritative_composed_c1_total_ppa")
+        authoritative = best.get(case_contract["authoritative_key"])
+    if not isinstance(authoritative, dict):
+        raise ValueError("service best lacks authoritative composed-service PPA")
     if _positive(authoritative.get("critical_path_ns"), "authoritative service critical_path_ns") > _EXPECTED_SERVICE_CLOCK_NS:
-        raise ValueError("authoritative composed c1 total instance is not timing-feasible at 10 ns")
+        raise ValueError("authoritative composed-service instance is not timing-feasible at 10 ns")
     if not math.isclose(
         _positive(authoritative.get("instance_area_um2"), "authoritative service instance_area_um2"),
         _positive(metric.get("instance_area_um2"), "service best instance_area_um2"),
         rel_tol=0.0,
         abs_tol=1e-9,
     ):
-        raise ValueError("authoritative composed c1 total instance area mismatches service best ppa_metric")
+        raise ValueError("authoritative composed-service instance area mismatches service best ppa_metric")
     if not math.isclose(
         _positive(authoritative.get("critical_path_ns"), "authoritative service critical_path_ns"),
         _positive(metric.get("critical_path_ns"), "service best critical_path_ns"),
         rel_tol=0.0,
         abs_tol=1e-9,
     ):
-        raise ValueError("authoritative composed c1 timing mismatches service best ppa_metric")
+        raise ValueError("authoritative composed-service timing mismatches service best ppa_metric")
     counts = service_report.get("macro_manifest_contract")
     if not isinstance(counts, dict) or not isinstance(counts.get("counts"), dict):
         raise ValueError("service report lacks macro_manifest_contract counts")
-    macro_counts = counts["counts"]
-    if macro_counts != _EXPECTED_SERVICE_MACRO_COUNTS:
+    if counts["counts"] != case_contract["macro_counts"]:
         raise ValueError("service macro count contract mismatch")
     macro_activity_contract = service_report.get("macro_activity_contract")
     if not isinstance(macro_activity_contract, dict):
@@ -362,10 +400,10 @@ def _validated_service_activity(
     macro_classes = macro_activity_contract.get("macro_classes")
     if not isinstance(macro_classes, dict):
         raise ValueError("service macro_activity_contract lacks macro_classes")
-    if set(macro_classes) != set(_EXPECTED_SERVICE_MACRO_COUNTS):
+    if set(macro_classes) != set(case_contract["macro_counts"]):
         raise ValueError("service macro_activity_contract macro_classes mismatch")
     assignment_total = 0
-    for macro_name, expected_count in _EXPECTED_SERVICE_MACRO_COUNTS.items():
+    for macro_name, expected_count in case_contract["macro_counts"].items():
         payload = macro_classes.get(macro_name)
         if not isinstance(payload, dict):
             raise ValueError(f"service macro_activity_contract missing {macro_name}")
@@ -397,11 +435,11 @@ def _validated_service_activity(
     bank3 = service_report.get("bank3_dynamic_inactivity")
     if not isinstance(bank3, dict):
         raise ValueError("service report lacks bank3_dynamic_inactivity")
-    if bank3.get("inactive_banks") != [3]:
-        raise ValueError("service report must keep bank3 inactive")
     bank3_statement = _string(bank3.get("statement"), "service bank3 statement")
     if "No artificial activity was injected" not in bank3_statement or "not required to toggle" not in bank3_statement:
         raise ValueError("service report bank3 inactivity must be explicitly unforced")
+    if case_id == "c1_p128_b4_rr" and bank3.get("inactive_banks") != [3]:
+        raise ValueError("service report must keep bank3 inactive for c1")
     service_window = best.get("component_service_window_energy")
     if not isinstance(service_window, dict):
         raise ValueError("service best lacks component_service_window_energy")
@@ -448,42 +486,64 @@ def _validated_service_activity(
             prior_precision.get(field), f"prior precision {field}"
         ):
             raise ValueError(f"service cluster equivalence {field} mismatch")
-    integrated_service = dependency_contract.get("integrated_service_c1")
+    integrated_service = dependency_contract.get(case_contract["dependency_key"])
     if not isinstance(integrated_service, dict):
-        raise ValueError("service dependency_contract lacks integrated_service_c1")
-    if _string(integrated_service.get("case_id"), "service integrated_service_c1 case_id") != _EXPECTED_CASE_ID:
-        raise ValueError("service integrated_service_c1 case_id mismatch")
-    if _string(integrated_service.get("decision"), "service integrated_service_c1 decision") != "pass":
-        raise ValueError("service integrated_service_c1 decision mismatch")
+        raise ValueError(f"service dependency_contract lacks {case_contract['dependency_key']}")
+    if _string(integrated_service.get("case_id"), "service integrated_service case_id") != case_id:
+        raise ValueError("service integrated_service case_id mismatch")
+    if _string(integrated_service.get("decision"), "service integrated_service decision") != "pass":
+        raise ValueError("service integrated_service decision mismatch")
     config = integrated_service.get("config")
     if not isinstance(config, dict):
-        raise ValueError("service integrated_service_c1 config is missing")
-    for key, expected in _EXPECTED_SERVICE_CONFIG.items():
-        config_value = config.get(key)
-        if config_value != expected:
-            raise ValueError(f"service integrated_service_c1 config mismatch for {key}")
+        raise ValueError("service integrated_service config is missing")
+    expected_config = {
+        "cluster_count": int(case_contract["cluster_count"]),
+        "packet_w": 128,
+        "banks": 4,
+        "req_queue_depth": 4,
+        "resp_queue_depth": 4,
+        "bank_queue_depth": 4,
+        "read_latency": 2,
+        "arb_mode": "round_robin",
+        "locality_burst_max": 2,
+    }
+    for key, expected in expected_config.items():
+        if config.get(key) != expected:
+            raise ValueError(f"service integrated_service config mismatch for {key}")
     integrated_workload_contract = _validated_workload_contract(
         integrated_service.get("workload_contract"),
-        "service integrated_service_c1 workload_contract",
+        "service integrated_service workload_contract",
     )
     if integrated_workload_contract != workload_contract:
-        raise ValueError("service integrated_service_c1 workload_contract mismatch vs activity workload_contract")
+        raise ValueError("service integrated_service workload_contract mismatch vs activity workload_contract")
     for key in ("exact_match", "no_protocol_errors", "no_drop_duplicate_deadlock_timeout", "cycle_bound_ok"):
         if integrated_service.get(key) is not True:
-            raise ValueError(f"service integrated_service_c1 {key} gate failed")
+            raise ValueError(f"service integrated_service {key} gate failed")
     hashes = integrated_service.get("hashes")
     if not isinstance(hashes, dict):
-        raise ValueError("service integrated_service_c1 lacks hashes")
+        raise ValueError("service integrated_service lacks hashes")
     integrated_hashes = {
-        "score_hash": _string(hashes.get("score_hash"), "service integrated_service_c1 score_hash"),
-        "final_hash": _string(hashes.get("final_hash"), "service integrated_service_c1 final_hash"),
-        "request_hash": _string(hashes.get("request_hash"), "service integrated_service_c1 request_hash"),
+        "score_hash": _string(hashes.get("score_hash"), "service integrated_service score_hash"),
+        "final_hash": _string(hashes.get("final_hash"), "service integrated_service final_hash"),
+        "request_hash": _string(hashes.get("request_hash"), "service integrated_service request_hash"),
         "wide_response_matrix_hash": _string(
             hashes.get("wide_response_matrix_hash"),
-            "service integrated_service_c1 wide_response_matrix_hash",
+            "service integrated_service wide_response_matrix_hash",
         ),
     }
-    return best, authoritative, service_window, activity_contract, workload_contract, macro_activity_contract, integrated_hashes
+    return {
+        "case_id": case_id,
+        "cluster_count": int(case_contract["cluster_count"]),
+        "best": best,
+        "authoritative_service_ppa": authoritative,
+        "service_window": service_window,
+        "activity_contract": activity_contract,
+        "workload_contract": workload_contract,
+        "macro_activity_contract": macro_activity_contract,
+        "integrated_hashes": integrated_hashes,
+        "flow_variant": case_contract["flow_variant"],
+        "design": case_contract["design"],
+    }
 
 
 def _recompute_dense_tiles(
@@ -518,7 +578,6 @@ def _recompute_dense_tiles(
         schedule.get("measured_tile_local_sram_area_um2", 0.0),
         "schedule measured_tile_local_sram_area_um2",
     )
-    embodied_area_um2 = logic_area_um2 + shared_sram_um2 + tile_sram_um2
     return (
         dense_count,
         qkv_useful_limit,
@@ -534,24 +593,36 @@ def _measured_row(
     *,
     schedule: JsonDict,
     dense_qkv_tile: JsonDict,
-    prior_c1_row: JsonDict,
-    authoritative_service_ppa: JsonDict,
-    service_window: JsonDict,
-    workload_contract: JsonDict,
+    prior_row: JsonDict,
+    service_activity: JsonDict,
 ) -> JsonDict:
+    case_id = str(service_activity["case_id"])
+    cluster_count = int(service_activity["cluster_count"])
     hidden = _positive_int(schedule.get("hidden_size"), "schedule hidden_size")
     heads = _positive_int(schedule.get("attention_heads"), "schedule attention_heads")
     kv_heads = _positive_int(schedule.get("kv_heads"), "schedule kv_heads")
     layers = _positive_int(schedule.get("layers"), "schedule layers")
     sequence_length = _positive_int(schedule.get("sequence_length"), "schedule sequence_length")
     prior_microkernel_cycle = _positive_int(
-        prior_c1_row.get("service_calibration_microkernel_integrated_completion_cycle"),
-        "prior c1 service_calibration_microkernel_integrated_completion_cycle",
+        prior_row.get("service_calibration_microkernel_integrated_completion_cycle"),
+        f"prior c{cluster_count} service_calibration_microkernel_integrated_completion_cycle",
     )
+    activity_contract = service_activity["activity_contract"]
+    service_window = service_activity["service_window"]
     measured_cycle_count = _positive_int(service_window.get("cycle_count"), "service window cycle_count")
+    if measured_cycle_count != _positive_int(
+        activity_contract.get("cycle_count"),
+        "service activity cycle_count",
+    ):
+        raise ValueError("service window cycle_count does not match service activity cycle_count")
     if measured_cycle_count != prior_microkernel_cycle:
-        raise ValueError("service VCD microkernel cycle_count does not match prior c1 calibration cycle")
-    service_area_um2 = _positive(authoritative_service_ppa.get("instance_area_um2"), "authoritative service area")
+        raise ValueError(
+            f"service activity cycle_count / service VCD microkernel cycle_count does not match prior c{cluster_count} calibration cycle"
+        )
+    service_area_um2 = _positive(
+        service_activity["authoritative_service_ppa"].get("instance_area_um2"),
+        "authoritative service area",
+    )
     (
         dense_count,
         qkv_useful_limit,
@@ -569,24 +640,34 @@ def _measured_row(
     head_dim = hidden // heads
     qkv_work = hidden**2 + 2 * hidden * kv_heads * head_dim
     qkv_cycles = math.ceil(qkv_work / (dense_count * dense_macs)) if dense_count else None
-    cluster_waves_per_layer = _positive_int(prior_c1_row.get("cluster_waves_per_layer"), "prior c1 cluster_waves_per_layer")
+    cluster_waves_per_layer = _positive_int(
+        prior_row.get("cluster_waves_per_layer"),
+        f"prior c{cluster_count} cluster_waves_per_layer",
+    )
     service_cycles_per_wave = _positive_int(
-        prior_c1_row.get("service_calibrated_full_context_cycles_per_wave"),
-        "prior c1 service_calibrated_full_context_cycles_per_wave",
+        prior_row.get("service_calibrated_full_context_cycles_per_wave"),
+        f"prior c{cluster_count} service_calibrated_full_context_cycles_per_wave",
     )
     attention_cycles = cluster_waves_per_layer * service_cycles_per_wave
-    fixed_cycles = _nonnegative_int(prior_c1_row.get("fixed_cycles"), "prior c1 fixed_cycles")
+    fixed_cycles = _nonnegative_int(prior_row.get("fixed_cycles"), f"prior c{cluster_count} fixed_cycles")
     layer_cycles = qkv_cycles + attention_cycles + fixed_cycles if qkv_cycles is not None else None
     total_cycles = layer_cycles * layers if layer_cycles is not None else None
-    prior_clock_ns = _positive(prior_c1_row.get("clock_ns"), "prior c1 clock_ns")
+    prior_clock_ns = _positive(prior_row.get("clock_ns"), f"prior c{cluster_count} clock_ns")
     clock_ns = max(prior_clock_ns, _EXPECTED_SERVICE_CLOCK_NS)
     latency_us = total_cycles * clock_ns / 1000.0 if total_cycles is not None else None
-    timing_feasible = _positive(authoritative_service_ppa.get("critical_path_ns"), "authoritative service critical_path_ns") <= clock_ns
+    timing_feasible = (
+        _positive(
+            service_activity["authoritative_service_ppa"].get("critical_path_ns"),
+            "authoritative service critical_path_ns",
+        )
+        <= clock_ns
+    )
 
     microkernel_duration_s = _positive(service_window.get("duration_s"), "service window duration_s")
     service_duration_s = service_cycles_per_wave * clock_ns * 1.0e-9
     dynamic_j = _positive(service_window.get("energy_j", {}).get("dynamic"), "service window dynamic energy")
     leakage_j = _positive(service_window.get("energy_j", {}).get("leakage"), "service window leakage energy")
+    workload_contract = service_activity["workload_contract"]
     active_context_tokens = _positive_int(
         workload_contract.get("active_context_tokens"),
         "workload_contract active_context_tokens",
@@ -598,34 +679,39 @@ def _measured_row(
     full_measured_window_count = math.ceil(sequence_length / active_context_tokens)
     full_measured_window_count_exact = sequence_length // active_context_tokens
     final_partial_tokens = sequence_length % active_context_tokens
-    full_context_dynamic_per_head_j = dynamic_j * full_measured_window_count
-    full_context_leakage_per_head_j = leakage_j * (service_duration_s / microkernel_duration_s)
-    full_context_component_per_head_j = full_context_dynamic_per_head_j + full_context_leakage_per_head_j
-    full_token_commands = heads * layers
-    component_dynamic_j = full_context_dynamic_per_head_j * full_token_commands
-    component_leakage_j = full_context_leakage_per_head_j * full_token_commands
-    component_total_j = full_context_component_per_head_j * full_token_commands
-    prior_cluster_area_mm2 = _positive(prior_c1_row.get("cluster_area_mm2"), "prior c1 cluster_area_mm2")
+    full_context_dynamic_per_service_wave_j = dynamic_j * full_measured_window_count
+    full_context_leakage_per_service_wave_j = leakage_j * (service_duration_s / microkernel_duration_s)
+    full_context_component_per_service_wave_j = (
+        full_context_dynamic_per_service_wave_j + full_context_leakage_per_service_wave_j
+    )
+    full_service_wave_count = cluster_waves_per_layer * layers
+    component_dynamic_j = full_context_dynamic_per_service_wave_j * full_service_wave_count
+    component_leakage_j = full_context_leakage_per_service_wave_j * full_service_wave_count
+    component_total_j = full_context_component_per_service_wave_j * full_service_wave_count
+    prior_cluster_area_mm2 = _positive(prior_row.get("cluster_area_mm2"), f"prior c{cluster_count} cluster_area_mm2")
 
     return {
-        "candidate_id": "decode_score_multivalue_service_measured_c1",
-        "source_prior_candidate_id": _string(prior_c1_row.get("candidate_id"), "prior c1 candidate_id"),
-        "cluster_count": 1,
-        "status": "directly_measured_c1_anchor",
+        "candidate_id": f"decode_score_multivalue_service_measured_c{cluster_count}",
+        "source_prior_candidate_id": _string(prior_row.get("candidate_id"), f"prior c{cluster_count} candidate_id"),
+        "cluster_count": cluster_count,
+        "status": f"directly_measured_c{cluster_count}_anchor",
         "promoted": True,
         "rankable_as_measured": True,
-        "measurement_scope": "strict_c1_activity_backed_microkernel_scaled_composed_service_anchor",
-        "service_calibration_case_id": _EXPECTED_CASE_ID,
+        "measurement_scope": f"strict_c{cluster_count}_activity_backed_microkernel_scaled_composed_service_anchor",
+        "service_calibration_case_id": case_id,
         "service_calibration_microkernel_integrated_completion_cycle": prior_microkernel_cycle,
         "service_activity_microkernel_cycle_count": measured_cycle_count,
         "service_no_stall_full_context_cycles_per_wave": _positive_int(
-            prior_c1_row.get("service_no_stall_full_context_cycles_per_wave"),
-            "prior c1 service_no_stall_full_context_cycles_per_wave",
+            prior_row.get("service_no_stall_full_context_cycles_per_wave"),
+            f"prior c{cluster_count} service_no_stall_full_context_cycles_per_wave",
         ),
         "service_calibrated_full_context_cycles_per_wave": service_cycles_per_wave,
-        "service_cycle_source": "preserved_from_prior_c1_full_context_calibration",
+        "service_cycle_source": f"preserved_from_prior_c{cluster_count}_full_context_calibration",
         "cluster_waves_per_layer": cluster_waves_per_layer,
-        "head_commands_per_layer": _positive_int(prior_c1_row.get("head_commands_per_layer"), "prior c1 head_commands_per_layer"),
+        "head_commands_per_layer": _positive_int(
+            prior_row.get("head_commands_per_layer"),
+            f"prior c{cluster_count} head_commands_per_layer",
+        ),
         "dense_qkv_tile_count": dense_count,
         "dense_qkv_useful_parallelism_limit": qkv_useful_limit,
         "qkv_cycles": qkv_cycles,
@@ -641,7 +727,10 @@ def _measured_row(
         "prior_cluster_area_mm2": round(prior_cluster_area_mm2, 9),
         "authoritative_composed_service_area_mm2": round(service_area_um2 / 1.0e6, 9),
         "area_replacement_delta_mm2": round(service_area_um2 / 1.0e6 - prior_cluster_area_mm2, 9),
-        "dense_qkv_area_mm2": round(dense_count * _positive(dense_qkv_tile.get("area_um2"), "dense_qkv_tile area_um2") / 1.0e6, 9),
+        "dense_qkv_area_mm2": round(
+            dense_count * _positive(dense_qkv_tile.get("area_um2"), "dense_qkv_tile area_um2") / 1.0e6,
+            9,
+        ),
         "retained_noncompute_logic_area_mm2": round(retained_noncompute_logic_um2 / 1.0e6, 9),
         "logic_area_mm2": round(logic_area_um2 / 1.0e6, 9),
         "existing_shared_sram_area_mm2": round(shared_sram_um2 / 1.0e6, 9),
@@ -658,7 +747,7 @@ def _measured_row(
         "compute_budget_area_fit": area_fit,
         "timing_feasible": timing_feasible,
         "area_replacement_provenance": (
-            "Authoritative composed c1 total instance area replaces the prior c1 cluster total instance area. "
+            f"Authoritative composed c{cluster_count} total instance area replaces the prior c{cluster_count} cluster total instance area. "
             "The 16KiB service value store remains counted inside the service instance area as a "
             "command-working-set macro component, and broader schedule shared/tile SRAM remains separately charged."
         ),
@@ -669,19 +758,24 @@ def _measured_row(
         "final_partial_tokens": final_partial_tokens,
         "final_partial_window_conservatively_charged_as_full_measured_window": final_partial_tokens > 0,
         "service_window_duration_s": microkernel_duration_s,
+        "full_context_service_duration_s_per_service_wave": service_duration_s,
         "full_context_service_duration_s_per_head_command": service_duration_s,
+        "full_context_service_wave_count": full_service_wave_count,
         "service_window_dynamic_energy_j": dynamic_j,
         "service_window_leakage_energy_j": leakage_j,
-        "full_context_dynamic_energy_j_per_head_command": full_context_dynamic_per_head_j,
-        "full_context_leakage_energy_j_per_head_command": full_context_leakage_per_head_j,
+        "full_context_dynamic_energy_j_per_service_wave": full_context_dynamic_per_service_wave_j,
+        "full_context_leakage_energy_j_per_service_wave": full_context_leakage_per_service_wave_j,
+        "full_context_dynamic_energy_j_per_head_command": full_context_dynamic_per_service_wave_j,
+        "full_context_leakage_energy_j_per_head_command": full_context_leakage_per_service_wave_j,
         "service_component_dynamic_energy_mj_per_token": component_dynamic_j * 1.0e3,
         "service_component_leakage_energy_mj_per_token": component_leakage_j * 1.0e3,
         "service_component_energy_mj_per_token": component_total_j * 1.0e3,
+        "service_window_energy_accounting": "whole_measured_service_window_scaled_by_measured_windows_and_service_waves",
+        "direct_total_token_energy": False,
         "energy_status": (
             "activity_backed_microkernel_scaled_composed_service_component_estimate_"
             "not_direct_total_token_energy"
         ),
-        "direct_total_token_energy": False,
         "energy_scope_exclusions": [
             "legacy cluster dynamic energy is excluded",
             "HBM/DRAM energy is excluded",
@@ -691,7 +785,7 @@ def _measured_row(
     }
 
 
-def _blocked_row(row: JsonDict) -> JsonDict:
+def _blocked_row(row: JsonDict, *, blocker: str | None = None) -> JsonDict:
     return {
         "candidate_id": f"{_string(row.get('candidate_id'), 'prior row candidate_id')}_blocked_pending_measured_service",
         "source_prior_candidate_id": _string(row.get("candidate_id"), "prior row candidate_id"),
@@ -700,9 +794,10 @@ def _blocked_row(row: JsonDict) -> JsonDict:
         "promoted": False,
         "rankable_as_measured": False,
         "measurement_scope": "not_measured",
-        "blocker": (
-            "Only the directly measured c1 composed physical/activity anchor is promoted. "
-            "Equivalent composed physical area and activity-backed service evidence is still required for c2+."
+        "blocker": blocker
+        or (
+            "Only directly measured composed physical/activity anchors are promoted. "
+            "Equivalent composed physical area and activity-backed service evidence is still required for this cluster count."
         ),
     }
 
@@ -710,15 +805,20 @@ def _blocked_row(row: JsonDict) -> JsonDict:
 def build_report(
     *,
     prior_cluster_frontier_json: Path,
-    service_activity_power_json: Path,
+    service_activity_power_json: Path | None = None,
+    service_activity_power_jsons: list[Path] | None = None,
 ) -> JsonDict:
     prior = _load(prior_cluster_frontier_json)
-    service = _load(service_activity_power_json)
+    selected_service_paths = list(service_activity_power_jsons or [])
+    if service_activity_power_json is not None:
+        selected_service_paths.append(service_activity_power_json)
+    if not selected_service_paths:
+        raise ValueError("at least one service_activity_power_json is required")
     (
         schedule,
         schedule_source,
         dense_qkv_tile,
-        prior_c1_row,
+        prior_rows_by_cluster,
         prior_rows,
         prior_precision,
         workload_contract,
@@ -726,41 +826,119 @@ def build_report(
         prior,
         prior_cluster_frontier_json,
     )
-    (
-        best,
-        authoritative_service_ppa,
-        service_window,
-        activity_contract,
-        workload_contract,
-        macro_activity_contract,
-        integrated_hashes,
-    ) = _validated_service_activity(
-        service,
-        prior_precision,
-        workload_contract,
-    )
-    measured = _measured_row(
+    validated_service_activities: dict[int, JsonDict] = {}
+    portable_service_inputs: list[str] = []
+    for service_path in selected_service_paths:
+        validated = _validated_service_activity(
+            _load(service_path),
+            prior_precision,
+            workload_contract,
+        )
+        cluster_count = int(validated["cluster_count"])
+        if cluster_count in validated_service_activities:
+            raise ValueError(f"duplicate measured service activity supplied for c{cluster_count}")
+        validated_service_activities[cluster_count] = validated
+        portable_service_inputs.append(_portable_path(service_path))
+    if 1 not in validated_service_activities:
+        raise ValueError("a strict c1 service activity-power report is required")
+
+    c1_measured = _measured_row(
         schedule=schedule,
         dense_qkv_tile=dense_qkv_tile,
-        prior_c1_row=prior_c1_row,
-        authoritative_service_ppa=authoritative_service_ppa,
-        service_window=service_window,
-        workload_contract=workload_contract,
+        prior_row=prior_rows_by_cluster[1],
+        service_activity=validated_service_activities[1],
     )
-    if not measured["compute_budget_area_fit"] or not measured["timing_feasible"]:
+    if not c1_measured["compute_budget_area_fit"] or not c1_measured["timing_feasible"]:
         raise ValueError("recomputed c1 measured anchor is not feasible for promotion")
-    blocked_rows = [
-        _blocked_row(row)
-        for row in sorted(prior_rows, key=lambda item: _positive_int(item.get("cluster_count"), "prior row cluster_count"))
-        if _positive_int(row.get("cluster_count"), "prior row cluster_count") > 1
-    ]
+
+    promoted_rows = [c1_measured]
+    rows: list[JsonDict] = []
+    blocked_rows: list[JsonDict] = []
+    for prior_row in prior_rows:
+        cluster_count = _positive_int(prior_row.get("cluster_count"), "prior row cluster_count")
+        if cluster_count == 1:
+            rows.append(c1_measured)
+            continue
+        service_activity = validated_service_activities.get(cluster_count)
+        if service_activity is None:
+            blocked = _blocked_row(
+                prior_row,
+                blocker=(
+                    "Strict activity-backed composed-service physical evidence is still required "
+                    f"before c{cluster_count} can be promoted."
+                ),
+            )
+            rows.append(blocked)
+            blocked_rows.append(blocked)
+            continue
+        measured_row = _measured_row(
+            schedule=schedule,
+            dense_qkv_tile=dense_qkv_tile,
+            prior_row=prior_row,
+            service_activity=service_activity,
+        )
+        if measured_row["compute_budget_area_fit"] and measured_row["timing_feasible"]:
+            rows.append(measured_row)
+            promoted_rows.append(measured_row)
+        else:
+            blocked = _blocked_row(
+                prior_row,
+                blocker=(
+                    f"Strict c{cluster_count} activity/physical evidence was supplied, but the recomputed "
+                    "composed-service point is not feasible for promotion under the measured schedule budget."
+                ),
+            )
+            rows.append(blocked)
+            blocked_rows.append(blocked)
+
+    best_anchor = max(promoted_rows, key=lambda row: float(row["token_throughput_per_s"]))
+    c2_promoted = any(row["cluster_count"] == 2 for row in promoted_rows)
+    c1_service = validated_service_activities[1]
+    c1_contract = _service_case(c1_service["case_id"])
+    selected_candidates = {
+        f"c{cluster_count}": {
+            "candidate_id": _string(service_activity["best"].get("candidate_id"), "service best candidate_id"),
+            "flow_variant": _string(service_activity["best"].get("flow_variant"), "service best flow_variant"),
+            "integrated_service_hashes": service_activity["integrated_hashes"],
+            "activity_contract": {
+                "clock_period_ns": _positive(
+                    service_activity["activity_contract"].get("clock_period_ns"),
+                    "service activity clock_period_ns",
+                ),
+                "cycle_count": _positive_int(
+                    service_activity["activity_contract"].get("cycle_count"),
+                    "service activity cycle_count",
+                ),
+            },
+            "activity_workload_contract": service_activity["workload_contract"],
+            "macro_activity_contract": service_activity["macro_activity_contract"],
+        }
+        for cluster_count, service_activity in sorted(validated_service_activities.items())
+    }
+    service_contracts = {
+        f"c{cluster_count}": {
+            "model": _EXPECTED_SERVICE_MODEL,
+            "decision": _EXPECTED_SERVICE_DECISION,
+            "promotion_gate_pass": True,
+            "required_flow_variant": service_activity["flow_variant"],
+            "required_design": service_activity["design"],
+            "required_platform": _EXPECTED_SERVICE_PLATFORM,
+            "required_clock_period_ns": _EXPECTED_SERVICE_CLOCK_NS,
+        }
+        for cluster_count, service_activity in sorted(validated_service_activities.items())
+    }
     return {
         "version": 1,
         "model": _MODEL,
-        "decision": "strict_c1_measured_service_anchor_promoted_c2plus_blocked",
+        "decision": (
+            "strict_c1_c2_measured_service_anchors_promoted_c3plus_blocked"
+            if c2_promoted
+            else "strict_c1_measured_service_anchor_promoted_c2plus_blocked"
+        ),
         "inputs": {
             "prior_cluster_frontier_json": _portable_path(prior_cluster_frontier_json),
-            "service_activity_power_json": _portable_path(service_activity_power_json),
+            "service_activity_power_json": portable_service_inputs[0],
+            "service_activity_power_jsons": portable_service_inputs,
             "source_schedule_json": schedule_source,
         },
         "prior_cluster_frontier_contract": {
@@ -773,11 +951,12 @@ def build_report(
             "model": _EXPECTED_SERVICE_MODEL,
             "decision": _EXPECTED_SERVICE_DECISION,
             "promotion_gate_pass": True,
-            "required_flow_variant": _EXPECTED_SERVICE_FLOW_VARIANT,
-            "required_design": _EXPECTED_SERVICE_DESIGN,
+            "required_flow_variant": c1_contract["flow_variant"],
+            "required_design": c1_contract["design"],
             "required_platform": _EXPECTED_SERVICE_PLATFORM,
             "required_clock_period_ns": _EXPECTED_SERVICE_CLOCK_NS,
         },
+        "service_activity_power_contracts": service_contracts,
         "schedule_contract": {
             "hidden_size": _positive_int(schedule.get("hidden_size"), "schedule hidden_size"),
             "attention_heads": _positive_int(schedule.get("attention_heads"), "schedule attention_heads"),
@@ -785,24 +964,15 @@ def build_report(
             "layers": _positive_int(schedule.get("layers"), "schedule layers"),
             "sequence_length": _positive_int(schedule.get("sequence_length"), "schedule sequence_length"),
             "workload_contract": dict(workload_contract),
-            "measured_window_active_context_tokens": measured["measured_window_active_context_tokens"],
-            "measured_window_context_capacity_tokens": measured["measured_window_context_capacity_tokens"],
-            "full_measured_window_count": measured["full_measured_window_count"],
-            "full_measured_window_count_exact": measured["full_measured_window_count_exact"],
-            "final_partial_tokens": measured["final_partial_tokens"],
+            "measured_window_active_context_tokens": c1_measured["measured_window_active_context_tokens"],
+            "measured_window_context_capacity_tokens": c1_measured["measured_window_context_capacity_tokens"],
+            "full_measured_window_count": c1_measured["full_measured_window_count"],
+            "full_measured_window_count_exact": c1_measured["full_measured_window_count_exact"],
+            "final_partial_tokens": c1_measured["final_partial_tokens"],
             "full_head_commands_per_token": _EXPECTED_HEADS * _EXPECTED_LAYERS,
         },
-        "selected_service_activity_candidate": {
-            "candidate_id": _string(best.get("candidate_id"), "service best candidate_id"),
-            "flow_variant": _string(best.get("flow_variant"), "service best flow_variant"),
-            "integrated_service_hashes": integrated_hashes,
-            "activity_contract": {
-                "clock_period_ns": _positive(activity_contract.get("clock_period_ns"), "service activity clock_period_ns"),
-                "cycle_count": _positive_int(activity_contract.get("cycle_count"), "service activity cycle_count"),
-            },
-            "activity_workload_contract": workload_contract,
-            "macro_activity_contract": macro_activity_contract,
-        },
+        "selected_service_activity_candidate": selected_candidates["c1"],
+        "selected_service_activity_candidates": selected_candidates,
         "precision": {
             "status": _EXPECTED_SERVICE_PRECISION_STATUS,
             "decision": _EXPECTED_PRIOR_PRECISION_DECISION,
@@ -810,20 +980,29 @@ def build_report(
             "final_tensor_hash": _string(prior_precision.get("final_tensor_hash"), "prior precision final_tensor_hash"),
             "quality_change": "none_exact_integer_semantics_preserved",
         },
-        "rows": [measured, *blocked_rows],
-        "promoted_rows": [measured],
+        "rows": rows,
+        "promoted_rows": promoted_rows,
         "blocked_rows": blocked_rows,
-        "best_measured_anchor": measured,
+        "best_measured_anchor": best_anchor,
         "promotion_status": (
-            "strict_c1_measured_anchor_promoted_c2plus_unpromoted_pending_equivalent_"
-            "composed_physical_activity_evidence"
+            "strict_c1_c2_measured_anchors_promoted_c3plus_unpromoted_pending_equivalent_composed_physical_activity_evidence"
+            if c2_promoted
+            else "strict_c1_measured_anchor_promoted_c2plus_unpromoted_pending_equivalent_composed_physical_activity_evidence"
         ),
         "remaining_abstractions": [
-            "This report promotes only the directly measured c1 composed service anchor.",
+            (
+                "This report promotes only directly measured composed-service anchors. "
+                + ("c1 and c2 are promoted; c3+ remain blocked." if c2_promoted else "Only c1 is promoted; c2+ remain blocked.")
+            ),
             "The activity-backed energy is a microkernel-scaled composed-service component estimate, not direct total-token energy.",
+            "Measured whole-service window energy is scaled with ceil(sequence_length / 24) and then multiplied by cluster_waves_per_layer * layers; c2 must not be multiplied by heads * layers.",
             "HBM/DRAM, broader SRAM/NoC, producer, and dense-QKV activity energy remain outside this report.",
             "The 16KiB service value store remains counted inside the service instance area, while broader schedule SRAM remains separately charged.",
-            "c2+ rows remain blocked until equivalent composed physical/activity evidence exists for those cluster counts.",
+            (
+                "c3+ rows remain blocked until equivalent composed physical/activity evidence exists for those cluster counts."
+                if c2_promoted
+                else "c2+ rows remain blocked until equivalent composed physical/activity evidence exists for those cluster counts."
+            ),
         ],
     }
 
@@ -831,10 +1010,10 @@ def build_report(
 def _write_markdown(payload: JsonDict, path: Path) -> None:
     anchor = payload["best_measured_anchor"]
     lines = [
-        "# Llama7B strict c1 measured-service frontier",
+        "# Llama7B measured composed-service frontier",
         "",
         f"- decision: `{payload['decision']}`",
-        f"- promoted anchor: `{anchor['candidate_id']}`",
+        f"- best measured anchor: `{anchor['candidate_id']}`",
         f"- clock ns: `{anchor['clock_ns']}`",
         f"- latency us: `{anchor['latency_us']}`",
         f"- dense QKV tiles: `{anchor['dense_qkv_tile_count']}`",
@@ -874,13 +1053,13 @@ def _write_markdown(payload: JsonDict, path: Path) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--prior-cluster-frontier-json", type=Path, required=True)
-    parser.add_argument("--service-activity-power-json", type=Path, required=True)
+    parser.add_argument("--service-activity-power-json", type=Path, action="append", required=True)
     parser.add_argument("--out", type=Path, required=True)
     parser.add_argument("--out-md", type=Path, required=True)
     args = parser.parse_args()
     payload = build_report(
         prior_cluster_frontier_json=args.prior_cluster_frontier_json,
-        service_activity_power_json=args.service_activity_power_json,
+        service_activity_power_jsons=args.service_activity_power_json,
     )
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/npu/eval/audit_attention_decode_score_multivalue_service_measured_frontier.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_service_measured_frontier.py
@@ -29,7 +29,6 @@ _EXPECTED_SERVICE_PRECISION_STATUS = (
     "unchanged_integer_contract_from_merged_cluster_equivalence_and_integrated_service"
 )
 _EXPECTED_SERVICE_PLATFORM = "nangate45"
-_EXPECTED_SERVICE_MACRO_PROFILE = "multivalue_service_c1_v1"
 _EXPECTED_HIDDEN = 4096
 _EXPECTED_HEADS = 32
 _EXPECTED_KV_HEADS = 4
@@ -185,7 +184,11 @@ def _service_case(case_id: str) -> JsonDict:
     contract = _SERVICE_CASES.get(str(case_id).strip())
     if contract is None:
         raise ValueError(f"unsupported measured-service case_id: {case_id}")
-    return dict(contract)
+    return {"case_id": str(case_id).strip(), **dict(contract)}
+
+
+def _service_macro_profile(case_contract: JsonDict) -> str:
+    return f"multivalue_service_{str(case_contract['case_id']).split('_', 1)[0]}_v1"
 
 
 def _validated_prior_frontier(
@@ -395,7 +398,9 @@ def _validated_service_activity(
     macro_activity_contract = service_report.get("macro_activity_contract")
     if not isinstance(macro_activity_contract, dict):
         raise ValueError("service report lacks macro_activity_contract")
-    if _string(macro_activity_contract.get("profile"), "service macro_activity profile") != _EXPECTED_SERVICE_MACRO_PROFILE:
+    if _string(macro_activity_contract.get("profile"), "service macro_activity profile") != _service_macro_profile(
+        case_contract
+    ):
         raise ValueError("service macro_activity profile mismatch")
     macro_classes = macro_activity_contract.get("macro_classes")
     if not isinstance(macro_classes, dict):
@@ -531,7 +536,7 @@ def _validated_service_activity(
             "service integrated_service wide_response_matrix_hash",
         ),
     }
-    return {
+    row = {
         "case_id": case_id,
         "cluster_count": int(case_contract["cluster_count"]),
         "best": best,
@@ -544,6 +549,7 @@ def _validated_service_activity(
         "flow_variant": case_contract["flow_variant"],
         "design": case_contract["design"],
     }
+    return row
 
 
 def _recompute_dense_tiles(
@@ -690,7 +696,7 @@ def _measured_row(
     component_total_j = full_context_component_per_service_wave_j * full_service_wave_count
     prior_cluster_area_mm2 = _positive(prior_row.get("cluster_area_mm2"), f"prior c{cluster_count} cluster_area_mm2")
 
-    return {
+    row = {
         "candidate_id": f"decode_score_multivalue_service_measured_c{cluster_count}",
         "source_prior_candidate_id": _string(prior_row.get("candidate_id"), f"prior c{cluster_count} candidate_id"),
         "cluster_count": cluster_count,
@@ -765,8 +771,6 @@ def _measured_row(
         "service_window_leakage_energy_j": leakage_j,
         "full_context_dynamic_energy_j_per_service_wave": full_context_dynamic_per_service_wave_j,
         "full_context_leakage_energy_j_per_service_wave": full_context_leakage_per_service_wave_j,
-        "full_context_dynamic_energy_j_per_head_command": full_context_dynamic_per_service_wave_j,
-        "full_context_leakage_energy_j_per_head_command": full_context_leakage_per_service_wave_j,
         "service_component_dynamic_energy_mj_per_token": component_dynamic_j * 1.0e3,
         "service_component_leakage_energy_mj_per_token": component_leakage_j * 1.0e3,
         "service_component_energy_mj_per_token": component_total_j * 1.0e3,
@@ -783,6 +787,32 @@ def _measured_row(
             "producer and dense QKV activity energy are excluded",
         ],
     }
+    if cluster_count == 1:
+        row["full_context_dynamic_energy_j_per_head_command"] = full_context_dynamic_per_service_wave_j
+        row["full_context_leakage_energy_j_per_head_command"] = full_context_leakage_per_service_wave_j
+    return row
+
+
+def _dominates(lhs: JsonDict, rhs: JsonDict) -> bool:
+    objective_keys = (
+        "latency_us",
+        "embodied_logic_plus_existing_shared_tile_sram_area_mm2",
+        "service_component_energy_mj_per_token",
+    )
+    lhs_values = [float(lhs[key]) for key in objective_keys]
+    rhs_values = [float(rhs[key]) for key in objective_keys]
+    return all(left <= right for left, right in zip(lhs_values, rhs_values)) and any(
+        left < right for left, right in zip(lhs_values, rhs_values)
+    )
+
+
+def _pareto_rows(rows: list[JsonDict]) -> list[JsonDict]:
+    pareto: list[JsonDict] = []
+    for candidate in rows:
+        if any(_dominates(other, candidate) for other in rows if other is not candidate):
+            continue
+        pareto.append(candidate)
+    return sorted(pareto, key=lambda row: (float(row["latency_us"]), int(row["cluster_count"])))
 
 
 def _blocked_row(row: JsonDict, *, blocker: str | None = None) -> JsonDict:
@@ -893,6 +923,7 @@ def build_report(
 
     best_anchor = max(promoted_rows, key=lambda row: float(row["token_throughput_per_s"]))
     c2_promoted = any(row["cluster_count"] == 2 for row in promoted_rows)
+    pareto_rows = _pareto_rows(promoted_rows) if c2_promoted else []
     c1_service = validated_service_activities[1]
     c1_contract = _service_case(c1_service["case_id"])
     selected_candidates = {
@@ -984,6 +1015,7 @@ def build_report(
         "promoted_rows": promoted_rows,
         "blocked_rows": blocked_rows,
         "best_measured_anchor": best_anchor,
+        **({"best_throughput_candidate": best_anchor, "pareto_rows": pareto_rows} if c2_promoted else {}),
         "promotion_status": (
             "strict_c1_c2_measured_anchors_promoted_c3plus_unpromoted_pending_equivalent_composed_physical_activity_evidence"
             if c2_promoted
@@ -993,6 +1025,12 @@ def build_report(
             (
                 "This report promotes only directly measured composed-service anchors. "
                 + ("c1 and c2 are promoted; c3+ remain blocked." if c2_promoted else "Only c1 is promoted; c2+ remain blocked.")
+            ),
+            (
+                "When multiple measured anchors are promoted, best_throughput_candidate is reported separately and pareto_rows define"
+                " the non-dominated latency/embodied-area/service-energy frontier."
+                if c2_promoted
+                else "best_measured_anchor remains the sole promoted c1 anchor in the c1-only path."
             ),
             "The activity-backed energy is a microkernel-scaled composed-service component estimate, not direct total-token energy.",
             "Measured whole-service window energy is scaled with ceil(sequence_length / 24) and then multiplied by cluster_waves_per_layer * layers; c2 must not be multiplied by heads * layers.",
@@ -1008,12 +1046,13 @@ def build_report(
 
 
 def _write_markdown(payload: JsonDict, path: Path) -> None:
-    anchor = payload["best_measured_anchor"]
+    anchor = payload.get("best_throughput_candidate", payload["best_measured_anchor"])
+    anchor_label = "best throughput candidate" if "best_throughput_candidate" in payload else "best measured anchor"
     lines = [
         "# Llama7B measured composed-service frontier",
         "",
         f"- decision: `{payload['decision']}`",
-        f"- best measured anchor: `{anchor['candidate_id']}`",
+        f"- {anchor_label}: `{anchor['candidate_id']}`",
         f"- clock ns: `{anchor['clock_ns']}`",
         f"- latency us: `{anchor['latency_us']}`",
         f"- dense QKV tiles: `{anchor['dense_qkv_tile_count']}`",
@@ -1033,9 +1072,16 @@ def _write_markdown(payload: JsonDict, path: Path) -> None:
         ),
         "- total-token energy: `not directly measured here`",
         "",
-        "| candidate | clusters | status | promoted | rankable | latency us | area mm2 | service component mJ/token |",
-        "|---|---:|---|---|---|---:|---:|---:|",
     ]
+    if "pareto_rows" in payload:
+        lines.append(f"- pareto rows: `{', '.join(row['candidate_id'] for row in payload['pareto_rows'])}`")
+        lines.append("")
+    lines.extend(
+        [
+            "| candidate | clusters | status | promoted | rankable | latency us | area mm2 | service component mJ/token |",
+        "|---|---:|---|---|---|---:|---:|---:|",
+        ]
+    )
     for row in payload["rows"]:
         area = row.get("embodied_logic_plus_existing_shared_tile_sram_area_mm2")
         energy = row.get("service_component_energy_mj_per_token")

--- a/npu/eval/extract_fakeram_vcd_activity.py
+++ b/npu/eval/extract_fakeram_vcd_activity.py
@@ -128,6 +128,7 @@ def _parse_range_indices(raw: str | None, width: int) -> list[int]:
 def _score_scope_result(
     parts: list[str],
     *,
+    cluster_count: int,
     group_indices: tuple[int, ...],
     slice_indices: tuple[int, ...],
 ) -> tuple[str, _MacroClassSpec] | None:
@@ -146,7 +147,11 @@ def _score_scope_result(
             continue
         if index + 2 != len(parts):
             continue
-        return (f"score_bank/{group_scope}", _SCORE_MACRO_SPEC)
+        if int(cluster_count) > 1 and index > 0:
+            full_scope = "/".join([*parts[:index], "score_bank", group_scope])
+        else:
+            full_scope = f"score_bank/{group_scope}"
+        return (full_scope, _SCORE_MACRO_SPEC)
     return None
 
 
@@ -185,6 +190,7 @@ def _parse_target_scope(
     scope_path: str,
     *,
     root_scope: str,
+    cluster_count: int,
     group_indices: tuple[int, ...],
     slice_indices: tuple[int, ...],
     include_value_memory: bool,
@@ -201,6 +207,7 @@ def _parse_target_scope(
     parts = remainder.split("/")
     score_result = _score_scope_result(
         parts,
+        cluster_count=cluster_count,
         group_indices=group_indices,
         slice_indices=slice_indices,
     )
@@ -259,6 +266,7 @@ def _pins_per_instance(spec: _MacroClassSpec) -> int:
 
 def _contract_rows(
     *,
+    cluster_count: int,
     include_value_memory: bool,
     group_indices: tuple[int, ...],
     slice_indices: tuple[int, ...],
@@ -268,7 +276,7 @@ def _contract_rows(
     pin_count_by_macro: dict[str, int],
 ) -> tuple[list[JsonDict], int]:
     expected: list[tuple[_MacroClassSpec, int]] = [
-        (_SCORE_MACRO_SPEC, len(group_indices) * len(slice_indices)),
+        (_SCORE_MACRO_SPEC, int(cluster_count) * len(group_indices) * len(slice_indices)),
     ]
     if include_value_memory:
         expected.append((_VALUE_MACRO_SPEC, len(value_bank_indices) * len(value_lane_indices)))
@@ -308,6 +316,7 @@ def _extract_macro_vcd_activity(
     *,
     source_vcd_sha256: str,
     scope: str,
+    cluster_count: int,
     group_indices: tuple[int, ...],
     slice_indices: tuple[int, ...],
     expected_pin_count: int | None,
@@ -376,6 +385,7 @@ def _extract_macro_vcd_activity(
         scope_result = _parse_target_scope(
             scope_path,
             root_scope=scope,
+            cluster_count=cluster_count,
             group_indices=group_indices,
             slice_indices=slice_indices,
             include_value_memory=include_value_memory,
@@ -445,7 +455,9 @@ def _extract_macro_vcd_activity(
             id_to_specs[var_id] = (_signal_base(full_names[0]), len(full_names))
 
     if expected_pin_count is None:
-        expected_pin_count = _pins_per_instance(_SCORE_MACRO_SPEC) * len(group_indices) * len(slice_indices)
+        expected_pin_count = (
+            _pins_per_instance(_SCORE_MACRO_SPEC) * int(cluster_count) * len(group_indices) * len(slice_indices)
+        )
         if include_value_memory:
             expected_pin_count += _pins_per_instance(_VALUE_MACRO_SPEC) * len(value_bank_indices) * len(
                 value_lane_indices
@@ -567,6 +579,7 @@ def _extract_macro_vcd_activity(
         )
 
     contract_rows, total_assignment_count = _contract_rows(
+        cluster_count=cluster_count,
         include_value_memory=include_value_memory,
         group_indices=group_indices,
         slice_indices=slice_indices,
@@ -615,6 +628,7 @@ def extract_fakeram_vcd_activity(
         vcd_path,
         source_vcd_sha256=source_vcd_sha256,
         scope=scope,
+        cluster_count=1,
         group_indices=group_indices,
         slice_indices=slice_indices,
         expected_pin_count=expected_pin_count,
@@ -630,23 +644,32 @@ def extract_multivalue_service_fakeram_vcd_activity(
     *,
     source_vcd_sha256: str,
     scope: str = TARGET_SCOPE_PREFIX,
+    cluster_count: int = 1,
+    case_id: str | None = None,
     group_indices: tuple[int, ...] = tuple(range(8)),
     slice_indices: tuple[int, ...] = tuple(range(7)),
     value_bank_indices: tuple[int, ...] = tuple(range(4)),
     value_lane_indices: tuple[int, ...] = tuple(range(16)),
     expected_pin_count: int | None = None,
 ) -> JsonDict:
+    if int(cluster_count) <= 0:
+        raise ValueError("cluster_count must be positive")
+    if case_id is not None and str(case_id).strip():
+        profile = f"multivalue_service_{str(case_id).split('_', 1)[0]}_v1"
+    else:
+        profile = f"multivalue_service_c{int(cluster_count)}_v1"
     return _extract_macro_vcd_activity(
         vcd_path,
         source_vcd_sha256=source_vcd_sha256,
         scope=scope,
+        cluster_count=cluster_count,
         group_indices=group_indices,
         slice_indices=slice_indices,
         expected_pin_count=expected_pin_count,
         include_value_memory=True,
         value_bank_indices=value_bank_indices,
         value_lane_indices=value_lane_indices,
-        target_profile="multivalue_service_c1_v1",
+        target_profile=profile,
     )
 
 

--- a/npu/eval/generate_attention_decode_score_multivalue_service_activity.py
+++ b/npu/eval/generate_attention_decode_score_multivalue_service_activity.py
@@ -30,6 +30,15 @@ _OUTPUT_SERVICE_MANIFEST_NAME = "attention_decode_score_multivalue_service_manif
 _OUTPUT_MACRO_MANIFEST_NAME = "macro_manifest.json"
 _VALUE_MODEL_PATH = REPO_ROOT / "npu/sim/rtl/fakeram45_64x32_model.sv"
 _C1_CASE = next(case for case in probe.DEFAULT_CASES if str(case["case_id"]) == "c1_p128_b4_rr")
+_SUPPORTED_CASE_IDS = ("c1_p128_b4_rr", "c2_p128_b4_rr")
+_SUPPORTED_CASES = {
+    str(case["case_id"]): json.loads(json.dumps(case))
+    for case in probe.DEFAULT_CASES
+    if str(case["case_id"]) in _SUPPORTED_CASE_IDS
+}
+_SUPPORTED_CASES_BY_CLUSTER_COUNT = {
+    int(case["cluster_count"]): dict(case) for case in _SUPPORTED_CASES.values()
+}
 _REQUIRED_SERVICE_FIELDS = {
     "cluster_count": int(_C1_CASE["cluster_count"]),
     "max_blocks": int(probe._workload_contract()["max_blocks"]),
@@ -44,6 +53,39 @@ _REQUIRED_SERVICE_FIELDS = {
     "score_scale_lanes_per_cycle": 1,
     "value_memory_backend": "macro_banked_4x16x64x32",
 }
+
+
+def _required_service_fields(case: JsonDict) -> JsonDict:
+    return {
+        "cluster_count": int(case["cluster_count"]),
+        "max_blocks": int(probe._workload_contract()["max_blocks"]),
+        "packet_w": int(case["packet_w"]),
+        "banks": int(case["banks"]),
+        "req_queue_depth": int(case["req_queue_depth"]),
+        "resp_queue_depth": int(case["resp_queue_depth"]),
+        "bank_queue_depth": int(case["bank_queue_depth"]),
+        "read_latency": int(case["read_latency"]),
+        "arb_mode": str(case["arb_mode"]),
+        "locality_burst_max": int(case["locality_burst_max"]),
+        "score_scale_lanes_per_cycle": 1,
+        "value_memory_backend": "macro_banked_4x16x64x32",
+    }
+
+
+def _supported_case(*, case_id: str | None = None, cluster_count: int | None = None) -> JsonDict:
+    if case_id is not None:
+        case = _SUPPORTED_CASES.get(str(case_id).strip())
+        if case is None:
+            raise ValueError(f"unsupported case_id: {case_id}")
+        return dict(case)
+    if cluster_count is None:
+        raise ValueError("case selection requires case_id or cluster_count")
+    case = _SUPPORTED_CASES_BY_CLUSTER_COUNT.get(int(cluster_count))
+    if case is None:
+        raise ValueError(
+            f"unsupported cluster_count {cluster_count}; expected one of {sorted(_SUPPORTED_CASES_BY_CLUSTER_COUNT)}"
+        )
+    return dict(case)
 
 
 def _load(path: Path) -> JsonDict:
@@ -79,20 +121,31 @@ def _normalize_vcd(path: Path) -> None:
     tmp_path.replace(path)
 
 
-def _normalize_config(config: JsonDict) -> JsonDict:
+def _normalize_config_with_case(
+    config: JsonDict,
+    *,
+    case_id: str | None = None,
+) -> tuple[JsonDict, JsonDict]:
     top_name = str(config.get("top_name") or "").strip()
     if not top_name:
         raise ValueError("config requires non-empty top_name")
     body = config.get("attention_decode_score_multivalue_service")
     if not isinstance(body, dict):
         raise ValueError("config requires attention_decode_score_multivalue_service object")
+    cluster_count = int(body.get("cluster_count", 0))
+    case = _supported_case(case_id=case_id, cluster_count=cluster_count)
     normalized_body: JsonDict = {}
-    for key, expected in _REQUIRED_SERVICE_FIELDS.items():
+    for key, expected in _required_service_fields(case).items():
         value = body.get(key, expected)
         if value != expected:
             raise ValueError(f"attention_decode_score_multivalue_service.{key} must be {expected!r}")
         normalized_body[key] = expected
-    return {"top_name": top_name, "attention_decode_score_multivalue_service": normalized_body}
+    return {"top_name": top_name, "attention_decode_score_multivalue_service": normalized_body}, case
+
+
+def _normalize_config(config: JsonDict) -> JsonDict:
+    normalized, _ = _normalize_config_with_case(config)
+    return normalized
 
 
 def _compile_and_run(*, sources: list[Path], timeout: int = 240) -> str:
@@ -112,7 +165,13 @@ def _compile_and_run(*, sources: list[Path], timeout: int = 240) -> str:
         return run.stdout
 
 
-def _run_macro_integrated(config: JsonDict, out_dir: Path, *, clock_period_ns: float) -> JsonDict:
+def _run_macro_integrated(
+    config: JsonDict,
+    out_dir: Path,
+    *,
+    case: JsonDict,
+    clock_period_ns: float,
+) -> JsonDict:
     values = probe._shared_value_matrices()
     with tempfile.TemporaryDirectory(prefix="multivalue-service-activity-") as tmp_text:
         tmp = Path(tmp_text)
@@ -129,7 +188,7 @@ def _run_macro_integrated(config: JsonDict, out_dir: Path, *, clock_period_ns: f
             raise RuntimeError("generated RTL is missing fakeram45_64x32 instances")
         tb_text = probe._integrated_testbench(
             top_name=str(config["top_name"]),
-            cluster_count=int(_C1_CASE["cluster_count"]),
+            cluster_count=int(case["cluster_count"]),
             values=values,
             vcd_path=str((out_dir / _OUTPUT_VCD_NAME).resolve()),
             vcd_dumpvars=["dut"],
@@ -268,16 +327,27 @@ def _assert_portable_manifest_strings(payload: object) -> None:
         raise RuntimeError("portable manifest field contains absolute evaluator path")
 
 
-def generate_activity(config: JsonDict, out_dir: Path, *, clock_period_ns: float = _DEFAULT_CLOCK_PERIOD_NS) -> JsonDict:
+def generate_activity(
+    config: JsonDict,
+    out_dir: Path,
+    *,
+    clock_period_ns: float = _DEFAULT_CLOCK_PERIOD_NS,
+    case_id: str | None = None,
+) -> JsonDict:
     if clock_period_ns <= 0.0:
         raise ValueError("clock_period_ns must be > 0")
-    normalized_config = _normalize_config(config)
+    normalized_config, case = _normalize_config_with_case(config, case_id=case_id)
     out_dir.mkdir(parents=True, exist_ok=True)
     values = probe._shared_value_matrices()
     workload_contract = probe._workload_contract()
     expected_counts = probe._workload_expected_counts(workload_contract)
-    reference = probe._run_integrated(dict(_C1_CASE), values)
-    macro = _run_macro_integrated(normalized_config, out_dir, clock_period_ns=clock_period_ns)
+    reference = probe._run_integrated(dict(case), values)
+    macro = _run_macro_integrated(
+        normalized_config,
+        out_dir,
+        case=case,
+        clock_period_ns=clock_period_ns,
+    )
     _assert_reference_equivalence(reference, macro)
 
     request_rows = probe._canonical_requests(macro["request_rows"])
@@ -292,9 +362,9 @@ def generate_activity(config: JsonDict, out_dir: Path, *, clock_period_ns: float
         raise RuntimeError("generated activity wide-response rows do not match the workload contract")
     if len(result_rows) != int(expected_counts["result_count"]):
         raise RuntimeError("generated activity result rows do not match the workload contract")
-    request_banks = sorted({int(row["addr"]) % int(_C1_CASE["banks"]) for row in request_rows})
-    preload_banks = sorted({int(entry["addr"]) % int(_C1_CASE["banks"]) for entry in probe._preload_entries(values)})
-    inactive_banks = sorted(set(range(int(_C1_CASE["banks"]))) - set(request_banks))
+    request_banks = sorted({int(row["addr"]) % int(case["banks"]) for row in request_rows})
+    preload_banks = sorted({int(entry["addr"]) % int(case["banks"]) for entry in probe._preload_entries(values)})
+    inactive_banks = sorted(set(range(int(case["banks"]))) - set(request_banks))
     if "fakeram45_2048x39" not in (out_dir / _OUTPUT_TOP_NAME).read_text(encoding="utf-8"):
         raise RuntimeError("generated top.v no longer contains fakeram45_2048x39")
     if "fakeram45_64x32" not in (out_dir / _OUTPUT_TOP_NAME).read_text(encoding="utf-8"):
@@ -304,7 +374,7 @@ def generate_activity(config: JsonDict, out_dir: Path, *, clock_period_ns: float
         "version": 1,
         "model": "attention_decode_score_multivalue_service_activity_v1",
         "generator": "npu/eval/generate_attention_decode_score_multivalue_service_activity.py",
-        "case_id": str(_C1_CASE["case_id"]),
+        "case_id": str(case["case_id"]),
         "workload_contract": workload_contract,
         "artifacts": {
             "config_json": _OUTPUT_CONFIG_NAME,
@@ -314,7 +384,7 @@ def generate_activity(config: JsonDict, out_dir: Path, *, clock_period_ns: float
             "vcd": _OUTPUT_VCD_NAME,
         },
         "hashes": {
-            "case_sha256": _hash_json(_C1_CASE),
+            "case_sha256": _hash_json(case),
             "config_sha256": _hash_json(normalized_config),
             "top_sha256": macro["top_sha256"],
             "vcd_sha256": _sha256_file(out_dir / _OUTPUT_VCD_NAME),
@@ -347,22 +417,31 @@ def generate_activity(config: JsonDict, out_dir: Path, *, clock_period_ns: float
         "compiled_behavioral_models": ["fakeram45_2048x39", "fakeram45_64x32"],
         "scope": {
             "exercised": [
-                "one deterministic c1_p128_b4_rr integrated-service command",
+                f"one deterministic {case['case_id']} integrated-service command",
                 "macro-backed value-memory backend macro_banked_4x16x64x32",
                 "bounded DUT VCD from reset release through command completion",
                 "active workload contract is 3 blocks x 8 context tokens = 24 active context tokens at value_dim=128",
-                "dynamic switching observed only on banks 0, 1, and 2 under the exact three-block reference workload",
+                (
+                    "dynamic switching observed on addressed value-memory banks only under the exact "
+                    "three-block reference workload"
+                ),
             ],
             "remaining": [
                 "no power audit, SAIF extraction, or post-route activity processing",
-                "no non-c1 cases, no multi-cluster cases, and no alternate arbitration points",
-                "c1 dynamic power from this exact workload does not cover bank3 switching while bank3 leakage remains present in total composed PPA/power",
+                (
+                    "no non-c1/c2 cases, no alternate arbitration points, and no broader sequence "
+                    "composition outside this exact workload"
+                ),
+                (
+                    f"{case['case_id']} dynamic power from this exact workload may not cover every bank's "
+                    "switching while leakage remains present in total composed PPA/power"
+                ),
             ],
         },
     }
-    if manifest["value_bank_coverage"]["addressed_banks_over_trace"] != [0, 1, 2]:
+    if str(case["case_id"]) == "c1_p128_b4_rr" and manifest["value_bank_coverage"]["addressed_banks_over_trace"] != [0, 1, 2]:
         raise RuntimeError("exact c1 workload must address only banks 0, 1, and 2 over the trace")
-    if manifest["value_bank_coverage"]["inactive_banks"] != [3]:
+    if str(case["case_id"]) == "c1_p128_b4_rr" and manifest["value_bank_coverage"]["inactive_banks"] != [3]:
         raise RuntimeError("exact c1 workload must leave bank3 inactive")
     _assert_portable_manifest_strings(manifest)
     (out_dir / _OUTPUT_MANIFEST_NAME).write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -374,8 +453,14 @@ def main() -> int:
     parser.add_argument("--config", type=Path, required=True)
     parser.add_argument("--out-dir", type=Path, required=True)
     parser.add_argument("--clock-period-ns", type=float, default=_DEFAULT_CLOCK_PERIOD_NS)
+    parser.add_argument("--case-id", type=str)
     args = parser.parse_args()
-    generate_activity(_load(args.config), args.out_dir, clock_period_ns=args.clock_period_ns)
+    generate_activity(
+        _load(args.config),
+        args.out_dir,
+        clock_period_ns=args.clock_period_ns,
+        case_id=args.case_id,
+    )
     return 0
 
 

--- a/npu/eval/generate_attention_decode_score_multivalue_service_activity.py
+++ b/npu/eval/generate_attention_decode_score_multivalue_service_activity.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate a deterministic c1 integrated-service VCD and portable activity manifest."""
+"""Generate a deterministic c1/c2 integrated-service VCD and portable activity manifest."""
 
 from __future__ import annotations
 
@@ -146,6 +146,13 @@ def _normalize_config_with_case(
 def _normalize_config(config: JsonDict) -> JsonDict:
     normalized, _ = _normalize_config_with_case(config)
     return normalized
+
+
+def _scaled_expected_counts(workload_contract: JsonDict, *, cluster_count: int) -> JsonDict:
+    expected_counts = dict(probe._workload_expected_counts(workload_contract))
+    for key in ("score_row_count", "request_count", "wide_response_count", "result_count"):
+        expected_counts[key] = int(expected_counts[key]) * int(cluster_count)
+    return expected_counts
 
 
 def _compile_and_run(*, sources: list[Path], timeout: int = 240) -> str:
@@ -340,7 +347,7 @@ def generate_activity(
     out_dir.mkdir(parents=True, exist_ok=True)
     values = probe._shared_value_matrices()
     workload_contract = probe._workload_contract()
-    expected_counts = probe._workload_expected_counts(workload_contract)
+    expected_counts = _scaled_expected_counts(workload_contract, cluster_count=int(case["cluster_count"]))
     reference = probe._run_integrated(dict(case), values)
     macro = _run_macro_integrated(
         normalized_config,

--- a/tests/test_attention_decode_score_multivalue_service_activity_power.py
+++ b/tests/test_attention_decode_score_multivalue_service_activity_power.py
@@ -16,13 +16,18 @@ from npu.eval import audit_attention_decode_score_multivalue_service_activity_po
 from npu.eval.probe_attention_decode_score_multivalue_integrated_service import _workload_contract
 
 
-def _config(path: Path) -> None:
+def _config(path: Path, *, cluster_count: int = 1) -> None:
+    top_name = (
+        "attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_macro_activity"
+        if cluster_count == 2
+        else "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_macro_activity"
+    )
     path.write_text(
         json.dumps(
             {
-                "top_name": "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_macro_activity",
+                "top_name": top_name,
                 "attention_decode_score_multivalue_service": {
-                    "cluster_count": 1,
+                    "cluster_count": cluster_count,
                     "max_blocks": 16,
                     "packet_w": 128,
                     "banks": 4,
@@ -61,18 +66,28 @@ def _write_metrics(path: Path, rows: list[dict[str, str]]) -> None:
         writer.writerows(rows)
 
 
-def _ok_metric(*, param_hash: str = "p1", flow_variant: str = audit._REQUIRED_FLOW_VARIANT) -> dict[str, str]:
+def _ok_metric(
+    *,
+    param_hash: str = "p1",
+    flow_variant: str = audit._REQUIRED_FLOW_VARIANT,
+    design: str = audit._EXPECTED_DESIGN,
+    critical_path_ns: str = "9.2",
+    die_area: str = "9000000",
+    total_power_mw: str = "12.75",
+    instance_area_um2: str = "3300000",
+    tag: str = "die3000",
+) -> dict[str, str]:
     return {
-        "design": audit._EXPECTED_DESIGN,
+        "design": design,
         "platform": audit._EXPECTED_PLATFORM,
         "config_hash": "cfg1",
         "param_hash": param_hash,
-        "tag": "die3000",
+        "tag": tag,
         "status": "ok",
-        "critical_path_ns": "9.2",
-        "die_area": "9000000",
-        "total_power_mw": "12.75",
-        "instance_area_um2": "3300000",
+        "critical_path_ns": critical_path_ns,
+        "die_area": die_area,
+        "total_power_mw": total_power_mw,
+        "instance_area_um2": instance_area_um2,
         "params_json": json.dumps({"CLOCK_PERIOD": 10, "FLOW_VARIANT": flow_variant}),
     }
 
@@ -92,7 +107,15 @@ def _cluster_equivalence(path: Path, *, passed: bool = True) -> None:
     )
 
 
-def _integrated_service(path: Path, *, exact_match: bool = True, include_counters: bool = True) -> None:
+def _integrated_service(
+    path: Path,
+    *,
+    case_id: str = "c1_p128_b4_rr",
+    cluster_count: int = 1,
+    exact_match: bool = True,
+    include_counters: bool = True,
+    cycle_count: int = 321,
+) -> None:
     counters = {
         "request_injection_stall_cycles": 0,
         "arbitration_contention_cycles": 1,
@@ -114,10 +137,10 @@ def _integrated_service(path: Path, *, exact_match: bool = True, include_counter
                 },
                 "cases": [
                     {
-                        "case_id": "c1_p128_b4_rr",
+                        "case_id": case_id,
                         "decision": "pass",
                         "config": {
-                            "cluster_count": 1,
+                            "cluster_count": cluster_count,
                             "packet_w": 128,
                             "banks": 4,
                             "req_queue_depth": 4,
@@ -135,6 +158,7 @@ def _integrated_service(path: Path, *, exact_match: bool = True, include_counter
                             "request_count": 48,
                             "wide_response_count": 48,
                             "result_count": 16,
+                            "completion_cycle": cycle_count,
                             "score_hash": "score-hash",
                             "final_hash": "final-hash",
                             "request_hash": "request-hash",
@@ -155,13 +179,21 @@ def _integrated_service(path: Path, *, exact_match: bool = True, include_counter
     )
 
 
-def _generated_activity_manifest() -> dict:
+def _generated_activity_manifest(
+    *,
+    case_id: str = "c1_p128_b4_rr",
+    cycle_count: int = 321,
+    score_hash: str = "score-hash",
+    final_hash: str = "final-hash",
+    request_hash: str = "request-hash",
+    wide_hash: str = "wide-hash",
+) -> dict:
     return {
         "model": "attention_decode_score_multivalue_service_activity_v1",
-        "case_id": "c1_p128_b4_rr",
+        "case_id": case_id,
         "workload_contract": _workload_contract(),
         "clock_period_ns": 10.0,
-        "cycle_count": 321,
+        "cycle_count": cycle_count,
         "request_result_protocol_counters": {
             "request_count": 48,
             "wide_response_count": 48,
@@ -175,15 +207,27 @@ def _generated_activity_manifest() -> dict:
         },
         "hashes": {
             "vcd_sha256": "vcd-hash",
-            "score_hash": "score-hash",
-            "final_hash": "final-hash",
-            "request_hash": "request-hash",
-            "wide_response_matrix_hash": "wide-hash",
+            "score_hash": score_hash,
+            "final_hash": final_hash,
+            "request_hash": request_hash,
+            "wide_response_matrix_hash": wide_hash,
         },
     }
 
 
-def _adapted_manifest(tmp_path: Path) -> tuple[dict, Path, dict]:
+def _adapted_manifest(
+    tmp_path: Path,
+    *,
+    cycle_count: int = 321,
+    macro_counts: dict[str, int] | None = None,
+    score_hash: str = "score-hash",
+    final_hash: str = "final-hash",
+    request_hash: str = "request-hash",
+    wide_hash: str = "wide-hash",
+) -> tuple[dict, Path, dict]:
+    macro_counts = macro_counts or {"fakeram45_2048x39": 56, "fakeram45_64x32": 64}
+    score_instances = int(macro_counts["fakeram45_2048x39"])
+    value_instances = int(macro_counts["fakeram45_64x32"])
     manifest = {
         "clock_period_ns": 10.0,
         "phases": [
@@ -195,8 +239,8 @@ def _adapted_manifest(tmp_path: Path) -> tuple[dict, Path, dict]:
                 "macro_activity_sha256": "macro-sidecar-hash",
                 "sequential_register_activity": "service_seq_activity.json",
                 "sequential_register_activity_sha256": "seq-sidecar-hash",
-                "measured_cycles": 321,
-                "full_context_cycles": 321,
+                "measured_cycles": cycle_count,
+                "full_context_cycles": cycle_count,
                 "requires_macro_activity": True,
             }
         ],
@@ -207,31 +251,31 @@ def _adapted_manifest(tmp_path: Path) -> tuple[dict, Path, dict]:
         "generated_activity_manifest_sha256": "generated-manifest-hash",
         "adapted_activity_manifest_sha256": audit._sha256_file(manifest_path),
         "vcd_sha256": "vcd-hash",
-        "cycle_count": 321,
+        "cycle_count": cycle_count,
         "generated_manifest_hashes": {
             "vcd_sha256": "vcd-hash",
-            "score_hash": "score-hash",
-            "final_hash": "final-hash",
-            "request_hash": "request-hash",
-            "wide_response_matrix_hash": "wide-hash",
+            "score_hash": score_hash,
+            "final_hash": final_hash,
+            "request_hash": request_hash,
+            "wide_response_matrix_hash": wide_hash,
         },
         "workload_contract": _workload_contract(),
-        "macro_counts": {"fakeram45_2048x39": 56, "fakeram45_64x32": 64},
+        "macro_counts": dict(macro_counts),
         "macro_activity_contract": {
             "profile": "multivalue_service_c1_v1",
-            "total_assignment_count": 9704,
+            "total_assignment_count": score_instances * 91 + value_instances * 72,
             "macro_classes": {
                 "fakeram45_2048x39": {
                     "instance_scope_prefix": "score_bank",
-                    "instance_count": 56,
+                    "instance_count": score_instances,
                     "pins_per_instance": 91,
-                    "assignment_count": 5096,
+                    "assignment_count": score_instances * 91,
                 },
                 "fakeram45_64x32": {
                     "instance_scope_prefix": "gen_value_macro_backend",
-                    "instance_count": 64,
+                    "instance_count": value_instances,
                     "pins_per_instance": 72,
-                    "assignment_count": 4608,
+                    "assignment_count": value_instances * 72,
                 },
             },
         },
@@ -239,19 +283,25 @@ def _adapted_manifest(tmp_path: Path) -> tuple[dict, Path, dict]:
     }
 
 
-def _power_report(*, manifest_sha256: str, with_abs_path: bool = False) -> dict:
+def _power_report(
+    *,
+    manifest_sha256: str,
+    with_abs_path: bool = False,
+    cycle_count: int = 321,
+    macro_activity_assignment_count: int = 9704,
+) -> dict:
     phase = {
         "phase": "service_window",
         "vcd": "/tmp/private/activity.vcd" if with_abs_path else "attention_decode_score_multivalue_service_activity.vcd",
         "vcd_sha256": "vcd-hash",
-        "measured_cycles": 321,
-        "full_context_cycles": 321,
+        "measured_cycles": cycle_count,
+        "full_context_cycles": cycle_count,
         "annotation_gate_pass": True,
         "macro_activity_gate_pass": True,
         "structural_macro_activity_gate_pass": True,
         "sequential_register_activity_gate_pass": True,
         "clock_period_gate_pass": True,
-        "macro_activity_assignment_count": 9704,
+        "macro_activity_assignment_count": macro_activity_assignment_count,
         "power": {
             "internal_w": 0.10,
             "switching_w": 0.20,
@@ -529,3 +579,135 @@ def test_build_report_does_not_compare_integrated_hashes_to_cluster_equivalence_
         )
 
     assert payload["promotion_gate_pass"] is True
+
+
+def test_build_report_supports_c2_case_and_validates_cycle_contract_before_power(tmp_path: Path) -> None:
+    config = tmp_path / "config_c2.json"
+    _config(config, cluster_count=2)
+    metrics = tmp_path / "metrics_c2.csv"
+    _write_metrics(
+        metrics,
+        [
+            _ok_metric(
+                flow_variant="decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_3700_v1",
+                design="attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr",
+                critical_path_ns="9.7",
+                die_area="13690000",
+                total_power_mw="18.1",
+                instance_area_um2="4500000",
+                tag="die3700",
+            )
+        ],
+    )
+    equivalence = tmp_path / "equivalence.json"
+    _cluster_equivalence(equivalence)
+    integrated = tmp_path / "integrated_c2.json"
+    _integrated_service(
+        integrated,
+        case_id="c2_p128_b4_rr",
+        cluster_count=2,
+        cycle_count=8863,
+    )
+    adapted_manifest, manifest_path, adapted_meta = _adapted_manifest(
+        tmp_path,
+        cycle_count=8863,
+        macro_counts={"fakeram45_2048x39": 112, "fakeram45_64x32": 64},
+    )
+
+    with mock.patch.object(
+        audit,
+        "generate_activity",
+        return_value=_generated_activity_manifest(case_id="c2_p128_b4_rr", cycle_count=8863),
+    ), mock.patch.object(
+        audit,
+        "_prepare_postroute_power_manifest",
+        return_value=(adapted_manifest, manifest_path, adapted_meta),
+    ), mock.patch.object(
+        audit,
+        "build_power_report",
+        return_value=_power_report(
+            manifest_sha256=adapted_meta["adapted_activity_manifest_sha256"],
+            with_abs_path=False,
+            cycle_count=8863,
+            macro_activity_assignment_count=14800,
+        ),
+    ):
+        payload = audit.build_report(
+            config=config,
+            metrics_csv=metrics,
+            case_id="c2_p128_b4_rr",
+            equivalence_json=equivalence,
+            integrated_service_json=integrated,
+            orfs_design_config=Path("/orfs/flow/designs/nangate45/service_c2/config.mk"),
+            clock_period_ns=10.0,
+            activity_dir=tmp_path / "activity_c2",
+        )
+
+    assert payload["promotion_gate_pass"] is True
+    assert payload["selection_contract"]["case_id"] == "c2_p128_b4_rr"
+    assert payload["selection_contract"]["cluster_count"] == 2
+    assert payload["dependency_contract"]["integrated_service_c2"]["case_id"] == "c2_p128_b4_rr"
+    assert payload["activity_contract"]["cycle_count"] == 8863
+    assert payload["best"]["authoritative_composed_c2_total_ppa"]["instance_area_um2"] == 4_500_000
+    assert payload["macro_manifest_contract"]["counts"]["fakeram45_2048x39"] == 112
+
+
+def test_build_report_rejects_c2_hash_mismatch_before_power(tmp_path: Path) -> None:
+    config = tmp_path / "config_c2.json"
+    _config(config, cluster_count=2)
+    metrics = tmp_path / "metrics_c2.csv"
+    _write_metrics(
+        metrics,
+        [
+            _ok_metric(
+                flow_variant="decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_3700_v1",
+                design="attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr",
+                critical_path_ns="9.7",
+                die_area="13690000",
+                total_power_mw="18.1",
+                instance_area_um2="4500000",
+                tag="die3700",
+            )
+        ],
+    )
+    equivalence = tmp_path / "equivalence.json"
+    _cluster_equivalence(equivalence)
+    integrated = tmp_path / "integrated_c2.json"
+    _integrated_service(
+        integrated,
+        case_id="c2_p128_b4_rr",
+        cluster_count=2,
+        cycle_count=8863,
+    )
+    generated = _generated_activity_manifest(
+        case_id="c2_p128_b4_rr",
+        cycle_count=8863,
+        request_hash="wrong-request-hash",
+    )
+    adapted_manifest, manifest_path, adapted_meta = _adapted_manifest(
+        tmp_path,
+        cycle_count=8863,
+        macro_counts={"fakeram45_2048x39": 112, "fakeram45_64x32": 64},
+        request_hash="wrong-request-hash",
+    )
+
+    with mock.patch.object(audit, "generate_activity", return_value=generated), mock.patch.object(
+        audit,
+        "_prepare_postroute_power_manifest",
+        return_value=(adapted_manifest, manifest_path, adapted_meta),
+    ), mock.patch.object(audit, "build_power_report") as build_power_report_mock:
+        with pytest.raises(
+            ValueError,
+            match="generated activity request_hash does not match integrated-service c2_p128_b4_rr request_hash",
+        ):
+            audit.build_report(
+                config=config,
+                metrics_csv=metrics,
+                case_id="c2_p128_b4_rr",
+                equivalence_json=equivalence,
+                integrated_service_json=integrated,
+                orfs_design_config=Path("/orfs/flow/designs/nangate45/service_c2/config.mk"),
+                clock_period_ns=10.0,
+                activity_dir=tmp_path / "activity_c2",
+            )
+    build_power_report_mock.assert_not_called()

--- a/tests/test_attention_decode_score_multivalue_service_activity_power.py
+++ b/tests/test_attention_decode_score_multivalue_service_activity_power.py
@@ -16,6 +16,14 @@ from npu.eval import audit_attention_decode_score_multivalue_service_activity_po
 from npu.eval.probe_attention_decode_score_multivalue_integrated_service import _workload_contract
 
 
+def _scaled_counts(cluster_count: int) -> dict[str, int]:
+    return {
+        "request_count": 48 * int(cluster_count),
+        "wide_response_count": 48 * int(cluster_count),
+        "result_count": 16 * int(cluster_count),
+    }
+
+
 def _config(path: Path, *, cluster_count: int = 1) -> None:
     top_name = (
         "attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_macro_activity"
@@ -126,6 +134,7 @@ def _integrated_service(
     }
     if not include_counters:
         counters.pop("max_occupancy")
+    counts = _scaled_counts(cluster_count)
     path.write_text(
         json.dumps(
             {
@@ -155,9 +164,9 @@ def _integrated_service(
                             "no_protocol_errors": True,
                             "no_drop_duplicate_deadlock_timeout": True,
                             "cycle_bound_ok": True,
-                            "request_count": 48,
-                            "wide_response_count": 48,
-                            "result_count": 16,
+                            "request_count": counts["request_count"],
+                            "wide_response_count": counts["wide_response_count"],
+                            "result_count": counts["result_count"],
                             "completion_cycle": cycle_count,
                             "score_hash": "score-hash",
                             "final_hash": "final-hash",
@@ -182,12 +191,14 @@ def _integrated_service(
 def _generated_activity_manifest(
     *,
     case_id: str = "c1_p128_b4_rr",
+    cluster_count: int = 1,
     cycle_count: int = 321,
     score_hash: str = "score-hash",
     final_hash: str = "final-hash",
     request_hash: str = "request-hash",
     wide_hash: str = "wide-hash",
 ) -> dict:
+    counts = _scaled_counts(cluster_count)
     return {
         "model": "attention_decode_score_multivalue_service_activity_v1",
         "case_id": case_id,
@@ -195,9 +206,9 @@ def _generated_activity_manifest(
         "clock_period_ns": 10.0,
         "cycle_count": cycle_count,
         "request_result_protocol_counters": {
-            "request_count": 48,
-            "wide_response_count": 48,
-            "result_count": 16,
+            "request_count": counts["request_count"],
+            "wide_response_count": counts["wide_response_count"],
+            "result_count": counts["result_count"],
             "shared": {"protocol_error": False},
         },
         "value_bank_coverage": {
@@ -617,7 +628,7 @@ def test_build_report_supports_c2_case_and_validates_cycle_contract_before_power
     with mock.patch.object(
         audit,
         "generate_activity",
-        return_value=_generated_activity_manifest(case_id="c2_p128_b4_rr", cycle_count=8863),
+        return_value=_generated_activity_manifest(case_id="c2_p128_b4_rr", cluster_count=2, cycle_count=8863),
     ), mock.patch.object(
         audit,
         "_prepare_postroute_power_manifest",
@@ -681,6 +692,7 @@ def test_build_report_rejects_c2_hash_mismatch_before_power(tmp_path: Path) -> N
     )
     generated = _generated_activity_manifest(
         case_id="c2_p128_b4_rr",
+        cluster_count=2,
         cycle_count=8863,
         request_hash="wrong-request-hash",
     )

--- a/tests/test_attention_decode_score_multivalue_service_measured_frontier.py
+++ b/tests/test_attention_decode_score_multivalue_service_measured_frontier.py
@@ -421,7 +421,7 @@ def _service_activity_power_c2(tmp_path: Path) -> Path:
                 "counts": {"fakeram45_2048x39": 112, "fakeram45_64x32": 64},
             },
             "macro_activity_contract": {
-                "profile": "multivalue_service_c1_v1",
+                "profile": "multivalue_service_c2_v1",
                 "total_assignment_count": 14800,
                 "macro_classes": {
                     "fakeram45_2048x39": {
@@ -639,6 +639,8 @@ def test_build_report_keeps_c2_blocked_unpromoted(tmp_path: Path) -> None:
     assert blocked[0]["promoted"] is False
     assert blocked[0]["rankable_as_measured"] is False
     assert "pending_equivalent_composed_physical_activity_evidence" in blocked[0]["status"]
+    assert "best_throughput_candidate" not in payload
+    assert "pareto_rows" not in payload
 
 
 def test_build_report_promotes_c2_with_whole_service_window_accounting(tmp_path: Path) -> None:
@@ -653,6 +655,8 @@ def test_build_report_promotes_c2_with_whole_service_window_accounting(tmp_path:
 
     assert payload["decision"] == "strict_c1_c2_measured_service_anchors_promoted_c3plus_blocked"
     assert len(payload["promoted_rows"]) == 2
+    assert payload["best_throughput_candidate"]["cluster_count"] == 2
+    assert {row["cluster_count"] for row in payload["pareto_rows"]} == {1, 2}
     c2_row = next(row for row in payload["promoted_rows"] if row["cluster_count"] == 2)
     assert c2_row["service_calibration_case_id"] == "c2_p128_b4_rr"
     assert c2_row["service_activity_microkernel_cycle_count"] == 8863
@@ -663,6 +667,11 @@ def test_build_report_promotes_c2_with_whole_service_window_accounting(tmp_path:
     assert c2_row["service_component_dynamic_energy_mj_per_token"] == pytest.approx(2796.544)
     assert c2_row["service_component_leakage_energy_mj_per_token"] == pytest.approx(0.00508360600248223)
     assert c2_row["service_component_energy_mj_per_token"] == pytest.approx(2796.5490836060025)
+    assert "full_context_dynamic_energy_j_per_head_command" not in c2_row
+    assert "full_context_leakage_energy_j_per_head_command" not in c2_row
+    c1_row = next(row for row in payload["promoted_rows"] if row["cluster_count"] == 1)
+    assert "full_context_dynamic_energy_j_per_head_command" in c1_row
+    assert "full_context_leakage_energy_j_per_head_command" in c1_row
 
 
 def test_build_report_c2_regression_guard_rejects_head_count_double_count(tmp_path: Path) -> None:

--- a/tests/test_attention_decode_score_multivalue_service_measured_frontier.py
+++ b/tests/test_attention_decode_score_multivalue_service_measured_frontier.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 import sys
 
@@ -108,7 +109,7 @@ def _prior_frontier(tmp_path: Path, *, sequence_length: int = 131072) -> Path:
             "service_calibrated_full_context_cycles_per_wave": 440,
             "service_calibration_case_id": "c2_p128_b4_rr",
             "service_calibration_microkernel_no_stall_completion_cycle": 128,
-            "service_calibration_microkernel_integrated_completion_cycle": 176,
+            "service_calibration_microkernel_integrated_completion_cycle": 8863,
             "dense_qkv_tile_count": 3,
             "dense_qkv_useful_parallelism_limit": 640,
             "qkv_cycles": 683,
@@ -192,6 +193,13 @@ def _service_activity_power(tmp_path: Path) -> Path:
             "decision": "activity_backed_service_power_measured",
             "promotion_gate_pass": True,
             "precision_status": "unchanged_integer_contract_from_merged_cluster_equivalence_and_integrated_service",
+            "selection_contract": {
+                "case_id": "c1_p128_b4_rr",
+                "cluster_count": 1,
+                "required_flow_variant": "decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1",
+                "clock_period_ns": 10.0,
+                "status": "exactly_one_status_ok_timing_feasible_row_required",
+            },
             "best_candidate_id": "multivalue_service_activity_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1",
             "best": {
                 "candidate_id": "multivalue_service_activity_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1",
@@ -226,6 +234,12 @@ def _service_activity_power(tmp_path: Path) -> Path:
                     },
                 },
                 "authoritative_composed_c1_total_ppa": {
+                    "critical_path_ns": 9.2,
+                    "instance_area_um2": 3_000_000,
+                    "die_area": 9_000_000,
+                    "total_power_mw": 12.75,
+                },
+                "authoritative_composed_total_ppa": {
                     "critical_path_ns": 9.2,
                     "instance_area_um2": 3_000_000,
                     "die_area": 9_000_000,
@@ -297,6 +311,138 @@ def _service_activity_power(tmp_path: Path) -> Path:
                 "statement": (
                     "No artificial activity was injected. Bank3 may remain dynamically inactive in this exact c1 "
                     "workload; it is not required to toggle, while leakage remains part of routed power."
+                ),
+            },
+        },
+    )
+
+
+def _service_activity_power_c2(tmp_path: Path) -> Path:
+    return _write(
+        tmp_path / "service_activity_power_c2.json",
+        {
+            "model": "decoder_attention_decode_score_multivalue_service_activity_power_v1",
+            "decision": "activity_backed_service_power_measured",
+            "promotion_gate_pass": True,
+            "precision_status": "unchanged_integer_contract_from_merged_cluster_equivalence_and_integrated_service",
+            "selection_contract": {
+                "case_id": "c2_p128_b4_rr",
+                "cluster_count": 2,
+                "required_flow_variant": "decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_3700_v1",
+                "clock_period_ns": 10.0,
+                "status": "exactly_one_status_ok_timing_feasible_row_required",
+            },
+            "best_candidate_id": "multivalue_service_activity_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_3700_v1",
+            "best": {
+                "candidate_id": "multivalue_service_activity_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_3700_v1",
+                "flow_variant": "decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_3700_v1",
+                "status": "activity_backed",
+                "promotion_gate_pass": True,
+                "ppa_metric": {
+                    "design": "attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr",
+                    "platform": "nangate45",
+                    "param_hash": "p2",
+                    "config_hash": "cfg2",
+                    "tag": "die3700",
+                    "status": "ok",
+                    "critical_path_ns": "9.7",
+                    "instance_area_um2": "4500000",
+                    "params_json": json.dumps(
+                        {
+                            "CLOCK_PERIOD": 10,
+                            "FLOW_VARIANT": "decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_3700_v1",
+                        }
+                    ),
+                },
+                "component_service_window_energy": {
+                    "label": "component_service_window_energy",
+                    "is_total_token_energy": False,
+                    "cycle_count": 8863,
+                    "duration_s": 8.863e-5,
+                    "energy_j": {
+                        "dynamic": 1.0e-6,
+                        "leakage": 2.0e-7,
+                        "dynamic_plus_leakage": 1.2e-6,
+                    },
+                },
+                "authoritative_composed_c2_total_ppa": {
+                    "critical_path_ns": 9.7,
+                    "instance_area_um2": 4_500_000,
+                    "die_area": 13_690_000,
+                    "total_power_mw": 18.1,
+                },
+                "authoritative_composed_total_ppa": {
+                    "critical_path_ns": 9.7,
+                    "instance_area_um2": 4_500_000,
+                    "die_area": 13_690_000,
+                    "total_power_mw": 18.1,
+                },
+            },
+            "dependency_contract": {
+                "cluster_equivalence": {
+                    "equivalence_pass": True,
+                    "decision": "decode_score_multivalue_cluster_equivalence_pass",
+                    "score_tensor_hash": "score-hash",
+                    "final_tensor_hash": "final-hash",
+                },
+                "integrated_service_c2": {
+                    "case_id": "c2_p128_b4_rr",
+                    "config": {
+                        "cluster_count": 2,
+                        "packet_w": 128,
+                        "banks": 4,
+                        "req_queue_depth": 4,
+                        "resp_queue_depth": 4,
+                        "bank_queue_depth": 4,
+                        "read_latency": 2,
+                        "arb_mode": "round_robin",
+                        "locality_burst_max": 2,
+                    },
+                    "workload_contract": _workload_contract(),
+                    "decision": "pass",
+                    "exact_match": True,
+                    "no_protocol_errors": True,
+                    "no_drop_duplicate_deadlock_timeout": True,
+                    "cycle_bound_ok": True,
+                    "hashes": {
+                        "score_hash": "integrated-c2-score-hash",
+                        "final_hash": "integrated-c2-final-hash",
+                        "request_hash": "integrated-c2-request-hash",
+                        "wide_response_matrix_hash": "integrated-c2-wide-hash",
+                    },
+                },
+            },
+            "activity_contract": {
+                "clock_period_ns": 10.0,
+                "cycle_count": 8863,
+                "workload_contract": _workload_contract(),
+            },
+            "macro_manifest_contract": {
+                "counts": {"fakeram45_2048x39": 112, "fakeram45_64x32": 64},
+            },
+            "macro_activity_contract": {
+                "profile": "multivalue_service_c1_v1",
+                "total_assignment_count": 14800,
+                "macro_classes": {
+                    "fakeram45_2048x39": {
+                        "instance_scope_prefix": "score_bank",
+                        "instance_count": 112,
+                        "pins_per_instance": 91,
+                        "assignment_count": 10192,
+                    },
+                    "fakeram45_64x32": {
+                        "instance_scope_prefix": "gen_value_macro_backend",
+                        "instance_count": 64,
+                        "pins_per_instance": 72,
+                        "assignment_count": 4608,
+                    },
+                },
+            },
+            "bank3_dynamic_inactivity": {
+                "inactive_banks": [3],
+                "statement": (
+                    "No artificial activity was injected. Banks [3] may remain dynamically inactive in this exact "
+                    "c2_p128_b4_rr workload; they are not required to toggle, while leakage remains part of routed power."
                 ),
             },
         },
@@ -493,3 +639,59 @@ def test_build_report_keeps_c2_blocked_unpromoted(tmp_path: Path) -> None:
     assert blocked[0]["promoted"] is False
     assert blocked[0]["rankable_as_measured"] is False
     assert "pending_equivalent_composed_physical_activity_evidence" in blocked[0]["status"]
+
+
+def test_build_report_promotes_c2_with_whole_service_window_accounting(tmp_path: Path) -> None:
+    prior = _prior_frontier(tmp_path)
+    service_c1 = _service_activity_power(tmp_path)
+    service_c2 = _service_activity_power_c2(tmp_path)
+
+    payload = build_report(
+        prior_cluster_frontier_json=prior,
+        service_activity_power_jsons=[service_c1, service_c2],
+    )
+
+    assert payload["decision"] == "strict_c1_c2_measured_service_anchors_promoted_c3plus_blocked"
+    assert len(payload["promoted_rows"]) == 2
+    c2_row = next(row for row in payload["promoted_rows"] if row["cluster_count"] == 2)
+    assert c2_row["service_calibration_case_id"] == "c2_p128_b4_rr"
+    assert c2_row["service_activity_microkernel_cycle_count"] == 8863
+    assert c2_row["service_window_energy_accounting"] == (
+        "whole_measured_service_window_scaled_by_measured_windows_and_service_waves"
+    )
+    assert c2_row["full_context_service_wave_count"] == 16 * 32
+    assert c2_row["service_component_dynamic_energy_mj_per_token"] == pytest.approx(2796.544)
+    assert c2_row["service_component_leakage_energy_mj_per_token"] == pytest.approx(0.00508360600248223)
+    assert c2_row["service_component_energy_mj_per_token"] == pytest.approx(2796.5490836060025)
+
+
+def test_build_report_c2_regression_guard_rejects_head_count_double_count(tmp_path: Path) -> None:
+    prior = _prior_frontier(tmp_path)
+    service_c1 = _service_activity_power(tmp_path)
+    service_c2 = _service_activity_power_c2(tmp_path)
+
+    payload = build_report(
+        prior_cluster_frontier_json=prior,
+        service_activity_power_jsons=[service_c1, service_c2],
+    )
+
+    c2_row = next(row for row in payload["promoted_rows"] if row["cluster_count"] == 2)
+    wrong_dynamic_mj = 1.0e-6 * math.ceil(131072 / 24) * 32 * 32 * 1.0e3
+    assert c2_row["service_component_dynamic_energy_mj_per_token"] != pytest.approx(wrong_dynamic_mj)
+
+
+def test_build_report_rejects_c2_cycle_mismatch(tmp_path: Path) -> None:
+    prior = _prior_frontier(tmp_path)
+    service_c1 = _service_activity_power(tmp_path)
+    service_c2 = _service_activity_power_c2(tmp_path)
+    payload = json.loads(service_c2.read_text(encoding="utf-8"))
+    payload["activity_contract"]["cycle_count"] = 8864
+    payload["best"]["component_service_window_energy"]["cycle_count"] = 8864
+    payload["best"]["component_service_window_energy"]["duration_s"] = 8.864e-5
+    service_c2.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="service activity cycle_count"):
+        build_report(
+            prior_cluster_frontier_json=prior,
+            service_activity_power_jsons=[service_c1, service_c2],
+        )

--- a/tests/test_extract_fakeram_vcd_activity.py
+++ b/tests/test_extract_fakeram_vcd_activity.py
@@ -20,6 +20,7 @@ from npu.eval.extract_fakeram_vcd_activity import (
 )
 from npu.eval.generate_attention_decode_score_multivalue_service_activity import (
     _REQUIRED_SERVICE_FIELDS,
+    _load,
     generate_activity,
 )
 
@@ -37,6 +38,13 @@ def _service_config() -> dict[str, object]:
         "top_name": "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_macro_activity",
         "attention_decode_score_multivalue_service": dict(_REQUIRED_SERVICE_FIELDS),
     }
+
+
+def _service_config_c2() -> dict[str, object]:
+    return _load(
+        REPO_ROOT
+        / "runs/designs/npu_blocks/attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr/config.json"
+    )
 
 
 def _mini_vcd() -> str:
@@ -370,6 +378,113 @@ def test_extract_multivalue_service_activity_tracks_both_macro_classes(tmp_path:
     assert classes["fakeram45_64x32"]["assignment_count"] == 72
 
 
+def test_extract_multivalue_service_activity_preserves_c2_cluster_identity(tmp_path: Path) -> None:
+    vcd_path = tmp_path / "service_macro_c2.vcd"
+    _write_vcd(
+        vcd_path,
+        "\n".join(
+            [
+                "$timescale",
+                "1ns/1ps",
+                "$end",
+                "$scope module tb $end",
+                "$scope module dut $end",
+                "$scope begin gen_cluster[0] $end",
+                "$scope module u_cluster $end",
+                "$scope module score_bank $end",
+                "$scope module u_group_0_slice_0 $end",
+                "$var reg 11 a addr_in [10:0] $end",
+                "$var reg 39 b wd_in [38:0] $end",
+                "$var reg 39 c w_mask_in [38:0] $end",
+                "$var reg 1 d we_in $end",
+                "$var reg 1 e ce_in $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$scope begin gen_cluster[1] $end",
+                "$scope module u_cluster $end",
+                "$scope module score_bank $end",
+                "$scope module u_group_0_slice_0 $end",
+                "$var reg 11 f addr_in [10:0] $end",
+                "$var reg 39 g wd_in [38:0] $end",
+                "$var reg 39 h w_mask_in [38:0] $end",
+                "$var reg 1 i we_in $end",
+                "$var reg 1 j ce_in $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$scope begin gen_value_macro_backend $end",
+                "$scope begin gen_value_bank[0] $end",
+                "$scope begin gen_value_lane[0] $end",
+                "$scope module u_value_mem_lane $end",
+                "$var reg 6 k addr_in [5:0] $end",
+                "$var reg 32 l wd_in [31:0] $end",
+                "$var reg 32 m w_mask_in [31:0] $end",
+                "$var reg 1 n we_in $end",
+                "$var reg 1 o ce_in $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$upscope $end",
+                "$enddefinitions",
+                "#0",
+                f"b{'0'*11} a",
+                f"b{'0'*39} b",
+                f"b{'0'*39} c",
+                "0d",
+                "1e",
+                f"b{'0'*11} f",
+                f"b{'0'*39} g",
+                f"b{'0'*39} h",
+                "0i",
+                "1j",
+                f"b{'0'*6} k",
+                f"b{'0'*32} l",
+                f"b{'0'*32} m",
+                "0n",
+                "0o",
+                "#10",
+                "$dumpon",
+                "#20",
+                "1d",
+                "1i",
+                "1o",
+                "#40",
+                "0d",
+                "0i",
+                "0o",
+                "#50",
+                "$dumpoff",
+            ]
+        ),
+    )
+    payload = extract_multivalue_service_fakeram_vcd_activity(
+        vcd_path,
+        source_vcd_sha256=hashlib.sha256(vcd_path.read_bytes()).hexdigest(),
+        scope="tb/dut",
+        cluster_count=2,
+        case_id="c2_p128_b4_rr",
+        group_indices=(0,),
+        slice_indices=(0,),
+        value_bank_indices=(0,),
+        value_lane_indices=(0,),
+        expected_pin_count=254,
+    )
+
+    assert payload["target_profile"] == "multivalue_service_c2_v1"
+    by_name = {row["full_name"]: row for row in payload["pins"]}
+    assert "gen_cluster[0]/u_cluster/score_bank/u_group_0_slice_0/we_in" in by_name
+    assert "gen_cluster[1]/u_cluster/score_bank/u_group_0_slice_0/we_in" in by_name
+    contract = payload["structural_macro_contract"]
+    classes = {row["macro_name"]: row for row in contract["macro_classes"]}
+    assert classes["fakeram45_2048x39"]["instance_count"] == 2
+    assert classes["fakeram45_64x32"]["instance_count"] == 1
+    assert contract["total_assignment_count"] == 254
+
+
 @pytest.mark.skipif(not _iverilog_available(), reason="iverilog/vvp unavailable")
 def test_extract_multivalue_service_activity_real_generated_vcd_sidecar(tmp_path: Path) -> None:
     activity_dir = tmp_path / "activity"
@@ -397,3 +512,34 @@ def test_extract_multivalue_service_activity_real_generated_vcd_sidecar(tmp_path
         "gen_value_macro_backend/gen_value_bank[3]/gen_value_lane[15]/u_value_mem_lane/ce_in"
         in full_names
     )
+
+
+@pytest.mark.skipif(not _iverilog_available(), reason="iverilog/vvp unavailable")
+def test_extract_multivalue_service_activity_real_generated_c2_vcd_sidecar(tmp_path: Path) -> None:
+    activity_dir = tmp_path / "activity_c2"
+    manifest = generate_activity(_service_config_c2(), activity_dir, case_id="c2_p128_b4_rr")
+    vcd_path = activity_dir / manifest["artifacts"]["vcd"]
+    payload = extract_multivalue_service_fakeram_vcd_activity(
+        vcd_path,
+        source_vcd_sha256=manifest["hashes"]["vcd_sha256"],
+        scope="tb/dut",
+        cluster_count=2,
+        case_id="c2_p128_b4_rr",
+    )
+
+    assert payload["target_profile"] == "multivalue_service_c2_v1"
+    assert len(payload["pins"]) == 14800
+    classes = {row["macro_name"]: row for row in payload["structural_macro_contract"]["macro_classes"]}
+    assert classes["fakeram45_2048x39"]["instance_count"] == 112
+    assert classes["fakeram45_2048x39"]["assignment_count"] == 10192
+    assert classes["fakeram45_64x32"]["instance_count"] == 64
+    assert classes["fakeram45_64x32"]["assignment_count"] == 4608
+    full_names = {row["full_name"] for row in payload["pins"]}
+    score_instances = {name.rsplit("/", 1)[0] for name in full_names if "/score_bank/" in name}
+    value_instances = {
+        name.rsplit("/", 1)[0] for name in full_names if name.startswith("gen_value_macro_backend/")
+    }
+    assert len(score_instances) == 112
+    assert len(value_instances) == 64
+    assert any(name.startswith("gen_cluster[0]/u_cluster/score_bank/") for name in full_names)
+    assert any(name.startswith("gen_cluster[1]/u_cluster/score_bank/") for name in full_names)

--- a/tests/test_generate_attention_decode_score_multivalue_service_activity.py
+++ b/tests/test_generate_attention_decode_score_multivalue_service_activity.py
@@ -16,7 +16,9 @@ from npu.eval.generate_attention_decode_score_multivalue_service_activity import
     _OUTPUT_TOP_NAME,
     _OUTPUT_VCD_NAME,
     _REQUIRED_SERVICE_FIELDS,
+    _load,
     _normalize_config,
+    generate_activity,
 )
 from npu.eval.probe_attention_decode_score_multivalue_integrated_service import _workload_contract
 
@@ -30,6 +32,13 @@ def _config() -> dict[str, object]:
         "top_name": "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_macro_activity",
         "attention_decode_score_multivalue_service": dict(_REQUIRED_SERVICE_FIELDS),
     }
+
+
+def _c2_repo_config() -> dict[str, object]:
+    return _load(
+        REPO_ROOT
+        / "runs/designs/npu_blocks/attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr/config.json"
+    )
 
 
 def test_normalize_config_requires_macro_backed_c1() -> None:
@@ -106,7 +115,7 @@ def test_generate_service_activity_is_deterministic(tmp_path: Path) -> None:
     assert manifest_a["artifacts"]["vcd"] == _OUTPUT_VCD_NAME
     assert not manifest_a["artifacts"]["vcd"].startswith("/")
     assert str(REPO_ROOT / "npu/eval") not in json.dumps(manifest_a, sort_keys=True)
-    assert "bank3 switching" in " ".join(manifest_a["scope"]["remaining"])
+    assert "every bank's switching" in " ".join(manifest_a["scope"]["remaining"])
     assert "24 active context tokens" in " ".join(manifest_a["scope"]["exercised"])
 
     top_text = (out_a / _OUTPUT_TOP_NAME).read_text(encoding="utf-8")
@@ -117,3 +126,16 @@ def test_generate_service_activity_is_deterministic(tmp_path: Path) -> None:
     vcd_b = (out_b / _OUTPUT_VCD_NAME).read_bytes()
     assert vcd_a == vcd_b
     assert manifest_a["hashes"]["vcd_sha256"] == manifest_b["hashes"]["vcd_sha256"]
+
+
+@pytest.mark.skipif(not _iverilog_available(), reason="iverilog/vvp unavailable")
+def test_generate_service_activity_c2_uses_aggregate_protocol_counts(tmp_path: Path) -> None:
+    activity_dir = tmp_path / "activity_c2"
+    manifest = generate_activity(_c2_repo_config(), activity_dir, case_id="c2_p128_b4_rr")
+
+    assert manifest["case_id"] == "c2_p128_b4_rr"
+    assert manifest["cycle_count"] == 8863
+    assert manifest["request_result_protocol_counters"]["request_count"] == 96
+    assert manifest["request_result_protocol_counters"]["wide_response_count"] == 96
+    assert manifest["request_result_protocol_counters"]["result_count"] == 32
+    assert manifest["request_result_protocol_counters"]["shared"]["protocol_error"] is False


### PR DESCRIPTION
## Summary
- generalize strict composed-service activity generation and routed power audit from c1 to c2
- preserve distinct c2 score-bank hierarchy and require 112 score macros plus 64 shared value macros
- aggregate c2 protocol counts correctly across two concurrent clusters and validate all generated hashes before physical power analysis
- add a dependency-gated c2 activity item and measured c1/c2 Llama7B frontier revision
- account c2 energy as a whole two-cluster service window scaled by service waves, avoiding a twofold per-head double count
- report throughput-best and latency/area/service-energy Pareto rows separately; c3+ remain blocked

## Why
The merged c1 frontier cannot determine whether two service clusters improve the Llama7B frontier because c2 physical and activity costs were unmeasured. The integrated RTL probe shows c1 completes in 8,719 cycles and c2 in 8,863 cycles for two concurrent clusters, making c2 a plausible throughput point that requires direct area and energy evidence.

## Real-path validation
- generated the actual c2 macro-backed VCD successfully
- cycle count: 8,863
- aggregate counts: 96 requests, 96 wide responses, 32 results
- all score/final/request/wide hashes match the integrated-service c2 case
- structural activity: 112 distinct score macros, 64 shared value macros, 14,800 macro-pin assignments

## Tests
- 327 focused integrated-service/activity/frontier/control-plane tests passed
- 19 campaign workflow tests passed
- `scripts/validate_runs.py` passed
- proposal JSON and changed Python compilation passed