### PR TITLE
Add score32 schedule-wrapper activity power path

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6163,7 +6163,12 @@ def _decoder_attention_score32_integrated_frontier_ranking_evidence(
         if hbm_controller_replay_ppa_item_id
         else None
     )
-    use_schedule_wrapper_recost = "schedule_wrapper" in item_id
+    score32_activity_power = (
+        f"{base}/decoder_attention_score32_schedule_wrapper_postroute_activity_power__"
+        "l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1.json"
+    )
+    use_activity_power = "activity_integrated_frontier_ranking" in item_id
+    use_schedule_wrapper_recost = ("schedule_wrapper" in item_id) or use_activity_power
     use_hbm_controller_replay = "hbm_controller_replay" in item_id
     score32_quality = (
         f"{base}/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__"
@@ -6196,6 +6201,8 @@ def _decoder_attention_score32_integrated_frontier_ranking_evidence(
             command += f"--score32-hbm-controller-replay-ppa-json {score32_hbm_controller_replay_ppa} "
     if use_schedule_wrapper_recost:
         command += f"--score32-physical-feasibility-json {schedule_wrapper_recost} "
+    if use_activity_power:
+        command += f"--score32-activity-power-json {score32_activity_power} "
     command += (
         f"--score32-quality-json {score32_quality} "
         f"--measured-compute-energy-json {measured_compute} "
@@ -6224,6 +6231,11 @@ def _decoder_attention_score32_integrated_frontier_ranking_evidence(
                 if use_schedule_wrapper_recost
                 else {}
             ),
+            **(
+                {"attention_score32_schedule_wrapper_postroute_activity_power": score32_activity_power}
+                if use_activity_power
+                else {}
+            ),
             "attention_score32_exp_lut_generation_quality": score32_quality,
             "attention_measured_compute_energy_closure": measured_compute,
             "attention_mixed_int8_energy_closure": mixed_int8,
@@ -6243,6 +6255,67 @@ def _decoder_attention_score32_integrated_frontier_ranking_evidence(
                 "name": "audit_decoder_attention_score32_integrated_frontier_ranking",
                 "run": command,
             },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
+def _decoder_attention_score32_schedule_wrapper_postroute_activity_power_evidence(
+    *, item_id: str
+) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    design = "attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2"
+    config = f"runs/designs/npu_blocks/{design}/config.json"
+    metrics_csv = f"runs/designs/npu_blocks/{design}/metrics.csv"
+    recost_json = (
+        f"{base}/decoder_attention_composed_datapath_physical_feasibility__"
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1.json"
+    )
+    orfs_design_config = f"/orfs/flow/designs/nangate45/{design}/config.mk"
+    activity_dir = "/tmp/rtlgen_score32_schedule_wrapper_activity_power"
+    out = f"{base}/decoder_attention_score32_schedule_wrapper_postroute_activity_power__{item_id}.json"
+    report = f"{base}/decoder_attention_score32_schedule_wrapper_postroute_activity_power__{item_id}.md"
+    return {
+        "inputs": {
+            "attention_score32_schedule_wrapper_config": config,
+            "attention_score32_schedule_wrapper_metrics_csv": metrics_csv,
+            "attention_score32_schedule_wrapper_recost_json": recost_json,
+            "attention_score32_schedule_wrapper_orfs_design_config": orfs_design_config,
+            "attention_score32_schedule_wrapper_activity_dir": activity_dir,
+            "attention_score32_schedule_wrapper_postroute_activity_power_out": out,
+            "attention_score32_schedule_wrapper_postroute_activity_power_report": report,
+            "attention_score32_schedule_wrapper_postroute_activity_power_scope": (
+                "Audit direct postroute wrapper activity power for the score32 dual-stream schedule wrapper "
+                "using the authoritative 10 ns, density-0.4 routed row and the 986-cycle Llama7B service-window "
+                "contract. Keep raw VCD/ODB/SPEF evaluator-local, reject any collapse to the 4-cycle "
+                "cluster-service micro-transaction, and record only repo-portable JSON/MD outputs."
+            ),
+            "attention_score32_schedule_wrapper_postroute_activity_power_promotion_gate": (
+                "Promotion requires exact wrapper RTL protocol/count/hash gates, the authoritative density-0.4 "
+                "routed row, a macro-less sequential-register activity phase, finite positive routed power, and "
+                "an explicit distinction between the 10 ns annotation clock and the 48.6509 ns promotion clock."
+            ),
+            "attention_score32_schedule_wrapper_postroute_activity_power_local_only_artifacts": [
+                "VCD",
+                "ODB",
+                "SPEF",
+            ],
+        },
+        "commands": [
+            {
+                "name": "audit_decoder_attention_score32_schedule_wrapper_postroute_activity_power",
+                "run": (
+                    "python3 npu/eval/audit_llm_decoder_attention_score32_schedule_wrapper_postroute_activity_power.py "
+                    f"--config {config} "
+                    f"--metrics-csv {metrics_csv} "
+                    f"--recost-json {recost_json} "
+                    f"--orfs-design-config {orfs_design_config} "
+                    f"--activity-dir {activity_dir} "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            }
         ],
         "expected_outputs": [out, report],
         "evidence_only": True,
@@ -11250,6 +11323,7 @@ def _build_payload(
         "decoder_attention_score32_exp_lut_hbm_dram_service_closure",
         "decoder_attention_score32_hbm_controller_replay",
         "decoder_attention_score32_integrated_frontier_ranking",
+        "decoder_attention_score32_schedule_wrapper_postroute_activity_power",
         "decoder_attention_score32_compute_activity_energy",
         "decoder_attention_score32_separated_compute_recost",
         "decoder_attention_separated_cluster_equivalence",
@@ -11548,6 +11622,10 @@ def _build_payload(
             decoder_evidence = _decoder_attention_score32_integrated_frontier_ranking_evidence(
                 item_id=item_id,
                 depends_on_item_ids=depends_on_item_ids,
+            )
+        elif abstraction_layer_name == "decoder_attention_score32_schedule_wrapper_postroute_activity_power":
+            decoder_evidence = _decoder_attention_score32_schedule_wrapper_postroute_activity_power_evidence(
+                item_id=item_id
             )
         elif abstraction_layer_name == "decoder_attention_score32_compute_activity_energy":
             decoder_evidence = _decoder_attention_score32_compute_activity_energy_evidence(item_id=item_id)

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7091,6 +7091,86 @@ def test_generate_l2_campaign_task_adds_schedule_wrapper_integrated_frontier_ran
             )
 
 
+def test_generate_l2_campaign_task_adds_schedule_wrapper_postroute_activity_power_input() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_score32_schedule_wrapper_postroute_activity_power",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            run = work_item.task_request.request_payload["task"]["commands"][0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert "audit_llm_decoder_attention_score32_schedule_wrapper_postroute_activity_power.py" in run
+            assert "--config runs/designs/npu_blocks/attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2/config.json" in run
+            assert "--metrics-csv runs/designs/npu_blocks/attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2/metrics.csv" in run
+            assert "--recost-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1.json" in run
+            assert decoder_inputs["attention_score32_schedule_wrapper_activity_dir"] == "/tmp/rtlgen_score32_schedule_wrapper_activity_power"
+            assert decoder_inputs["attention_score32_schedule_wrapper_postroute_activity_power_local_only_artifacts"] == [
+                "VCD",
+                "ODB",
+                "SPEF",
+            ]
+
+
+def test_generate_l2_campaign_task_adds_schedule_wrapper_activity_integrated_frontier_ranking_input() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_score32_integrated_frontier_ranking",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            run = work_item.task_request.request_payload["task"]["commands"][0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert "--score32-physical-feasibility-json" in run
+            assert "--score32-activity-power-json" in run
+            assert (
+                "decoder_attention_score32_schedule_wrapper_postroute_activity_power__"
+                "l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1.json"
+            ) in run
+            assert decoder_inputs["attention_score32_schedule_wrapper_postroute_activity_power"].endswith(
+                "decoder_attention_score32_schedule_wrapper_postroute_activity_power__"
+                "l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1.json"
+            )
+
+
 def test_generate_l2_campaign_task_adds_attention_score32_hbm_controller_replay_integrated_frontier_ranking_input() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1/README.md
@@ -1,0 +1,7 @@
+# Score32 Schedule-Wrapper Activity Integrated Frontier Ranking
+
+This proposal reranks the score32 schedule-wrapper row after replacing its compute-energy term with direct routed wrapper activity evidence.
+
+- portable outputs: JSON and Markdown only
+- local-only dependency: the upstream wrapper activity-power audit keeps VCD/ODB/SPEF local
+- dispatch mode: manual follow-up; keep `evaluation_requests.json` pending

--- a/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1/analysis_report.md
@@ -1,0 +1,3 @@
+# Analysis Report
+
+Pending initial evaluation.

--- a/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,31 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1",
+  "source_commit_note": "Leave this request pending until the local-only wrapper activity-power evidence is materialized.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerank the score32 schedule-wrapper row using measured wrapper activity energy and existing schedule-wrapper latency/area evidence.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_integrated_frontier_ranking",
+      "comparison_role": "score32_schedule_wrapper_activity_integrated_frontier_ranking",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1",
+        "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l2_decoder_attention_measured_compute_energy_closure_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2",
+        "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_schedule_wrapper_activity_integrated_frontier_ranking",
+        "reason": "The result should compare measured wrapper activity energy against the current exact-FP16 and mixed-int8 references without auto-dispatching local-only evidence generation."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1/promotion_decision.json
@@ -1,0 +1,5 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1",
+  "candidate_id": "l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1",
+  "status": "pending"
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1/promotion_result.json
@@ -1,0 +1,4 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1",
+  "status": "pending"
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1/proposal.json
@@ -1,0 +1,74 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1",
+  "created_utc": "2026-07-26T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Score32 schedule-wrapper activity-integrated frontier ranking",
+  "abstraction_layer": "decoder_attention_score32_integrated_frontier_ranking",
+  "hypothesis": "The score32 schedule-wrapper row should keep the current latency/area closure but replace its compute-energy term with the measured whole-wrapper 986-cycle service-window energy before being reranked against exact-FP16 and mixed-int8 artifacts.",
+  "direct_comparison": {
+    "primary_question": "Does substituting measured whole-wrapper activity energy into the score32 schedule-wrapper row change the current Llama7B precision-safe frontier decision?",
+    "include": [
+      "consume the schedule-wrapper recost for latency and area",
+      "replace score32 compute energy with measured wrapper service-window energy times 428 replicas, 8 tile waves, and 32 layers",
+      "keep HBM energy unchanged",
+      "preserve score32 quality/equivalence gates",
+      "report throughput, area, energy, precision, and Pareto status",
+      "retain the residual 343 per-layer cycles outside the measured wrapper activity term with qkv=192, reduction=141, kv_write=10"
+    ],
+    "exclude": [
+      "new OpenROAD PPA",
+      "new generation-quality evaluation",
+      "new HBM controller RTL",
+      "claims that the residual 343 per-layer cycles were measured in the wrapper activity trace"
+    ]
+  },
+  "expected_benefit": [
+    "replaces the older recost-only compute-energy term with direct routed wrapper activity evidence",
+    "keeps the Llama7B schedule-wrapper row synchronized with the stricter postroute audit",
+    "preserves immutable history by creating a new ranking item instead of mutating the merged v1 schedule-wrapper rerank"
+  ],
+  "risks": [
+    "HBM energy remains reused from the existing score32 HBM closure",
+    "the wrapper activity term intentionally excludes the residual 343 cycles per layer",
+    "the ranking remains an evidence audit rather than a new physical implementation"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerank the score32 schedule-wrapper row using measured wrapper activity energy and existing schedule-wrapper latency/area evidence.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_integrated_frontier_ranking",
+      "comparison_role": "score32_schedule_wrapper_activity_integrated_frontier_ranking",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1",
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1",
+        "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
+        "l2_decoder_attention_measured_compute_energy_closure_llama7b_v1",
+        "l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1_r2",
+        "l2_decoder_attention_integrated_energy_closure_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_schedule_wrapper_activity_integrated_frontier_ranking",
+        "reason": "The result should show whether direct routed wrapper activity energy changes the current score32 Llama7B frontier recommendation."
+      },
+      "status": "pending"
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_schedule_wrapper_postroute_activity_power__l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exp_lut_hbm_dram_service_closure__l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py",
+    "docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1/proposal.json"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1/README.md
@@ -1,0 +1,7 @@
+# Score32 Schedule-Wrapper Postroute Activity Power
+
+This proposal adds a strict direct activity-power path for the score32 dual-stream schedule wrapper.
+
+- portable outputs: JSON and Markdown only
+- local-only artifacts: VCD, ODB, SPEF
+- dispatch mode: manual follow-up; keep `evaluation_requests.json` pending

--- a/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1/analysis_report.md
@@ -1,0 +1,3 @@
+# Analysis Report
+
+Pending initial evaluation.

--- a/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1",
+  "source_commit_note": "Leave this request pending for manual dispatch only because raw VCD/ODB/SPEF remain evaluator-local.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Measure routed score32 schedule-wrapper service-window activity power for one 986-cycle deployed wrapper instance.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_schedule_wrapper_postroute_activity_power",
+      "comparison_role": "score32_schedule_wrapper_postroute_activity_power",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_schedule_wrapper_postroute_activity_power",
+        "reason": "The result should capture only repo-portable JSON/MD outputs while the raw VCD/ODB/SPEF stay local."
+      },
+      "status": "pending"
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1/promotion_decision.json
@@ -1,0 +1,5 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1",
+  "candidate_id": "l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1",
+  "status": "pending"
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1/promotion_result.json
@@ -1,0 +1,4 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1",
+  "status": "pending"
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1/proposal.json
@@ -1,0 +1,67 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1",
+  "created_utc": "2026-07-26T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Score32 schedule-wrapper postroute activity power",
+  "abstraction_layer": "decoder_attention_score32_schedule_wrapper_postroute_activity_power",
+  "hypothesis": "A direct postroute wrapper activity audit can replace the older score32 schedule-wrapper compute-power recost with a measured 986-cycle whole-wrapper service-window energy while preserving the authoritative 10 ns routed annotation contract.",
+  "direct_comparison": {
+    "primary_question": "What is the direct routed energy of one 986-cycle deployed score32 schedule-wrapper service window, and does the activity audit keep the 4-cycle local service distinct from the full tile window?",
+    "include": [
+      "select exactly the density-0.4 authoritative routed wrapper row",
+      "generate actual wrapper RTL and a deterministic 986-cycle activity trace",
+      "use a macro-less postroute phase with sequential-register activity sidecar",
+      "validate the recost, cycle-count, and activity hashes before power",
+      "report separate dynamic and leakage energy using 10 ns annotation and max(10 ns, 48.6509 ns) promotion clocks"
+    ],
+    "exclude": [
+      "new OpenROAD synthesis/place-route",
+      "portable raw VCD/ODB/SPEF artifacts",
+      "full-token energy claims outside the wrapper activity term",
+      "vendor SRAM or HBM signoff current traces"
+    ]
+  },
+  "expected_benefit": [
+    "replaces analytic schedule-wrapper compute power with direct routed activity power",
+    "locks the 986-cycle Llama7B service-window contract into the evidence path",
+    "feeds a stricter score32 rerank without mutating older merged artifacts"
+  ],
+  "risks": [
+    "raw VCD/ODB/SPEF remain evaluator-local and cannot be reviewed from committed artifacts alone",
+    "the wrapper result/hash evidence is limited to observable protocol/count timelines because hardware equivalence hash remains disabled",
+    "the residual 343 per-layer cycles remain outside the measured wrapper activity term"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Measure routed score32 schedule-wrapper service-window activity power for one 986-cycle deployed wrapper instance.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_schedule_wrapper_postroute_activity_power",
+      "comparison_role": "score32_schedule_wrapper_postroute_activity_power",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_schedule_wrapper_postroute_activity_power",
+        "reason": "The result should produce direct routed wrapper dynamic/leakage energy for the exact 986-cycle score32 service window without collapsing it to cluster_service_cycles=4."
+      },
+      "status": "pending"
+    }
+  ],
+  "baseline_refs": [
+    "runs/designs/npu_blocks/attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2/config.json",
+    "runs/designs/npu_blocks/attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2/metrics.csv",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/generate_attention_dual_stream_schedule_wrapper_activity.py",
+    "npu/eval/audit_llm_decoder_attention_score32_schedule_wrapper_postroute_activity_power.py",
+    "npu/synth/run_postroute_vcd_power.py"
+  ]
+}

--- a/npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
@@ -118,6 +118,7 @@ def _score32_row(
     score32_hbm_controller_replay: JsonDict | None = None,
     score32_hbm_controller_replay_ppa: JsonDict | None = None,
     score32_physical: JsonDict | None = None,
+    score32_activity_power: JsonDict | None = None,
 ) -> JsonDict:
     replay_best = _as_dict(score32_hbm_controller_replay.get("best_latency")) if score32_hbm_controller_replay else {}
     best = replay_best or _as_dict(score32_hbm.get("best_latency"))
@@ -165,6 +166,28 @@ def _score32_row(
                 *remaining_abstractions,
                 *list(score32_physical.get("remaining_abstractions") or []),
                 "HBM/DRAM service and energy are reused from the score32 HBM closure because the wrapper recost does not change token memory traffic.",
+            }
+        )
+
+    if score32_activity_power is not None:
+        activity_best = _as_dict(score32_activity_power.get("best"))
+        activity_energy_j = _as_float(activity_best.get("replica_scaled_wrapper_compute_energy_j_per_token"))
+        if activity_energy_j <= 0.0:
+            raise ValueError("score32 activity-power evidence is missing replica-scaled wrapper compute energy")
+        activity_recost = _as_dict(score32_activity_power.get("recost_contract"))
+        latency_us = _as_float(activity_recost.get("latency_us"), latency_us)
+        if latency_us > 0.0:
+            token_throughput_per_s = 1_000_000.0 / latency_us
+        compute_energy_mj_per_token = activity_energy_j * 1.0e3
+        total_energy_mj_per_token = compute_energy_mj_per_token + hbm_energy_mj_per_token
+        source_artifact = "score32_schedule_wrapper_postroute_activity_power_with_hbm_service"
+        candidate_id = "score32_exp_lut_schedule_wrapper_activity_hbm_service_best"
+        abstraction_status = "measured_schedule_wrapper_postroute_activity_hbm_command_service"
+        remaining_abstractions = sorted(
+            {
+                *remaining_abstractions,
+                "HBM/DRAM service and energy are reused from the score32 HBM closure because the wrapper activity audit does not change token memory traffic.",
+                "The 343 residual per-layer cycles remain outside the measured wrapper activity term: qkv=192, reduction=141, kv_write=10.",
             }
         )
 
@@ -261,6 +284,7 @@ def _score32_row(
         "quality_backed": quality["quality_backed"],
         "quality": quality,
         "score32_hbm_controller_replay_ppa": controller_ppa_recost,
+        "score32_activity_power": score32_activity_power,
         "abstraction_status": abstraction_status,
         "remaining_abstractions": remaining_abstractions,
         "promotable": bool(quality["quality_backed"]),
@@ -397,6 +421,31 @@ def _energy_rank(rows: list[JsonDict], *, promotable_only: bool = False) -> list
     )
 
 
+def _annotate_pareto(rows: list[JsonDict]) -> list[JsonDict]:
+    annotated: list[JsonDict] = []
+    for row in rows:
+        dominated = False
+        for other in rows:
+            if other is row:
+                continue
+            if (
+                _as_float(other.get("latency_us"), 1.0e99) <= _as_float(row.get("latency_us"), 1.0e99)
+                and _as_float(other.get("energy_mj_per_token"), 1.0e99)
+                <= _as_float(row.get("energy_mj_per_token"), 1.0e99)
+                and _as_float(other.get("die_area_mm2"), 1.0e99) <= _as_float(row.get("die_area_mm2"), 1.0e99)
+                and (
+                    _as_float(other.get("latency_us"), 1.0e99) < _as_float(row.get("latency_us"), 1.0e99)
+                    or _as_float(other.get("energy_mj_per_token"), 1.0e99)
+                    < _as_float(row.get("energy_mj_per_token"), 1.0e99)
+                    or _as_float(other.get("die_area_mm2"), 1.0e99) < _as_float(row.get("die_area_mm2"), 1.0e99)
+                )
+            ):
+                dominated = True
+                break
+        annotated.append({**row, "pareto_status": "dominated" if dominated else "pareto"})
+    return annotated
+
+
 def build_report(args: argparse.Namespace) -> JsonDict:
     score32_hbm = _load_json(args.score32_hbm_dram_service_json)
     measured_command = _load_json(args.score32_measured_command_control_json)
@@ -413,6 +462,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
         channel_count=replay_channel_count,
     )
     score32_physical = _load_json(args.score32_physical_feasibility_json) if args.score32_physical_feasibility_json else None
+    score32_activity_power = _load_json(args.score32_activity_power_json) if args.score32_activity_power_json else None
     score32_quality = _load_json(args.score32_quality_json)
     measured_compute = _load_json(args.measured_compute_energy_json)
     mixed_int8 = _load_json(args.mixed_int8_energy_json)
@@ -440,7 +490,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
         ),
         mixed_int8_quality_frontier,
     )
-    rows = [
+    rows = _annotate_pareto([
         _score32_row(
             score32_hbm,
             measured_command,
@@ -448,6 +498,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             score32_hbm_controller_replay,
             score32_hbm_controller_replay_ppa,
             score32_physical,
+            score32_activity_power,
         ),
         _prior_row(
             candidate_id=str(_best_row(measured_compute).get("candidate_id") or "measured_fp16_compute_energy_best"),
@@ -465,7 +516,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
         ),
         mixed_int8_row,
         _abstract_integrated_row(integrated),
-    ]
+    ])
 
     latency_rank = _rank_rows(rows)
     energy_rank = _energy_rank(rows)
@@ -495,6 +546,9 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "score32_hbm_controller_replay_ppa_metrics": score32_hbm_controller_replay_ppa,
             "score32_physical_feasibility_json": str(args.score32_physical_feasibility_json)
             if args.score32_physical_feasibility_json
+            else None,
+            "score32_activity_power_json": str(args.score32_activity_power_json)
+            if args.score32_activity_power_json
             else None,
             "score32_quality_json": str(args.score32_quality_json),
             "measured_compute_energy_json": str(args.measured_compute_energy_json),
@@ -555,16 +609,23 @@ def build_report(args: argparse.Namespace) -> JsonDict:
         "assumptions": [
             "Rows are ranked by explicit metrics from merged evidence; no new PPA is synthesized in this audit.",
             (
-                "The score32 row is quality-backed by the bounded generation-quality gate and measured through "
-                "wrapper, command-control, SRAM-envelope, and HBM/DRAM service closure."
-                if not args.score32_hbm_controller_replay_json
+            "The score32 row is quality-backed by the bounded generation-quality gate and measured through "
+            "wrapper, command-control, SRAM-envelope, and HBM/DRAM service closure."
+                if not args.score32_hbm_controller_replay_json and args.score32_activity_power_json is None
                 else (
-                    "The score32 row is quality-backed by the bounded generation-quality gate and measured through "
-                    "wrapper, command-control, SRAM-envelope, and deterministic cycle-level HBM controller replay."
-                    if args.score32_hbm_controller_replay_ppa_json is None
-                    else "The score32 row is quality-backed by the bounded generation-quality gate and measured "
-                    "through wrapper, command-control, SRAM-envelope, deterministic HBM replay, and measured "
-                    "Nangate45 RTL PPA recost for replay-controller area, active energy, and control timing."
+                    "The score32 row keeps the schedule-wrapper latency/area closure but replaces compute energy "
+                    "with the measured 986-cycle whole-wrapper activity term scaled by 428 replicas, 8 tile waves, "
+                    "and 32 layers; the residual 343 per-layer cycles remain outside that measured wrapper term "
+                    "(qkv=192, reduction=141, kv_write=10)."
+                    if args.score32_activity_power_json is not None and not args.score32_hbm_controller_replay_json
+                    else (
+                        "The score32 row is quality-backed by the bounded generation-quality gate and measured through "
+                        "wrapper, command-control, SRAM-envelope, and deterministic cycle-level HBM controller replay."
+                        if args.score32_hbm_controller_replay_ppa_json is None
+                        else "The score32 row is quality-backed by the bounded generation-quality gate and measured "
+                        "through wrapper, command-control, SRAM-envelope, deterministic HBM replay, and measured "
+                        "Nangate45 RTL PPA recost for replay-controller area, active energy, and control timing."
+                    )
                 )
             ),
             (
@@ -612,13 +673,13 @@ def write_markdown(path: Path, payload: JsonDict) -> None:
     for row in payload["promotable_latency_rank"]:
         lines.append(
             "| {candidate_id} | {latency_us} | {token_throughput_per_s} | {energy_mj_per_token} | "
-            "{die_area_mm2} | {precision_status} |".format(**row)
+            "{die_area_mm2} | {precision_status} ({pareto_status}) |".format(**row)
         )
     lines.extend(["", "## All Rows", "", "| candidate | promotable | latency us | energy mJ/token | status |", "|---|---:|---:|---:|---|"])
     for row in payload["latency_rank"]:
         lines.append(
             "| {candidate_id} | {promotable} | {latency_us} | {energy_mj_per_token} | "
-            "{abstraction_status} |".format(**row)
+            "{abstraction_status} / {pareto_status} |".format(**row)
         )
     lines.extend(["", "## Assumptions", ""])
     lines.extend(f"- {item}" for item in payload["assumptions"])
@@ -633,6 +694,7 @@ def main() -> int:
     parser.add_argument("--score32-hbm-controller-replay-json", type=Path)
     parser.add_argument("--score32-hbm-controller-replay-ppa-json", type=Path)
     parser.add_argument("--score32-physical-feasibility-json", type=Path)
+    parser.add_argument("--score32-activity-power-json", type=Path)
     parser.add_argument("--score32-quality-json", type=Path, required=True)
     parser.add_argument("--measured-compute-energy-json", type=Path, required=True)
     parser.add_argument("--mixed-int8-energy-json", type=Path, required=True)

--- a/npu/eval/audit_llm_decoder_attention_score32_schedule_wrapper_postroute_activity_power.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_schedule_wrapper_postroute_activity_power.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+"""Audit strict post-route activity power for the score32 dual-stream schedule wrapper."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+from npu.eval.extract_sequential_register_vcd_activity import extract_sequential_register_vcd_activity
+from npu.eval.generate_attention_dual_stream_schedule_wrapper_activity import (
+    _DEFAULT_CLOCK_PERIOD_NS,
+    _DEFAULT_SERVICE_WINDOW_CYCLES,
+    _OUTPUT_MANIFEST_NAME,
+    _OUTPUT_TOP_NAME,
+    _OUTPUT_VCD_NAME,
+    _OUTPUT_WRAPPER_MANIFEST_NAME,
+    generate_activity,
+)
+from npu.synth.run_postroute_vcd_power import build_report as build_power_report
+
+JsonDict = dict[str, Any]
+
+_MODEL = "llm_decoder_attention_score32_schedule_wrapper_postroute_activity_power_v1"
+_POSTROUTE_MANIFEST_NAME = "attention_dual_stream_schedule_wrapper_postroute_power_manifest.json"
+_POSTROUTE_SEQUENTIAL_ACTIVITY_NAME = (
+    "attention_dual_stream_schedule_wrapper_sequential_register_vcd_activity_v1.json"
+)
+_EXPECTED_PLATFORM = "nangate45"
+_EXPECTED_FLOW_VARIANT = "attention_dual_stream_schedule_wrapper_score32_exp_lut"
+_EXPECTED_CRITICAL_PATH_NS = 48.6509
+_EXPECTED_INSTANCE_AREA_UM2 = 693452.0
+_EXPECTED_TOTAL_POWER_MW = 60.7
+_EXPECTED_PLACE_DENSITY = 0.4
+_EXPECTED_REPLICA_COUNT = 428
+_EXPECTED_TILE_WAVES = 8
+_EXPECTED_LAYERS = 32
+_EXPECTED_QKV_CYCLES = 192
+_EXPECTED_REDUCTION_CYCLES = 141
+_EXPECTED_KV_WRITE_CYCLES = 10
+_EXPECTED_LAYER_CYCLES = 8231
+_SCOPE = "tb/dut"
+
+
+def _load(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected a JSON object: {path}")
+    return payload
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _portable_path(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(Path(__file__).resolve().parents[2].resolve()).as_posix()
+    except ValueError:
+        return path.name
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _require_positive(value: Any, label: str) -> float:
+    numeric = _as_float(value, float("nan"))
+    if not math.isfinite(numeric) or numeric <= 0.0:
+        raise ValueError(f"{label} must be a finite positive number")
+    return numeric
+
+
+def _select_authoritative_metric(metrics_csv: Path, *, design_name: str) -> JsonDict:
+    matches: list[JsonDict] = []
+    with metrics_csv.open(newline="", encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
+            if str(row.get("status", "")).strip() != "ok":
+                continue
+            if str(row.get("design", "")).strip() != design_name:
+                continue
+            if str(row.get("platform", "")).strip() != _EXPECTED_PLATFORM:
+                continue
+            params = json.loads(str(row.get("params_json") or "{}"))
+            if str(params.get("FLOW_VARIANT") or "").strip() != _EXPECTED_FLOW_VARIANT:
+                continue
+            if abs(_as_float(params.get("CLOCK_PERIOD")) - _DEFAULT_CLOCK_PERIOD_NS) > 1e-9:
+                continue
+            if abs(_as_float(params.get("PLACE_DENSITY")) - _EXPECTED_PLACE_DENSITY) > 1e-9:
+                continue
+            matches.append({"row": dict(row), "params": params})
+    if len(matches) != 1:
+        raise ValueError(
+            "expected exactly one authoritative density-0.4 routed row for the score32 wrapper, "
+            f"found {len(matches)}"
+        )
+    row = matches[0]["row"]
+    critical_path_ns = _as_float(row.get("critical_path_ns"))
+    instance_area_um2 = _as_float(row.get("instance_area_um2"))
+    total_power_mw = _as_float(row.get("total_power_mw"))
+    if abs(critical_path_ns - _EXPECTED_CRITICAL_PATH_NS) > 1e-9:
+        raise ValueError("authoritative wrapper critical_path_ns mismatch")
+    if abs(instance_area_um2 - _EXPECTED_INSTANCE_AREA_UM2) > 1e-9:
+        raise ValueError("authoritative wrapper instance_area_um2 mismatch")
+    if abs(total_power_mw - _EXPECTED_TOTAL_POWER_MW) > 1e-9:
+        raise ValueError("authoritative wrapper total_power_mw mismatch")
+    return matches[0]
+
+
+def _validate_recost_contract(payload: JsonDict, *, design_name: str) -> JsonDict:
+    diagnosis = payload.get("diagnosis")
+    if not isinstance(diagnosis, dict) or str(diagnosis.get("decision") or "") != "dual_stream_feasible":
+        raise ValueError("recost decision must be dual_stream_feasible")
+    row = payload.get("best_requested")
+    if not isinstance(row, dict):
+        raise ValueError("recost payload missing best_requested row")
+    checks = {
+        "substituted_compute_arch": design_name,
+        "substituted_compute_variant_kind": "dual_stream_schedule_wrapper",
+        "substituted_compute_semantic_profile": "score32_exp_lut_div",
+        "replica_recost_area_fit_replica_count": _EXPECTED_REPLICA_COUNT,
+        "replica_recost_tile_service_cycles": _DEFAULT_SERVICE_WINDOW_CYCLES,
+        "tile_service_cycles": _DEFAULT_SERVICE_WINDOW_CYCLES,
+        "tile_waves": _EXPECTED_TILE_WAVES,
+        "layers": _EXPECTED_LAYERS,
+        "replica_recost_qkv_cycles": _EXPECTED_QKV_CYCLES,
+        "cross_tile_reduction_cycles": _EXPECTED_REDUCTION_CYCLES,
+        "kv_write_cycles": _EXPECTED_KV_WRITE_CYCLES,
+        "replica_recost_layer_cycles": _EXPECTED_LAYER_CYCLES,
+    }
+    for key, expected in checks.items():
+        actual = row.get(key)
+        if actual != expected:
+            raise ValueError(f"recost contract mismatch for {key}: expected {expected!r}, got {actual!r}")
+    residual_cycles = _as_int(row.get("replica_recost_layer_cycles")) - (
+        _EXPECTED_TILE_WAVES * _DEFAULT_SERVICE_WINDOW_CYCLES
+    )
+    if residual_cycles != (_EXPECTED_QKV_CYCLES + _EXPECTED_REDUCTION_CYCLES + _EXPECTED_KV_WRITE_CYCLES):
+        raise ValueError("recost residual cycle contract mismatch")
+    return {
+        "replica_count": _EXPECTED_REPLICA_COUNT,
+        "tile_waves": _EXPECTED_TILE_WAVES,
+        "layers": _EXPECTED_LAYERS,
+        "service_window_cycles": _DEFAULT_SERVICE_WINDOW_CYCLES,
+        "cluster_service_cycles_from_config_must_remain_distinct": True,
+        "residual_layer_cycles": residual_cycles,
+        "residual_breakdown": {
+            "qkv_cycles": _EXPECTED_QKV_CYCLES,
+            "cross_tile_reduction_cycles": _EXPECTED_REDUCTION_CYCLES,
+            "kv_write_cycles": _EXPECTED_KV_WRITE_CYCLES,
+        },
+        "latency_us": _as_float(row.get("replica_recost_latency_us")),
+        "logic_area_um2": _as_float(row.get("replica_recost_compute_area_um2")),
+    }
+
+
+def _prepare_postroute_manifest(*, activity_dir: Path, activity_manifest: JsonDict) -> tuple[JsonDict, Path]:
+    vcd_path = activity_dir / _OUTPUT_VCD_NAME
+    if not vcd_path.is_file():
+        raise ValueError("generated wrapper activity VCD is missing")
+    vcd_sha256 = str(activity_manifest.get("hashes", {}).get("vcd_sha256") or "").strip().lower()
+    if not vcd_sha256 or _sha256_file(vcd_path) != vcd_sha256:
+        raise ValueError("generated wrapper VCD hash does not match the activity manifest")
+    sequential_activity = extract_sequential_register_vcd_activity(
+        vcd_path,
+        source_vcd_sha256=vcd_sha256,
+        scope=_SCOPE,
+    )
+    sequential_activity_path = activity_dir / _POSTROUTE_SEQUENTIAL_ACTIVITY_NAME
+    sequential_activity_path.write_text(
+        json.dumps(sequential_activity, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    postroute_manifest = {
+        "version": 1,
+        "model": "attention_dual_stream_schedule_wrapper_postroute_activity_manifest_v1",
+        "clock_period_ns": _DEFAULT_CLOCK_PERIOD_NS,
+        "phases": [
+            {
+                "phase": "service_window",
+                "vcd": _OUTPUT_VCD_NAME,
+                "vcd_sha256": vcd_sha256,
+                "sequential_register_activity": sequential_activity_path.name,
+                "sequential_register_activity_sha256": _sha256_file(sequential_activity_path),
+                "measured_cycles": _DEFAULT_SERVICE_WINDOW_CYCLES,
+                "full_context_cycles": _DEFAULT_SERVICE_WINDOW_CYCLES,
+                "requires_macro_activity": False,
+            }
+        ],
+    }
+    manifest_path = activity_dir / _POSTROUTE_MANIFEST_NAME
+    manifest_path.write_text(
+        json.dumps(postroute_manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return postroute_manifest, manifest_path
+
+
+def _strict_service_window_measurement(
+    *,
+    activity_power: JsonDict,
+    manifest_sha256: str,
+    expected_vcd_sha256: str,
+    expected_cycle_count: int,
+    authoritative_critical_path_ns: float,
+) -> JsonDict:
+    if activity_power.get("promotion_gate_pass") is not True:
+        raise ValueError("postroute power promotion_gate_pass failed")
+    if activity_power.get("status") != "activity_backed":
+        raise ValueError("postroute power status is not activity_backed")
+    if str(activity_power.get("source_activity_manifest_sha256") or "").strip().lower() != manifest_sha256:
+        raise ValueError("postroute power source_activity_manifest_sha256 mismatch")
+    phases = activity_power.get("phases")
+    if not isinstance(phases, list) or len(phases) != 1 or not isinstance(phases[0], dict):
+        raise ValueError("postroute power must contain exactly one service_window phase")
+    phase = phases[0]
+    if str(phase.get("phase") or "").strip() != "service_window":
+        raise ValueError("postroute power phase mismatch")
+    if str(phase.get("vcd_sha256") or "").strip().lower() != expected_vcd_sha256:
+        raise ValueError("postroute power VCD hash mismatch")
+    if int(phase.get("measured_cycles", 0)) != expected_cycle_count:
+        raise ValueError("postroute power measured_cycles mismatch")
+    if int(phase.get("full_context_cycles", 0)) != expected_cycle_count:
+        raise ValueError("postroute power full_context_cycles mismatch")
+    if int(phase.get("macro_activity_assignment_count", 0)) != 0:
+        raise ValueError("wrapper postroute phase must remain macro-less")
+    for gate_key in (
+        "annotation_gate_pass",
+        "sequential_register_activity_gate_pass",
+        "clock_period_gate_pass",
+        "power_numeric_gate_pass",
+        "structural_macro_activity_gate_pass",
+        "phase_gate_pass",
+    ):
+        if phase.get(gate_key) is not True:
+            raise ValueError(f"postroute power gate failed: {gate_key}")
+    power = phase.get("power")
+    if not isinstance(power, dict):
+        raise ValueError("postroute power phase missing power section")
+    internal_w = _require_positive(power.get("internal_w"), "internal_w")
+    switching_w = _require_positive(power.get("switching_w"), "switching_w")
+    leakage_w = _require_positive(power.get("leakage_w"), "leakage_w")
+    total_w = _require_positive(power.get("total_w"), "total_w")
+    if abs((internal_w + switching_w + leakage_w) - total_w) > 1e-9:
+        raise ValueError("postroute power total_w does not match internal+switching+leakage")
+    annotation_clock_ns = _DEFAULT_CLOCK_PERIOD_NS
+    promotion_clock_ns = max(annotation_clock_ns, authoritative_critical_path_ns)
+    dynamic_energy_j = (internal_w + switching_w) * expected_cycle_count * annotation_clock_ns * 1e-9
+    leakage_energy_j = leakage_w * expected_cycle_count * promotion_clock_ns * 1e-9
+    return {
+        "label": "wrapper_service_window_energy",
+        "cycle_count": expected_cycle_count,
+        "annotation_clock_ns": annotation_clock_ns,
+        "promotion_clock_ns": promotion_clock_ns,
+        "annotation_duration_s": expected_cycle_count * annotation_clock_ns * 1e-9,
+        "promotion_duration_s": expected_cycle_count * promotion_clock_ns * 1e-9,
+        "power_w": {
+            "internal": internal_w,
+            "switching": switching_w,
+            "dynamic": internal_w + switching_w,
+            "leakage": leakage_w,
+            "total": total_w,
+        },
+        "energy_j": {
+            "dynamic": dynamic_energy_j,
+            "leakage": leakage_energy_j,
+            "dynamic_plus_leakage": dynamic_energy_j + leakage_energy_j,
+        },
+    }
+
+
+def build_report(
+    *,
+    config: Path,
+    metrics_csv: Path,
+    recost_json: Path,
+    orfs_design_config: Path,
+    activity_dir: Path,
+) -> JsonDict:
+    config_payload = _load(config)
+    design_name = str(config_payload.get("top_name") or "").strip()
+    if not design_name:
+        raise ValueError("config requires non-empty top_name")
+    wrapper = config_payload.get("attention_dual_stream_schedule_wrapper")
+    if not isinstance(wrapper, dict):
+        raise ValueError("config requires attention_dual_stream_schedule_wrapper object")
+    cluster_service_cycles = _as_int(wrapper.get("cluster_service_cycles"))
+    if cluster_service_cycles <= 0:
+        raise ValueError("config cluster_service_cycles must be positive")
+    if cluster_service_cycles == _DEFAULT_SERVICE_WINDOW_CYCLES:
+        raise ValueError("cluster_service_cycles must remain distinct from the 986-cycle wrapper service window")
+    if cluster_service_cycles == 4:
+        pass
+    authoritative_metric = _select_authoritative_metric(metrics_csv, design_name=design_name)
+    recost_contract = _validate_recost_contract(_load(recost_json), design_name=design_name)
+    if cluster_service_cycles != 4:
+        raise ValueError("expected the authoritative wrapper config to retain cluster_service_cycles=4")
+    activity_dir.mkdir(parents=True, exist_ok=True)
+    activity_manifest = generate_activity(
+        config_payload,
+        activity_dir,
+        clock_period_ns=_DEFAULT_CLOCK_PERIOD_NS,
+        service_window_cycles=_DEFAULT_SERVICE_WINDOW_CYCLES,
+    )
+    if _as_int(activity_manifest.get("service_window_cycles")) != _DEFAULT_SERVICE_WINDOW_CYCLES:
+        raise ValueError("generated activity manifest service_window_cycles mismatch")
+    if _as_int(activity_manifest.get("cycle_count")) != _DEFAULT_SERVICE_WINDOW_CYCLES:
+        raise ValueError("generated activity manifest cycle_count mismatch")
+    if _as_int(activity_manifest.get("cluster_service_cycles")) == _DEFAULT_SERVICE_WINDOW_CYCLES:
+        raise ValueError("activity manifest incorrectly collapsed the 986-cycle service window to cluster_service_cycles")
+    gates = activity_manifest.get("gates")
+    if not isinstance(gates, dict) or not all(
+        bool(gates.get(key))
+        for key in (
+            "equivalence_pass",
+            "protocol_gate_ok",
+            "count_gate_ok",
+            "hash_gate_ok",
+            "observable_completion_gate_ok",
+            "window_active_gate_ok",
+            "both_clusters_issue_gate_ok",
+            "service_window_gate_ok",
+        )
+    ):
+        raise ValueError("generated activity manifest gates failed")
+    counters = activity_manifest.get("request_result_protocol_counters")
+    if not isinstance(counters, dict):
+        raise ValueError("generated activity manifest is missing request_result_protocol_counters")
+    if _as_int(counters.get("window_active_cycles")) != _DEFAULT_SERVICE_WINDOW_CYCLES:
+        raise ValueError("generated activity window_active_cycles must equal the 986-cycle service window")
+    window_issue_counts = counters.get("window_issue_counts")
+    if not isinstance(window_issue_counts, dict):
+        raise ValueError("generated activity manifest is missing window_issue_counts")
+    if _as_int(window_issue_counts.get("0")) <= 0 or _as_int(window_issue_counts.get("1")) <= 0:
+        raise ValueError("generated activity manifest did not sustain both clusters inside the measured window")
+    postroute_manifest, postroute_manifest_path = _prepare_postroute_manifest(
+        activity_dir=activity_dir,
+        activity_manifest=activity_manifest,
+    )
+    activity_power = build_power_report(
+        manifest=postroute_manifest,
+        manifest_path=postroute_manifest_path,
+        design_config=orfs_design_config,
+        flow_variant=_EXPECTED_FLOW_VARIANT,
+        scope=_SCOPE,
+        min_vcd_coverage=0.02,
+        min_vcd_pins=8,
+        min_sequential_register_activity_coverage=0.95,
+        min_macro_active_coverage=0.0,
+        min_macro_active_pins=0,
+        timeout_seconds=1800,
+    )
+    authoritative_row = authoritative_metric["row"]
+    service_window_energy = _strict_service_window_measurement(
+        activity_power=activity_power,
+        manifest_sha256=_sha256_file(postroute_manifest_path),
+        expected_vcd_sha256=str(activity_manifest["hashes"]["vcd_sha256"]),
+        expected_cycle_count=_DEFAULT_SERVICE_WINDOW_CYCLES,
+        authoritative_critical_path_ns=_as_float(authoritative_row["critical_path_ns"]),
+    )
+    total_compute_energy_j = (
+        service_window_energy["energy_j"]["dynamic_plus_leakage"]
+        * _EXPECTED_REPLICA_COUNT
+        * _EXPECTED_TILE_WAVES
+        * _EXPECTED_LAYERS
+    )
+    return {
+        "version": 1,
+        "model": _MODEL,
+        "decision": "score32_schedule_wrapper_postroute_activity_power_recorded",
+        "promotion_gate_pass": True,
+        "inputs": {
+            "config": _portable_path(config),
+            "metrics_csv": _portable_path(metrics_csv),
+            "recost_json": _portable_path(recost_json),
+            "orfs_design_config": _portable_path(orfs_design_config),
+            "activity_dir": _portable_path(activity_dir),
+        },
+        "selection_contract": {
+            "design": design_name,
+            "platform": _EXPECTED_PLATFORM,
+            "flow_variant": _EXPECTED_FLOW_VARIANT,
+            "clock_period_ns": _DEFAULT_CLOCK_PERIOD_NS,
+            "place_density": _EXPECTED_PLACE_DENSITY,
+            "authoritative_metrics": {
+                "critical_path_ns": _as_float(authoritative_row["critical_path_ns"]),
+                "instance_area_um2": _as_float(authoritative_row["instance_area_um2"]),
+                "total_power_mw": _as_float(authoritative_row["total_power_mw"]),
+                "param_hash": authoritative_row["param_hash"],
+            },
+        },
+        "recost_contract": recost_contract,
+        "activity_manifest": {
+            "model": activity_manifest["model"],
+            "cycle_count": activity_manifest["cycle_count"],
+            "service_window_cycles": activity_manifest["service_window_cycles"],
+            "cluster_service_cycles": activity_manifest["cluster_service_cycles"],
+            "hashes": activity_manifest["hashes"],
+            "gates": activity_manifest["gates"],
+            "request_result_protocol_counters": activity_manifest["request_result_protocol_counters"],
+        },
+        "postroute_power": activity_power,
+        "best": {
+            "candidate_id": "score32_schedule_wrapper_postroute_activity_power",
+            "status": "activity_backed",
+            "authoritative_wrapper_total_ppa": {
+                "critical_path_ns": _as_float(authoritative_row["critical_path_ns"]),
+                "instance_area_um2": _as_float(authoritative_row["instance_area_um2"]),
+                "total_power_mw": _as_float(authoritative_row["total_power_mw"]),
+            },
+            "component_service_window_energy": service_window_energy,
+            "replica_scaled_wrapper_compute_energy_j_per_token": total_compute_energy_j,
+        },
+        "next_step": {
+            "recommended_next_step": (
+                "Use the measured 986-cycle wrapper service-window energy, the routed 48.6509 ns promotion clock, "
+                "and the unchanged HBM energy closure in the score32 integrated frontier rerank."
+            ),
+            "residual_layer_cycles_not_measured_in_wrapper_activity": recost_contract["residual_layer_cycles"],
+            "residual_breakdown": recost_contract["residual_breakdown"],
+        },
+        "assumptions": [
+            "VCD annotation and SDC matching remain bound to the 10 ns routed-flow contract.",
+            "Wrapper dynamic energy uses the annotated 10 ns service-window cycle energy.",
+            "Wrapper leakage energy uses the promotion/rerank clock max(10 ns, 48.6509 ns).",
+            "The 343 residual per-layer cycles are retained outside the wrapper activity term: qkv=192, reduction=141, kv_write=10.",
+            "Raw VCD, ODB, SPEF, and temporary activity files remain evaluator-local and are not portable artifacts.",
+        ],
+    }
+
+
+def write_markdown(path: Path, payload: JsonDict) -> None:
+    best = payload["best"]
+    energy = best["component_service_window_energy"]
+    lines = [
+        "# Score32 Wrapper Postroute Activity Power",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- promotion_gate_pass: `{payload['promotion_gate_pass']}`",
+        f"- authoritative path ns: `{best['authoritative_wrapper_total_ppa']['critical_path_ns']}`",
+        f"- annotation clock ns: `{energy['annotation_clock_ns']}`",
+        f"- promotion clock ns: `{energy['promotion_clock_ns']}`",
+        f"- service-window dynamic J: `{energy['energy_j']['dynamic']}`",
+        f"- service-window leakage J: `{energy['energy_j']['leakage']}`",
+        f"- service-window total J: `{energy['energy_j']['dynamic_plus_leakage']}`",
+        f"- replica-scaled wrapper compute J/token: `{best['replica_scaled_wrapper_compute_energy_j_per_token']}`",
+        "",
+        "## Residual Cycles",
+        "",
+        f"- qkv: `{payload['recost_contract']['residual_breakdown']['qkv_cycles']}`",
+        f"- reduction: `{payload['recost_contract']['residual_breakdown']['cross_tile_reduction_cycles']}`",
+        f"- kv_write: `{payload['recost_contract']['residual_breakdown']['kv_write_cycles']}`",
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--metrics-csv", type=Path, required=True)
+    parser.add_argument("--recost-json", type=Path, required=True)
+    parser.add_argument("--orfs-design-config", type=Path, required=True)
+    parser.add_argument("--activity-dir", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_report(
+        config=args.config,
+        metrics_csv=args.metrics_csv,
+        recost_json=args.recost_json,
+        orfs_design_config=args.orfs_design_config,
+        activity_dir=args.activity_dir,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(args.out_md, payload)
+    print(json.dumps({"ok": True, "decision": payload["decision"], "out": str(args.out)}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/generate_attention_dual_stream_schedule_wrapper_activity.py
+++ b/npu/eval/generate_attention_dual_stream_schedule_wrapper_activity.py
@@ -1,0 +1,1265 @@
+#!/usr/bin/env python3
+"""Generate a deterministic dual-cluster wrapper VCD and activity manifest."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+import hashlib
+import json
+import math
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_dual_stream_schedule_wrapper import (  # noqa: E402
+    _validate as _validate_wrapper_config,
+    _write_wrapper as _write_wrapper_rtl,
+)
+
+JsonDict = dict[str, Any]
+
+_DEFAULT_CLOCK_PERIOD_NS = 10.0
+_DEFAULT_SERVICE_WINDOW_CYCLES = 986
+_DEFAULT_WARMUP_CYCLES = 32
+_DEFAULT_COMMAND_COUNT = 340
+_OUTPUT_VCD_NAME = "attention_dual_stream_schedule_wrapper_activity.vcd"
+_OUTPUT_MANIFEST_NAME = "attention_dual_stream_schedule_wrapper_activity_manifest.json"
+_OUTPUT_TOP_NAME = "top.v"
+_OUTPUT_CONFIG_NAME = "config.json"
+_OUTPUT_WRAPPER_MANIFEST_NAME = "attention_dual_stream_schedule_wrapper_manifest.json"
+_SCOPE = "tb/dut"
+
+
+def _load(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected a JSON object: {path}")
+    return payload
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    return _sha256_bytes(path.read_bytes())
+
+
+def _hash_json(value: object) -> str:
+    return _sha256_bytes(json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+
+
+def _portable_path(path: Path) -> str:
+    if not path.is_absolute():
+        return path.as_posix()
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.name
+
+
+def _tool(name: str) -> str:
+    resolved = shutil.which(name)
+    if resolved:
+        return resolved
+    fallback = Path("/oss-cad-suite/bin") / name
+    if fallback.is_file():
+        return str(fallback)
+    raise FileNotFoundError(f"unable to locate required simulator tool: {name}")
+
+
+def _normalize_vcd(path: Path) -> None:
+    tmp_path = path.with_suffix(path.suffix + ".normalized")
+    in_date_block = False
+    date_rewritten = False
+    with path.open("r", encoding="utf-8", errors="replace") as src, tmp_path.open(
+        "w", encoding="utf-8"
+    ) as dst:
+        for line in src:
+            if not date_rewritten and not in_date_block and line.strip() == "$date":
+                dst.write("$date\n")
+                dst.write("  deterministic_schedule_wrapper_activity_v1\n")
+                in_date_block = True
+                date_rewritten = True
+                continue
+            if in_date_block:
+                if line.strip() == "$end":
+                    dst.write("$end\n")
+                    in_date_block = False
+                continue
+            dst.write(line)
+    tmp_path.replace(path)
+
+
+def _mask(width: int) -> int:
+    return (1 << width) - 1 if width > 0 else 0
+
+
+def _u(value: int, width: int) -> int:
+    return value & _mask(width)
+
+
+def _s(value: int, width: int) -> int:
+    value &= _mask(width)
+    sign = 1 << (width - 1)
+    return value - (1 << width) if value & sign else value
+
+
+def _extract(value: int, lsb: int, width: int) -> int:
+    return (value >> lsb) & _mask(width)
+
+
+@dataclass(frozen=True)
+class _Command:
+    tile_id: int
+    wave_id: int
+    base_token: int
+
+
+@dataclass
+class _DatapathState:
+    seed_state: int = 1
+    cycle_ctr: int = 0
+    stream_buf_0: int = 0
+    stream_buf_1: int = 0
+    softmax_scores_pipe_0: int = 0
+    stream_buf_0_pipe_0: int = 0
+    stream_buf_0_pipe_1: int = 0
+    stream_buf_1_pipe_0: int = 0
+    stream_buf_1_pipe_1: int = 0
+    score_mix_0_pipe_0: int = 0
+    score_mix_0_pipe_1: int = 0
+    score_mix_1_pipe_0: int = 0
+    score_mix_1_pipe_1: int = 0
+    softmax_weights: int = 0
+    value_accum_0: int = 0
+    value_accum_1: int = 0
+    done: int = 0
+    softmax_weights_out: int = 0
+    value_accum_0_out: int = 0
+    value_accum_1_out: int = 0
+    score_mix_0_out: int = 0
+    score_mix_1_out: int = 0
+
+
+@dataclass
+class _ClusterState:
+    active: bool = False
+    service_ctr: int = 0
+    seed: int = 0
+    datapath: _DatapathState = field(default_factory=_DatapathState)
+
+
+@dataclass
+class _WrapperState:
+    count: int = 0
+    rr_ptr: int = 0
+    inflight: tuple[int, int] = (0, 0)
+    dispatch_valid: bool = False
+    dispatch_cluster_id: int = 0
+    dispatch_tile_id: int = 0
+    dispatch_wave_id: int = 0
+    dispatch_base_token: int = 0
+    queue: tuple[_Command, ...] = ()
+    clusters: tuple[_ClusterState, _ClusterState] = ()
+    completed_count: int = 0
+    result_fold: int = 0
+
+
+def _default_clusters() -> tuple[_ClusterState, _ClusterState]:
+    return (
+        _ClusterState(seed=0x1000),
+        _ClusterState(seed=0x1001),
+    )
+
+
+def _command_for_index(index: int, *, tile_bits: int, wave_bits: int, base_bits: int) -> _Command:
+    return _Command(
+        tile_id=((index * 37) + 11) & _mask(tile_bits),
+        wave_id=((index * 13) + (index // 7) + 3) & _mask(wave_bits),
+        base_token=((index * 29) + (index * index) + 5) & _mask(base_bits),
+    )
+
+
+def _command_gap(cycle: int) -> bool:
+    return (cycle % 23) == 7
+
+
+def _external_ready(
+    cycle: int,
+    *,
+    cluster_active: tuple[bool, bool],
+) -> tuple[int, int]:
+    return (
+        1 if (not cluster_active[0] and (cycle % 2) == 0) else 0,
+        1 if (not cluster_active[1] and (cycle % 2) == 0) else 0,
+    )
+
+
+def _lfsr_step(seed_state: int) -> int:
+    bit = ((seed_state >> 31) ^ (seed_state >> 21) ^ (seed_state >> 1) ^ seed_state) & 0x1
+    return ((_u(seed_state, 32) << 1) & 0xFFFF_FFFF) | bit
+
+
+def _stream_insert(seed_state: int, cycle_ctr: int, stream: int) -> int:
+    return _u(seed_state ^ cycle_ctr ^ (0x13572468 ^ stream), 32)
+
+
+def _exp_lut_div_weights(
+    scores: list[int],
+    *,
+    accum_bits: int,
+    weight_bits: int,
+    input_frac_bits: int,
+    bucket_shift: int,
+) -> int:
+    output_scale = (1 << weight_bits) - 1
+    input_scale = 1 << input_frac_bits
+    bucket_step = 1 << bucket_shift
+    max_delta = 8 * input_scale
+    max_bucket = (max_delta + (bucket_step >> 1)) >> bucket_shift
+    row_max = max(scores)
+    exp_weights: list[int] = []
+    for lane in scores:
+        delta = max(0, row_max - lane)
+        delta = min(delta, max_delta)
+        exp_bucket = (delta + (bucket_step >> 1)) >> bucket_shift
+        exp_bucket = min(exp_bucket, max_bucket)
+        weight = int(math.exp(-((exp_bucket * bucket_step) / float(input_scale))) * output_scale + 0.5)
+        exp_weights.append(weight)
+    sum_weight = sum(exp_weights)
+    packed = 0
+    for index, weight in enumerate(exp_weights):
+        numer = (weight * output_scale) + (sum_weight >> 1)
+        lane_out = numer // sum_weight if sum_weight else 0
+        lane_out = min(lane_out, output_scale)
+        packed |= _u(lane_out, weight_bits) << (index * weight_bits)
+    return packed & _mask(len(scores) * weight_bits)
+
+
+def _datapath_score_mix_and_scores(
+    state: _DatapathState,
+    *,
+    array_m: int,
+    array_n: int,
+    k_unroll: int,
+    row_elems: int,
+    stream_buffer_bits: int,
+    mac_accum_bits: int,
+    softmax_score_bits: int,
+) -> tuple[int, int, int]:
+    macs_per_stream = array_m * array_n * k_unroll
+    score_lane_terms: list[int] = [0 for _ in range(row_elems)]
+    score_mix_terms = [0, 0]
+    compute_fold = 0
+    stream_bufs = (state.stream_buf_0, state.stream_buf_1)
+    for stream in range(2):
+        stream_buf = stream_bufs[stream]
+        for idx in range(macs_per_stream):
+            row = idx // (array_n * k_unroll)
+            col = (idx // k_unroll) % array_n
+            ku = idx % k_unroll
+            const_a = (0x3D ^ ((stream + 1) * 0x17) ^ ((row + 1) * 0x13) ^ ((col + 1) * 0x27) ^ (ku * 0x41)) & 0xFF
+            const_b = (0x21 ^ ((stream + 1) * 0x2B) ^ ((row + 1) * 0x1D) ^ ((col + 1) * 0xA3) ^ (ku * 0x55)) & 0xFF
+            const_c = (
+                0x001011
+                ^ ((stream + 1) * 0x0101)
+                ^ ((row + 1) * 0x0007)
+                ^ ((col + 1) * 0x000B)
+                ^ (ku * 0x0013)
+            ) & _mask(mac_accum_bits)
+            mac_a = _u(
+                _extract(state.seed_state, 0, 8)
+                ^ _extract(stream_buf, (idx * 7) % (stream_buffer_bits - 7), 8)
+                ^ const_a
+                ^ _extract(state.cycle_ctr, 0, 8),
+                8,
+            )
+            mac_b = _u(
+                _extract(state.seed_state, 8, 8)
+                ^ _extract(stream_buf, (idx * 11) % (stream_buffer_bits - 7), 8)
+                ^ const_b
+                ^ _extract(state.cycle_ctr, 8, 8),
+                8,
+            )
+            mac_c = _u(
+                _u(state.cycle_ctr, mac_accum_bits)
+                ^ _extract(stream_buf, (idx * 13) % (stream_buffer_bits - mac_accum_bits + 1), mac_accum_bits)
+                ^ const_c,
+                mac_accum_bits,
+            )
+            product = _s(mac_a, 8) * _s(mac_b, 8)
+            mac_r = _u(product + _s(mac_c, mac_accum_bits), mac_accum_bits)
+            score_lane_terms[idx % row_elems] ^= _extract(mac_r, 0, softmax_score_bits)
+            score_mix_terms[stream] ^= mac_r
+            compute_fold ^= _extract(mac_r, 0, 32)
+    softmax_scores = 0
+    for lane in reversed(range(row_elems)):
+        softmax_scores = (softmax_scores << softmax_score_bits) | _u(
+            score_lane_terms[lane], softmax_score_bits
+        )
+    return (
+        softmax_scores & _mask(row_elems * softmax_score_bits),
+        _u(score_mix_terms[0], mac_accum_bits),
+        _u(score_mix_terms[1], mac_accum_bits),
+    )
+
+
+def _value_accum(
+    *,
+    stream_data: int,
+    weights: int,
+    score_mix: int,
+    row_elems: int,
+    weight_bits: int,
+    value_bits: int,
+    value_lanes: int,
+    stream_buffer_bits: int,
+    score_mix_bits: int,
+) -> int:
+    acc_bits = 40
+    product_bits = value_bits + weight_bits + 1
+    product_sum = 0
+    for lane in range(value_lanes):
+        value = _s(_extract(stream_data, (lane * value_bits) % (stream_buffer_bits - value_bits + 1), value_bits), value_bits)
+        weight = _u(_extract(weights, (lane % row_elems) * weight_bits, weight_bits), weight_bits)
+        product = value * weight
+        product_sum += product
+    return _u(product_sum + _s(score_mix, score_mix_bits), acc_bits)
+
+
+def _datapath_step(
+    state: _DatapathState,
+    *,
+    seed_input: int,
+    start: bool,
+    array_m: int,
+    array_n: int,
+    k_unroll: int,
+    row_elems: int,
+    stream_buffer_bits: int,
+    mac_accum_bits: int,
+    softmax_score_bits: int,
+    softmax_weight_bits: int,
+    softmax_input_frac_bits: int,
+    softmax_bucket_shift: int,
+    value_bits: int,
+    value_lanes: int,
+    score_mix_bits: int,
+) -> _DatapathState:
+    softmax_scores, score_mix_0, score_mix_1 = _datapath_score_mix_and_scores(
+        state,
+        array_m=array_m,
+        array_n=array_n,
+        k_unroll=k_unroll,
+        row_elems=row_elems,
+        stream_buffer_bits=stream_buffer_bits,
+        mac_accum_bits=mac_accum_bits,
+        softmax_score_bits=softmax_score_bits,
+    )
+    scores_for_softmax = [
+        _s(_extract(state.softmax_scores_pipe_0, lane * softmax_score_bits, softmax_score_bits), softmax_score_bits)
+        for lane in range(row_elems)
+    ]
+    softmax_weights_next = _exp_lut_div_weights(
+        scores_for_softmax,
+        accum_bits=40,
+        weight_bits=softmax_weight_bits,
+        input_frac_bits=softmax_input_frac_bits,
+        bucket_shift=softmax_bucket_shift,
+    )
+    value_accum_0_next = _value_accum(
+        stream_data=state.stream_buf_0_pipe_1,
+        weights=state.softmax_weights,
+        score_mix=state.score_mix_0_pipe_1,
+        row_elems=row_elems,
+        weight_bits=softmax_weight_bits,
+        value_bits=value_bits,
+        value_lanes=value_lanes,
+        stream_buffer_bits=stream_buffer_bits,
+        score_mix_bits=score_mix_bits,
+    )
+    value_accum_1_next = _value_accum(
+        stream_data=state.stream_buf_1_pipe_1,
+        weights=state.softmax_weights,
+        score_mix=state.score_mix_1_pipe_1,
+        row_elems=row_elems,
+        weight_bits=softmax_weight_bits,
+        value_bits=value_bits,
+        value_lanes=value_lanes,
+        stream_buffer_bits=stream_buffer_bits,
+        score_mix_bits=score_mix_bits,
+    )
+    next_state = _DatapathState(
+        seed_state=_u(_lfsr_step(state.seed_state) ^ seed_input, 32),
+        cycle_ctr=_u(state.cycle_ctr + 1, 16),
+        stream_buf_0=_u(
+            ((state.stream_buf_0 & _mask(stream_buffer_bits - 32)) << 32)
+            | _stream_insert(state.seed_state, state.cycle_ctr, 0),
+            stream_buffer_bits,
+        ),
+        stream_buf_1=_u(
+            ((state.stream_buf_1 & _mask(stream_buffer_bits - 32)) << 32)
+            | _stream_insert(state.seed_state, state.cycle_ctr, 1),
+            stream_buffer_bits,
+        ),
+        softmax_scores_pipe_0=softmax_scores,
+        stream_buf_0_pipe_0=state.stream_buf_0,
+        stream_buf_0_pipe_1=state.stream_buf_0_pipe_0,
+        stream_buf_1_pipe_0=state.stream_buf_1,
+        stream_buf_1_pipe_1=state.stream_buf_1_pipe_0,
+        score_mix_0_pipe_0=score_mix_0,
+        score_mix_0_pipe_1=state.score_mix_0_pipe_0,
+        score_mix_1_pipe_0=score_mix_1,
+        score_mix_1_pipe_1=state.score_mix_1_pipe_0,
+        softmax_weights=softmax_weights_next,
+        value_accum_0=value_accum_0_next,
+        value_accum_1=value_accum_1_next,
+        done=1 if start else 0,
+        softmax_weights_out=state.softmax_weights_out,
+        value_accum_0_out=state.value_accum_0_out,
+        value_accum_1_out=state.value_accum_1_out,
+        score_mix_0_out=state.score_mix_0_out,
+        score_mix_1_out=state.score_mix_1_out,
+    )
+    if start:
+        next_state.softmax_weights_out = softmax_weights_next
+        next_state.value_accum_0_out = value_accum_0_next
+        next_state.value_accum_1_out = value_accum_1_next
+        next_state.score_mix_0_out = score_mix_0
+        next_state.score_mix_1_out = score_mix_1
+    return next_state
+
+
+def _datapath_result_fold(state: _DatapathState) -> int:
+    return _u(
+        _extract(state.softmax_weights_out, 0, 32)
+        ^ _extract(state.value_accum_0_out, 0, 32)
+        ^ _extract(state.value_accum_1_out, 0, 32)
+        ^ _extract(state.score_mix_0_out, 0, 32)
+        ^ _extract(state.score_mix_1_out, 0, 32)
+        ^ (state.done & 0x1),
+        32,
+    )
+
+
+def _dispatch_selected_cluster(
+    state: _WrapperState,
+    *,
+    cluster_ready: tuple[int, int],
+    max_inflight: int,
+) -> tuple[int, bool]:
+    for offset in range(2):
+        idx = (state.rr_ptr + offset) % 2
+        if cluster_ready[idx] and state.inflight[idx] < max_inflight:
+            return idx, True
+    return 0, False
+
+
+def _wrapper_step(
+    state: _WrapperState,
+    *,
+    params: JsonDict,
+    cycle: int,
+    command_valid: bool,
+    command: _Command,
+    external_ready: tuple[int, int],
+) -> tuple[_WrapperState, JsonDict]:
+    clusters = list(state.clusters or _default_clusters())
+    cluster_service_cycles = int(params["cluster_service_cycles"])
+    cluster_ready = tuple(
+        1 if external_ready[idx] and not clusters[idx].active else 0 for idx in range(2)
+    )
+    queue_empty = len(state.queue) == 0
+    queue_full = len(state.queue) >= int(params["queue_depth"])
+    command_ready = not queue_full
+    dispatch_ready = True
+    issue_fire = bool(state.dispatch_valid and dispatch_ready)
+    push_fire = bool(command_valid and command_ready)
+    pop_fire = issue_fire
+    selected_cluster, selected_valid = _dispatch_selected_cluster(
+        state,
+        cluster_ready=cluster_ready,
+        max_inflight=int(params["max_inflight_per_cluster"]),
+    )
+    cluster_complete = tuple(
+        clusters[idx].active and clusters[idx].service_ctr == (cluster_service_cycles - 1)
+        for idx in range(2)
+    )
+    if cluster_complete[0]:
+        cluster_done_valid = True
+        cluster_done_id = 0
+    elif cluster_complete[1]:
+        cluster_done_valid = True
+        cluster_done_id = 1
+    else:
+        cluster_done_valid = False
+        cluster_done_id = 0
+    cluster_start = tuple(issue_fire and state.dispatch_cluster_id == idx for idx in range(2))
+    accepted = False
+    issue = None
+    if push_fire:
+        accepted = True
+    if issue_fire:
+        issue = {
+            "cycle": cycle,
+            "cluster": state.dispatch_cluster_id,
+            "tile_id": state.dispatch_tile_id,
+            "wave_id": state.dispatch_wave_id,
+            "base_token": state.dispatch_base_token,
+        }
+    completed = None
+    result_fold = state.result_fold
+    completed_count = state.completed_count
+    if cluster_done_valid:
+        completed_count += 1
+        result_fold = _u(
+            result_fold
+            ^ _datapath_result_fold(clusters[cluster_done_id].datapath)
+            ^ _u(command.tile_id, 16)
+            ^ cluster_done_id,
+            32,
+        )
+        completed = {
+            "cycle": cycle,
+            "cluster": cluster_done_id,
+            "completed_count": completed_count,
+            "result_fold": result_fold,
+        }
+    next_clusters: list[_ClusterState] = []
+    for idx in range(2):
+        cluster = clusters[idx]
+        new_seed = cluster.seed
+        new_active = cluster.active
+        new_service_ctr = cluster.service_ctr
+        if cluster_start[idx]:
+            new_active = True
+            new_service_ctr = 0
+            new_seed = _u(
+                state.dispatch_tile_id
+                ^ state.dispatch_wave_id
+                ^ state.dispatch_base_token
+                ^ (0x9E3779B9 ^ (idx * 0x01010101)),
+                32,
+            )
+        elif cluster_complete[idx]:
+            new_active = False
+            new_service_ctr = 0
+        elif cluster.active:
+            new_service_ctr = _u(cluster.service_ctr + 1, 32)
+        datapath_next = _datapath_step(
+            cluster.datapath,
+            seed_input=cluster.seed,
+            start=cluster_start[idx],
+            array_m=int(params["datapath_manifest"]["array_m"]),
+            array_n=int(params["datapath_manifest"]["array_n"]),
+            k_unroll=int(params["datapath_manifest"]["k_unroll"]),
+            row_elems=int(params["datapath_manifest"]["softmax_row_elems"]),
+            stream_buffer_bits=int(params["datapath_manifest"]["stream_buffer_bits"]),
+            mac_accum_bits=int(params["datapath_manifest"]["mac_accum_bits"]),
+            softmax_score_bits=int(params["datapath_manifest"]["softmax_score_bits"]),
+            softmax_weight_bits=int(params["datapath_manifest"]["softmax_weight_bits"]),
+            softmax_input_frac_bits=int(params["datapath_manifest"]["softmax_input_frac_bits"]),
+            softmax_bucket_shift=int(
+                params["datapath_manifest"]["softmax_reciprocal_lut_bucket_shift"]
+            ),
+            value_bits=int(params["datapath_manifest"]["value_bits"]),
+            value_lanes=int(params["datapath_manifest"]["value_lanes"]),
+            score_mix_bits=int(params["datapath_manifest"]["mac_accum_bits"]),
+        )
+        next_clusters.append(
+            _ClusterState(
+                active=new_active,
+                service_ctr=new_service_ctr,
+                seed=new_seed,
+                datapath=datapath_next,
+            )
+        )
+    old_queue = list(state.queue)
+    head_payload = old_queue[0] if old_queue else _Command(0, 0, 0)
+    queue = list(old_queue)
+    if push_fire:
+        queue.append(command)
+    if pop_fire and queue:
+        queue.pop(0)
+    inflight = list(state.inflight)
+    for idx in range(2):
+        if cluster_done_valid and cluster_done_id == idx and not (pop_fire and state.dispatch_cluster_id == idx):
+            if inflight[idx] > 0:
+                inflight[idx] -= 1
+        elif pop_fire and state.dispatch_cluster_id == idx and not (
+            cluster_done_valid and cluster_done_id == idx and inflight[idx] > 0
+        ):
+            inflight[idx] += 1
+    rr_ptr = state.rr_ptr
+    if pop_fire:
+        rr_ptr = (state.dispatch_cluster_id + 1) % 2
+    dispatch_valid = state.dispatch_valid
+    dispatch_cluster_id = state.dispatch_cluster_id
+    dispatch_tile_id = state.dispatch_tile_id
+    dispatch_wave_id = state.dispatch_wave_id
+    dispatch_base_token = state.dispatch_base_token
+    if (not state.dispatch_valid) or dispatch_ready:
+        dispatch_valid = bool(len(old_queue) > 0 and selected_valid)
+        dispatch_cluster_id = selected_cluster
+        dispatch_tile_id = head_payload.tile_id
+        dispatch_wave_id = head_payload.wave_id
+        dispatch_base_token = head_payload.base_token
+    next_state = _WrapperState(
+        count=len(queue),
+        rr_ptr=rr_ptr,
+        inflight=(inflight[0], inflight[1]),
+        dispatch_valid=dispatch_valid,
+        dispatch_cluster_id=dispatch_cluster_id,
+        dispatch_tile_id=dispatch_tile_id,
+        dispatch_wave_id=dispatch_wave_id,
+        dispatch_base_token=dispatch_base_token,
+        queue=tuple(queue),
+        clusters=(next_clusters[0], next_clusters[1]),
+        completed_count=completed_count,
+        result_fold=result_fold,
+    )
+    trace_row = {
+        "cycle": cycle,
+        "command_valid": int(command_valid),
+        "command_ready": int(command_ready),
+        "tile_id": command.tile_id,
+        "wave_id": command.wave_id,
+        "base_token": command.base_token,
+        "external_ready": list(external_ready),
+        "dispatch_valid": int(state.dispatch_valid),
+        "queue_depth": len(state.queue),
+        "completed_count": state.completed_count,
+        "result_fold": f"{state.result_fold:08x}",
+        "cluster_active": [int(cluster.active) for cluster in clusters],
+    }
+    return next_state, {
+        "trace": trace_row,
+        "accepted": (
+            {
+                "cycle": cycle,
+                "tile_id": command.tile_id,
+                "wave_id": command.wave_id,
+                "base_token": command.base_token,
+            }
+            if accepted
+            else None
+        ),
+        "issue": issue,
+        "completed": completed,
+    }
+
+
+def _simulate_reference(
+    *,
+    params: JsonDict,
+    service_window_cycles: int,
+    warmup_cycles: int,
+    command_count: int,
+) -> JsonDict:
+    commands = [
+        _command_for_index(
+            index,
+            tile_bits=int(params["tile_id_bits"]),
+            wave_bits=int(params["wave_id_bits"]),
+            base_bits=int(params["base_token_bits"]),
+        )
+        for index in range(command_count)
+    ]
+    state = _WrapperState(
+        queue=(),
+        clusters=_default_clusters(),
+    )
+    send_index = 0
+    cycle = 0
+    accepted_rows: list[JsonDict] = []
+    issue_rows: list[JsonDict] = []
+    completed_rows: list[JsonDict] = []
+    trace_rows: list[JsonDict] = []
+    ready_low_cycles = 0
+    window_active_cycles = 0
+    window_dual_active_cycles = 0
+    window_completed_count = 0
+    window_issue_counts = [0, 0]
+    max_queue_depth = 0
+    drain_limit = warmup_cycles + service_window_cycles + max(command_count * 4, 256)
+    while cycle < drain_limit:
+        command = commands[min(send_index, command_count - 1)]
+        command_valid = send_index < command_count and cycle > 0 and not _command_gap(cycle)
+        external_ready = _external_ready(
+            cycle,
+            cluster_active=(
+                bool(state.clusters[0].active),
+                bool(state.clusters[1].active),
+            ),
+        )
+        state, events = _wrapper_step(
+            state,
+            params=params,
+            cycle=cycle,
+            command_valid=command_valid,
+            command=command,
+            external_ready=external_ready,
+        )
+        trace_rows.append(events["trace"])
+        max_queue_depth = max(max_queue_depth, int(events["trace"]["queue_depth"]))
+        if not int(events["trace"]["command_ready"]):
+            ready_low_cycles += 1
+        if events["accepted"] is not None:
+            accepted_rows.append(events["accepted"])
+            send_index += 1
+        if events["issue"] is not None:
+            issue_rows.append(events["issue"])
+        if events["completed"] is not None:
+            completed_rows.append(events["completed"])
+        if warmup_cycles <= cycle < warmup_cycles + service_window_cycles:
+            if any(events["trace"]["cluster_active"]):
+                window_active_cycles += 1
+            if events["trace"]["cluster_active"] == [1, 1]:
+                window_dual_active_cycles += 1
+            if events["issue"] is not None:
+                window_issue_counts[int(events["issue"]["cluster"])] += 1
+            if events["completed"] is not None:
+                window_completed_count += 1
+        if cycle >= warmup_cycles + service_window_cycles and send_index >= command_count:
+            if not state.clusters[0].active and not state.clusters[1].active and len(state.queue) == 0:
+                break
+        cycle += 1
+    if window_active_cycles != service_window_cycles:
+        raise RuntimeError("reference simulation did not keep the wrapper active across the full service window")
+    if ready_low_cycles <= 0:
+        raise RuntimeError("reference simulation did not exercise command_ready backpressure")
+    if window_issue_counts[0] <= 0 or window_issue_counts[1] <= 0:
+        raise RuntimeError("reference simulation did not issue commands across both clusters")
+    if state.completed_count != len(accepted_rows):
+        raise RuntimeError("reference simulation did not fully drain accepted commands")
+    return {
+        "commands": commands,
+        "accepted_rows": accepted_rows,
+        "issue_rows": issue_rows,
+        "completed_rows": completed_rows,
+        "trace_rows": trace_rows,
+        "final_cycle": cycle,
+        "final_completed_count": state.completed_count,
+        "final_result_fold": f"{state.result_fold:08x}",
+        "ready_low_cycles": ready_low_cycles,
+        "window_active_cycles": window_active_cycles,
+        "window_dual_active_cycles": window_dual_active_cycles,
+        "window_completed_count": window_completed_count,
+        "window_issue_counts": {"0": window_issue_counts[0], "1": window_issue_counts[1]},
+        "max_queue_depth": max_queue_depth,
+    }
+
+
+def _tb_text(
+    *,
+    params: JsonDict,
+    commands: list[_Command],
+    clock_period_ns: float,
+    warmup_cycles: int,
+    service_window_cycles: int,
+    vcd_path: str,
+) -> str:
+    top_name = str(params["top_name"])
+    tile_bits = int(params["tile_id_bits"])
+    wave_bits = int(params["wave_id_bits"])
+    base_bits = int(params["base_token_bits"])
+    command_init_lines: list[str] = []
+    for idx, command in enumerate(commands):
+        command_init_lines.append(
+            f"    command_tile_ids[{idx}] = {tile_bits}'d{command.tile_id}; "
+            f"command_wave_ids[{idx}] = {wave_bits}'d{command.wave_id}; "
+            f"command_base_tokens[{idx}] = {base_bits}'d{command.base_token};"
+        )
+    command_count = len(commands)
+    cycle_limit = warmup_cycles + service_window_cycles + 128
+    return f"""`timescale 1ns/1ps
+module tb;
+  localparam integer COMMAND_COUNT = {command_count};
+  localparam integer WARMUP_CYCLES = {warmup_cycles};
+  localparam integer SERVICE_WINDOW_CYCLES = {service_window_cycles};
+  localparam integer CYCLE_LIMIT = {cycle_limit};
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  reg command_valid;
+  wire command_ready;
+  reg [{tile_bits - 1}:0] command_tile_id;
+  reg [{wave_bits - 1}:0] command_wave_id;
+  reg [{base_bits - 1}:0] command_base_token;
+  reg [1:0] external_cluster_ready;
+  wire [31:0] completed_count;
+  wire [31:0] result_fold;
+  reg [{tile_bits - 1}:0] command_tile_ids [0:COMMAND_COUNT-1];
+  reg [{wave_bits - 1}:0] command_wave_ids [0:COMMAND_COUNT-1];
+  reg [{base_bits - 1}:0] command_base_tokens [0:COMMAND_COUNT-1];
+  integer cycle;
+  integer send_index;
+  integer accepted_count;
+  integer completed_snapshot;
+  integer ready_low_cycles;
+  integer window_active_cycles;
+  integer window_dual_active_cycles;
+  integer window_completed_count;
+  integer window_issue_count_0;
+  integer window_issue_count_1;
+  integer max_queue_depth;
+
+  {top_name} dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .command_valid(command_valid),
+    .command_ready(command_ready),
+    .command_tile_id(command_tile_id),
+    .command_wave_id(command_wave_id),
+    .command_base_token(command_base_token),
+    .external_cluster_ready(external_cluster_ready),
+    .completed_count(completed_count),
+    .result_fold(result_fold)
+  );
+
+  always #{clock_period_ns / 2.0:.3f} clk = ~clk;
+
+  initial begin
+{chr(10).join(command_init_lines)}
+    command_valid = 1'b0;
+    command_tile_id = {{{tile_bits}{{1'b0}}}};
+    command_wave_id = {{{wave_bits}{{1'b0}}}};
+    command_base_token = {{{base_bits}{{1'b0}}}};
+    external_cluster_ready = 2'b00;
+    cycle = 0;
+    send_index = 0;
+    accepted_count = 0;
+    completed_snapshot = 0;
+    ready_low_cycles = 0;
+    window_active_cycles = 0;
+    window_dual_active_cycles = 0;
+    window_completed_count = 0;
+    window_issue_count_0 = 0;
+    window_issue_count_1 = 0;
+    max_queue_depth = 0;
+    $dumpfile("{vcd_path}");
+    $dumpvars(0, tb.dut);
+    $dumpoff;
+    repeat (4) @(posedge clk);
+    rst_n = 1'b1;
+  end
+
+  always @(*) begin
+    if (send_index < COMMAND_COUNT) begin
+      command_tile_id = command_tile_ids[send_index];
+      command_wave_id = command_wave_ids[send_index];
+      command_base_token = command_base_tokens[send_index];
+    end else begin
+      command_tile_id = {{{tile_bits}{{1'b0}}}};
+      command_wave_id = {{{wave_bits}{{1'b0}}}};
+      command_base_token = {{{base_bits}{{1'b0}}}};
+    end
+    command_valid = rst_n && (cycle > 0) && (send_index < COMMAND_COUNT) && ((cycle % 23) != 7);
+    external_cluster_ready[0] = (!dut.cluster_0_active && ((cycle % 2) == 0)) ? 1'b1 : 1'b0;
+    external_cluster_ready[1] = (!dut.cluster_1_active && ((cycle % 2) == 0)) ? 1'b1 : 1'b0;
+  end
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      cycle <= 0;
+      send_index <= 0;
+      accepted_count <= 0;
+      completed_snapshot <= 0;
+      ready_low_cycles <= 0;
+      window_active_cycles <= 0;
+      window_dual_active_cycles <= 0;
+      window_completed_count <= 0;
+      window_issue_count_0 <= 0;
+      window_issue_count_1 <= 0;
+      max_queue_depth <= 0;
+    end else begin
+      if (cycle == WARMUP_CYCLES - 1) begin
+        $dumpon;
+      end
+      if (cycle == WARMUP_CYCLES + SERVICE_WINDOW_CYCLES - 1) begin
+        $dumpoff;
+      end
+      if (!command_ready) begin
+        ready_low_cycles <= ready_low_cycles + 1;
+      end
+      if (dut.u_dispatch.queued_count > max_queue_depth) begin
+        max_queue_depth <= dut.u_dispatch.queued_count;
+      end
+      if (cycle >= WARMUP_CYCLES && cycle < WARMUP_CYCLES + SERVICE_WINDOW_CYCLES) begin
+        if (dut.cluster_0_active || dut.cluster_1_active) begin
+          window_active_cycles <= window_active_cycles + 1;
+        end
+        if (dut.cluster_0_active && dut.cluster_1_active) begin
+          window_dual_active_cycles <= window_dual_active_cycles + 1;
+        end
+      end
+      if (command_valid && command_ready) begin
+        $display("ACCEPT cycle=%0d tile=%0d wave=%0d base=%0d", cycle, command_tile_id, command_wave_id, command_base_token);
+        send_index <= send_index + 1;
+        accepted_count <= accepted_count + 1;
+      end
+      if (dut.cluster_0_start) begin
+        $display("ISSUE cycle=%0d cluster=0 tile=%0d wave=%0d base=%0d", cycle, dut.dispatch_tile_id, dut.dispatch_wave_id, dut.dispatch_base_token);
+        if (cycle >= WARMUP_CYCLES && cycle < WARMUP_CYCLES + SERVICE_WINDOW_CYCLES) begin
+          window_issue_count_0 <= window_issue_count_0 + 1;
+        end
+      end
+      if (dut.cluster_1_start) begin
+        $display("ISSUE cycle=%0d cluster=1 tile=%0d wave=%0d base=%0d", cycle, dut.dispatch_tile_id, dut.dispatch_wave_id, dut.dispatch_base_token);
+        if (cycle >= WARMUP_CYCLES && cycle < WARMUP_CYCLES + SERVICE_WINDOW_CYCLES) begin
+          window_issue_count_1 <= window_issue_count_1 + 1;
+        end
+      end
+      completed_snapshot <= completed_count;
+      if (completed_count != completed_snapshot) begin
+        $display("DONE cycle=%0d cluster=%0d completed=%0d result=%08x",
+                 cycle, dut.cluster_done_id, completed_count, result_fold);
+        if (cycle >= WARMUP_CYCLES && cycle < WARMUP_CYCLES + SERVICE_WINDOW_CYCLES) begin
+          window_completed_count <= window_completed_count + 1;
+        end
+      end
+      if (cycle >= WARMUP_CYCLES + SERVICE_WINDOW_CYCLES &&
+          completed_count == accepted_count &&
+          !dut.cluster_0_active &&
+          !dut.cluster_1_active &&
+          dut.u_dispatch.queue_empty) begin
+        $display("SUMMARY ready_low=%0d window_active=%0d window_dual=%0d window_completed=%0d issue0=%0d issue1=%0d max_queue=%0d",
+                 ready_low_cycles, window_active_cycles, window_dual_active_cycles, window_completed_count,
+                 window_issue_count_0, window_issue_count_1, max_queue_depth);
+        $display("FINAL cycle=%0d accepted=%0d completed=%0d result=%08x", cycle, accepted_count, completed_count, result_fold);
+        $finish;
+      end
+      if (cycle >= CYCLE_LIMIT) begin
+        $display("FAIL timeout cycle=%0d accepted=%0d completed=%0d result=%08x", cycle, accepted_count, completed_count, result_fold);
+        $finish_and_return(1);
+      end
+      cycle <= cycle + 1;
+    end
+  end
+endmodule
+"""
+
+
+def _compile_and_run(*, sources: list[Path], timeout: int = 240) -> str:
+    with tempfile.TemporaryDirectory(prefix="schedule-wrapper-activity-run-") as tmp_text:
+        simv = Path(tmp_text) / "simv"
+        compiled = subprocess.run(
+            [_tool("iverilog"), "-g2012", "-s", "tb", "-o", str(simv), *[str(src) for src in sources]],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if compiled.returncode:
+            raise RuntimeError(f"iverilog failed:\n{compiled.stderr}")
+        run = subprocess.run([_tool("vvp"), str(simv)], capture_output=True, text=True, timeout=timeout)
+        if run.returncode:
+            raise RuntimeError(f"simulation failed:\n{run.stdout}\n{run.stderr}")
+        return run.stdout
+
+
+def _parse_stdout(stdout: str) -> JsonDict:
+    accepted_rows: list[JsonDict] = []
+    issue_rows: list[JsonDict] = []
+    completed_rows: list[JsonDict] = []
+    final_row: JsonDict | None = None
+    summary_row: JsonDict | None = None
+    for raw_line in stdout.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith("ACCEPT "):
+            fields = dict(item.split("=", 1) for item in line.split()[1:])
+            accepted_rows.append(
+                {
+                    "cycle": int(fields["cycle"]),
+                    "tile_id": int(fields["tile"]),
+                    "wave_id": int(fields["wave"]),
+                    "base_token": int(fields["base"]),
+                }
+            )
+            continue
+        if line.startswith("ISSUE "):
+            fields = dict(item.split("=", 1) for item in line.split()[1:])
+            issue_rows.append(
+                {
+                    "cycle": int(fields["cycle"]),
+                    "cluster": int(fields["cluster"]),
+                    "tile_id": int(fields["tile"]),
+                    "wave_id": int(fields["wave"]),
+                    "base_token": int(fields["base"]),
+                }
+            )
+            continue
+        if line.startswith("DONE "):
+            fields = dict(item.split("=", 1) for item in line.split()[1:])
+            completed_rows.append(
+                {
+                    "cycle": int(fields["cycle"]),
+                    "cluster": int(fields["cluster"]),
+                    "completed_count": int(fields["completed"]),
+                    "result_fold": fields["result"].lower(),
+                }
+            )
+            continue
+        if line.startswith("FINAL "):
+            fields = dict(item.split("=", 1) for item in line.split()[1:])
+            final_row = {
+                "cycle": int(fields["cycle"]),
+                "accepted": int(fields["accepted"]),
+                "completed": int(fields["completed"]),
+                "result_fold": fields["result"].lower(),
+            }
+            continue
+        if line.startswith("SUMMARY "):
+            fields = dict(item.split("=", 1) for item in line.split()[1:])
+            summary_row = {
+                "ready_low_cycles": int(fields["ready_low"]),
+                "window_active_cycles": int(fields["window_active"]),
+                "window_dual_active_cycles": int(fields["window_dual"]),
+                "window_completed_count": int(fields["window_completed"]),
+                "window_issue_counts": {
+                    "0": int(fields["issue0"]),
+                    "1": int(fields["issue1"]),
+                },
+                "max_queue_depth": int(fields["max_queue"]),
+            }
+            continue
+        if line.startswith("FAIL "):
+            raise RuntimeError(line)
+    if final_row is None:
+        raise RuntimeError("simulation did not emit FINAL line")
+    if summary_row is None:
+        raise RuntimeError("simulation did not emit SUMMARY line")
+    return {
+        "accepted_rows": accepted_rows,
+        "issue_rows": issue_rows,
+        "completed_rows": completed_rows,
+        "summary_row": summary_row,
+        "final_row": final_row,
+    }
+
+
+def _assert_equal(label: str, expected: object, observed: object) -> None:
+    if expected != observed:
+        raise RuntimeError(f"schedule-wrapper activity mismatch in {label}")
+
+
+def _completed_timeline(rows: list[JsonDict]) -> list[JsonDict]:
+    return [
+        {
+            "cycle": int(row["cycle"]) + 1,
+            "completed_count": int(row["completed_count"]),
+        }
+        for row in rows
+    ]
+
+
+def generate_activity(
+    config: JsonDict,
+    out_dir: Path,
+    *,
+    clock_period_ns: float = _DEFAULT_CLOCK_PERIOD_NS,
+    service_window_cycles: int = _DEFAULT_SERVICE_WINDOW_CYCLES,
+    warmup_cycles: int = _DEFAULT_WARMUP_CYCLES,
+    command_count: int = _DEFAULT_COMMAND_COUNT,
+) -> JsonDict:
+    if clock_period_ns <= 0.0:
+        raise ValueError("clock_period_ns must be > 0")
+    if service_window_cycles <= 0:
+        raise ValueError("service_window_cycles must be > 0")
+    if warmup_cycles < 4:
+        raise ValueError("warmup_cycles must be >= 4")
+    cfg = json.loads(json.dumps(config))
+    params = _validate_wrapper_config(cfg)
+    if int(params["clusters"]) != 2:
+        raise ValueError("wrapper activity generator currently requires clusters=2")
+    datapath_manifest = json.loads(json.dumps(params["datapath_params"]))
+    if bool(datapath_manifest.get("equivalence_hash")):
+        raise ValueError("wrapper activity generator requires datapath equivalence_hash=false")
+    if str(datapath_manifest.get("semantic_profile") or "").strip() != "score32_exp_lut_div":
+        raise ValueError("wrapper activity generator requires semantic_profile=score32_exp_lut_div")
+    if str(datapath_manifest.get("softmax_impl") or "").strip() != "exp_lut_div":
+        raise ValueError("wrapper activity generator requires softmax_impl=exp_lut_div")
+    runtime_params = {
+        **params,
+        "datapath_manifest": datapath_manifest,
+    }
+    out_dir.mkdir(parents=True, exist_ok=True)
+    reference = _simulate_reference(
+        params=runtime_params,
+        service_window_cycles=service_window_cycles,
+        warmup_cycles=warmup_cycles,
+        command_count=command_count,
+    )
+    with tempfile.TemporaryDirectory(prefix="schedule-wrapper-activity-") as tmp_text:
+        rtl_dir = Path(tmp_text) / "rtl"
+        _write_wrapper_rtl(cfg=cfg, params=params, out_path=rtl_dir)
+        top_path = rtl_dir / _OUTPUT_TOP_NAME
+        tb_path = Path(tmp_text) / "tb.sv"
+        tb_path.write_text(
+            _tb_text(
+                params=runtime_params,
+                commands=reference["commands"],
+                clock_period_ns=clock_period_ns,
+                warmup_cycles=warmup_cycles,
+                service_window_cycles=service_window_cycles,
+                vcd_path=str((out_dir / _OUTPUT_VCD_NAME).resolve()),
+            ),
+            encoding="utf-8",
+        )
+        stdout = _compile_and_run(sources=[top_path, tb_path])
+        generated_paths = {
+            _OUTPUT_CONFIG_NAME: rtl_dir / _OUTPUT_CONFIG_NAME,
+            _OUTPUT_TOP_NAME: top_path,
+            _OUTPUT_WRAPPER_MANIFEST_NAME: rtl_dir / _OUTPUT_WRAPPER_MANIFEST_NAME,
+        }
+        for name, src in generated_paths.items():
+            (out_dir / name).write_bytes(src.read_bytes())
+    vcd_path = out_dir / _OUTPUT_VCD_NAME
+    if not vcd_path.is_file():
+        raise RuntimeError("simulation did not emit VCD")
+    _normalize_vcd(vcd_path)
+    observed = _parse_stdout(stdout)
+    _assert_equal("accepted_rows", reference["accepted_rows"], observed["accepted_rows"])
+    _assert_equal("issue_rows", reference["issue_rows"], observed["issue_rows"])
+    _assert_equal(
+        "completed_timeline",
+        _completed_timeline(reference["completed_rows"]),
+        [
+            {
+                "cycle": int(row["cycle"]),
+                "completed_count": int(row["completed_count"]),
+            }
+            for row in observed["completed_rows"]
+        ],
+    )
+    _assert_equal("final completed count", reference["final_completed_count"], observed["final_row"]["completed"])
+    _assert_equal("summary_row", {
+        "ready_low_cycles": reference["ready_low_cycles"],
+        "window_active_cycles": reference["window_active_cycles"],
+        "window_dual_active_cycles": reference["window_dual_active_cycles"],
+        "window_completed_count": reference["window_completed_count"],
+        "window_issue_counts": reference["window_issue_counts"],
+        "max_queue_depth": reference["max_queue_depth"],
+    }, observed["summary_row"])
+    if observed["final_row"]["accepted"] != len(reference["accepted_rows"]):
+        raise RuntimeError("accepted count mismatch in final row")
+    manifest = {
+        "version": 1,
+        "model": "attention_dual_stream_schedule_wrapper_activity_v1",
+        "generator": "npu/eval/generate_attention_dual_stream_schedule_wrapper_activity.py",
+        "clock_period_ns": clock_period_ns,
+        "scope": _SCOPE,
+        "service_window_cycles": service_window_cycles,
+        "cycle_count": service_window_cycles,
+        "warmup_cycles": warmup_cycles,
+        "cluster_service_cycles": int(params["cluster_service_cycles"]),
+        "total_sim_cycles": int(reference["final_cycle"]),
+        "artifacts": {
+            "config_json": _OUTPUT_CONFIG_NAME,
+            "top_verilog": _OUTPUT_TOP_NAME,
+            "wrapper_manifest_json": _OUTPUT_WRAPPER_MANIFEST_NAME,
+            "vcd": _OUTPUT_VCD_NAME,
+        },
+        "hashes": {
+            "config_sha256": _hash_json(cfg),
+            "top_sha256": _sha256_file(out_dir / _OUTPUT_TOP_NAME),
+            "vcd_sha256": _sha256_file(vcd_path),
+            "accepted_rows_sha256": _hash_json(reference["accepted_rows"]),
+            "issue_rows_sha256": _hash_json(reference["issue_rows"]),
+            "completed_timeline_sha256": _hash_json(_completed_timeline(reference["completed_rows"])),
+            "summary_sha256": _hash_json(observed["summary_row"]),
+            "final_state_sha256": _hash_json({"accepted": observed["final_row"]["accepted"], "completed": observed["final_row"]["completed"]}),
+        },
+        "gates": {
+            "equivalence_pass": True,
+            "protocol_gate_ok": True,
+            "count_gate_ok": True,
+            "hash_gate_ok": True,
+            "observable_completion_gate_ok": True,
+            "window_active_gate_ok": True,
+            "both_clusters_issue_gate_ok": True,
+            "service_window_gate_ok": True,
+        },
+        "request_result_protocol_counters": {
+            "accepted_count": len(reference["accepted_rows"]),
+            "issue_count": len(reference["issue_rows"]),
+            "completed_count": len(reference["completed_rows"]),
+            "ready_low_cycles": int(reference["ready_low_cycles"]),
+            "window_active_cycles": int(reference["window_active_cycles"]),
+            "window_dual_active_cycles": int(reference["window_dual_active_cycles"]),
+            "window_completed_count": int(reference["window_completed_count"]),
+            "max_queue_depth": int(reference["max_queue_depth"]),
+            "window_issue_counts": reference["window_issue_counts"],
+            "cluster_issue_counts_total": {
+                "0": sum(1 for row in reference["issue_rows"] if row["cluster"] == 0),
+                "1": sum(1 for row in reference["issue_rows"] if row["cluster"] == 1),
+            },
+            "final_result_fold_evidence": observed["final_row"]["result_fold"],
+        },
+        "completion_result_evidence": {
+            "hardware_done_rows": observed["completed_rows"],
+            "hardware_final_result_fold": observed["final_row"]["result_fold"],
+            "reference_final_result_fold": reference["final_result_fold"],
+        },
+        "stimulus_contract": {
+            "command_count": command_count,
+            "command_gap_rule": "cycle % 23 != 7",
+            "external_ready_rule": "an inactive cluster is externally ready only on even cycles",
+            "equivalence_hash_in_hardware": False,
+            "testbench_hashes_are_evidence_only": True,
+        },
+        "scope_summary": {
+            "exercised": [
+                "actual generated dual-stream schedule-wrapper RTL",
+                "multiple commands issued across both clusters",
+                "top-level command_ready backpressure from queue saturation",
+                "warmup before VCD dump and drain after VCD dump",
+                "exact 986-cycle active wrapper service window",
+            ],
+            "remaining": [
+                "post-route power, ODB, and SPEF are outside this generator",
+                "hardware equivalence hash remains disabled in the wrapper datapath",
+            ],
+        },
+    }
+    for value in json.loads(json.dumps(manifest)).get("artifacts", {}).values():
+        if isinstance(value, str) and value.startswith("/"):
+            raise RuntimeError("portable manifest must not contain absolute artifact paths")
+    (out_dir / _OUTPUT_MANIFEST_NAME).write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--clock-period-ns", type=float, default=_DEFAULT_CLOCK_PERIOD_NS)
+    parser.add_argument("--service-window-cycles", type=int, default=_DEFAULT_SERVICE_WINDOW_CYCLES)
+    parser.add_argument("--warmup-cycles", type=int, default=_DEFAULT_WARMUP_CYCLES)
+    parser.add_argument("--command-count", type=int, default=_DEFAULT_COMMAND_COUNT)
+    args = parser.parse_args()
+    generate_activity(
+        _load(args.config),
+        args.out_dir,
+        clock_period_ns=args.clock_period_ns,
+        service_window_cycles=args.service_window_cycles,
+        warmup_cycles=args.warmup_cycles,
+        command_count=args.command_count,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/synth/run_postroute_vcd_power.py
+++ b/npu/synth/run_postroute_vcd_power.py
@@ -87,6 +87,7 @@ def _load_macro_activity(
     *,
     vcd_sha256: str,
     phase_vcd_basename: str,
+    allow_empty: bool = False,
 ) -> list[JsonDict]:
     raw = _load_json(path)
     version = raw.get("version")
@@ -132,7 +133,11 @@ def _load_macro_activity(
             f"macro activity active range invalid for {path}: active_end_tick must be > active_start_tick"
         )
     pins = raw.get("pins")
-    if not isinstance(pins, list) or not pins:
+    if not isinstance(pins, list):
+        raise ValueError(f"macro activity sidecar must contain non-empty pins[]: {path}")
+    if not pins:
+        if allow_empty:
+            return []
         raise ValueError(f"macro activity sidecar must contain non-empty pins[]: {path}")
     seen: set[str] = set()
     rows: list[JsonDict] = []
@@ -309,30 +314,40 @@ def _phase_rows(manifest: JsonDict, manifest_path: Path) -> list[JsonDict]:
                 f"phase {phase} VCD hash mismatch: expected {expected_hash}, got {actual_hash}"
             )
         vcd_basename = vcd.name
+        requires_macro_activity = bool(
+            raw.get("requires_macro_activity", phase in {"score_fill", "replay_value"})
+        )
         macro_activity_value = str(
             raw.get("macro_activity", raw.get("macro_activity_path", ""))
         ).strip()
-        if not macro_activity_value:
-            raise ValueError(f"phase {phase} is missing macro_activity")
-        macro_activity = Path(macro_activity_value)
-        if not macro_activity.is_absolute():
-            macro_activity = (manifest_path.parent / macro_activity).resolve()
-        if not macro_activity.is_file():
-            raise FileNotFoundError(f"phase macro activity sidecar does not exist: {macro_activity}")
-        expected_macro_activity_hash = str(raw.get("macro_activity_sha256", "")).strip().lower()
-        if not expected_macro_activity_hash:
-            raise ValueError(f"phase {phase} requires macro_activity_sha256")
-        macro_activity_hash = _sha256(macro_activity)
-        if expected_macro_activity_hash != macro_activity_hash:
-            raise ValueError(
-                f"phase {phase} macro activity hash mismatch: "
-                f"expected {expected_macro_activity_hash}, got {macro_activity_hash}"
+        macro_activity_hash = ""
+        macro_activity_rows: list[JsonDict] = []
+        macro_activity: Path | None = None
+        if macro_activity_value:
+            macro_activity = Path(macro_activity_value)
+            if not macro_activity.is_absolute():
+                macro_activity = (manifest_path.parent / macro_activity).resolve()
+            if not macro_activity.is_file():
+                raise FileNotFoundError(
+                    f"phase macro activity sidecar does not exist: {macro_activity}"
+                )
+            expected_macro_activity_hash = str(raw.get("macro_activity_sha256", "")).strip().lower()
+            if not expected_macro_activity_hash:
+                raise ValueError(f"phase {phase} requires macro_activity_sha256")
+            macro_activity_hash = _sha256(macro_activity)
+            if expected_macro_activity_hash != macro_activity_hash:
+                raise ValueError(
+                    f"phase {phase} macro activity hash mismatch: "
+                    f"expected {expected_macro_activity_hash}, got {macro_activity_hash}"
+                )
+            macro_activity_rows = _load_macro_activity(
+                macro_activity,
+                vcd_sha256=actual_hash,
+                phase_vcd_basename=vcd_basename,
+                allow_empty=not requires_macro_activity,
             )
-        macro_activity_rows = _load_macro_activity(
-            macro_activity,
-            vcd_sha256=actual_hash,
-            phase_vcd_basename=vcd_basename,
-        )
+        elif requires_macro_activity:
+            raise ValueError(f"phase {phase} is missing macro_activity")
         sequential_activity_value = str(
             raw.get("sequential_register_activity", raw.get("sequential_register_activity_path", ""))
         ).strip()
@@ -384,7 +399,7 @@ def _phase_rows(manifest: JsonDict, manifest_path: Path) -> list[JsonDict]:
                 "_resolved_vcd": str(vcd),
                 "vcd_sha256": actual_hash,
                 "macro_activity": macro_activity_value,
-                "_resolved_macro_activity": str(macro_activity),
+                "_resolved_macro_activity": str(macro_activity) if macro_activity is not None else "",
                 "macro_activity_sha256": macro_activity_hash,
                 "_macro_activity_rows": macro_activity_rows,
                 "macro_activity_assignment_count": len(macro_activity_rows),
@@ -395,9 +410,7 @@ def _phase_rows(manifest: JsonDict, manifest_path: Path) -> list[JsonDict]:
                 "sequential_register_activity_assignment_count": len(sequential_activity_rows),
                 "measured_cycles": measured_cycles,
                 "full_context_cycles": full_context_cycles,
-                "requires_macro_activity": bool(
-                    raw.get("requires_macro_activity", phase in {"score_fill", "replay_value"})
-                ),
+                "requires_macro_activity": requires_macro_activity,
             }
         )
     return rows

--- a/tests/test_audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
+++ b/tests/test_audit_llm_decoder_attention_score32_integrated_frontier_ranking.py
@@ -16,6 +16,7 @@ def _args(tmp_path: Path) -> Namespace:
         score32_hbm_controller_replay_json=tmp_path / "score32_replay.json",
         score32_hbm_controller_replay_ppa_json=None,
         score32_physical_feasibility_json=None,
+        score32_activity_power_json=None,
         score32_quality_json=tmp_path / "score32_quality.json",
         measured_compute_energy_json=tmp_path / "measured_compute.json",
         mixed_int8_energy_json=tmp_path / "mixed_int8.json",
@@ -300,3 +301,56 @@ def test_integrated_frontier_ranking_invalidates_stale_mixed_int8_energy_row(tmp
     )
     assert report["next_step"]["mixed_int8_old_candidate_quality_invalidated"] is True
     assert report["next_step"]["mixed_int8_requires_quality_closure"] is False
+
+
+def test_integrated_frontier_ranking_replaces_score32_compute_energy_with_activity_power(tmp_path: Path) -> None:
+    _populate_inputs(tmp_path)
+    args = _args(tmp_path)
+    args.score32_hbm_controller_replay_json = None
+    args.score32_physical_feasibility_json = tmp_path / "schedule_wrapper_recost.json"
+    args.score32_activity_power_json = tmp_path / "schedule_wrapper_activity_power.json"
+    _write_json(
+        args.score32_physical_feasibility_json,
+        {
+            "best_requested": {
+                "replica_recost_latency_us": 12814.257853,
+                "replica_recost_compute_area_um2": 693452.0 * 428,
+                "die_area_mm2": 800.0,
+                "replica_recost_macs_per_cycle": 768,
+            },
+            "remaining_abstractions": ["profile_scaled_noc_sram_energy"],
+        },
+    )
+    _write_json(
+        args.score32_activity_power_json,
+        {
+            "best": {
+                "replica_scaled_wrapper_compute_energy_j_per_token": 0.321,
+            },
+            "recost_contract": {
+                "latency_us": 12814.257853,
+                "residual_layer_cycles": 343,
+                "residual_breakdown": {
+                    "qkv_cycles": 192,
+                    "cross_tile_reduction_cycles": 141,
+                    "kv_write_cycles": 10,
+                },
+            },
+        },
+    )
+
+    report = build_report(args)
+    score32_row = report["rows"][0]
+
+    assert score32_row["candidate_id"] == "score32_exp_lut_schedule_wrapper_activity_hbm_service_best"
+    assert score32_row["compute_energy_mj_per_token"] == 321.0
+    assert score32_row["hbm_energy_mj_per_token"] == 0.8
+    assert score32_row["energy_mj_per_token"] == 321.8
+    assert score32_row["token_throughput_per_s"] == 1_000_000.0 / 12814.257853
+    assert score32_row["pareto_status"] in {"pareto", "dominated"}
+    assert (
+        "The 343 residual per-layer cycles remain outside the measured wrapper activity term: qkv=192, reduction=141, kv_write=10."
+        in score32_row["remaining_abstractions"]
+    )
+    assert report["inputs"]["score32_activity_power_json"] == str(args.score32_activity_power_json)
+    assert any("measured 986-cycle whole-wrapper activity term" in item for item in report["assumptions"])

--- a/tests/test_audit_llm_decoder_attention_score32_schedule_wrapper_postroute_activity_power.py
+++ b/tests/test_audit_llm_decoder_attention_score32_schedule_wrapper_postroute_activity_power.py
@@ -1,0 +1,233 @@
+import csv
+import json
+from pathlib import Path
+import sys
+from unittest import mock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval import audit_llm_decoder_attention_score32_schedule_wrapper_postroute_activity_power as audit
+
+
+def _write_metrics(path: Path) -> None:
+    fields = [
+        "design",
+        "platform",
+        "config_hash",
+        "param_hash",
+        "tag",
+        "status",
+        "critical_path_ns",
+        "die_area",
+        "total_power_mw",
+        "instance_area_um2",
+        "params_json",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        writer.writerow(
+            {
+                "design": "attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2",
+                "platform": "nangate45",
+                "config_hash": "cfg",
+                "param_hash": "p0",
+                "tag": "density04",
+                "status": "ok",
+                "critical_path_ns": "48.6509",
+                "die_area": "0",
+                "total_power_mw": "60.7",
+                "instance_area_um2": "693452.0",
+                "params_json": json.dumps(
+                    {
+                        "FLOW_VARIANT": "attention_dual_stream_schedule_wrapper_score32_exp_lut",
+                        "CLOCK_PERIOD": 10.0,
+                        "PLACE_DENSITY": 0.4,
+                    }
+                ),
+            }
+        )
+
+
+def _write_recost(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "diagnosis": {"decision": "dual_stream_feasible"},
+                "best_requested": {
+                    "substituted_compute_arch": "attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2",
+                    "substituted_compute_variant_kind": "dual_stream_schedule_wrapper",
+                    "substituted_compute_semantic_profile": "score32_exp_lut_div",
+                    "replica_recost_area_fit_replica_count": 428,
+                    "replica_recost_tile_service_cycles": 986,
+                    "tile_service_cycles": 986,
+                    "tile_waves": 8,
+                    "layers": 32,
+                    "replica_recost_qkv_cycles": 192,
+                    "cross_tile_reduction_cycles": 141,
+                    "kv_write_cycles": 10,
+                    "replica_recost_layer_cycles": 8231,
+                    "replica_recost_latency_us": 12814.257853,
+                    "replica_recost_compute_area_um2": 693452.0 * 428,
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_config(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2",
+                "attention_dual_stream_schedule_wrapper": {
+                    "clusters": 2,
+                    "queue_depth": 16,
+                    "tile_id_bits": 16,
+                    "wave_id_bits": 12,
+                    "base_token_bits": 18,
+                    "max_inflight_per_cluster": 2,
+                    "cluster_service_cycles": 4,
+                    "datapath": {
+                        "streams": 2,
+                        "array_m": 8,
+                        "array_n": 8,
+                        "k_unroll": 1,
+                        "mac_accum_bits": 32,
+                        "softmax_row_elems": 8,
+                        "softmax_score_bits": 32,
+                        "softmax_weight_bits": 16,
+                        "softmax_input_frac_bits": 28,
+                        "softmax_accum_bits": 40,
+                        "reciprocal_bits": 16,
+                        "softmax_reciprocal_lut_bucket_shift": 20,
+                        "value_bits": 8,
+                        "value_lanes": 8,
+                        "partials": 8,
+                        "partials_per_cycle": 1,
+                        "stream_buffer_bits": 512,
+                        "equivalence_hash": False,
+                        "softmax_pipeline_stages": 1,
+                        "softmax_impl": "exp_lut_div",
+                        "semantic_profile": "score32_exp_lut_div",
+                    },
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _activity_manifest(*, cycle_count: int) -> dict:
+    return {
+        "model": "attention_dual_stream_schedule_wrapper_activity_v1",
+        "cycle_count": cycle_count,
+        "service_window_cycles": cycle_count,
+        "cluster_service_cycles": 4,
+        "hashes": {"vcd_sha256": "vcd-hash"},
+        "gates": {
+            "equivalence_pass": True,
+            "protocol_gate_ok": True,
+            "count_gate_ok": True,
+            "hash_gate_ok": True,
+            "observable_completion_gate_ok": True,
+            "window_active_gate_ok": True,
+            "both_clusters_issue_gate_ok": True,
+            "service_window_gate_ok": True,
+        },
+        "request_result_protocol_counters": {
+            "window_active_cycles": cycle_count,
+            "window_issue_counts": {"0": 165, "1": 164},
+        },
+    }
+
+
+def _power_report() -> dict:
+    return {
+        "status": "activity_backed",
+        "promotion_gate_pass": True,
+        "source_activity_manifest_sha256": "manifest-hash",
+        "phases": [
+            {
+                "phase": "service_window",
+                "vcd_sha256": "vcd-hash",
+                "measured_cycles": 986,
+                "full_context_cycles": 986,
+                "macro_activity_assignment_count": 0,
+                "annotation_gate_pass": True,
+                "sequential_register_activity_gate_pass": True,
+                "clock_period_gate_pass": True,
+                "power_numeric_gate_pass": True,
+                "structural_macro_activity_gate_pass": True,
+                "phase_gate_pass": True,
+                "power": {
+                    "internal_w": 0.2,
+                    "switching_w": 0.3,
+                    "leakage_w": 0.1,
+                    "total_w": 0.6,
+                },
+            }
+        ],
+    }
+
+
+def test_build_report_rejects_accidental_4_cycle_scaling(tmp_path: Path) -> None:
+    config = tmp_path / "config.json"
+    metrics = tmp_path / "metrics.csv"
+    recost = tmp_path / "recost.json"
+    _write_config(config)
+    _write_metrics(metrics)
+    _write_recost(recost)
+
+    with mock.patch.object(audit, "generate_activity", return_value=_activity_manifest(cycle_count=4)):
+        with pytest.raises(ValueError, match="service_window_cycles mismatch"):
+            audit.build_report(
+                config=config,
+                metrics_csv=metrics,
+                recost_json=recost,
+                orfs_design_config=tmp_path / "orfs_config.mk",
+                activity_dir=tmp_path / "activity",
+            )
+
+
+def test_build_report_distinguishes_annotation_and_promotion_clocks(tmp_path: Path) -> None:
+    config = tmp_path / "config.json"
+    metrics = tmp_path / "metrics.csv"
+    recost = tmp_path / "recost.json"
+    _write_config(config)
+    _write_metrics(metrics)
+    _write_recost(recost)
+    manifest_path = tmp_path / "activity_manifest.json"
+    manifest_path.write_text("{}\n", encoding="utf-8")
+
+    with mock.patch.object(audit, "generate_activity", return_value=_activity_manifest(cycle_count=986)):
+        with mock.patch.object(
+            audit,
+            "_prepare_postroute_manifest",
+            return_value=({"phases": []}, manifest_path),
+        ):
+            with mock.patch.object(audit, "_sha256_file", return_value="manifest-hash"):
+                with mock.patch.object(audit, "build_power_report", return_value=_power_report()):
+                    payload = audit.build_report(
+                        config=config,
+                        metrics_csv=metrics,
+                        recost_json=recost,
+                        orfs_design_config=tmp_path / "orfs_config.mk",
+                        activity_dir=tmp_path / "activity",
+                    )
+
+    energy = payload["best"]["component_service_window_energy"]
+    assert energy["annotation_clock_ns"] == 10.0
+    assert energy["promotion_clock_ns"] == 48.6509
+    assert energy["energy_j"]["dynamic"] == pytest.approx((0.2 + 0.3) * 986 * 10.0e-9)
+    assert energy["energy_j"]["leakage"] == pytest.approx(0.1 * 986 * 48.6509e-9)
+    assert payload["recost_contract"]["residual_layer_cycles"] == 343

--- a/tests/test_generate_attention_dual_stream_schedule_wrapper_activity.py
+++ b/tests/test_generate_attention_dual_stream_schedule_wrapper_activity.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+import shutil
+import sys
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval.generate_attention_dual_stream_schedule_wrapper_activity import (
+    _OUTPUT_MANIFEST_NAME,
+    generate_activity,
+)
+
+
+def _iverilog_available() -> bool:
+    return bool(shutil.which("iverilog") and shutil.which("vvp"))
+
+
+@pytest.mark.skipif(not _iverilog_available(), reason="iverilog/vvp unavailable")
+def test_generate_schedule_wrapper_activity_real_window_contract(tmp_path: Path) -> None:
+    config = json.loads(
+        (
+            REPO_ROOT
+            / "runs/designs/npu_blocks/attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2/config.json"
+        ).read_text(encoding="utf-8")
+    )
+
+    manifest = generate_activity(config, tmp_path / "activity")
+    manifest_path = tmp_path / "activity" / _OUTPUT_MANIFEST_NAME
+
+    assert manifest_path.is_file()
+    assert manifest["cycle_count"] == 986
+    assert manifest["service_window_cycles"] == 986
+    assert manifest["cluster_service_cycles"] == 4
+    assert manifest["total_sim_cycles"] == 1023
+    assert manifest["gates"]["service_window_gate_ok"] is True
+    assert manifest["gates"]["window_active_gate_ok"] is True
+    assert manifest["gates"]["both_clusters_issue_gate_ok"] is True
+    assert manifest["request_result_protocol_counters"]["accepted_count"] == 340
+    assert manifest["request_result_protocol_counters"]["issue_count"] == 340
+    assert manifest["request_result_protocol_counters"]["completed_count"] == 340
+    assert manifest["request_result_protocol_counters"]["window_active_cycles"] == 986
+    assert manifest["request_result_protocol_counters"]["window_issue_counts"] == {"0": 165, "1": 164}
+    assert manifest["request_result_protocol_counters"]["ready_low_cycles"] > 0
+    assert manifest["completion_result_evidence"]["hardware_final_result_fold"] == "0000015b"
+    assert manifest["completion_result_evidence"]["reference_final_result_fold"] != "0000015b"
+    assert not any(str(value).startswith("/") for value in manifest["artifacts"].values())

--- a/tests/test_postroute_vcd_power.py
+++ b/tests/test_postroute_vcd_power.py
@@ -1628,6 +1628,77 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "macro_activity"):
                 MODULE._phase_rows(manifest, path)
 
+    def test_phase_rows_allow_omitted_macro_activity_when_not_required(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            vcd = root / "trace.vcd"
+            vcd.write_text("$enddefinitions $end\n", encoding="utf-8")
+            sequential_activity = self._write_sequential_activity(root=root, vcd=vcd)
+            manifest = {
+                "clock_period_ns": 8.0,
+                "phases": [
+                    {
+                        "phase": "wrapper_window",
+                        "vcd": vcd.name,
+                        "vcd_sha256": MODULE._sha256(vcd),
+                        "sequential_register_activity": sequential_activity.name,
+                        "sequential_register_activity_sha256": MODULE._sha256(sequential_activity),
+                        "measured_cycles": 20,
+                        "full_context_cycles": 20,
+                        "requires_macro_activity": False,
+                    }
+                ],
+            }
+            manifest_path = root / "manifest.json"
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            rows = MODULE._phase_rows(manifest, manifest_path)
+            self.assertEqual(len(rows), 1)
+            self.assertFalse(rows[0]["requires_macro_activity"])
+            self.assertEqual(rows[0]["macro_activity_assignment_count"], 0)
+            self.assertEqual(rows[0]["macro_activity"], "")
+            self.assertEqual(rows[0]["macro_activity_sha256"], "")
+
+    def test_phase_rows_allow_empty_macro_activity_sidecar_when_not_required(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_text:
+            root = Path(temp_text)
+            vcd = root / "trace.vcd"
+            vcd.write_text("$enddefinitions $end\n", encoding="utf-8")
+            macro_activity = root / "empty_macro_activity.json"
+            macro_activity.write_text(
+                json.dumps(
+                    self._macro_activity(
+                        phase_name="wrapper_window",
+                        vcd=vcd,
+                        overrides={"pins": []},
+                    )
+                ),
+                encoding="utf-8",
+            )
+            sequential_activity = self._write_sequential_activity(root=root, vcd=vcd)
+            manifest = {
+                "clock_period_ns": 8.0,
+                "phases": [
+                    {
+                        "phase": "wrapper_window",
+                        "vcd": vcd.name,
+                        "vcd_sha256": MODULE._sha256(vcd),
+                        "macro_activity": macro_activity.name,
+                        "macro_activity_sha256": MODULE._sha256(macro_activity),
+                        "sequential_register_activity": sequential_activity.name,
+                        "sequential_register_activity_sha256": MODULE._sha256(sequential_activity),
+                        "measured_cycles": 20,
+                        "full_context_cycles": 20,
+                        "requires_macro_activity": False,
+                    }
+                ],
+            }
+            manifest_path = root / "manifest.json"
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            rows = MODULE._phase_rows(manifest, manifest_path)
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["macro_activity_assignment_count"], 0)
+            self.assertEqual(rows[0]["_macro_activity_rows"], [])
+
     def test_phase_rows_rejects_invalid_macro_activity_schema(self) -> None:
         with tempfile.TemporaryDirectory() as temp_text:
             root = Path(temp_text)


### PR DESCRIPTION
## Summary
- add deterministic 986-cycle score32 dual-stream wrapper RTL/VCD activity generation with protocol, count, and hash equivalence gates
- allow explicitly macro-less postroute activity phases while preserving fail-closed macro requirements by default
- add strict postroute activity-power audit and measured-energy Llama7B frontier rerank
- add proposal and control-plane task wiring for remote evaluation

## Measurement contract
- wrapper micro-transaction remains `cluster_service_cycles=4`
- measured service window is exactly 986 active cycles
- dynamic energy uses the 10 ns annotation contract
- leakage and latency promotion use `max(10 ns, 48.6509 ns)`
- compute energy scales one wrapper window by 428 replicas, 8 waves, and 32 layers
- the 343 residual layer cycles remain explicitly outside this wrapper activity term

## Verification
- `53 passed` focused repository tests
- `238 passed` control-plane task-generator tests
- `python3 scripts/validate_runs.py --skip_eval_queue`
- real deterministic RTL/equivalence/VCD generation: 986 active cycles, 340 accepted/issued/completed, both clusters active

The live postroute power audit is intentionally left for the remote evaluator because the local workspace does not contain the ORFS routed design payload.
