### PR TITLE
Fail closed evaluator daemon identity and persistence

### DIFF
--- a/control_plane/control_plane/tests/test_restart_local_control_plane_daemons.py
+++ b/control_plane/control_plane/tests/test_restart_local_control_plane_daemons.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "restart_local_control_plane_daemons.sh"
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def _make_service_repo(tmp_path: Path, *, with_venv: bool = True) -> Path:
+    repo_root = tmp_path / "service-repo"
+    package_root = repo_root / "control_plane" / "control_plane"
+    services_root = package_root / "services"
+    services_root.mkdir(parents=True)
+    (package_root / "__init__.py").write_text("", encoding="utf-8")
+    (services_root / "__init__.py").write_text("", encoding="utf-8")
+    (services_root / "l2_result_consumer.py").write_text("VALUE = 'ok'\n", encoding="utf-8")
+
+    if with_venv:
+        bin_dir = repo_root / "control_plane" / ".venv" / "bin"
+        bin_dir.mkdir(parents=True)
+        _write_executable(
+            bin_dir / "python",
+            f"#!/usr/bin/env bash\nexec {sys.executable} \"$@\"\n",
+        )
+        (bin_dir / "activate").write_text("# test fixture\n", encoding="utf-8")
+
+    return repo_root
+
+
+def _run_script(repo_root: Path, action: str, **env_overrides: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    for key in (
+        "RTLCP_ALLOW_FINITE_WORKER_DAEMON",
+        "RTLCP_DATABASE_URL",
+        "RTLCP_DB_MODE",
+        "RTLCP_MACHINE_KEY",
+        "RTLCP_MAX_POLLS",
+        "RTLCP_ROLE",
+        "RTLCP_STOP_ON_NO_WORK",
+        "REPO_ROOT",
+        "RTLGEN_SERVICE_REPO",
+        "VENV_PATH",
+    ):
+        env.pop(key, None)
+    env["RTLGEN_SERVICE_REPO"] = str(repo_root)
+    env.update(env_overrides)
+    return subprocess.run(
+        [str(SCRIPT_PATH), action],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_preflight_requires_database_url(tmp_path: Path) -> None:
+    repo_root = _make_service_repo(tmp_path)
+
+    result = _run_script(repo_root, "preflight", RTLCP_MACHINE_KEY="eval-stable-1")
+
+    assert result.returncode == 1
+    assert "RTLCP_DATABASE_URL must be exported explicitly for preflight" in result.stderr
+
+
+def test_check_import_requires_database_url(tmp_path: Path) -> None:
+    repo_root = _make_service_repo(tmp_path)
+
+    result = _run_script(repo_root, "check-import")
+
+    assert result.returncode == 1
+    assert "RTLCP_DATABASE_URL must be exported explicitly for check-import" in result.stderr
+
+
+def test_preflight_requires_machine_key(tmp_path: Path) -> None:
+    repo_root = _make_service_repo(tmp_path)
+
+    result = _run_script(
+        repo_root,
+        "preflight",
+        RTLCP_DATABASE_URL="postgresql+psycopg://rtlgen:secret@db.example.com:5432/rtlgen_control_plane",
+    )
+
+    assert result.returncode == 1
+    assert "RTLCP_MACHINE_KEY must be exported explicitly for preflight" in result.stderr
+
+
+def test_preflight_rejects_remote_localhost_database(tmp_path: Path) -> None:
+    repo_root = _make_service_repo(tmp_path)
+
+    result = _run_script(
+        repo_root,
+        "preflight",
+        RTLCP_ROLE="evaluator",
+        RTLCP_DB_MODE="remote",
+        RTLCP_MACHINE_KEY="eval-stable-1",
+        RTLCP_DATABASE_URL="postgresql+psycopg://rtlgen:secret@localhost:5432/rtlgen_control_plane",
+    )
+
+    assert result.returncode == 1
+    assert "must not target localhost/127.0.0.1/::1" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("env_overrides", "expected_fragment"),
+    [
+        (
+            {"RTLCP_STOP_ON_NO_WORK": "1"},
+            "RTLCP_STOP_ON_NO_WORK=1 is not allowed for a managed daemon",
+        ),
+        (
+            {"RTLCP_MAX_POLLS": "3"},
+            "RTLCP_MAX_POLLS=3 is not allowed for a managed daemon",
+        ),
+    ],
+)
+def test_preflight_rejects_finite_worker_settings(
+    tmp_path: Path, env_overrides: dict[str, str], expected_fragment: str
+) -> None:
+    repo_root = _make_service_repo(tmp_path)
+
+    result = _run_script(
+        repo_root,
+        "preflight",
+        RTLCP_ROLE="evaluator",
+        RTLCP_DB_MODE="remote",
+        RTLCP_MACHINE_KEY="eval-stable-1",
+        RTLCP_DATABASE_URL="postgresql+psycopg://rtlgen:secret@db.example.com:5432/rtlgen_control_plane",
+        **env_overrides,
+    )
+
+    assert result.returncode == 1
+    assert expected_fragment in result.stderr
+
+
+def test_preflight_allows_finite_worker_override(tmp_path: Path) -> None:
+    repo_root = _make_service_repo(tmp_path)
+
+    result = _run_script(
+        repo_root,
+        "preflight",
+        RTLCP_ROLE="evaluator",
+        RTLCP_DB_MODE="remote",
+        RTLCP_MACHINE_KEY="eval-stable-1",
+        RTLCP_DATABASE_URL="postgresql+psycopg://rtlgen:secret@db.example.com:5432/rtlgen_control_plane",
+        RTLCP_STOP_ON_NO_WORK="1",
+        RTLCP_MAX_POLLS="3",
+        RTLCP_ALLOW_FINITE_WORKER_DAEMON="1",
+    )
+
+    assert result.returncode == 0
+    assert "preflight OK" in result.stdout
+    assert "allow_finite_worker_daemon=1" in result.stdout
+    assert "max_polls=3" in result.stdout
+
+
+def test_preflight_requires_virtualenv_files(tmp_path: Path) -> None:
+    repo_root = _make_service_repo(tmp_path, with_venv=False)
+
+    result = _run_script(
+        repo_root,
+        "preflight",
+        RTLCP_ROLE="evaluator",
+        RTLCP_DB_MODE="remote",
+        RTLCP_MACHINE_KEY="eval-stable-1",
+        RTLCP_DATABASE_URL="postgresql+psycopg://rtlgen:secret@db.example.com:5432/rtlgen_control_plane",
+    )
+
+    assert result.returncode == 1
+    assert "Set VENV_PATH explicitly" in result.stderr
+    assert f"{repo_root}/control_plane/.venv/bin/python" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("role", "db_mode", "database_url", "expected_host"),
+    [
+        (
+            "server",
+            "local",
+            "postgresql+psycopg://rtlgen:secret@localhost:5432/rtlgen_control_plane",
+            "localhost",
+        ),
+        (
+            "evaluator",
+            "remote",
+            "postgresql+psycopg://rtlgen:secret@db.example.com:5432/rtlgen_control_plane",
+            "db.example.com",
+        ),
+    ],
+)
+def test_preflight_succeeds_for_explicit_local_and_remote_configs(
+    tmp_path: Path, role: str, db_mode: str, database_url: str, expected_host: str
+) -> None:
+    repo_root = _make_service_repo(tmp_path)
+
+    result = _run_script(
+        repo_root,
+        "preflight",
+        RTLCP_ROLE=role,
+        RTLCP_DB_MODE=db_mode,
+        RTLCP_MACHINE_KEY="eval-stable-1",
+        RTLCP_DATABASE_URL=database_url,
+    )
+
+    assert result.returncode == 0
+    assert "preflight OK" in result.stdout
+    assert f"repo_root={repo_root}" in result.stdout
+    assert f"venv_path={repo_root}/control_plane/.venv" in result.stdout
+    assert "machine_key=eval-stable-1" in result.stdout
+    assert f"role={role}" in result.stdout
+    assert f"db_mode={db_mode}" in result.stdout
+    assert f"db_host={expected_host}" in result.stdout
+    assert "stop_on_no_work=0" in result.stdout
+    assert "max_polls=persistent" in result.stdout
+    assert "secret" not in result.stdout
+    assert "control_plane import path OK:" in result.stdout

--- a/control_plane/control_plane/tests/test_restart_local_control_plane_daemons.py
+++ b/control_plane/control_plane/tests/test_restart_local_control_plane_daemons.py
@@ -44,10 +44,13 @@ def _run_script(repo_root: Path, action: str, **env_overrides: str) -> subproces
         "RTLCP_ALLOW_FINITE_WORKER_DAEMON",
         "RTLCP_DATABASE_URL",
         "RTLCP_DB_MODE",
+        "RTLCP_LOG_ROOT",
         "RTLCP_MACHINE_KEY",
         "RTLCP_MAX_POLLS",
         "RTLCP_ROLE",
+        "RTLCP_RUNTIME_DIR",
         "RTLCP_STOP_ON_NO_WORK",
+        "RTLCP_STOP_LEGACY_PROCESSES",
         "REPO_ROOT",
         "RTLGEN_SERVICE_REPO",
         "VENV_PATH",
@@ -179,6 +182,35 @@ def test_preflight_requires_virtualenv_files(tmp_path: Path) -> None:
     assert result.returncode == 1
     assert "Set VENV_PATH explicitly" in result.stderr
     assert f"{repo_root}/control_plane/.venv/bin/python" in result.stderr
+
+
+def test_invalid_restart_does_not_stop_existing_pid(tmp_path: Path) -> None:
+    repo_root = _make_service_repo(tmp_path)
+    runtime_dir = tmp_path / "runtime"
+    runtime_dir.mkdir()
+    running = subprocess.Popen(["sleep", "60"])
+    pid_file = runtime_dir / "api.pid"
+    pid_file.write_text(f"{running.pid}\n", encoding="utf-8")
+
+    try:
+        result = _run_script(
+            repo_root,
+            "restart",
+            RTLCP_ROLE="evaluator",
+            RTLCP_DB_MODE="remote",
+            RTLCP_RUNTIME_DIR=str(runtime_dir),
+            RTLCP_STOP_LEGACY_PROCESSES="0",
+            RTLCP_DATABASE_URL="postgresql+psycopg://rtlgen:secret@db.example.com:5432/rtlgen_control_plane",
+        )
+
+        assert result.returncode == 1
+        assert "RTLCP_MACHINE_KEY must be exported explicitly for restart" in result.stderr
+        assert pid_file.exists()
+        assert running.poll() is None
+        os.kill(running.pid, 0)
+    finally:
+        running.terminate()
+        running.wait(timeout=5)
 
 
 @pytest.mark.parametrize(

--- a/control_plane/operator_runbook.md
+++ b/control_plane/operator_runbook.md
@@ -48,11 +48,39 @@ Evaluator host before opening the devcontainer:
 export RTLCP_ROLE=evaluator
 export RTLCP_DB_MODE=remote
 export RTLCP_DATABASE_URL='postgresql+psycopg://rtlgen:rtlgen@<notebook-host-ip>:5432/rtlgen_control_plane'
+export RTLCP_MACHINE_KEY='<stable evaluator machine key>'
 export RTLCP_AUTOSTART_WORKER_DAEMON=1
+# export VENV_PATH='/workspaces/RTLGen/control_plane/.venv'  # required when the clean service checkout has no .venv
 ```
 
 After changing these values:
 - recreate or reopen the devcontainer
+
+Managed evaluator daemons fail closed now:
+- `RTLCP_DATABASE_URL` must be exported explicitly for `start`, `restart`, `check-import`, and `preflight`
+- `RTLCP_MACHINE_KEY` must be exported explicitly for `start`, `restart`, and `preflight`
+- `RTLCP_STOP_ON_NO_WORK=1` and any finite positive `RTLCP_MAX_POLLS` are rejected unless `RTLCP_ALLOW_FINITE_WORKER_DAEMON=1` is also set
+- when the clean service checkout does not contain its own `.venv`, set `VENV_PATH` to a real control-plane virtualenv before running the managed daemon wrapper
+
+Evaluator managed-daemon preflight:
+```sh
+export RTLCP_ROLE=evaluator
+export RTLCP_DB_MODE=remote
+export RTLCP_DATABASE_URL='postgresql+psycopg://rtlgen:rtlgen@<notebook-host-ip>:5432/rtlgen_control_plane'
+export RTLCP_MACHINE_KEY='<stable evaluator machine key>'
+export VENV_PATH='/workspaces/RTLGen/control_plane/.venv'
+/workspaces/rtlgen-eval-clean/control_plane/scripts/restart_local_control_plane_daemons.sh preflight
+```
+
+Developer-local explicit preflight is still allowed with localhost when you declare local mode:
+```sh
+export RTLCP_ROLE=server
+export RTLCP_DB_MODE=local
+export RTLCP_DATABASE_URL='postgresql+psycopg://rtlgen:rtlgen@localhost:5432/rtlgen_control_plane'
+export RTLCP_MACHINE_KEY='dev-local-control-plane'
+export VENV_PATH='/workspaces/RTLGen/control_plane/.venv'
+/workspaces/rtlgen-eval-clean/control_plane/scripts/restart_local_control_plane_daemons.sh preflight
+```
 
 ## Standard Automatic Flow
 
@@ -135,6 +163,11 @@ Evaluator worker restart:
 /workspaces/RTLGen/control_plane/scripts/restart_worker_daemon.sh
 ```
 
+Managed evaluator bundle restart:
+```sh
+/workspaces/rtlgen-eval-clean/control_plane/scripts/restart_local_control_plane_daemons.sh restart
+```
+
 Operator dashboard:
 ```sh
 /workspaces/RTLGen/control_plane/scripts/operator_status.sh --format table
@@ -152,6 +185,17 @@ Request remote evaluator refresh after a control-plane merge:
 ```
 
 The command opens or updates a GitHub issue with the target commit, pull/update checklist, daemon restart checklist, and a machine-readable evaluator acknowledgement block. Use it instead of drafting ad hoc evaluator update issues.
+
+## Managed Daemon Paths
+
+Default managed-daemon diagnostics under the clean evaluator service checkout:
+- daemon PID files: `/workspaces/rtlgen-eval-clean/control_plane/runtime_logs/daemons/<service>.pid`
+- daemon stdout/stderr logs: `/workspaces/rtlgen-eval-clean/control_plane/runtime_logs/daemons/<service>.log`
+- worker job logs: `/workspaces/rtlgen-eval-clean/control_plane/runtime_logs/worker_jobs/`
+
+The wrapper prints the effective paths during `preflight`. Override them only with:
+- `RTLCP_RUNTIME_DIR` for daemon PID/log files
+- `RTLCP_LOG_ROOT` for worker job logs
 
 ## What Healthy Looks Like
 

--- a/control_plane/remote_operator_workflow.md
+++ b/control_plane/remote_operator_workflow.md
@@ -61,9 +61,17 @@ export RTLCP_ROLE=evaluator
 export RTLCP_DB_MODE=remote
 export RTLCP_AUTOSTART_WORKER_DAEMON=1
 export RTLCP_DATABASE_URL='postgresql+psycopg://rtlgen:rtlgen@<notebook-host-ip>:5432/rtlgen_control_plane'
+export RTLCP_MACHINE_KEY='<stable evaluator machine key>'
+# export VENV_PATH='/workspaces/RTLGen/control_plane/.venv'  # required when the clean service checkout has no .venv
 ```
 
 After changing these values, recreate or reopen the devcontainer so `containerEnv` is refreshed.
+
+Managed evaluator wrappers fail closed:
+- do not rely on a default localhost `RTLCP_DATABASE_URL`
+- export `RTLCP_MACHINE_KEY` explicitly so hostname changes do not create a detached worker identity
+- keep daemon settings persistent unless `RTLCP_ALLOW_FINITE_WORKER_DAEMON=1` is deliberately set
+- set `VENV_PATH` explicitly when the clean service checkout does not contain its own `.venv`
 
 ## Database URLs
 
@@ -243,3 +251,13 @@ Operational restart shortcuts:
   - `control_plane/scripts/restart_completion_loop.sh`
 - evaluator worker daemon:
   - `control_plane/scripts/restart_worker_daemon.sh`
+
+Managed evaluator bundle preflight:
+```sh
+export RTLCP_ROLE=evaluator
+export RTLCP_DB_MODE=remote
+export RTLCP_DATABASE_URL='postgresql+psycopg://rtlgen:rtlgen@<notebook-host-ip>:5432/rtlgen_control_plane'
+export RTLCP_MACHINE_KEY='<stable evaluator machine key>'
+export VENV_PATH='/workspaces/RTLGen/control_plane/.venv'
+/workspaces/rtlgen-eval-clean/control_plane/scripts/restart_local_control_plane_daemons.sh preflight
+```

--- a/control_plane/scripts/restart_local_control_plane_daemons.sh
+++ b/control_plane/scripts/restart_local_control_plane_daemons.sh
@@ -259,7 +259,11 @@ _start_service() {
 }
 
 _start_all() {
-  _preflight
+  local run_preflight
+  run_preflight="${1:-1}"
+  if [[ "${run_preflight}" == "1" ]]; then
+    _preflight
+  fi
   mkdir -p "${RUNTIME_DIR}" "${WORKER_LOG_ROOT}"
   _start_service api "${REPO_ROOT}/control_plane/scripts/run_api_service.sh"
   _start_service dev-resolver "${REPO_ROOT}/control_plane/scripts/run_dev_resolver_service.sh"
@@ -296,8 +300,9 @@ case "${ACTION}" in
     _stop_all
     ;;
   restart)
+    _preflight
     _stop_all
-    _start_all
+    _start_all 0
     ;;
   status)
     _status_all

--- a/control_plane/scripts/restart_local_control_plane_daemons.sh
+++ b/control_plane/scripts/restart_local_control_plane_daemons.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 DEFAULT_SERVICE_REPO="/workspaces/rtlgen-eval-clean"
-DEFAULT_DATABASE_URL="postgresql+psycopg://rtlgen:rtlgen@localhost:5432/rtlgen_control_plane"
 DEFAULT_REPO_SLUG="yhmtmt/RTLGen"
 
 ACTION="${1:-restart}"
@@ -11,11 +10,9 @@ VENV_PATH="${VENV_PATH:-${REPO_ROOT}/control_plane/.venv}"
 RUNTIME_DIR="${RTLCP_RUNTIME_DIR:-${REPO_ROOT}/control_plane/runtime_logs/daemons}"
 WORKER_LOG_ROOT="${RTLCP_LOG_ROOT:-${REPO_ROOT}/control_plane/runtime_logs/worker_jobs}"
 
-export RTLCP_DATABASE_URL="${RTLCP_DATABASE_URL:-${DEFAULT_DATABASE_URL}}"
 export RTLCP_REPO_SLUG="${RTLCP_REPO_SLUG:-${DEFAULT_REPO_SLUG}}"
 export RTLCP_RESOLVER_REPO="${RTLCP_RESOLVER_REPO:-${RTLCP_REPO_SLUG}}"
 export RTLCP_HOSTNAME="${RTLCP_HOSTNAME:-$(hostname)}"
-export RTLCP_MACHINE_KEY="${RTLCP_MACHINE_KEY:-eval-daemon-${RTLCP_HOSTNAME}}"
 export RTLCP_CAPABILITY_FILTER_JSON="${RTLCP_CAPABILITY_FILTER_JSON:-{\"platform\":\"nangate45\",\"flow\":\"openroad\"}}"
 export RTLCP_WORKER_CONCURRENCY="${RTLCP_WORKER_CONCURRENCY:-16}"
 export RTLCP_MAX_ITEMS_PER_POLL="${RTLCP_MAX_ITEMS_PER_POLL:-${RTLCP_WORKER_CONCURRENCY}}"
@@ -25,14 +22,111 @@ export RTLCP_COMPLETION_REPO="${RTLCP_COMPLETION_REPO:-${RTLCP_REPO_SLUG}}"
 export RTLCP_LOG_ROOT="${WORKER_LOG_ROOT}"
 export RTLGEN_SERVICE_REPO="${REPO_ROOT}"
 
-mkdir -p "${RUNTIME_DIR}" "${WORKER_LOG_ROOT}"
-
 _timestamp() {
   date -u +%Y-%m-%dT%H:%M:%SZ
 }
 
+_usage() {
+  echo "Usage: $0 <start|stop|restart|status|check-import|preflight>" >&2
+}
+
+_die() {
+  echo "$*" >&2
+  exit 1
+}
+
 _python() {
   printf '%s/bin/python' "${VENV_PATH}"
+}
+
+_require_database_url() {
+  if [[ -z "${RTLCP_DATABASE_URL:-}" ]]; then
+    _die "RTLCP_DATABASE_URL must be exported explicitly for ${ACTION}; managed daemons will not default to localhost."
+  fi
+}
+
+_require_machine_key() {
+  if [[ -z "${RTLCP_MACHINE_KEY:-}" ]]; then
+    _die "RTLCP_MACHINE_KEY must be exported explicitly for ${ACTION}; managed evaluator daemons must keep a stable worker identity."
+  fi
+}
+
+_require_venv() {
+  local python_path activate_path
+  python_path="$(_python)"
+  activate_path="${VENV_PATH}/bin/activate"
+  if [[ ! -x "${python_path}" || ! -f "${activate_path}" ]]; then
+    _die "Managed daemon preflight requires ${VENV_PATH}/bin/python and ${VENV_PATH}/bin/activate. Set VENV_PATH explicitly when the clean service checkout does not contain its own virtualenv."
+  fi
+}
+
+_database_host() {
+  local url remainder hostport host
+  url="${RTLCP_DATABASE_URL:-}"
+  if [[ -z "${url}" || "${url}" != *"://"* ]]; then
+    echo "n/a"
+    return
+  fi
+  remainder="${url#*://}"
+  remainder="${remainder##*@}"
+  hostport="${remainder%%/*}"
+  hostport="${hostport%%\?*}"
+  hostport="${hostport%%#*}"
+  if [[ -z "${hostport}" ]]; then
+    echo "n/a"
+    return
+  fi
+  if [[ "${hostport}" == \[* ]]; then
+    host="${hostport#\[}"
+    host="${host%%]*}"
+  else
+    host="${hostport%%:*}"
+  fi
+  if [[ -z "${host}" ]]; then
+    echo "n/a"
+    return
+  fi
+  echo "${host}"
+}
+
+_is_localhost_host() {
+  local host
+  host="${1,,}"
+  [[ "${host}" == "localhost" || "${host}" == "127.0.0.1" || "${host}" == "::1" ]]
+}
+
+_validate_database_host() {
+  local db_host
+  db_host="$(_database_host)"
+  if [[ "${RTLCP_DB_MODE:-}" == "remote" || "${RTLCP_ROLE:-}" == "evaluator" ]]; then
+    if _is_localhost_host "${db_host}"; then
+      _die "RTLCP_DATABASE_URL must not target localhost/127.0.0.1/::1 when RTLCP_DB_MODE=remote or RTLCP_ROLE=evaluator."
+    fi
+  fi
+}
+
+_is_integer() {
+  [[ "$1" =~ ^-?[0-9]+$ ]]
+}
+
+_validate_persistence_settings() {
+  local stop_on_no_work max_polls allow_finite
+  stop_on_no_work="${RTLCP_STOP_ON_NO_WORK:-0}"
+  max_polls="${RTLCP_MAX_POLLS:-}"
+  allow_finite="${RTLCP_ALLOW_FINITE_WORKER_DAEMON:-0}"
+
+  if [[ "${stop_on_no_work}" == "1" && "${allow_finite}" != "1" ]]; then
+    _die "RTLCP_STOP_ON_NO_WORK=1 is not allowed for a managed daemon. Leave it persistent or set RTLCP_ALLOW_FINITE_WORKER_DAEMON=1 for a narrow explicit override."
+  fi
+
+  if [[ -n "${max_polls}" ]]; then
+    if ! _is_integer "${max_polls}"; then
+      _die "RTLCP_MAX_POLLS must be an integer when set; got '${max_polls}'."
+    fi
+    if (( max_polls > 0 )) && [[ "${allow_finite}" != "1" ]]; then
+      _die "RTLCP_MAX_POLLS=${max_polls} is not allowed for a managed daemon. Leave it unset for persistent mode or set RTLCP_ALLOW_FINITE_WORKER_DAEMON=1 for a narrow explicit override."
+    fi
+  fi
 }
 
 _check_import_path() {
@@ -55,6 +149,45 @@ for path in paths:
         raise SystemExit(f"control_plane import resolved outside service repo: {path} (expected under {expected})")
 print(f"control_plane import path OK: {paths[0]}")
 PY
+}
+
+_preflight() {
+  local db_host db_mode role max_polls_display stop_on_no_work allow_finite
+  _require_database_url
+  _require_machine_key
+  _require_venv
+  _validate_database_host
+  _validate_persistence_settings
+  _check_import_path
+
+  db_host="$(_database_host)"
+  db_mode="${RTLCP_DB_MODE:-unset}"
+  role="${RTLCP_ROLE:-unset}"
+  stop_on_no_work="${RTLCP_STOP_ON_NO_WORK:-0}"
+  allow_finite="${RTLCP_ALLOW_FINITE_WORKER_DAEMON:-0}"
+  if [[ -n "${RTLCP_MAX_POLLS:-}" ]] && _is_integer "${RTLCP_MAX_POLLS}" && (( RTLCP_MAX_POLLS > 0 )); then
+    max_polls_display="${RTLCP_MAX_POLLS}"
+  else
+    max_polls_display="persistent"
+  fi
+
+  cat <<EOF
+preflight OK
+repo_root=${REPO_ROOT}
+venv_path=${VENV_PATH}
+machine_key=${RTLCP_MACHINE_KEY}
+hostname=${RTLCP_HOSTNAME}
+role=${role}
+db_mode=${db_mode}
+db_host=${db_host}
+runtime_dir=${RUNTIME_DIR}
+pid_dir=${RUNTIME_DIR}
+daemon_log_dir=${RUNTIME_DIR}
+worker_log_root=${WORKER_LOG_ROOT}
+stop_on_no_work=${stop_on_no_work}
+max_polls=${max_polls_display}
+allow_finite_worker_daemon=${allow_finite}
+EOF
 }
 
 _pid_file() {
@@ -126,7 +259,8 @@ _start_service() {
 }
 
 _start_all() {
-  _check_import_path
+  _preflight
+  mkdir -p "${RUNTIME_DIR}" "${WORKER_LOG_ROOT}"
   _start_service api "${REPO_ROOT}/control_plane/scripts/run_api_service.sh"
   _start_service dev-resolver "${REPO_ROOT}/control_plane/scripts/run_dev_resolver_service.sh"
   _start_service worker "${REPO_ROOT}/control_plane/scripts/run_worker_daemon_service.sh"
@@ -169,10 +303,16 @@ case "${ACTION}" in
     _status_all
     ;;
   check-import)
+    _require_database_url
+    _require_venv
+    _validate_database_host
     _check_import_path
     ;;
+  preflight)
+    _preflight
+    ;;
   *)
-    echo "Usage: $0 <start|stop|restart|status|check-import>" >&2
+    _usage
     exit 1
     ;;
 esac

--- a/control_plane/systemd_operator_workflow.md
+++ b/control_plane/systemd_operator_workflow.md
@@ -69,6 +69,9 @@ Evaluator:
 - `RTLCP_DATABASE_URL`
 - `RTLCP_MACHINE_KEY`
 - `RTLCP_HOSTNAME`
+- `RTLCP_ROLE=evaluator`
+- `RTLCP_DB_MODE=remote`
+- `VENV_PATH` when the clean service checkout has no `.venv`
 
 Notebook:
 - `RTLCP_DATABASE_URL`
@@ -89,12 +92,38 @@ PYTHONPATH=/workspaces/rtlgen-eval-clean/control_plane
 For the local evaluator container, prefer the checked-in wrapper:
 
 ```sh
+/workspaces/rtlgen-eval-clean/control_plane/scripts/restart_local_control_plane_daemons.sh preflight
 /workspaces/rtlgen-eval-clean/control_plane/scripts/restart_local_control_plane_daemons.sh restart
 ```
 
 The wrapper starts the API, dev resolver, worker daemon, and eval resolver from
-the same service checkout and fails fast if `control_plane` imports resolve
-outside that checkout.
+the same service checkout and fails fast when:
+- `RTLCP_DATABASE_URL` is missing
+- `RTLCP_MACHINE_KEY` is missing
+- the selected `VENV_PATH` is incomplete
+- `RTLCP_DB_MODE=remote` or `RTLCP_ROLE=evaluator` points at localhost / `127.0.0.1` / `::1`
+- `RTLCP_STOP_ON_NO_WORK=1` or a finite positive `RTLCP_MAX_POLLS` is set without `RTLCP_ALLOW_FINITE_WORKER_DAEMON=1`
+- `control_plane` imports resolve outside that checkout
+
+Recommended evaluator env file entries:
+
+```sh
+RTLCP_ROLE=evaluator
+RTLCP_DB_MODE=remote
+RTLCP_DATABASE_URL=postgresql+psycopg://rtlgen:rtlgen@<notebook-host-ip>:5432/rtlgen_control_plane
+RTLCP_MACHINE_KEY=<stable evaluator machine key>
+VENV_PATH=/workspaces/RTLGen/control_plane/.venv
+```
+
+Use localhost only for explicitly declared local developer mode:
+
+```sh
+RTLCP_ROLE=server
+RTLCP_DB_MODE=local
+RTLCP_DATABASE_URL=postgresql+psycopg://rtlgen:rtlgen@localhost:5432/rtlgen_control_plane
+RTLCP_MACHINE_KEY=dev-local-control-plane
+VENV_PATH=/workspaces/RTLGen/control_plane/.venv
+```
 
 ## Service Behavior
 
@@ -151,6 +180,15 @@ python3 -m control_plane.cli.main submission-status \
   --database-url "$RTLCP_DATABASE_URL" \
   --format table
 ```
+
+Managed daemon diagnostics from the clean evaluator service checkout:
+- PID files: `/workspaces/rtlgen-eval-clean/control_plane/runtime_logs/daemons/<service>.pid`
+- daemon logs: `/workspaces/rtlgen-eval-clean/control_plane/runtime_logs/daemons/<service>.log`
+- worker job logs: `/workspaces/rtlgen-eval-clean/control_plane/runtime_logs/worker_jobs/`
+
+Override only when needed:
+- `RTLCP_RUNTIME_DIR` for PID and daemon log files
+- `RTLCP_LOG_ROOT` for worker job logs
 
 ## Recovery
 


### PR DESCRIPTION
## Summary
- require explicit database URL and stable machine key for managed daemon starts
- reject remote/evaluator localhost database targets and accidentally finite workers
- validate the selected virtualenv before stopping or starting services
- add a non-secret `preflight` action and document exact PID/log paths

## Failure addressed
The evaluator resolver can remain healthy while the worker is absent when the worker silently targets localhost, derives a different machine key, or exits due to `STOP_ON_NO_WORK`/finite `MAX_POLLS`. The old restart path also could stop healthy daemons before discovering invalid configuration.

## Verification
- `bash -n control_plane/scripts/restart_local_control_plane_daemons.sh`
- 11 behavioral preflight/restart tests
- 39 total focused daemon/worker/resolver tests
