### PR TITLE
Add streamed exact score32 partial reduction tree

### DIFF
--- a/npu/docs/attention_score32_exact_partial_tree_contract.md
+++ b/npu/docs/attention_score32_exact_partial_tree_contract.md
@@ -1,0 +1,44 @@
+# Score32 Exact Partial Tree Contract
+
+This phase closes the cross-cluster merge semantics with a streamed radix-2
+tree built from the exact-partial pair primitive.
+
+## Contract
+
+- Each leaf is an independent ready/valid exact-partial stream.
+- Each beat carries `command_id`, `head_id`, signed `S32` global max, unsigned
+  `U33` exponent sum, slice index, `last`, and `8 x signed S41` numerators
+  (`328` payload bits).
+- The tree preserves left-to-right level-wise pairing. There is no merge path
+  through locally normalized values.
+- Each pair node buffers only its current left/right beat. There is no
+  monolithic 16-cluster x full-head exact-state register in this phase.
+- Sticky protocol errors and completed-count monitors are exposed per node and
+  per stage.
+
+## Capacity And Traffic
+
+- Theoretical full-Llama `32`-head exact preserved state remains
+  `21252 B/cluster`.
+- The streamed leaf link repeats metadata on every slice beat, so one cluster
+  emits `26816 B` for `32` heads across the direct exact-partial link.
+- A 16-cluster spatial tree therefore carries `429056 B` of leaf traffic for a
+  full `32`-head reduction wave before the finalizer.
+
+## Probe Evidence
+
+- Quick smoke probes may use smaller head counts for `c2`/`c4` runtime.
+- The real `c16` regression now runs the full `32`-head workload:
+  `512` accepted beats per leaf, `8192` total leaf beats, and `512` root
+  outputs under deterministic skew and root backpressure.
+- Probe reports must label measured workload counts/cycles separately from the
+  theoretical `32`-head capacity numbers above.
+
+## Boundaries Still Open
+
+- The links are still direct `328`-bit numerator payload streams with repeated
+  metadata. No NoC or placement closure is claimed here.
+- Final normalization/division is still the next boundary. The root currently
+  emits merged exact partial state, not finalized values.
+- Folded/time-multiplexed trees and radix-4 fan-in remain later area
+  sensitivity work, not part of this verified phase-B implementation.

--- a/npu/eval/probe_attention_score32_exact_partial_tree.py
+++ b/npu/eval/probe_attention_score32_exact_partial_tree.py
@@ -1,0 +1,559 @@
+#!/usr/bin/env python3
+"""Probe the streamed exact-partial radix-2 reduction tree against an independent Python reference."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_score32_exact_partial_tree import generate as generate_tree
+from npu.sim.perf.attention_exact_partial import (
+    ExactPartialBeat,
+    exact_partial_tree_service_manifest,
+    merge_balanced_partial_streams,
+    pack_numerators,
+    partial_stream_from_blocks,
+    unpack_numerators,
+)
+
+JsonDict = dict[str, Any]
+
+_ROOT_RE = re.compile(
+    r"ROOT_RESULT cmd=(\d+) head=(\d+) slice=(\d+) last=(\d+) max=(-?\d+) sum=(\d+) value=([0-9a-fA-F]+) cycle=(\d+)"
+)
+_LEAF_RE = re.compile(r"LEAF_SUMMARY leaf=(\d+) accepted=(\d+) issued=(\d+)")
+_NODE_RE = re.compile(r"NODE_SUMMARY stage=(\d+) node=(\d+) count=(\d+) error=(\d+)")
+_STAGE_RE = re.compile(r"STAGE_SUMMARY stage=(\d+) count=(\d+) error=(\d+)")
+_SUMMARY_RE = re.compile(
+    r"SUMMARY outputs=(\d+) dut_cycle=(\d+) tb_cycle=(\d+) first=(\d+) last=(\d+) protocol_error=(\d+) root_completed=(\d+)"
+)
+
+
+def _tool(name: str) -> str:
+    path = shutil.which(name)
+    if path:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    if fallback.exists():
+        return str(fallback)
+    raise RuntimeError(f"required tool unavailable: {name}")
+
+
+def _hash(value: object) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def _signed_literal(value: int, bits: int) -> str:
+    return f"-{bits}'sd{abs(value)}" if value < 0 else f"{bits}'sd{value}"
+
+
+def _commands(heads: int) -> tuple[dict[str, int], ...]:
+    head_count = int(heads)
+    if head_count < 1 or head_count > 32:
+        raise ValueError("heads must be in [1, 32]")
+    return tuple({"command_id": 0x5A00 + head_index, "head_id": head_index} for head_index in range(head_count))
+
+
+def _score_rows(leaf: int, command_index: int) -> tuple[tuple[int, ...], ...]:
+    return tuple(
+        tuple(
+            ((leaf * 43 + command_index * 29 + block * 17 + lane * 11) % 255) - 127 + (14 if lane == block else 0)
+            for lane in range(8)
+        )
+        for block in range(3)
+    )
+
+
+def _value_blocks(leaf: int, command_index: int) -> tuple[tuple[tuple[tuple[int, ...], ...], ...], ...]:
+    return tuple(
+        tuple(
+            tuple(
+                tuple(
+                    ((leaf * 59 + command_index * 31 + block * 23 + value_slice * 13 + row * 7 + lane * 5) % 255) - 127
+                    for lane in range(8)
+                )
+                for row in range(8)
+            )
+            for value_slice in range(16)
+        )
+        for block in range(3)
+    )
+
+
+def _leaf_stream(leaf: int, *, heads: int) -> tuple[ExactPartialBeat, ...]:
+    beats: list[ExactPartialBeat] = []
+    for command_index, command in enumerate(_commands(heads)):
+        beats.extend(
+            partial_stream_from_blocks(
+                command_id=int(command["command_id"]),
+                head_id=int(command["head_id"]),
+                score_rows=_score_rows(leaf, command_index),
+                value_blocks=_value_blocks(leaf, command_index),
+            )
+        )
+    return tuple(beats)
+
+
+def _shape(clusters: int) -> list[list[int]]:
+    level_sizes: list[list[int]] = []
+    next_index = 0
+    width = clusters // 2
+    while width:
+        level_sizes.append(list(range(next_index, next_index + width)))
+        next_index += width
+        width //= 2
+    return level_sizes
+
+
+def _expected(clusters: int, *, heads: int) -> dict[str, object]:
+    leaves = [_leaf_stream(leaf, heads=heads) for leaf in range(clusters)]
+    root = merge_balanced_partial_streams(leaves)
+    root_rows = [
+        {
+            "command_id": beat.command_id,
+            "head_id": beat.head_id,
+            "slice": beat.slice_index,
+            "last": beat.last,
+            "global_max": beat.max_score,
+            "exp_sum": beat.exp_sum,
+            "value": list(beat.numerators),
+        }
+        for beat in root
+    ]
+    levels = _shape(clusters)
+    total_results = len(root_rows)
+    leaf_rows = [
+        [
+            {
+                "command_id": beat.command_id,
+                "head_id": beat.head_id,
+                "slice": beat.slice_index,
+                "last": beat.last,
+                "global_max": beat.max_score,
+                "exp_sum": beat.exp_sum,
+                "value": list(beat.numerators),
+            }
+            for beat in leaf
+        ]
+        for leaf in leaves
+    ]
+    return {
+        "heads": heads,
+        "leaves": leaf_rows,
+        "root": root_rows,
+        "leaf_hash": _hash(leaf_rows),
+        "root_hash": _hash(root_rows),
+        "leaf_accept_count": [total_results] * clusters,
+        "node_completed_count": [total_results] * (clusters - 1),
+        "stage_completed_count": [len(level) * total_results for level in levels],
+        "node_protocol_error": [False] * (clusters - 1),
+        "stage_protocol_error": [False] * len(levels),
+    }
+
+
+def _config(clusters: int) -> dict[str, object]:
+    return {
+        "top_name": f"attention_score32_exact_partial_tree_c{clusters}_r2",
+        "attention_score32_exact_partial_tree": {
+            "clusters": clusters,
+            "radix": 2,
+            "value_slices": 16,
+            "head_id_bits": 5,
+        },
+    }
+
+
+def _testbench(*, top_name: str, clusters: int, heads: int, expected: dict[str, object]) -> str:
+    leaf_rows = expected["leaves"]
+    total_results = len(expected["root"])
+    mem_depth = clusters * total_results
+    leaf_init: list[str] = []
+    for leaf in range(clusters):
+        rows = leaf_rows[leaf]
+        for beat_index, beat in enumerate(rows):
+            flat_index = (leaf * total_results) + beat_index
+            leaf_init.append(
+                f"    leaf_cmd_mem[{flat_index}] = 16'h{int(beat['command_id']):04x}; "
+                f"leaf_head_mem[{flat_index}] = 5'd{int(beat['head_id'])}; "
+                f"leaf_max_mem[{flat_index}] = {_signed_literal(int(beat['global_max']), 32)}; "
+                f"leaf_sum_mem[{flat_index}] = 33'd{int(beat['exp_sum'])}; "
+                f"leaf_slice_mem[{flat_index}] = 4'd{int(beat['slice'])}; "
+                f"leaf_last_mem[{flat_index}] = 1'b{1 if beat['last'] else 0}; "
+                f"leaf_value_mem[{flat_index}] = 328'h{pack_numerators(beat['value']):082x};"
+            )
+
+    launch_blocks = []
+    leaf_accept_displays = []
+    for leaf in range(clusters):
+        launch_blocks.append(
+            f"""      if (!leaf_pending[{leaf}] && leaf_issue[{leaf}] < TOTAL_RESULTS) begin
+        if ((((cycle + {leaf * 3}) % (3 + ({leaf} % 5))) != 0) && (((cycle + leaf_issue[{leaf}] + {leaf}) % 7) != 1)) begin
+          leaf_pending[{leaf}] <= 1'b1;
+        end
+      end
+      if (leaf_pending[{leaf}] && leaf_ready[{leaf}]) begin
+        leaf_pending[{leaf}] <= 1'b0;
+        leaf_accept_count[{leaf}] <= leaf_accept_count[{leaf}] + 1;
+        leaf_issue[{leaf}] <= leaf_issue[{leaf}] + 1;
+      end"""
+        )
+        leaf_accept_displays.append(
+            f'        $display("LEAF_SUMMARY leaf={leaf} accepted=%0d issued=%0d", leaf_accept_count[{leaf}], leaf_issue[{leaf}]);'
+        )
+
+    node_stage_displays = []
+    stage_levels = _shape(clusters)
+    for stage, indices in enumerate(stage_levels):
+        for node_index in indices:
+            node_stage_displays.append(
+                f'        $display("NODE_SUMMARY stage={stage} node={node_index} count=%0d error=%0d", '
+                f"node_completed_count[{node_index * 32} +: 32], node_protocol_error[{node_index}]);"
+            )
+
+    stage_displays = [
+        f'        $display("STAGE_SUMMARY stage={stage} count=%0d error=%0d", '
+        f"stage_completed_count[{stage * 32} +: 32], stage_protocol_error[{stage}]);"
+        for stage in range(len(stage_levels))
+    ]
+
+    return f"""`timescale 1ns/1ps
+module tb;
+  localparam integer CLUSTERS = {clusters};
+  localparam integer HEADS = {heads};
+  localparam integer TOTAL_RESULTS = {total_results};
+  localparam integer MEM_DEPTH = {mem_depth};
+  reg clk = 0, rst_n = 0;
+  reg [CLUSTERS-1:0] leaf_valid;
+  wire [CLUSTERS-1:0] leaf_ready;
+  reg [(CLUSTERS*16)-1:0] leaf_command_id;
+  reg [(CLUSTERS*5)-1:0] leaf_head_id;
+  reg [(CLUSTERS*32)-1:0] leaf_global_max;
+  reg [(CLUSTERS*33)-1:0] leaf_exp_sum;
+  reg [(CLUSTERS*4)-1:0] leaf_slice;
+  reg [CLUSTERS-1:0] leaf_last;
+  reg [(CLUSTERS*328)-1:0] leaf_value;
+  wire root_valid;
+  reg root_ready;
+  wire [15:0] root_command_id;
+  wire [4:0] root_head_id;
+  wire signed [31:0] root_global_max;
+  wire [32:0] root_exp_sum;
+  wire [3:0] root_slice;
+  wire root_last;
+  wire [327:0] root_value;
+  wire [31:0] cycle_count;
+  wire [31:0] root_completed_count;
+  wire [{(clusters - 1) * 32 - 1}:0] node_completed_count;
+  wire [{int(math.log2(clusters)) * 32 - 1}:0] stage_completed_count;
+  wire [{clusters - 2}:0] node_protocol_error;
+  wire [{int(math.log2(clusters)) - 1}:0] stage_protocol_error;
+  wire protocol_error;
+
+  reg [15:0] leaf_cmd_mem [0:MEM_DEPTH-1];
+  reg [4:0] leaf_head_mem [0:MEM_DEPTH-1];
+  reg signed [31:0] leaf_max_mem [0:MEM_DEPTH-1];
+  reg [32:0] leaf_sum_mem [0:MEM_DEPTH-1];
+  reg [3:0] leaf_slice_mem [0:MEM_DEPTH-1];
+  reg leaf_last_mem [0:MEM_DEPTH-1];
+  reg [327:0] leaf_value_mem [0:MEM_DEPTH-1];
+  reg leaf_pending [0:CLUSTERS-1];
+  reg [31:0] leaf_issue [0:CLUSTERS-1];
+  reg [31:0] leaf_accept_count [0:CLUSTERS-1];
+  integer init_index;
+  integer cycle = 0;
+  integer root_seen = 0;
+  integer first_output_cycle = -1;
+  integer last_output_cycle = -1;
+  reg pending_summary = 0;
+  integer leaf_index;
+
+  always #5 clk = ~clk;
+
+  {top_name} dut (
+      .clk(clk),
+      .rst_n(rst_n),
+      .leaf_valid(leaf_valid),
+      .leaf_ready(leaf_ready),
+      .leaf_command_id(leaf_command_id),
+      .leaf_head_id(leaf_head_id),
+      .leaf_global_max(leaf_global_max),
+      .leaf_exp_sum(leaf_exp_sum),
+      .leaf_slice(leaf_slice),
+      .leaf_last(leaf_last),
+      .leaf_value(leaf_value),
+      .root_valid(root_valid),
+      .root_ready(root_ready),
+      .root_command_id(root_command_id),
+      .root_head_id(root_head_id),
+      .root_global_max(root_global_max),
+      .root_exp_sum(root_exp_sum),
+      .root_slice(root_slice),
+      .root_last(root_last),
+      .root_value(root_value),
+      .cycle_count(cycle_count),
+      .root_completed_count(root_completed_count),
+      .node_completed_count(node_completed_count),
+      .stage_completed_count(stage_completed_count),
+      .node_protocol_error(node_protocol_error),
+      .stage_protocol_error(stage_protocol_error),
+      .protocol_error(protocol_error)
+  );
+
+  always @* begin
+    leaf_valid = {{CLUSTERS{{1'b0}}}};
+    leaf_command_id = {{(CLUSTERS*16){{1'b0}}}};
+    leaf_head_id = {{(CLUSTERS*5){{1'b0}}}};
+    leaf_global_max = {{(CLUSTERS*32){{1'b0}}}};
+    leaf_exp_sum = {{(CLUSTERS*33){{1'b0}}}};
+    leaf_slice = {{(CLUSTERS*4){{1'b0}}}};
+    leaf_last = {{CLUSTERS{{1'b0}}}};
+    leaf_value = {{(CLUSTERS*328){{1'b0}}}};
+    root_ready = ((cycle % 5) != 2) && ((cycle % 11) != 7);
+    for (leaf_index = 0; leaf_index < CLUSTERS; leaf_index = leaf_index + 1) begin
+      if (leaf_pending[leaf_index]) begin
+        leaf_valid[leaf_index] = 1'b1;
+        leaf_command_id[(leaf_index * 16) +: 16] =
+            leaf_cmd_mem[(leaf_index * TOTAL_RESULTS) + leaf_issue[leaf_index]];
+        leaf_head_id[(leaf_index * 5) +: 5] =
+            leaf_head_mem[(leaf_index * TOTAL_RESULTS) + leaf_issue[leaf_index]];
+        leaf_global_max[(leaf_index * 32) +: 32] =
+            leaf_max_mem[(leaf_index * TOTAL_RESULTS) + leaf_issue[leaf_index]];
+        leaf_exp_sum[(leaf_index * 33) +: 33] =
+            leaf_sum_mem[(leaf_index * TOTAL_RESULTS) + leaf_issue[leaf_index]];
+        leaf_slice[(leaf_index * 4) +: 4] =
+            leaf_slice_mem[(leaf_index * TOTAL_RESULTS) + leaf_issue[leaf_index]];
+        leaf_last[leaf_index] =
+            leaf_last_mem[(leaf_index * TOTAL_RESULTS) + leaf_issue[leaf_index]];
+        leaf_value[(leaf_index * 328) +: 328] =
+            leaf_value_mem[(leaf_index * TOTAL_RESULTS) + leaf_issue[leaf_index]];
+      end
+    end
+  end
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      cycle <= 0;
+      root_seen <= 0;
+      first_output_cycle <= -1;
+      last_output_cycle <= -1;
+      pending_summary <= 1'b0;
+      for (leaf_index = 0; leaf_index < CLUSTERS; leaf_index = leaf_index + 1) begin
+        leaf_pending[leaf_index] <= 1'b0;
+        leaf_issue[leaf_index] <= 32'd0;
+        leaf_accept_count[leaf_index] <= 32'd0;
+      end
+    end else begin
+      cycle <= cycle + 1;
+{chr(10).join(launch_blocks)}
+      if (root_valid && root_ready) begin
+        $display("ROOT_RESULT cmd=%0d head=%0d slice=%0d last=%0d max=%0d sum=%0d value=%082x cycle=%0d",
+                 root_command_id, root_head_id, root_slice, root_last, $signed(root_global_max), root_exp_sum, root_value, cycle);
+        if (first_output_cycle < 0) first_output_cycle <= cycle;
+        last_output_cycle <= cycle;
+        root_seen <= root_seen + 1;
+        if (root_seen + 1 == TOTAL_RESULTS) pending_summary <= 1'b1;
+      end
+      if (pending_summary) begin
+{chr(10).join(leaf_accept_displays)}
+{chr(10).join(node_stage_displays)}
+{chr(10).join(stage_displays)}
+        $display("SUMMARY outputs=%0d dut_cycle=%0d tb_cycle=%0d first=%0d last=%0d protocol_error=%0d root_completed=%0d",
+                 root_seen, cycle_count, cycle, first_output_cycle, last_output_cycle, protocol_error, root_completed_count);
+        #1 $finish;
+      end
+      if (cycle > {max(4000, clusters * total_results * 8)}) $fatal(1, "timeout");
+    end
+  end
+
+  initial begin
+    for (init_index = 0; init_index < MEM_DEPTH; init_index = init_index + 1) begin
+      leaf_cmd_mem[init_index] = 16'd0;
+      leaf_head_mem[init_index] = 5'd0;
+      leaf_max_mem[init_index] = 32'sd0;
+      leaf_sum_mem[init_index] = 33'd0;
+      leaf_slice_mem[init_index] = 4'd0;
+      leaf_last_mem[init_index] = 1'b0;
+      leaf_value_mem[init_index] = 328'd0;
+    end
+{chr(10).join(leaf_init)}
+    repeat (3) @(posedge clk);
+    @(negedge clk);
+    rst_n = 1'b1;
+  end
+endmodule
+"""
+
+
+def build_report(clusters: int = 16, heads: int = 32) -> JsonDict:
+    expected = _expected(clusters, heads=heads)
+    with tempfile.TemporaryDirectory(prefix=f"score32_exact_partial_tree_c{clusters}_") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        generate_tree(_config(clusters), temp_dir / "rtl")
+        tb_path = temp_dir / "tb.sv"
+        top_name = str(_config(clusters)["top_name"])
+        tb_path.write_text(
+            _testbench(top_name=top_name, clusters=clusters, heads=heads, expected=expected),
+            encoding="utf-8",
+        )
+
+        simv = temp_dir / "simv"
+        compiled = subprocess.run(
+            [
+                _tool("iverilog"),
+                "-g2012",
+                "-s",
+                "tb",
+                "-o",
+                str(simv),
+                str(temp_dir / "rtl" / "top.v"),
+                str(tb_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        if compiled.returncode:
+            raise RuntimeError(f"iverilog failed:\n{compiled.stderr}")
+        run = subprocess.run([_tool("vvp"), str(simv)], capture_output=True, text=True, timeout=300)
+        if run.returncode:
+            raise RuntimeError(f"simulation failed:\n{run.stdout}\n{run.stderr}")
+
+    observed_root: list[dict[str, object]] = []
+    leaf_summary: list[int] = [0] * clusters
+    node_count = clusters - 1
+    stage_count = int(math.log2(clusters))
+    node_completed_count: list[int] = [0] * node_count
+    node_protocol_error: list[bool] = [False] * node_count
+    stage_completed_count: list[int] = [0] * stage_count
+    stage_protocol_error: list[bool] = [False] * stage_count
+    summary: dict[str, object] | None = None
+    for line in run.stdout.splitlines():
+        stripped = line.strip()
+        if match := _ROOT_RE.fullmatch(stripped):
+            observed_root.append(
+                {
+                    "command_id": int(match.group(1)),
+                    "head_id": int(match.group(2)),
+                    "slice": int(match.group(3)),
+                    "last": bool(int(match.group(4))),
+                    "global_max": int(match.group(5)),
+                    "exp_sum": int(match.group(6)),
+                    "value": list(unpack_numerators(int(match.group(7), 16))),
+                    "cycle": int(match.group(8)),
+                }
+            )
+        elif match := _LEAF_RE.fullmatch(stripped):
+            leaf = int(match.group(1))
+            leaf_summary[leaf] = int(match.group(2))
+            if int(match.group(3)) != int(match.group(2)):
+                raise RuntimeError(f"leaf issue/accept mismatch in leaf {leaf}: {stripped}")
+        elif match := _NODE_RE.fullmatch(stripped):
+            node = int(match.group(2))
+            node_completed_count[node] = int(match.group(3))
+            node_protocol_error[node] = bool(int(match.group(4)))
+        elif match := _STAGE_RE.fullmatch(stripped):
+            stage = int(match.group(1))
+            stage_completed_count[stage] = int(match.group(2))
+            stage_protocol_error[stage] = bool(int(match.group(3)))
+        elif match := _SUMMARY_RE.fullmatch(stripped):
+            summary = {
+                "outputs": int(match.group(1)),
+                "dut_cycle": int(match.group(2)),
+                "tb_cycle": int(match.group(3)),
+                "first_output_cycle": int(match.group(4)),
+                "last_output_cycle": int(match.group(5)),
+                "protocol_error": bool(int(match.group(6))),
+                "root_completed_count": int(match.group(7)),
+            }
+    if summary is None:
+        raise RuntimeError("summary missing from tree probe")
+
+    observed_rows = [{key: value for key, value in row.items() if key != "cycle"} for row in observed_root]
+    root_hash = _hash(observed_rows)
+    expected_hash = str(expected["root_hash"])
+    first_output_cycle = int(summary["first_output_cycle"])
+    last_output_cycle = int(summary["last_output_cycle"])
+    sustained_window = max(1, (last_output_cycle - first_output_cycle) + 1)
+    measured_workload_manifest = exact_partial_tree_service_manifest(clusters=clusters, heads=heads)
+    measured_workload_manifest.update(
+        {
+            "leaf_accepts_per_leaf": len(expected["root"]),
+            "total_leaf_beats": clusters * len(expected["root"]),
+            "root_outputs": len(expected["root"]),
+            "first_output_cycle": first_output_cycle,
+            "last_output_cycle": last_output_cycle,
+            "drain_cycles": int(summary["tb_cycle"]),
+            "root_sustained_beats": int(summary["outputs"]),
+            "root_sustained_cycles": sustained_window,
+            "root_sustained_beats_per_cycle": round(int(summary["outputs"]) / sustained_window, 6),
+            "protocol_error": bool(summary["protocol_error"]),
+        }
+    )
+    theoretical_full_llama_service_manifest = exact_partial_tree_service_manifest(clusters=clusters, heads=32)
+    passed = (
+        observed_rows == expected["root"]
+        and leaf_summary == expected["leaf_accept_count"]
+        and node_completed_count == expected["node_completed_count"]
+        and stage_completed_count == expected["stage_completed_count"]
+        and node_protocol_error == expected["node_protocol_error"]
+        and stage_protocol_error == expected["stage_protocol_error"]
+        and bool(summary["protocol_error"]) is False
+        and int(summary["outputs"]) == len(expected["root"])
+        and int(summary["root_completed_count"]) == len(expected["root"])
+        and root_hash == expected_hash
+    )
+    return {
+        "clusters": clusters,
+        "heads": heads,
+        "decision": "pass" if passed else "fail",
+        "equivalence_pass": passed,
+        "leaf_input_hash": expected["leaf_hash"],
+        "root_hash": root_hash,
+        "expected_root_hash": expected_hash,
+        "leaf_accept_count": leaf_summary,
+        "leaf_total_accept_count": sum(leaf_summary),
+        "root_result_count": len(observed_rows),
+        "node_completed_count": node_completed_count,
+        "stage_completed_count": stage_completed_count,
+        "node_protocol_error": node_protocol_error,
+        "stage_protocol_error": stage_protocol_error,
+        "summary": summary,
+        "measured_workload_manifest": measured_workload_manifest,
+        "theoretical_full_llama_service_manifest": theoretical_full_llama_service_manifest,
+        "expected": {
+            "heads": expected["heads"],
+            "leaf_accept_count": expected["leaf_accept_count"],
+            "node_completed_count": expected["node_completed_count"],
+            "stage_completed_count": expected["stage_completed_count"],
+            "node_protocol_error": expected["node_protocol_error"],
+            "stage_protocol_error": expected["stage_protocol_error"],
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--clusters", type=int, choices=(2, 4, 8, 16), default=16)
+    parser.add_argument("--heads", type=int, choices=tuple(range(1, 33)), default=32)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_report(clusters=args.clusters, heads=args.heads)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0 if payload["equivalence_pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/rtlgen/gen_attention_score32_exact_partial_tree.py
+++ b/npu/rtlgen/gen_attention_score32_exact_partial_tree.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Generate a radix-2 streamed exact-partial reduction tree for score32 online merge."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_score32_online_state_merge import generate as generate_merge
+from npu.sim.perf.attention_exact_partial import (
+    PARTIAL_LINK_BITS,
+    PARTIAL_PAYLOAD_BITS,
+    exact_partial_tree_service_manifest,
+)
+
+JsonDict = dict[str, Any]
+
+
+def _load(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit(f"config must decode to a JSON object: {path}")
+    return payload
+
+
+def _clog2(value: int) -> int:
+    return max(1, math.ceil(math.log2(max(2, value))))
+
+
+def _validate(config: JsonDict) -> JsonDict:
+    top_name = str(config.get("top_name") or "").strip()
+    body = config.get("attention_score32_exact_partial_tree")
+    if not top_name or not isinstance(body, dict):
+        raise SystemExit("config requires top_name and attention_score32_exact_partial_tree")
+
+    clusters = int(body.get("clusters", 16))
+    radix = int(body.get("radix", 2))
+    value_slices = int(body.get("value_slices", 16))
+    head_id_bits = int(body.get("head_id_bits", 5))
+    if clusters < 2 or clusters > 16 or (clusters & (clusters - 1)):
+        raise SystemExit("clusters must be a power of two in [2, 16]")
+    if radix != 2:
+        raise SystemExit("phase B only implements radix=2")
+    if value_slices < 1 or value_slices > 16 or (value_slices & (value_slices - 1)):
+        raise SystemExit("value_slices must be a power of two in [1, 16]")
+    if head_id_bits < 1 or head_id_bits > 8:
+        raise SystemExit("head_id_bits must be in [1, 8]")
+    return {
+        "top_name": top_name,
+        "clusters": clusters,
+        "radix": radix,
+        "value_slices": value_slices,
+        "head_id_bits": head_id_bits,
+    }
+
+
+def _tree_levels(clusters: int) -> list[list[dict[str, Any]]]:
+    levels: list[list[dict[str, Any]]] = []
+    previous: list[tuple[str, int]] = [("leaf", index) for index in range(clusters)]
+    next_node_index = 0
+    stage = 0
+    while len(previous) > 1:
+        level: list[dict[str, Any]] = []
+        for slot in range(0, len(previous), 2):
+            level.append(
+                {
+                    "stage": stage,
+                    "slot": slot // 2,
+                    "node_index": next_node_index,
+                    "left": previous[slot],
+                    "right": previous[slot + 1],
+                }
+            )
+            next_node_index += 1
+        levels.append(level)
+        previous = [("node", node["node_index"]) for node in level]
+        stage += 1
+    return levels
+
+
+def _top_pin_bits(*, clusters: int, head_id_bits: int, stages: int, nodes: int, slice_bits: int) -> int:
+    leaf_bits = clusters * (1 + 16 + head_id_bits + 32 + 33 + slice_bits + 1 + PARTIAL_PAYLOAD_BITS + 1)
+    root_bits = 1 + 1 + 16 + head_id_bits + 32 + 33 + slice_bits + 1 + PARTIAL_PAYLOAD_BITS
+    monitor_bits = 32 + 32 + (nodes * 32) + (stages * 32) + nodes + stages + 1
+    return 2 + leaf_bits + root_bits + monitor_bits
+
+
+def _source_expr(source: tuple[str, int], *, field: str, width: int, head_id_bits: int, slice_bits: int) -> str:
+    kind, index = source
+    if kind == "leaf":
+        if field == "valid":
+            return f"leaf_valid[{index}]"
+        if field == "ready":
+            return f"leaf_ready[{index}]"
+        if field == "command_id":
+            return f"leaf_command_id[{index * 16} +: 16]"
+        if field == "head_id":
+            return f"leaf_head_id[{index * head_id_bits} +: HEAD_ID_BITS]"
+        if field == "global_max":
+            return f"leaf_global_max[{index * 32} +: 32]"
+        if field == "exp_sum":
+            return f"leaf_exp_sum[{index * 33} +: 33]"
+        if field == "slice":
+            return f"leaf_slice[{index * slice_bits} +: SLICE_BITS]"
+        if field == "last":
+            return f"leaf_last[{index}]"
+        if field == "value":
+            return f"leaf_value[{index * PARTIAL_PAYLOAD_BITS} +: PARTIAL_PAYLOAD_BITS]"
+        raise AssertionError(field)
+    if field == "valid":
+        return f"node_valid_w[{index}]"
+    if field == "ready":
+        return f"node_ready_w[{index}]"
+    if field == "command_id":
+        return f"node_command_id_w[{index}]"
+    if field == "head_id":
+        return f"node_head_id_w[{index}]"
+    if field == "global_max":
+        return f"node_global_max_w[{index}]"
+    if field == "exp_sum":
+        return f"node_exp_sum_w[{index}]"
+    if field == "slice":
+        return f"node_slice_w[{index}]"
+    if field == "last":
+        return f"node_last_w[{index}]"
+    if field == "value":
+        return f"node_value_w[{index}]"
+    raise AssertionError(field)
+
+
+def _instance_block(*, pair_top_name: str, levels: list[list[dict[str, Any]]], head_id_bits: int, slice_bits: int) -> str:
+    root_index = levels[-1][0]["node_index"]
+    blocks: list[str] = []
+    for level in levels:
+        for node in level:
+            node_index = int(node["node_index"])
+            out_ready = "root_ready" if node_index == root_index else f"node_ready_w[{node_index}]"
+            blocks.append(
+                f"""  {pair_top_name} u_node_{node_index} (
+      .clk(clk),
+      .rst_n(rst_n),
+      .left_valid({_source_expr(node["left"], field="valid", width=1, head_id_bits=head_id_bits, slice_bits=slice_bits)}),
+      .left_ready({_source_expr(node["left"], field="ready", width=1, head_id_bits=head_id_bits, slice_bits=slice_bits)}),
+      .left_command_id({_source_expr(node["left"], field="command_id", width=16, head_id_bits=head_id_bits, slice_bits=slice_bits)}),
+      .left_head_id({_source_expr(node["left"], field="head_id", width=head_id_bits, head_id_bits=head_id_bits, slice_bits=slice_bits)}),
+      .left_global_max({_source_expr(node["left"], field="global_max", width=32, head_id_bits=head_id_bits, slice_bits=slice_bits)}),
+      .left_exp_sum({_source_expr(node["left"], field="exp_sum", width=33, head_id_bits=head_id_bits, slice_bits=slice_bits)}),
+      .left_slice({_source_expr(node["left"], field="slice", width=slice_bits, head_id_bits=head_id_bits, slice_bits=slice_bits)}),
+      .left_last({_source_expr(node["left"], field="last", width=1, head_id_bits=head_id_bits, slice_bits=slice_bits)}),
+      .left_value({_source_expr(node["left"], field="value", width=PARTIAL_PAYLOAD_BITS, head_id_bits=head_id_bits, slice_bits=slice_bits)}),
+      .right_valid({_source_expr(node["right"], field="valid", width=1, head_id_bits=head_id_bits, slice_bits=slice_bits)}),
+      .right_ready({_source_expr(node["right"], field="ready", width=1, head_id_bits=head_id_bits, slice_bits=slice_bits)}),
+      .right_command_id({_source_expr(node["right"], field="command_id", width=16, head_id_bits=head_id_bits, slice_bits=slice_bits)}),
+      .right_head_id({_source_expr(node["right"], field="head_id", width=head_id_bits, head_id_bits=head_id_bits, slice_bits=slice_bits)}),
+      .right_global_max({_source_expr(node["right"], field="global_max", width=32, head_id_bits=head_id_bits, slice_bits=slice_bits)}),
+      .right_exp_sum({_source_expr(node["right"], field="exp_sum", width=33, head_id_bits=head_id_bits, slice_bits=slice_bits)}),
+      .right_slice({_source_expr(node["right"], field="slice", width=slice_bits, head_id_bits=head_id_bits, slice_bits=slice_bits)}),
+      .right_last({_source_expr(node["right"], field="last", width=1, head_id_bits=head_id_bits, slice_bits=slice_bits)}),
+      .right_value({_source_expr(node["right"], field="value", width=PARTIAL_PAYLOAD_BITS, head_id_bits=head_id_bits, slice_bits=slice_bits)}),
+      .out_valid(node_valid_w[{node_index}]),
+      .out_ready({out_ready}),
+      .out_command_id(node_command_id_w[{node_index}]),
+      .out_head_id(node_head_id_w[{node_index}]),
+      .out_global_max(node_global_max_w[{node_index}]),
+      .out_exp_sum(node_exp_sum_w[{node_index}]),
+      .out_slice(node_slice_w[{node_index}]),
+      .out_last(node_last_w[{node_index}]),
+      .out_value(node_value_w[{node_index}]),
+      .completed_count(node_completed_count_w[{node_index}]),
+      .cycle_count(node_cycle_count_w[{node_index}]),
+      .protocol_error(node_protocol_error_w[{node_index}])
+  );"""
+            )
+    return "\n\n".join(blocks)
+
+
+def _stage_assigns(levels: list[list[dict[str, Any]]]) -> tuple[str, str]:
+    stage_count_lines: list[str] = []
+    stage_error_lines: list[str] = []
+    for stage, level in enumerate(levels):
+        indices = [int(node["node_index"]) for node in level]
+        count_expr = " + ".join(f"node_completed_count_w[{index}]" for index in indices)
+        error_expr = " | ".join(f"node_protocol_error_w[{index}]" for index in indices)
+        stage_count_lines.append(f"  assign stage_completed_count[{stage * 32} +: 32] = {count_expr};")
+        stage_error_lines.append(f"  assign stage_protocol_error[{stage}] = {error_expr};")
+    return "\n".join(stage_count_lines), "\n".join(stage_error_lines)
+
+
+def _node_assigns(node_count: int) -> tuple[str, str]:
+    count_lines = [
+        f"  assign node_completed_count[{index * 32} +: 32] = node_completed_count_w[{index}];"
+        for index in range(node_count)
+    ]
+    error_lines = [
+        f"  assign node_protocol_error[{index}] = node_protocol_error_w[{index}];"
+        for index in range(node_count)
+    ]
+    return "\n".join(count_lines), "\n".join(error_lines)
+
+
+def _top(*, top_name: str, pair_top_name: str, clusters: int, value_slices: int, head_id_bits: int) -> str:
+    slice_bits = _clog2(value_slices)
+    levels = _tree_levels(clusters)
+    node_count = clusters - 1
+    stage_count = len(levels)
+    root_index = levels[-1][0]["node_index"]
+    node_count_assigns, node_error_assigns = _node_assigns(node_count)
+    stage_count_assigns, stage_error_assigns = _stage_assigns(levels)
+    instances = _instance_block(
+        pair_top_name=pair_top_name,
+        levels=levels,
+        head_id_bits=head_id_bits,
+        slice_bits=slice_bits,
+    )
+    return f"""// Auto-generated by npu/rtlgen/gen_attention_score32_exact_partial_tree.py
+module {top_name} (
+    input  wire         clk,
+    input  wire         rst_n,
+    input  wire [{clusters - 1}:0] leaf_valid,
+    output wire [{clusters - 1}:0] leaf_ready,
+    input  wire [{clusters * 16 - 1}:0] leaf_command_id,
+    input  wire [{clusters * head_id_bits - 1}:0] leaf_head_id,
+    input  wire [{clusters * 32 - 1}:0] leaf_global_max,
+    input  wire [{clusters * 33 - 1}:0] leaf_exp_sum,
+    input  wire [{clusters * slice_bits - 1}:0] leaf_slice,
+    input  wire [{clusters - 1}:0] leaf_last,
+    input  wire [{clusters * PARTIAL_PAYLOAD_BITS - 1}:0] leaf_value,
+    output wire         root_valid,
+    input  wire         root_ready,
+    output wire [15:0]  root_command_id,
+    output wire [{head_id_bits - 1}:0] root_head_id,
+    output wire signed [31:0] root_global_max,
+    output wire [32:0]  root_exp_sum,
+    output wire [{slice_bits - 1}:0] root_slice,
+    output wire         root_last,
+    output wire [327:0] root_value,
+    output wire [31:0]  cycle_count,
+    output wire [31:0]  root_completed_count,
+    output wire [{node_count * 32 - 1}:0] node_completed_count,
+    output wire [{stage_count * 32 - 1}:0] stage_completed_count,
+    output wire [{node_count - 1}:0] node_protocol_error,
+    output wire [{stage_count - 1}:0] stage_protocol_error,
+    output wire         protocol_error
+);
+  localparam integer CLUSTERS = {clusters};
+  localparam integer TREE_STAGES = {stage_count};
+  localparam integer TREE_NODES = {node_count};
+  localparam integer HEAD_ID_BITS = {head_id_bits};
+  localparam integer VALUE_SLICES = {value_slices};
+  localparam integer SLICE_BITS = {slice_bits};
+  localparam integer PARTIAL_PAYLOAD_BITS = {PARTIAL_PAYLOAD_BITS};
+
+  wire node_valid_w [0:TREE_NODES-1];
+  wire node_ready_w [0:TREE_NODES-1];
+  wire [15:0] node_command_id_w [0:TREE_NODES-1];
+  wire [HEAD_ID_BITS-1:0] node_head_id_w [0:TREE_NODES-1];
+  wire signed [31:0] node_global_max_w [0:TREE_NODES-1];
+  wire [32:0] node_exp_sum_w [0:TREE_NODES-1];
+  wire [SLICE_BITS-1:0] node_slice_w [0:TREE_NODES-1];
+  wire node_last_w [0:TREE_NODES-1];
+  wire [PARTIAL_PAYLOAD_BITS-1:0] node_value_w [0:TREE_NODES-1];
+  wire [31:0] node_completed_count_w [0:TREE_NODES-1];
+  wire [31:0] node_cycle_count_w [0:TREE_NODES-1];
+  wire node_protocol_error_w [0:TREE_NODES-1];
+
+  assign root_valid = node_valid_w[{root_index}];
+  assign root_command_id = node_command_id_w[{root_index}];
+  assign root_head_id = node_head_id_w[{root_index}];
+  assign root_global_max = node_global_max_w[{root_index}];
+  assign root_exp_sum = node_exp_sum_w[{root_index}];
+  assign root_slice = node_slice_w[{root_index}];
+  assign root_last = node_last_w[{root_index}];
+  assign root_value = node_value_w[{root_index}];
+  assign root_completed_count = node_completed_count_w[{root_index}];
+  assign cycle_count = node_cycle_count_w[{root_index}];
+  assign protocol_error = |node_protocol_error;
+
+{node_count_assigns}
+{node_error_assigns}
+{stage_count_assigns}
+{stage_error_assigns}
+
+{instances}
+endmodule
+"""
+
+
+def generate(config: JsonDict, out_dir: Path) -> None:
+    params = _validate(json.loads(json.dumps(config)))
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    pair_top_name = f"{params['top_name']}__pair_node"
+    with tempfile.TemporaryDirectory(prefix="score32_exact_partial_tree_pair_") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        generate_merge(
+            {
+                "top_name": pair_top_name,
+                "attention_score32_online_state_merge": {
+                    "value_slices": int(params["value_slices"]),
+                    "head_id_bits": int(params["head_id_bits"]),
+                },
+            },
+            temp_dir,
+        )
+        pair_rtl = (temp_dir / "top.v").read_text(encoding="utf-8")
+        pair_manifest = json.loads(
+            (temp_dir / "attention_score32_online_state_merge_manifest.json").read_text(encoding="utf-8")
+        )
+
+    top_text = _top(
+        top_name=str(params["top_name"]),
+        pair_top_name=pair_top_name,
+        clusters=int(params["clusters"]),
+        value_slices=int(params["value_slices"]),
+        head_id_bits=int(params["head_id_bits"]),
+    )
+    (out_dir / "top.v").write_text(pair_rtl + "\n\n" + top_text, encoding="utf-8")
+    (out_dir / "config.json").write_text(json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    theoretical_full_llama_service_manifest = exact_partial_tree_service_manifest(
+        clusters=int(params["clusters"]),
+        heads=32,
+    )
+    node_count = int(params["clusters"]) - 1
+    stage_count = int(math.log2(int(params["clusters"])))
+    manifest = {
+        "version": 1,
+        "top_name": params["top_name"],
+        "generator": "npu/rtlgen/gen_attention_score32_exact_partial_tree.py",
+        "semantic_profile": "score32_online_exact_partial_radix2_tree_v1",
+        "clusters": int(params["clusters"]),
+        "radix": int(params["radix"]),
+        "value_slices": int(params["value_slices"]),
+        "head_id_bits": int(params["head_id_bits"]),
+        "tree_stages": stage_count,
+        "tree_nodes": node_count,
+        "result_interface": "clusters_ready_valid_exact_partial_leaf_streams_to_root_stream",
+        "partial_payload_bits_per_beat": PARTIAL_PAYLOAD_BITS,
+        "partial_link_bits_per_beat": PARTIAL_LINK_BITS,
+        "equivalence_hash": False,
+        "direct_328bit_links_unclosed": True,
+        "final_divider_embodied": False,
+        "macro_eval_excludes_io_pads": True,
+        "top_pin_bits": _top_pin_bits(
+            clusters=int(params["clusters"]),
+            head_id_bits=int(params["head_id_bits"]),
+            stages=stage_count,
+            nodes=node_count,
+            slice_bits=_clog2(int(params["value_slices"])),
+        ),
+        "theoretical_full_llama_service_manifest": theoretical_full_llama_service_manifest,
+        "submodule_manifests": {"pair_merge": pair_manifest},
+    }
+    (out_dir / "attention_score32_exact_partial_tree_manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    generate(_load(args.config), args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/rtlgen/gen_attention_score32_online_state_merge.py
+++ b/npu/rtlgen/gen_attention_score32_online_state_merge.py
@@ -101,7 +101,7 @@ module {top_name} (
 );
   localparam integer VALUE_SLICES = {value_slices};
   localparam integer HEAD_ID_BITS = {head_id_bits};
-  localparam [{slice_bits - 1}:0] LAST_SLICE = VALUE_SLICES - 1;
+  localparam [{slice_bits - 1}:0] LAST_SLICE = {slice_bits}'d{value_slices - 1};
 
   reg left_hold_valid_q;
   reg [15:0] left_command_id_hold_q;

--- a/npu/sim/perf/attention_exact_partial.py
+++ b/npu/sim/perf/attention_exact_partial.py
@@ -26,7 +26,12 @@ from npu.sim.perf.attention_separated import (
 HEAD_ID_BITS = 5
 SLICE_LANES = 8
 VALUE_SLICES = 16
+SLICE_INDEX_BITS = (VALUE_SLICES - 1).bit_length()
 PARTIAL_PAYLOAD_BITS = SLICE_LANES * WEIGHTED_NUMERATOR_BITS
+PARTIAL_LINK_BITS = PARTIAL_PAYLOAD_BITS + 16 + HEAD_ID_BITS + SCORE_BITS + EXP_SUM_BITS + SLICE_INDEX_BITS + 1
+EXACT_STATE_BITS_PER_HEAD = (VALUE_SLICES * PARTIAL_PAYLOAD_BITS) + SCORE_BITS + EXP_SUM_BITS
+EXACT_STATE_BYTES_PER_CLUSTER_32_HEADS = (EXACT_STATE_BITS_PER_HEAD * 32) // 8
+LEAF_STREAM_BYTES_PER_CLUSTER_32_HEADS = (PARTIAL_LINK_BITS * VALUE_SLICES * 32) // 8
 MERGE_SCALE = (1 << MERGE_SCALE_BITS) - 1
 
 
@@ -207,6 +212,30 @@ def merge_partial_streams(
     return tuple(merge_partial_beats(left_beats[index], right_beats[index]) for index in range(VALUE_SLICES))
 
 
+def merge_balanced_partial_streams(streams: Iterable[Iterable[ExactPartialBeat]]) -> tuple[ExactPartialBeat, ...]:
+    level = [tuple(stream) for stream in streams]
+    if not level:
+        raise ValueError("expected at least one partial stream")
+    if len(level) & (len(level) - 1):
+        raise ValueError("stream count must be a power of two")
+    expected_beats = len(level[0])
+    if expected_beats == 0:
+        raise ValueError("partial streams must be non-empty")
+    if any(len(stream) != expected_beats for stream in level):
+        raise ValueError("all partial streams must contain the same beat count")
+    while len(level) > 1:
+        next_level: list[tuple[ExactPartialBeat, ...]] = []
+        for index in range(0, len(level), 2):
+            next_level.append(
+                tuple(
+                    merge_partial_beats(level[index][beat_index], level[index + 1][beat_index])
+                    for beat_index in range(expected_beats)
+                )
+            )
+        level = next_level
+    return level[0]
+
+
 def merge_partial_streams_via_local_normalization(
     left: Iterable[ExactPartialBeat],
     right: Iterable[ExactPartialBeat],
@@ -278,13 +307,50 @@ def normalized_merge_guard_case() -> tuple[tuple[ExactPartialBeat, ...], tuple[E
     return left, right
 
 
+def exact_partial_tree_service_manifest(*, clusters: int, heads: int = 32) -> dict[str, int | bool | str]:
+    cluster_count = int(clusters)
+    head_count = int(heads)
+    if cluster_count < 2 or cluster_count > 16 or (cluster_count & (cluster_count - 1)):
+        raise ValueError("clusters must be a power of two in [2, 16]")
+    if head_count < 1:
+        raise ValueError("heads must be positive")
+    stages = int(math.log2(cluster_count))
+    nodes = cluster_count - 1
+    exact_state_bytes_per_cluster = (EXACT_STATE_BITS_PER_HEAD * head_count) // 8
+    leaf_stream_bytes_per_cluster = (PARTIAL_LINK_BITS * VALUE_SLICES * head_count) // 8
+    return {
+        "clusters": cluster_count,
+        "heads": head_count,
+        "radix": 2,
+        "tree_stages": stages,
+        "tree_nodes": nodes,
+        "value_slices": VALUE_SLICES,
+        "slice_lanes": SLICE_LANES,
+        "partial_payload_bits_per_beat": PARTIAL_PAYLOAD_BITS,
+        "partial_link_bits_per_beat": PARTIAL_LINK_BITS,
+        "exact_state_bytes_per_cluster": exact_state_bytes_per_cluster,
+        "leaf_stream_bytes_per_cluster": leaf_stream_bytes_per_cluster,
+        "total_leaf_stream_bytes": leaf_stream_bytes_per_cluster * cluster_count,
+        "direct_328bit_links_unclosed": True,
+        "final_divider_embodied": False,
+        "finalizer_boundary": "next_phase",
+        "future_area_sensitivity": "folded_or_radix4_tree",
+    }
+
+
 __all__ = [
+    "EXACT_STATE_BYTES_PER_CLUSTER_32_HEADS",
     "ExactPartialBeat",
     "HEAD_ID_BITS",
+    "LEAF_STREAM_BYTES_PER_CLUSTER_32_HEADS",
     "PARTIAL_PAYLOAD_BITS",
+    "PARTIAL_LINK_BITS",
     "SLICE_LANES",
+    "SLICE_INDEX_BITS",
     "VALUE_SLICES",
+    "exact_partial_tree_service_manifest",
     "finalize_partial_stream",
+    "merge_balanced_partial_streams",
     "merge_partial_beats",
     "merge_partial_streams",
     "merge_partial_streams_via_local_normalization",

--- a/runs/designs/npu_blocks/attention_score32_exact_partial_tree_c16_r2/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_partial_tree_c16_r2/config.json
@@ -1,0 +1,9 @@
+{
+  "top_name": "attention_score32_exact_partial_tree_c16_r2",
+  "attention_score32_exact_partial_tree": {
+    "clusters": 16,
+    "radix": 2,
+    "value_slices": 16,
+    "head_id_bits": 5
+  }
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_partial_tree_c2_r2/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_partial_tree_c2_r2/config.json
@@ -1,0 +1,9 @@
+{
+  "top_name": "attention_score32_exact_partial_tree_c2_r2",
+  "attention_score32_exact_partial_tree": {
+    "clusters": 2,
+    "radix": 2,
+    "value_slices": 16,
+    "head_id_bits": 5
+  }
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_partial_tree_c4_r2/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_partial_tree_c4_r2/config.json
@@ -1,0 +1,9 @@
+{
+  "top_name": "attention_score32_exact_partial_tree_c4_r2",
+  "attention_score32_exact_partial_tree": {
+    "clusters": 4,
+    "radix": 2,
+    "value_slices": 16,
+    "head_id_bits": 5
+  }
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_partial_tree_c8_r2/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_partial_tree_c8_r2/config.json
@@ -1,0 +1,9 @@
+{
+  "top_name": "attention_score32_exact_partial_tree_c8_r2",
+  "attention_score32_exact_partial_tree": {
+    "clusters": 8,
+    "radix": 2,
+    "value_slices": 16,
+    "head_id_bits": 5
+  }
+}

--- a/tests/test_attention_exact_partial.py
+++ b/tests/test_attention_exact_partial.py
@@ -1,7 +1,11 @@
 from npu.sim.perf.attention_exact_partial import (
+    EXACT_STATE_BYTES_PER_CLUSTER_32_HEADS,
     ExactPartialBeat,
+    LEAF_STREAM_BYTES_PER_CLUSTER_32_HEADS,
     PARTIAL_PAYLOAD_BITS,
+    exact_partial_tree_service_manifest,
     finalize_partial_stream,
+    merge_balanced_partial_streams,
     merge_partial_beats,
     merge_partial_streams,
     merge_partial_streams_via_local_normalization,
@@ -89,6 +93,39 @@ def test_partial_stream_merge_survives_finalization() -> None:
 
     assert len(finalized) == 16
     assert all(len(value_slice) == 8 for value_slice in finalized)
+
+
+def test_balanced_tree_merge_matches_left_to_right_pairing() -> None:
+    leaves = [
+        partial_stream_from_blocks(
+            command_id=0x4A21,
+            head_id=3,
+            score_rows=_score_rows(seed),
+            value_blocks=_value_blocks(seed + 2),
+        )
+        for seed in (5, 11, 17, 23)
+    ]
+
+    merged = merge_balanced_partial_streams(leaves)
+    expected = merge_partial_streams(
+        merge_partial_streams(leaves[0], leaves[1]),
+        merge_partial_streams(leaves[2], leaves[3]),
+    )
+
+    assert merged == expected
+
+
+def test_exact_partial_tree_service_manifest_is_consistent() -> None:
+    manifest = exact_partial_tree_service_manifest(clusters=16)
+
+    assert manifest["radix"] == 2
+    assert manifest["tree_stages"] == 4
+    assert manifest["tree_nodes"] == 15
+    assert manifest["exact_state_bytes_per_cluster"] == EXACT_STATE_BYTES_PER_CLUSTER_32_HEADS == 21252
+    assert manifest["leaf_stream_bytes_per_cluster"] == LEAF_STREAM_BYTES_PER_CLUSTER_32_HEADS == 26816
+    assert manifest["total_leaf_stream_bytes"] == 16 * 26816
+    assert manifest["direct_328bit_links_unclosed"] is True
+    assert manifest["final_divider_embodied"] is False
 
 
 def test_normalized_merge_boundary_is_not_exact() -> None:

--- a/tests/test_attention_score32_exact_partial_tree.py
+++ b/tests/test_attention_score32_exact_partial_tree.py
@@ -1,0 +1,542 @@
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+from npu.eval.probe_attention_score32_exact_partial_tree import build_report
+from npu.rtlgen.gen_attention_score32_exact_partial_tree import generate as generate_tree
+from npu.sim.perf.attention_exact_partial import ExactPartialBeat, merge_partial_beats, pack_numerators, unpack_numerators
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _tree_config(clusters: int) -> dict[str, object]:
+    return {
+        "top_name": f"attention_score32_exact_partial_tree_c{clusters}_r2",
+        "attention_score32_exact_partial_tree": {
+            "clusters": clusters,
+            "radix": 2,
+            "value_slices": 16,
+            "head_id_bits": 5,
+        },
+    }
+
+
+def _rtl_tools_available() -> bool:
+    return bool(shutil.which("iverilog") and shutil.which("vvp") and shutil.which("verilator"))
+
+
+def _tool(name: str) -> str:
+    path = shutil.which(name)
+    if path:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    if fallback.exists():
+        return str(fallback)
+    raise RuntimeError(f"required tool unavailable: {name}")
+
+
+def _signed_literal(value: int, bits: int) -> str:
+    return f"-{bits}'sd{abs(value)}" if value < 0 else f"{bits}'sd{value}"
+
+
+def _beat(
+    *,
+    command_id: int,
+    head_id: int,
+    max_score: int,
+    exp_sum: int,
+    numerators: tuple[int, ...],
+    slice_index: int = 0,
+    last: bool = False,
+) -> ExactPartialBeat:
+    return ExactPartialBeat(
+        command_id=command_id,
+        head_id=head_id,
+        slice_index=slice_index,
+        last=last,
+        max_score=max_score,
+        exp_sum=exp_sum,
+        numerators=numerators,
+    )
+
+
+def _run_protocol_vectors(tmp_path: Path) -> dict[str, object]:
+    cases = [
+        {
+            "name": "metadata_mismatch",
+            "canonical": [
+                _beat(
+                    command_id=0x4A21,
+                    head_id=3,
+                    max_score=15,
+                    exp_sum=19,
+                    numerators=(11, -9, 7, -5, 3, -1, 2, -2),
+                ),
+                _beat(
+                    command_id=0x4A21,
+                    head_id=3,
+                    max_score=13,
+                    exp_sum=17,
+                    numerators=(-4, 6, -8, 10, -12, 14, -16, 18),
+                ),
+                _beat(
+                    command_id=0x4A21,
+                    head_id=3,
+                    max_score=12,
+                    exp_sum=11,
+                    numerators=(5, -4, 3, -2, 1, -1, 2, -3),
+                ),
+                _beat(
+                    command_id=0x4A21,
+                    head_id=3,
+                    max_score=9,
+                    exp_sum=7,
+                    numerators=(-7, 5, -3, 1, -2, 4, -6, 8),
+                ),
+            ],
+            "overrides": [{}, {"command_id": 0x4A22}, {}, {}],
+        },
+        {
+            "name": "invalid_last",
+            "canonical": [
+                _beat(
+                    command_id=0x4A23,
+                    head_id=7,
+                    max_score=27,
+                    exp_sum=23,
+                    numerators=(9, -7, 5, -3, 1, -1, 2, -2),
+                ),
+                _beat(
+                    command_id=0x4A23,
+                    head_id=7,
+                    max_score=22,
+                    exp_sum=21,
+                    numerators=(-8, 6, -4, 2, -1, 3, -5, 7),
+                ),
+                _beat(
+                    command_id=0x4A23,
+                    head_id=7,
+                    max_score=25,
+                    exp_sum=15,
+                    numerators=(4, -3, 2, -1, 0, 1, -2, 3),
+                ),
+                _beat(
+                    command_id=0x4A23,
+                    head_id=7,
+                    max_score=19,
+                    exp_sum=13,
+                    numerators=(-3, 4, -5, 6, -7, 8, -9, 10),
+                ),
+            ],
+            "overrides": [{}, {"last": True}, {}, {}],
+        },
+    ]
+
+    expected_rows = []
+    for case in cases:
+        left_stage = merge_partial_beats(case["canonical"][0], case["canonical"][1])
+        right_stage = merge_partial_beats(case["canonical"][2], case["canonical"][3])
+        merged = merge_partial_beats(left_stage, right_stage)
+        expected_rows.append(
+            {
+                "command_id": merged.command_id,
+                "head_id": merged.head_id,
+                "slice": merged.slice_index,
+                "last": merged.last,
+                "global_max": merged.max_score,
+                "exp_sum": merged.exp_sum,
+                "value": list(merged.numerators),
+            }
+        )
+
+    generate_tree(_tree_config(4), tmp_path / "rtl")
+    tb_path = tmp_path / "tb.sv"
+    leaf_init: list[str] = []
+    for leaf in range(4):
+        for case_index, case in enumerate(cases):
+            beat = case["canonical"][leaf]
+            override = case["overrides"][leaf]
+            flat_index = (leaf * len(cases)) + case_index
+            command_id = int(override.get("command_id", beat.command_id))
+            last = bool(override.get("last", beat.last))
+            leaf_init.append(
+                f"    leaf_cmd_mem[{flat_index}] = 16'h{command_id:04x}; "
+                f"leaf_head_mem[{flat_index}] = 5'd{beat.head_id}; "
+                f"leaf_max_mem[{flat_index}] = {_signed_literal(beat.max_score, 32)}; "
+                f"leaf_sum_mem[{flat_index}] = 33'd{beat.exp_sum}; "
+                f"leaf_slice_mem[{flat_index}] = 4'd{beat.slice_index}; "
+                f"leaf_last_mem[{flat_index}] = 1'b{1 if last else 0}; "
+                f"leaf_value_mem[{flat_index}] = 328'h{pack_numerators(beat.numerators):082x};"
+            )
+    tb_path.write_text(
+        f"""`timescale 1ns/1ps
+module tb;
+  localparam integer CLUSTERS = 4;
+  localparam integer CASE_COUNT = {len(cases)};
+  localparam integer MEM_DEPTH = CLUSTERS * CASE_COUNT;
+  reg clk = 0, rst_n = 0;
+  reg [CLUSTERS-1:0] leaf_valid;
+  wire [CLUSTERS-1:0] leaf_ready;
+  reg [(CLUSTERS*16)-1:0] leaf_command_id;
+  reg [(CLUSTERS*5)-1:0] leaf_head_id;
+  reg [(CLUSTERS*32)-1:0] leaf_global_max;
+  reg [(CLUSTERS*33)-1:0] leaf_exp_sum;
+  reg [(CLUSTERS*4)-1:0] leaf_slice;
+  reg [CLUSTERS-1:0] leaf_last;
+  reg [(CLUSTERS*328)-1:0] leaf_value;
+  wire root_valid;
+  reg root_ready;
+  wire [15:0] root_command_id;
+  wire [4:0] root_head_id;
+  wire signed [31:0] root_global_max;
+  wire [32:0] root_exp_sum;
+  wire [3:0] root_slice;
+  wire root_last;
+  wire [327:0] root_value;
+  wire [31:0] cycle_count;
+  wire [31:0] root_completed_count;
+  wire [95:0] node_completed_count;
+  wire [63:0] stage_completed_count;
+  wire [2:0] node_protocol_error;
+  wire [1:0] stage_protocol_error;
+  wire protocol_error;
+  reg [15:0] leaf_cmd_mem [0:MEM_DEPTH-1];
+  reg [4:0] leaf_head_mem [0:MEM_DEPTH-1];
+  reg signed [31:0] leaf_max_mem [0:MEM_DEPTH-1];
+  reg [32:0] leaf_sum_mem [0:MEM_DEPTH-1];
+  reg [3:0] leaf_slice_mem [0:MEM_DEPTH-1];
+  reg leaf_last_mem [0:MEM_DEPTH-1];
+  reg [327:0] leaf_value_mem [0:MEM_DEPTH-1];
+  reg [31:0] leaf_issue [0:CLUSTERS-1];
+  reg [31:0] leaf_accept [0:CLUSTERS-1];
+  integer cycle = 0;
+  integer seen = 0;
+  reg pending_summary = 0;
+  integer leaf_index;
+  integer init_index;
+
+  always #5 clk = ~clk;
+
+  attention_score32_exact_partial_tree_c4_r2 dut (
+      .clk(clk),
+      .rst_n(rst_n),
+      .leaf_valid(leaf_valid),
+      .leaf_ready(leaf_ready),
+      .leaf_command_id(leaf_command_id),
+      .leaf_head_id(leaf_head_id),
+      .leaf_global_max(leaf_global_max),
+      .leaf_exp_sum(leaf_exp_sum),
+      .leaf_slice(leaf_slice),
+      .leaf_last(leaf_last),
+      .leaf_value(leaf_value),
+      .root_valid(root_valid),
+      .root_ready(root_ready),
+      .root_command_id(root_command_id),
+      .root_head_id(root_head_id),
+      .root_global_max(root_global_max),
+      .root_exp_sum(root_exp_sum),
+      .root_slice(root_slice),
+      .root_last(root_last),
+      .root_value(root_value),
+      .cycle_count(cycle_count),
+      .root_completed_count(root_completed_count),
+      .node_completed_count(node_completed_count),
+      .stage_completed_count(stage_completed_count),
+      .node_protocol_error(node_protocol_error),
+      .stage_protocol_error(stage_protocol_error),
+      .protocol_error(protocol_error)
+  );
+
+  always @* begin
+    leaf_valid = 4'b0;
+    leaf_command_id = 64'b0;
+    leaf_head_id = 20'b0;
+    leaf_global_max = 128'b0;
+    leaf_exp_sum = 132'b0;
+    leaf_slice = 16'b0;
+    leaf_last = 4'b0;
+    leaf_value = 1312'b0;
+    root_ready = (cycle % 3) != 1;
+    for (leaf_index = 0; leaf_index < CLUSTERS; leaf_index = leaf_index + 1) begin
+      if (rst_n && leaf_issue[leaf_index] < CASE_COUNT) begin
+        leaf_valid[leaf_index] = 1'b1;
+        leaf_command_id[(leaf_index * 16) +: 16] =
+            leaf_cmd_mem[(leaf_index * CASE_COUNT) + leaf_issue[leaf_index]];
+        leaf_head_id[(leaf_index * 5) +: 5] =
+            leaf_head_mem[(leaf_index * CASE_COUNT) + leaf_issue[leaf_index]];
+        leaf_global_max[(leaf_index * 32) +: 32] =
+            leaf_max_mem[(leaf_index * CASE_COUNT) + leaf_issue[leaf_index]];
+        leaf_exp_sum[(leaf_index * 33) +: 33] =
+            leaf_sum_mem[(leaf_index * CASE_COUNT) + leaf_issue[leaf_index]];
+        leaf_slice[(leaf_index * 4) +: 4] =
+            leaf_slice_mem[(leaf_index * CASE_COUNT) + leaf_issue[leaf_index]];
+        leaf_last[leaf_index] =
+            leaf_last_mem[(leaf_index * CASE_COUNT) + leaf_issue[leaf_index]];
+        leaf_value[(leaf_index * 328) +: 328] =
+            leaf_value_mem[(leaf_index * CASE_COUNT) + leaf_issue[leaf_index]];
+      end
+    end
+  end
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      cycle <= 0;
+      seen <= 0;
+      pending_summary <= 1'b0;
+      for (leaf_index = 0; leaf_index < CLUSTERS; leaf_index = leaf_index + 1) begin
+        leaf_issue[leaf_index] <= 0;
+        leaf_accept[leaf_index] <= 0;
+      end
+    end else begin
+      cycle <= cycle + 1;
+      for (leaf_index = 0; leaf_index < CLUSTERS; leaf_index = leaf_index + 1) begin
+        if (leaf_valid[leaf_index] && leaf_ready[leaf_index]) begin
+          leaf_accept[leaf_index] <= leaf_accept[leaf_index] + 1;
+          leaf_issue[leaf_index] <= leaf_issue[leaf_index] + 1;
+        end
+      end
+      if (root_valid && root_ready) begin
+        $display("RESULT idx=%0d cmd=%0d head=%0d slice=%0d last=%0d max=%0d sum=%0d value=%082x",
+                 seen, root_command_id, root_head_id, root_slice, root_last, $signed(root_global_max), root_exp_sum, root_value);
+        seen <= seen + 1;
+        if (seen + 1 == CASE_COUNT) pending_summary <= 1'b1;
+      end
+      if (pending_summary) begin
+        for (leaf_index = 0; leaf_index < CLUSTERS; leaf_index = leaf_index + 1) begin
+          $display("LEAF leaf=%0d accepted=%0d", leaf_index, leaf_accept[leaf_index]);
+        end
+        $display("NODE node=0 count=%0d error=%0d", node_completed_count[0 +: 32], node_protocol_error[0]);
+        $display("NODE node=1 count=%0d error=%0d", node_completed_count[32 +: 32], node_protocol_error[1]);
+        $display("NODE node=2 count=%0d error=%0d", node_completed_count[64 +: 32], node_protocol_error[2]);
+        $display("STAGE stage=0 count=%0d error=%0d", stage_completed_count[0 +: 32], stage_protocol_error[0]);
+        $display("STAGE stage=1 count=%0d error=%0d", stage_completed_count[32 +: 32], stage_protocol_error[1]);
+        $display("SUMMARY outputs=%0d protocol_error=%0d root_completed=%0d cycle=%0d", seen, protocol_error, root_completed_count, cycle_count);
+        #1 $finish;
+      end
+      if (cycle > 200) $fatal(1, "timeout");
+    end
+  end
+
+  initial begin
+    for (init_index = 0; init_index < MEM_DEPTH; init_index = init_index + 1) begin
+      leaf_cmd_mem[init_index] = 16'd0;
+      leaf_head_mem[init_index] = 5'd0;
+      leaf_max_mem[init_index] = 32'sd0;
+      leaf_sum_mem[init_index] = 33'd0;
+      leaf_slice_mem[init_index] = 4'd0;
+      leaf_last_mem[init_index] = 1'b0;
+      leaf_value_mem[init_index] = 328'd0;
+    end
+{chr(10).join(leaf_init)}
+    repeat (3) @(posedge clk);
+    @(negedge clk);
+    rst_n = 1'b1;
+  end
+endmodule
+""",
+        encoding="utf-8",
+    )
+    simv = tmp_path / "simv"
+    compiled = subprocess.run(
+        [
+            _tool("iverilog"),
+            "-g2012",
+            "-s",
+            "tb",
+            "-o",
+            str(simv),
+            str(tmp_path / "rtl" / "top.v"),
+            str(tb_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if compiled.returncode:
+        raise RuntimeError(f"iverilog failed:\n{compiled.stderr}")
+    run = subprocess.run([_tool("vvp"), str(simv)], capture_output=True, text=True, timeout=60)
+    if run.returncode:
+        raise RuntimeError(f"simulation failed:\n{run.stdout}\n{run.stderr}")
+
+    result_re = re.compile(
+        r"RESULT idx=(\d+) cmd=(\d+) head=(\d+) slice=(\d+) last=(\d+) max=(-?\d+) sum=(\d+) value=([0-9a-fA-F]+)"
+    )
+    leaf_re = re.compile(r"LEAF leaf=(\d+) accepted=(\d+)")
+    node_re = re.compile(r"NODE node=(\d+) count=(\d+) error=(\d+)")
+    stage_re = re.compile(r"STAGE stage=(\d+) count=(\d+) error=(\d+)")
+    summary_re = re.compile(r"SUMMARY outputs=(\d+) protocol_error=(\d+) root_completed=(\d+) cycle=(\d+)")
+    observed_rows = []
+    leaf_accept = [0] * 4
+    node_count = [0] * 3
+    node_error = [False] * 3
+    stage_count = [0] * 2
+    stage_error = [False] * 2
+    summary = None
+    for line in run.stdout.splitlines():
+        stripped = line.strip()
+        if match := result_re.fullmatch(stripped):
+            observed_rows.append(
+                {
+                    "command_id": int(match.group(2)),
+                    "head_id": int(match.group(3)),
+                    "slice": int(match.group(4)),
+                    "last": bool(int(match.group(5))),
+                    "global_max": int(match.group(6)),
+                    "exp_sum": int(match.group(7)),
+                    "value": list(unpack_numerators(int(match.group(8), 16))),
+                }
+            )
+        elif match := leaf_re.fullmatch(stripped):
+            leaf_accept[int(match.group(1))] = int(match.group(2))
+        elif match := node_re.fullmatch(stripped):
+            node = int(match.group(1))
+            node_count[node] = int(match.group(2))
+            node_error[node] = bool(int(match.group(3)))
+        elif match := stage_re.fullmatch(stripped):
+            stage = int(match.group(1))
+            stage_count[stage] = int(match.group(2))
+            stage_error[stage] = bool(int(match.group(3)))
+        elif match := summary_re.fullmatch(stripped):
+            summary = {
+                "outputs": int(match.group(1)),
+                "protocol_error": bool(int(match.group(2))),
+                "root_completed": int(match.group(3)),
+                "cycle": int(match.group(4)),
+            }
+    if summary is None:
+        raise RuntimeError("protocol regression summary missing")
+    return {
+        "expected_rows": expected_rows,
+        "observed_rows": observed_rows,
+        "leaf_accept": leaf_accept,
+        "node_count": node_count,
+        "node_error": node_error,
+        "stage_count": stage_count,
+        "stage_error": stage_error,
+        "summary": summary,
+    }
+
+
+def test_exact_partial_tree_manifest_and_ports(tmp_path: Path) -> None:
+    generate_tree(_tree_config(16), tmp_path)
+
+    manifest = json.loads((tmp_path / "attention_score32_exact_partial_tree_manifest.json").read_text(encoding="utf-8"))
+    rtl = (tmp_path / "top.v").read_text(encoding="utf-8")
+
+    assert manifest["semantic_profile"] == "score32_online_exact_partial_radix2_tree_v1"
+    assert manifest["clusters"] == 16
+    assert manifest["tree_stages"] == 4
+    assert manifest["tree_nodes"] == 15
+    assert manifest["partial_payload_bits_per_beat"] == 328
+    assert manifest["theoretical_full_llama_service_manifest"]["heads"] == 32
+    assert manifest["theoretical_full_llama_service_manifest"]["exact_state_bytes_per_cluster"] == 21252
+    assert manifest["theoretical_full_llama_service_manifest"]["total_leaf_stream_bytes"] == 429056
+    assert manifest["direct_328bit_links_unclosed"] is True
+    assert manifest["final_divider_embodied"] is False
+    assert "input  wire [15:0] leaf_valid" in rtl
+    assert "output wire         root_valid" in rtl
+    assert "output wire [479:0] node_protocol_error" not in rtl
+    assert "output wire [14:0] node_protocol_error" in rtl
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="iverilog/vvp/verilator unavailable")
+def test_exact_partial_tree_protocol_errors_are_sticky_and_localized(tmp_path: Path) -> None:
+    report = _run_protocol_vectors(tmp_path)
+
+    assert report["observed_rows"] == report["expected_rows"]
+    assert report["leaf_accept"] == [2, 2, 2, 2]
+    assert report["node_count"] == [2, 2, 2]
+    assert report["stage_count"] == [4, 2]
+    assert report["node_error"] == [True, False, False]
+    assert report["stage_error"] == [True, False]
+    assert report["summary"]["outputs"] == 2
+    assert report["summary"]["root_completed"] == 2
+    assert report["summary"]["protocol_error"] is True
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="iverilog/vvp/verilator unavailable")
+@pytest.mark.parametrize("clusters,heads,stage_counts", [(2, 3, [48]), (4, 3, [96, 48])])
+def test_exact_partial_tree_probe_quick_passes(clusters: int, heads: int, stage_counts: list[int]) -> None:
+    report = build_report(clusters=clusters, heads=heads)
+
+    assert report["decision"] == "pass", json.dumps(report, indent=2)
+    assert report["equivalence_pass"] is True
+    assert report["heads"] == heads
+    assert report["root_result_count"] == heads * 16
+    assert report["leaf_accept_count"] == [heads * 16] * clusters
+    assert report["leaf_total_accept_count"] == clusters * heads * 16
+    assert report["node_completed_count"] == [heads * 16] * (clusters - 1)
+    assert report["stage_completed_count"] == stage_counts
+    assert report["node_protocol_error"] == [False] * (clusters - 1)
+    assert report["stage_protocol_error"] == [False] * len(stage_counts)
+    assert report["summary"]["protocol_error"] is False
+    assert report["root_hash"] == report["expected_root_hash"]
+    assert report["measured_workload_manifest"]["heads"] == heads
+    assert report["measured_workload_manifest"]["root_outputs"] == heads * 16
+    assert report["theoretical_full_llama_service_manifest"]["heads"] == 32
+    assert report["theoretical_full_llama_service_manifest"]["total_leaf_stream_bytes"] == clusters * 26816
+    assert report["measured_workload_manifest"]["first_output_cycle"] >= 0
+    assert report["measured_workload_manifest"]["last_output_cycle"] >= report["measured_workload_manifest"]["first_output_cycle"]
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="iverilog/vvp/verilator unavailable")
+def test_exact_partial_tree_probe_c16_32_heads_passes() -> None:
+    report = build_report(clusters=16, heads=32)
+
+    assert report["decision"] == "pass", json.dumps(report, indent=2)
+    assert report["equivalence_pass"] is True
+    assert report["heads"] == 32
+    assert report["root_result_count"] == 512
+    assert report["leaf_accept_count"] == [512] * 16
+    assert report["leaf_total_accept_count"] == 8192
+    assert report["node_completed_count"] == [512] * 15
+    assert report["stage_completed_count"] == [4096, 2048, 1024, 512]
+    assert report["summary"]["protocol_error"] is False
+    assert report["summary"]["root_completed_count"] == 512
+    assert report["root_hash"] == report["expected_root_hash"]
+    assert report["measured_workload_manifest"]["heads"] == 32
+    assert report["measured_workload_manifest"]["leaf_accepts_per_leaf"] == 512
+    assert report["measured_workload_manifest"]["total_leaf_beats"] == 8192
+    assert report["measured_workload_manifest"]["root_outputs"] == 512
+    assert report["measured_workload_manifest"]["root_sustained_beats_per_cycle"] > 0.0
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="iverilog/vvp/verilator unavailable")
+def test_exact_partial_tree_probe_cli_bootstraps_repo_root(tmp_path: Path) -> None:
+    out_path = tmp_path / "probe.json"
+    env = {
+        "HOME": os.environ.get("HOME", str(tmp_path)),
+        "LANG": os.environ.get("LANG", "C.UTF-8"),
+        "PATH": os.environ.get("PATH", ""),
+    }
+
+    run = subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/probe_attention_score32_exact_partial_tree.py",
+            "--clusters",
+            "2",
+            "--heads",
+            "3",
+            "--out",
+            str(out_path),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+    assert run.returncode == 0, run.stderr or run.stdout
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert payload["clusters"] == 2
+    assert payload["heads"] == 3
+    assert payload["decision"] == "pass"
+    assert payload["equivalence_pass"] is True


### PR DESCRIPTION
## Summary

- generate a balanced radix-2 ready/valid tree from the measured score32 exact-partial pair merge primitive
- preserve max, exponent sum, and 8xS41 numerator slices through all 16 clusters without locally normalized intermediate values
- add per-node and per-stage completion/protocol monitors plus c2/c4/c8/c16 design configs
- add an independent Python reference and full 16-cluster, 32-head RTL equivalence probe
- document remaining physical boundaries: direct 328-bit links and the root finalizer/divider

## Evidence

The full Llama7B-head probe accepts 512 beats per leaf across 16 leaves (8,192 leaf beats) and produces 512 matching root outputs. It reports no protocol errors and measures 0.333986 root beats/cycle under deterministic skew and root backpressure.

## Validation

- `PYTHONPATH=/workspaces/RTLGen-exact-reduction-tree pytest -q tests/test_attention_exact_partial.py tests/test_attention_score32_exact_partial.py tests/test_attention_score32_exact_partial_tree.py` (`21 passed`)
- `env -u PYTHONPATH python3 npu/eval/probe_attention_score32_exact_partial_tree.py --clusters 16 --heads 32 --out /tmp/score32_exact_partial_tree_c16_h32_probe.json`
- generated c16 RTL passes `verilator --lint-only`
- `python3 scripts/validate_runs.py --skip_eval_queue`

## Scope

This closes phase B reduction semantics and streaming behavior. It does not claim NoC/placement closure for the wide links and does not yet embody final normalization/division at the root.