### PR TITLE
Prepare exact root finalizer lane PPA sweep

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -793,6 +793,56 @@ def _read_config_target(
                 },
             ],
         )
+    elif "top_name" in cfg and "attention_score32_exact_root_finalizer" in cfg:
+        top_name = str(cfg["top_name"]).strip()
+        if not top_name:
+            raise Layer1TaskGenerationError(f"top_name must not be empty in {config_path}")
+        try:
+            design_dir = str(config_path.parent.resolve().relative_to(repo_root.resolve()))
+        except ValueError as exc:
+            raise Layer1TaskGenerationError(
+                f"score32 exact root finalizer config must live under repo_root/runs/designs/...: {config_path}"
+            ) from exc
+        design_name = config_path.parent.name
+        return Layer1ConfigTarget(
+            design_kind="block",
+            design_name=design_name,
+            expected_metrics_path=block_metrics_path(design_name),
+            expected_report_paths=[f"{design_dir}/timing_debug_report.md"],
+            commands=[
+                {
+                    "name": "generate_attention_score32_exact_root_finalizer_rtl",
+                    "run": _with_oss_cad_path(
+                        "python3 npu/rtlgen/gen_attention_score32_exact_root_finalizer.py "
+                        f"--config {config_rel} --out {design_dir}/verilog"
+                    ),
+                },
+                {
+                    "name": "check_attention_score32_exact_root_finalizer_guard",
+                    "run": (
+                        "python3 npu/eval/check_attention_score32_exact_root_finalizer_guard.py "
+                        f"--design-dir {design_dir} --config {config_rel}"
+                    ),
+                },
+                {
+                    "name": "run_block_sweep",
+                    "run": _with_oss_cad_path(
+                        "python3 npu/synth/run_block_sweep.py "
+                        f"--design_dir {design_dir} --platform {{platform}} --top {top_name} "
+                        f"--sweep {{sweep_path}} --out_root {out_root} "
+                        + (f"--make_target {make_target} " if make_target else "")
+                        + "--skip_existing"
+                    ),
+                },
+                {
+                    "name": "extract_attention_score32_exact_root_finalizer_timing_paths",
+                    "run": (
+                        "python3 npu/eval/extract_openroad_timing_summary.py "
+                        f"--design-dir {design_dir} --out {design_dir}/timing_debug_report.md --max-paths 8"
+                    ),
+                },
+            ],
+        )
     elif "top_name" in cfg and "attention_decode_score_multivalue_gqa_array" in cfg:
         top_name = str(cfg["top_name"]).strip()
         if not top_name:

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -1651,6 +1651,77 @@ def _write_second_attention_command_dispatch_repo(repo_root: Path) -> str:
     return str(config_path.relative_to(repo_root))
 
 
+def _write_example_attention_score32_exact_root_finalizer_repo(repo_root: Path) -> tuple[str, str]:
+    design_dir = repo_root / "runs" / "designs" / "npu_blocks" / "attention_score32_exact_root_finalizer_smoke_l4"
+    design_dir.mkdir(parents=True, exist_ok=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_score32_exact_root_finalizer_smoke_l4",
+                "attention_score32_exact_root_finalizer": {
+                    "value_slices": 16,
+                    "head_id_bits": 5,
+                    "divider_lanes": 4,
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    sweep_path = (
+        repo_root
+        / "runs"
+        / "campaigns"
+        / "npu"
+        / "attention_score32_exact_root_finalizer_v1"
+        / "sweeps"
+        / "nangate45_attention_score32_exact_root_finalizer_lane_firstpass.json"
+    )
+    sweep_path.parent.mkdir(parents=True, exist_ok=True)
+    sweep_path.write_text(
+        json.dumps(
+            {
+                "tag_prefix": "attention_score32_exact_root_finalizer_lane_firstpass_v1",
+                "flow_params": {
+                    "CLOCK_PERIOD": [8.0],
+                    "DIE_AREA": ["0 0 1000 1000"],
+                    "CORE_AREA": ["50 50 950 950"],
+                    "PLACE_DENSITY": [0.3, 0.5],
+                    "SYNTH_HIERARCHICAL": [1],
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return str(config_path.relative_to(repo_root)), str(sweep_path.relative_to(repo_root))
+
+
+def _write_second_attention_score32_exact_root_finalizer_repo(repo_root: Path) -> str:
+    design_dir = repo_root / "runs" / "designs" / "npu_blocks" / "attention_score32_exact_root_finalizer_smoke_l8"
+    design_dir.mkdir(parents=True, exist_ok=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_score32_exact_root_finalizer_smoke_l8",
+                "attention_score32_exact_root_finalizer": {
+                    "value_slices": 16,
+                    "head_id_bits": 5,
+                    "divider_lanes": 8,
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return str(config_path.relative_to(repo_root))
+
+
 
 def test_generate_l1_sweep_task_creates_ready_work_item() -> None:
     with tempfile.TemporaryDirectory() as td:
@@ -3019,6 +3090,66 @@ def test_generate_l1_sweep_task_supports_attention_command_dispatch_configs() ->
             }
 
 
+def test_generate_l1_sweep_task_supports_attention_score32_exact_root_finalizer_configs() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_attention_score32_exact_root_finalizer_repo(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/npu_blocks",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="architecture_block",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert [command["name"] for command in work_item.command_manifest] == [
+                "generate_attention_score32_exact_root_finalizer_rtl",
+                "check_attention_score32_exact_root_finalizer_guard",
+                "run_block_sweep",
+                "extract_attention_score32_exact_root_finalizer_timing_paths",
+                "build_runs_index",
+                "validate",
+            ]
+            assert work_item.command_manifest[0]["run"] == (
+                "export PATH=/oss-cad-suite/bin:$PATH && "
+                "python3 npu/rtlgen/gen_attention_score32_exact_root_finalizer.py "
+                "--config runs/designs/npu_blocks/attention_score32_exact_root_finalizer_smoke_l4/config.json "
+                "--out runs/designs/npu_blocks/attention_score32_exact_root_finalizer_smoke_l4/verilog"
+            )
+            assert work_item.command_manifest[1]["run"] == (
+                "python3 npu/eval/check_attention_score32_exact_root_finalizer_guard.py "
+                "--design-dir runs/designs/npu_blocks/attention_score32_exact_root_finalizer_smoke_l4 "
+                "--config runs/designs/npu_blocks/attention_score32_exact_root_finalizer_smoke_l4/config.json"
+            )
+            assert "--top attention_score32_exact_root_finalizer_smoke_l4" in work_item.command_manifest[2]["run"]
+            assert work_item.command_manifest[3]["run"] == (
+                "python3 npu/eval/extract_openroad_timing_summary.py "
+                "--design-dir runs/designs/npu_blocks/attention_score32_exact_root_finalizer_smoke_l4 "
+                "--out runs/designs/npu_blocks/attention_score32_exact_root_finalizer_smoke_l4/timing_debug_report.md "
+                "--max-paths 8"
+            )
+            assert work_item.expected_outputs == [
+                "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_smoke_l4/metrics.csv",
+                "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_smoke_l4/timing_debug_report.md",
+            ]
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "architecture_block"
+            }
+
+
 def test_generate_l1_sweep_task_supports_attention_hbm_replay_controller_configs() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"
@@ -3494,6 +3625,41 @@ def test_multivalue_service_pnr_proposal_keeps_c2_gated_on_c1_dependency() -> No
     assert c2_proposal["depends_on_item_ids"] == [service_dep_id, c1_item_id]
     assert c2_request["depends_on_item_ids"] == [service_dep_id, c1_item_id]
     assert c1_item_id in (proposal_dir / "design_brief.md").read_text(encoding="utf-8")
+
+
+def test_exact_root_finalizer_lane_ppa_proposal_is_pending_merge_with_all_lane_configs() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    proposal_dir = (
+        repo_root
+        / "docs"
+        / "proposals"
+        / "prop_l1_decoder_attention_score32_exact_root_finalizer_lane_ppa_v1"
+    )
+    proposal = json.loads((proposal_dir / "proposal.json").read_text(encoding="utf-8"))
+    evaluation_requests = json.loads((proposal_dir / "evaluation_requests.json").read_text(encoding="utf-8"))
+
+    item_id = "l1_decoder_attention_score32_exact_root_finalizer_lane_ppa_v1"
+    expected_configs = [
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l1/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l4/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l8/config.json",
+    ]
+    expected_sweep = (
+        "runs/campaigns/npu/attention_score32_exact_root_finalizer_v1/sweeps/"
+        "nangate45_attention_score32_exact_root_finalizer_lane_firstpass.json"
+    )
+    proposal_entry = {entry["item_id"]: entry for entry in proposal["required_evaluations"]}[item_id]
+    request_entry = {entry["item_id"]: entry for entry in evaluation_requests["requested_items"]}[item_id]
+
+    assert proposal["abstraction_layer"] == "architecture_block"
+    assert proposal_entry["status"] == "pending_implementation_merge"
+    assert request_entry["status"] == "pending_implementation_merge"
+    assert proposal_entry["configs"] == expected_configs
+    assert request_entry["configs"] == expected_configs
+    assert proposal_entry["sweep_path"] == expected_sweep
+    assert request_entry["sweep_path"] == expected_sweep
+    assert "isolated finalizer baseline" in proposal_entry["notes"]
 
 
 def test_generate_l1_sweep_task_checked_in_service_requests_gate_and_refresh_release() -> None:
@@ -4333,6 +4499,54 @@ def test_generate_l1_sweep_task_supports_multi_attention_command_dispatch_config
                 "runs/designs/npu_blocks/attention_command_dispatch_smoke/timing_debug_report.md",
                 "runs/designs/npu_blocks/attention_command_dispatch_c16_q32/metrics.csv",
                 "runs/designs/npu_blocks/attention_command_dispatch_c16_q32/timing_debug_report.md",
+            ]
+
+
+def test_generate_l1_sweep_task_supports_multi_attention_score32_exact_root_finalizer_configs() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_attention_score32_exact_root_finalizer_repo(repo_root)
+        second_config_path = _write_second_attention_score32_exact_root_finalizer_repo(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path, second_config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/npu_blocks",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="architecture_block",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert [command["name"] for command in work_item.command_manifest] == [
+                "generate_attention_score32_exact_root_finalizer_rtl_attention_score32_exact_root_finalizer_smoke_l4",
+                "check_attention_score32_exact_root_finalizer_guard_attention_score32_exact_root_finalizer_smoke_l4",
+                "run_block_sweep_attention_score32_exact_root_finalizer_smoke_l4",
+                "extract_attention_score32_exact_root_finalizer_timing_paths_attention_score32_exact_root_finalizer_smoke_l4",
+                "generate_attention_score32_exact_root_finalizer_rtl_attention_score32_exact_root_finalizer_smoke_l8",
+                "check_attention_score32_exact_root_finalizer_guard_attention_score32_exact_root_finalizer_smoke_l8",
+                "run_block_sweep_attention_score32_exact_root_finalizer_smoke_l8",
+                "extract_attention_score32_exact_root_finalizer_timing_paths_attention_score32_exact_root_finalizer_smoke_l8",
+                "build_runs_index",
+                "validate",
+            ]
+            assert "attention_score32_exact_root_finalizer_smoke_l4/config.json" in work_item.command_manifest[0]["run"]
+            assert "attention_score32_exact_root_finalizer_smoke_l8/config.json" in work_item.command_manifest[4]["run"]
+            assert work_item.expected_outputs == [
+                "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_smoke_l4/metrics.csv",
+                "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_smoke_l4/timing_debug_report.md",
+                "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_smoke_l8/metrics.csv",
+                "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_smoke_l8/timing_debug_report.md",
             ]
 
 

--- a/docs/proposals/prop_l1_decoder_attention_score32_exact_root_finalizer_lane_ppa_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_exact_root_finalizer_lane_ppa_v1/evaluation_requests.json
@@ -1,0 +1,38 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_score32_exact_root_finalizer_lane_ppa_v1",
+  "source_commit_note": "Replace with the merge commit that adds the standalone exact-root-finalizer configs, strict guard, sweep, and L1 task-generator support before dispatch.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_score32_exact_root_finalizer_lane_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for standalone score32 exact root finalizers at divider lanes 1, 2, 4, and 8.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "exact_root_finalizer_lane_anchor",
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l1/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l4/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_root_finalizer_v1/sweeps/nangate45_attention_score32_exact_root_finalizer_lane_firstpass.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l1/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l1/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l2/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l2/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l4/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l4/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l8/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "measure_exact_root_finalizer_lane_cost",
+        "reason": "This isolates sequential divider-lane area and timing before any composed-tree or wide-link closure claim is attempted."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "Isolated finalizer-lane baseline only; tree, NoC, direct 328-bit links, and the composed macro remain separate abstractions."
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_score32_exact_root_finalizer_lane_ppa_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_exact_root_finalizer_lane_ppa_v1/proposal.json
@@ -1,0 +1,83 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_score32_exact_root_finalizer_lane_ppa_v1",
+  "created_utc": "2026-07-27T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "title": "Score32 exact root finalizer lane PPA baseline",
+  "abstraction_layer": "architecture_block",
+  "hypothesis": "A standalone exact root finalizer lane sweep can isolate sequential divider lane count cost before any composed-tree or wide-link closure work is treated as physically grounded.",
+  "direct_comparison": {
+    "primary_question": "What Nangate45 area/timing tradeoff is introduced by 1/2/4/8 sequential divider lanes in the standalone score32 exact root finalizer under a fixed first-pass 8 ns, 1000 um die, 900 um core envelope?",
+    "candidate": "l1_decoder_attention_score32_exact_root_finalizer_lane_ppa_v1",
+    "include": [
+      "actual attention_score32_exact_root_finalizer RTL generation",
+      "strict config/manifest/RTL guard before synthesis",
+      "hierarchical OpenROAD block sweeps at place densities 0.30 and 0.50",
+      "timing-summary extraction for each lane configuration"
+    ],
+    "exclude": [
+      "no partial-tree or composed-tree PPA in this patch",
+      "no NoC, SRAM, or wide internal exact-partial link closure claim",
+      "no claim that this standalone macro represents full decoder-attention closure"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "die_area",
+      "total_power_mw",
+      "stdcell_count",
+      "timing_debug_report"
+    ]
+  },
+  "remaining_abstractions": [
+    "This item measures only the standalone exact root finalizer; it does not include the exact-partial reduction tree or direct 328-bit internal links.",
+    "Tree fan-in, NoC transport, and macro composition remain separate sources of area and timing risk.",
+    "Any later composed macro or Llama-scale recost must consume this as a divider-lane anchor, not as full-path closure evidence."
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_score32_exact_root_finalizer_lane_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for standalone score32 exact root finalizers at divider lanes 1, 2, 4, and 8.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "exact_root_finalizer_lane_anchor",
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l1/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l4/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_root_finalizer_v1/sweeps/nangate45_attention_score32_exact_root_finalizer_lane_firstpass.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l1/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l1/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l2/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l2/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l4/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l4/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l8/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "measure_exact_root_finalizer_lane_cost",
+        "reason": "This isolates sequential divider-lane area and timing before any composed-tree or wide-link closure claim is attempted."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "This is an isolated finalizer baseline only; tree/NoC links and the composed macro stay out of scope for this item."
+    }
+  ],
+  "source_refs": [
+    "npu/rtlgen/gen_attention_score32_exact_root_finalizer.py",
+    "npu/eval/check_attention_score32_exact_root_finalizer_guard.py",
+    "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l1/config.json",
+    "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l2/config.json",
+    "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l4/config.json",
+    "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l8/config.json",
+    "runs/campaigns/npu/attention_score32_exact_root_finalizer_v1/sweeps/nangate45_attention_score32_exact_root_finalizer_lane_firstpass.json"
+  ],
+  "knowledge_refs": [
+    "npu/docs/attention_score32_exact_root_finalizer_contract.md"
+  ]
+}

--- a/npu/eval/check_attention_score32_exact_root_finalizer_guard.py
+++ b/npu/eval/check_attention_score32_exact_root_finalizer_guard.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Strict generated RTL guard for standalone score32 exact root finalizers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+
+
+_SUPPORTED_LANES = {1, 2, 4, 8}
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _resolve_selected_config(*, design_dir: Path, selected: Path | None) -> Path:
+    config_path = selected or (design_dir / "config.json")
+    config_path = config_path.resolve()
+    if not config_path.exists():
+        raise SystemExit(f"missing config: {config_path}")
+    try:
+        relative_path = config_path.relative_to(design_dir)
+    except ValueError as exc:
+        raise SystemExit(f"selected config must live under design-dir: {config_path}") from exc
+    if len(relative_path.parts) != 1:
+        raise SystemExit(f"selected config must be a direct child of design-dir, got: {relative_path.as_posix()}")
+    return config_path
+
+
+def _require(mapping: dict[str, object], key: str, expected: object, label: str) -> None:
+    if mapping.get(key) != expected:
+        raise SystemExit(f"{label} {key} must be {expected}")
+
+
+def _strip_comments(text: str) -> str:
+    no_block = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    return re.sub(r"//.*", "", no_block)
+
+
+def _contains_operator_division(text: str) -> bool:
+    stripped = _strip_comments(text)
+    return re.search(r"(?<![*/])/(?![/*])", stripped) is not None
+
+
+def _require_token(text: str, token: str, label: str) -> None:
+    if token not in text:
+        raise SystemExit(f"{label} missing semantic token: {token}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--design-dir", type=Path, required=True)
+    ap.add_argument("--config", type=Path, default=None)
+    args = ap.parse_args(argv)
+
+    design_dir = args.design_dir.resolve()
+    config_path = _resolve_selected_config(design_dir=design_dir, selected=args.config)
+    rtl_dir = design_dir / "verilog"
+    generated_config_path = rtl_dir / "config.json"
+    manifest_path = rtl_dir / "attention_score32_exact_root_finalizer_manifest.json"
+    top_path = rtl_dir / "top.v"
+    for path in (config_path, generated_config_path, manifest_path, top_path):
+        if not path.is_file():
+            raise SystemExit(f"missing exact root finalizer artifact: {path}")
+
+    config = _load_json(config_path)
+    generated_config = _load_json(generated_config_path)
+    if config != generated_config:
+        raise SystemExit("generated config does not match source config")
+
+    top_name = str(config.get("top_name") or "").strip()
+    if not top_name:
+        raise SystemExit("top_name must not be empty")
+    body = config.get("attention_score32_exact_root_finalizer")
+    if not isinstance(body, dict):
+        raise SystemExit("config must contain attention_score32_exact_root_finalizer object")
+    divider_lanes = int(body.get("divider_lanes", 0))
+    if divider_lanes not in _SUPPORTED_LANES:
+        raise SystemExit("divider_lanes must be one of 1, 2, 4, 8")
+    value_slices = int(body.get("value_slices", 0))
+    head_id_bits = int(body.get("head_id_bits", 0))
+
+    manifest = _load_json(manifest_path)
+    expected_manifest = {
+        "top_name": top_name,
+        "generator": "npu/rtlgen/gen_attention_score32_exact_root_finalizer.py",
+        "semantic_profile": "score32_online_exact_root_finalizer_iterdiv_v1",
+        "value_slices": value_slices,
+        "head_id_bits": head_id_bits,
+        "divider_lanes": divider_lanes,
+        "physical_divider_lanes": divider_lanes,
+        "divider_groups_per_beat": 8 // divider_lanes,
+        "divider_iterations_per_group": 57,
+        "divider_cycles_per_beat": (8 // divider_lanes) * 57,
+        "input_value_bits_per_beat": 328,
+        "output_value_bits_per_beat": 320,
+        "result_interface": "ready_valid_exact_finalized_slice_stream",
+        "protocol_error_conditions": ["last_semantics", "exp_sum_zero", "final_value_overflow"],
+        "final_divider_embodied": True,
+        "equivalence_hash": False,
+    }
+    for key, expected in expected_manifest.items():
+        _require(manifest, key, expected, "generated manifest")
+
+    rtl = top_path.read_text(encoding="utf-8", errors="replace")
+    if not re.search(rf"^\s*module\s+{re.escape(top_name)}\b", rtl, re.MULTILINE):
+        raise SystemExit(f"generated RTL does not define top module {top_name}")
+    for token in (
+        f"localparam integer DIVIDER_LANES = {divider_lanes};",
+        "localparam integer DIVIDE_ITERATIONS = 57;",
+        "localparam integer DIVIDEND_BITS = 57;",
+        "assign in_ready = (state_q == IDLE) && !out_valid_q;",
+        "assign out_valid = out_valid_q;",
+        "assign protocol_error = protocol_error_q;",
+        "accepted_count <= accepted_count + 1'b1;",
+        "completed_count <= completed_count + 1'b1;",
+        "if (out_valid_q && out_ready) begin",
+        "rounded_dividend =",
+    ):
+        _require_token(rtl, token, "generated RTL")
+    for token in (
+        "input  wire         in_valid,",
+        "output wire         in_ready,",
+        "output wire         out_valid,",
+        "input  wire         out_ready,",
+        "output reg  [31:0]  accepted_count,",
+        "output reg  [31:0]  completed_count,",
+        "output reg  [31:0]  cycle_count,",
+        "output wire         protocol_error",
+    ):
+        _require_token(rtl, token, "generated RTL")
+    if _contains_operator_division(rtl):
+        raise SystemExit("generated RTL must not contain combinational division operators")
+
+    print(
+        json.dumps(
+            {
+                "design": top_name,
+                "guard": "attention_score32_exact_root_finalizer_v1",
+                "divider_lanes": divider_lanes,
+                "divider_iterations_per_group": 57,
+                "status": "ok",
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runs/campaigns/npu/attention_score32_exact_root_finalizer_v1/sweeps/nangate45_attention_score32_exact_root_finalizer_lane_firstpass.json
+++ b/runs/campaigns/npu/attention_score32_exact_root_finalizer_v1/sweeps/nangate45_attention_score32_exact_root_finalizer_lane_firstpass.json
@@ -1,0 +1,21 @@
+{
+  "tag_prefix": "attention_score32_exact_root_finalizer_lane_firstpass_v1",
+  "flow_params": {
+    "CLOCK_PERIOD": [
+      8.0
+    ],
+    "DIE_AREA": [
+      "0 0 1000 1000"
+    ],
+    "CORE_AREA": [
+      "50 50 950 950"
+    ],
+    "PLACE_DENSITY": [
+      0.3,
+      0.5
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ]
+  }
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l1/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l1/config.json
@@ -1,0 +1,8 @@
+{
+  "top_name": "attention_score32_exact_root_finalizer_l1",
+  "attention_score32_exact_root_finalizer": {
+    "value_slices": 16,
+    "head_id_bits": 5,
+    "divider_lanes": 1
+  }
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l2/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l2/config.json
@@ -1,0 +1,8 @@
+{
+  "top_name": "attention_score32_exact_root_finalizer_l2",
+  "attention_score32_exact_root_finalizer": {
+    "value_slices": 16,
+    "head_id_bits": 5,
+    "divider_lanes": 2
+  }
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l4/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l4/config.json
@@ -1,0 +1,8 @@
+{
+  "top_name": "attention_score32_exact_root_finalizer_l4",
+  "attention_score32_exact_root_finalizer": {
+    "value_slices": 16,
+    "head_id_bits": 5,
+    "divider_lanes": 4
+  }
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l8/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_root_finalizer_l8/config.json
@@ -1,0 +1,8 @@
+{
+  "top_name": "attention_score32_exact_root_finalizer_l8",
+  "attention_score32_exact_root_finalizer": {
+    "value_slices": 16,
+    "head_id_bits": 5,
+    "divider_lanes": 8
+  }
+}

--- a/tests/test_check_attention_score32_exact_root_finalizer_guard.py
+++ b/tests/test_check_attention_score32_exact_root_finalizer_guard.py
@@ -1,0 +1,104 @@
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+from npu.rtlgen.gen_attention_score32_exact_root_finalizer import generate
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _config_path(lanes: int) -> Path:
+    return (
+        REPO_ROOT
+        / "runs"
+        / "designs"
+        / "npu_blocks"
+        / f"attention_score32_exact_root_finalizer_l{lanes}"
+        / "config.json"
+    )
+
+
+def _prepare_design_dir(tmp_path: Path, *, lanes: int) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    design_dir = tmp_path / f"attention_score32_exact_root_finalizer_l{lanes}"
+    design_dir.mkdir()
+    config = json.loads(_config_path(lanes).read_text(encoding="utf-8"))
+    (design_dir / "config.json").write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    generate(config, design_dir / "verilog")
+    return design_dir
+
+
+def test_exact_root_finalizer_guard_accepts_all_checked_in_lane_configs(tmp_path: Path) -> None:
+    for lanes in (1, 2, 4, 8):
+        design_dir = _prepare_design_dir(tmp_path / f"case_{lanes}", lanes=lanes)
+        result = subprocess.run(
+            [
+                sys.executable,
+                "npu/eval/check_attention_score32_exact_root_finalizer_guard.py",
+                "--design-dir",
+                str(design_dir),
+                "--config",
+                str(design_dir / "config.json"),
+            ],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["divider_lanes"] == lanes
+        assert payload["divider_iterations_per_group"] == 57
+        assert payload["status"] == "ok"
+
+
+def test_exact_root_finalizer_guard_rejects_stale_generated_config(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, lanes=4)
+    config = json.loads((design_dir / "config.json").read_text(encoding="utf-8"))
+    config["attention_score32_exact_root_finalizer"]["divider_lanes"] = 2
+    (design_dir / "config.json").write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/check_attention_score32_exact_root_finalizer_guard.py",
+            "--design-dir",
+            str(design_dir),
+            "--config",
+            str(design_dir / "config.json"),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "generated config does not match source config" in result.stderr
+
+
+def test_exact_root_finalizer_guard_rejects_combinational_divide(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, lanes=8)
+    top_path = design_dir / "verilog" / "top.v"
+    text = top_path.read_text(encoding="utf-8")
+    top_path.write_text(
+        text.replace("endmodule\n", "  wire [31:0] bad_div = 32'd8 / 32'd2;\nendmodule\n"),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/check_attention_score32_exact_root_finalizer_guard.py",
+            "--design-dir",
+            str(design_dir),
+            "--config",
+            str(design_dir / "config.json"),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "must not contain combinational division operators" in result.stderr


### PR DESCRIPTION
## Summary

- add standalone score32 exact-root-finalizer configs for 1, 2, 4, and 8 physical divider lanes
- teach the L1 task generator to generate, guard, sweep, and extract timing evidence for this block type
- add a strict config/manifest/RTL guard that rejects stale or mismatched generation, non-57-cycle implementations, and combinational division
- add an isolated Nangate45 first-pass sweep at 8 ns, 1000 um die, 900 um core, and placement densities 0.30/0.50
- add proposal linkage for `l1_decoder_attention_score32_exact_root_finalizer_lane_ppa_v1`

## Why isolated first

The composed exact-reduction tree still has direct 328-bit internal links and unresolved NoC/placement cost. Measuring the finalizer alone gives a defensible divider-lane area/timing anchor without mislabeling it as full decoder-attention closure.

## Validation

- focused L1 generator and guard suite: `63 passed`
- direct RTL generation and strict guard: passed for lane counts 1/2/4/8
- `python3 scripts/validate_runs.py --skip_eval_queue`: passed

## Dispatch

This PR does not create or dispatch a database item. After merge, the existing proposal will be materialized with the merge commit as its source requirement. Remote execution remains gated on a fresh evaluator worker poll.