### PR TITLE
Add exact partial tree PPA control path

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -843,6 +843,56 @@ def _read_config_target(
                 },
             ],
         )
+    elif "top_name" in cfg and "attention_score32_exact_partial_tree" in cfg:
+        top_name = str(cfg["top_name"]).strip()
+        if not top_name:
+            raise Layer1TaskGenerationError(f"top_name must not be empty in {config_path}")
+        try:
+            design_dir = str(config_path.parent.resolve().relative_to(repo_root.resolve()))
+        except ValueError as exc:
+            raise Layer1TaskGenerationError(
+                f"score32 exact partial tree config must live under repo_root/runs/designs/...: {config_path}"
+            ) from exc
+        design_name = config_path.parent.name
+        return Layer1ConfigTarget(
+            design_kind="block",
+            design_name=design_name,
+            expected_metrics_path=block_metrics_path(design_name),
+            expected_report_paths=[f"{design_dir}/timing_debug_report.md"],
+            commands=[
+                {
+                    "name": "generate_attention_score32_exact_partial_tree_rtl",
+                    "run": _with_oss_cad_path(
+                        "python3 npu/rtlgen/gen_attention_score32_exact_partial_tree.py "
+                        f"--config {config_rel} --out {design_dir}/verilog"
+                    ),
+                },
+                {
+                    "name": "check_attention_score32_exact_partial_tree_guard",
+                    "run": (
+                        "python3 npu/eval/check_attention_score32_exact_partial_tree_guard.py "
+                        f"--design-dir {design_dir} --config {config_rel}"
+                    ),
+                },
+                {
+                    "name": "run_block_sweep",
+                    "run": _with_oss_cad_path(
+                        "python3 npu/synth/run_block_sweep.py "
+                        f"--design_dir {design_dir} --platform {{platform}} --top {top_name} "
+                        f"--sweep {{sweep_path}} --out_root {out_root} "
+                        + (f"--make_target {make_target} " if make_target else "")
+                        + "--skip_existing"
+                    ),
+                },
+                {
+                    "name": "extract_attention_score32_exact_partial_tree_timing_paths",
+                    "run": (
+                        "python3 npu/eval/extract_openroad_timing_summary.py "
+                        f"--design-dir {design_dir} --out {design_dir}/timing_debug_report.md --max-paths 8"
+                    ),
+                },
+            ],
+        )
     elif "top_name" in cfg and "attention_decode_score_multivalue_gqa_array" in cfg:
         top_name = str(cfg["top_name"]).strip()
         if not top_name:

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -1700,6 +1700,79 @@ def _write_example_attention_score32_exact_root_finalizer_repo(repo_root: Path) 
     return str(config_path.relative_to(repo_root)), str(sweep_path.relative_to(repo_root))
 
 
+def _write_example_attention_score32_exact_partial_tree_repo(repo_root: Path) -> tuple[str, str]:
+    design_dir = repo_root / "runs" / "designs" / "npu_blocks" / "attention_score32_exact_partial_tree_smoke_c4_r2"
+    design_dir.mkdir(parents=True, exist_ok=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_score32_exact_partial_tree_smoke_c4_r2",
+                "attention_score32_exact_partial_tree": {
+                    "clusters": 4,
+                    "radix": 2,
+                    "value_slices": 16,
+                    "head_id_bits": 5,
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    sweep_path = (
+        repo_root
+        / "runs"
+        / "campaigns"
+        / "npu"
+        / "attention_score32_exact_partial_tree_v1"
+        / "sweeps"
+        / "nangate45_attention_score32_exact_partial_tree_cluster_firstpass.json"
+    )
+    sweep_path.parent.mkdir(parents=True, exist_ok=True)
+    sweep_path.write_text(
+        json.dumps(
+            {
+                "tag_prefix": "attention_score32_exact_partial_tree_cluster_firstpass_v1",
+                "flow_params": {
+                    "CLOCK_PERIOD": [8.0],
+                    "DIE_AREA": ["0 0 2500 2500"],
+                    "CORE_AREA": ["50 50 2450 2450"],
+                    "PLACE_DENSITY": [0.3, 0.5],
+                    "SYNTH_HIERARCHICAL": [1],
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return str(config_path.relative_to(repo_root)), str(sweep_path.relative_to(repo_root))
+
+
+def _write_second_attention_score32_exact_partial_tree_repo(repo_root: Path) -> str:
+    design_dir = repo_root / "runs" / "designs" / "npu_blocks" / "attention_score32_exact_partial_tree_smoke_c16_r2"
+    design_dir.mkdir(parents=True, exist_ok=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_score32_exact_partial_tree_smoke_c16_r2",
+                "attention_score32_exact_partial_tree": {
+                    "clusters": 16,
+                    "radix": 2,
+                    "value_slices": 16,
+                    "head_id_bits": 5,
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return str(config_path.relative_to(repo_root))
+
+
 def _write_second_attention_score32_exact_root_finalizer_repo(repo_root: Path) -> str:
     design_dir = repo_root / "runs" / "designs" / "npu_blocks" / "attention_score32_exact_root_finalizer_smoke_l8"
     design_dir.mkdir(parents=True, exist_ok=True)
@@ -3150,6 +3223,66 @@ def test_generate_l1_sweep_task_supports_attention_score32_exact_root_finalizer_
             }
 
 
+def test_generate_l1_sweep_task_supports_attention_score32_exact_partial_tree_configs() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_attention_score32_exact_partial_tree_repo(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/npu_blocks",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="architecture_block",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert [command["name"] for command in work_item.command_manifest] == [
+                "generate_attention_score32_exact_partial_tree_rtl",
+                "check_attention_score32_exact_partial_tree_guard",
+                "run_block_sweep",
+                "extract_attention_score32_exact_partial_tree_timing_paths",
+                "build_runs_index",
+                "validate",
+            ]
+            assert work_item.command_manifest[0]["run"] == (
+                "export PATH=/oss-cad-suite/bin:$PATH && "
+                "python3 npu/rtlgen/gen_attention_score32_exact_partial_tree.py "
+                "--config runs/designs/npu_blocks/attention_score32_exact_partial_tree_smoke_c4_r2/config.json "
+                "--out runs/designs/npu_blocks/attention_score32_exact_partial_tree_smoke_c4_r2/verilog"
+            )
+            assert work_item.command_manifest[1]["run"] == (
+                "python3 npu/eval/check_attention_score32_exact_partial_tree_guard.py "
+                "--design-dir runs/designs/npu_blocks/attention_score32_exact_partial_tree_smoke_c4_r2 "
+                "--config runs/designs/npu_blocks/attention_score32_exact_partial_tree_smoke_c4_r2/config.json"
+            )
+            assert "--top attention_score32_exact_partial_tree_smoke_c4_r2" in work_item.command_manifest[2]["run"]
+            assert work_item.command_manifest[3]["run"] == (
+                "python3 npu/eval/extract_openroad_timing_summary.py "
+                "--design-dir runs/designs/npu_blocks/attention_score32_exact_partial_tree_smoke_c4_r2 "
+                "--out runs/designs/npu_blocks/attention_score32_exact_partial_tree_smoke_c4_r2/timing_debug_report.md "
+                "--max-paths 8"
+            )
+            assert work_item.expected_outputs == [
+                "runs/designs/npu_blocks/attention_score32_exact_partial_tree_smoke_c4_r2/metrics.csv",
+                "runs/designs/npu_blocks/attention_score32_exact_partial_tree_smoke_c4_r2/timing_debug_report.md",
+            ]
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "architecture_block"
+            }
+
+
 def test_generate_l1_sweep_task_supports_attention_hbm_replay_controller_configs() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"
@@ -3660,6 +3793,41 @@ def test_exact_root_finalizer_lane_ppa_proposal_is_pending_merge_with_all_lane_c
     assert proposal_entry["sweep_path"] == expected_sweep
     assert request_entry["sweep_path"] == expected_sweep
     assert "isolated finalizer baseline" in proposal_entry["notes"]
+
+
+def test_exact_partial_tree_cluster_ppa_proposal_is_pending_merge_with_all_cluster_configs() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    proposal_dir = (
+        repo_root
+        / "docs"
+        / "proposals"
+        / "prop_l1_decoder_attention_score32_exact_partial_tree_cluster_ppa_v1"
+    )
+    proposal = json.loads((proposal_dir / "proposal.json").read_text(encoding="utf-8"))
+    evaluation_requests = json.loads((proposal_dir / "evaluation_requests.json").read_text(encoding="utf-8"))
+
+    item_id = "l1_decoder_attention_score32_exact_partial_tree_cluster_ppa_v1"
+    expected_configs = [
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c2_r2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c4_r2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c8_r2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c16_r2/config.json",
+    ]
+    expected_sweep = (
+        "runs/campaigns/npu/attention_score32_exact_partial_tree_v1/sweeps/"
+        "nangate45_attention_score32_exact_partial_tree_cluster_firstpass.json"
+    )
+    proposal_entry = {entry["item_id"]: entry for entry in proposal["required_evaluations"]}[item_id]
+    request_entry = {entry["item_id"]: entry for entry in evaluation_requests["requested_items"]}[item_id]
+
+    assert proposal["abstraction_layer"] == "architecture_block"
+    assert proposal_entry["status"] == "pending_implementation_merge"
+    assert request_entry["status"] == "pending_implementation_merge"
+    assert proposal_entry["configs"] == expected_configs
+    assert request_entry["configs"] == expected_configs
+    assert proposal_entry["sweep_path"] == expected_sweep
+    assert request_entry["sweep_path"] == expected_sweep
+    assert "Boundary evidence is valid here" in proposal_entry["notes"]
 
 
 def test_generate_l1_sweep_task_checked_in_service_requests_gate_and_refresh_release() -> None:
@@ -4547,6 +4715,54 @@ def test_generate_l1_sweep_task_supports_multi_attention_score32_exact_root_fina
                 "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_smoke_l4/timing_debug_report.md",
                 "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_smoke_l8/metrics.csv",
                 "runs/designs/npu_blocks/attention_score32_exact_root_finalizer_smoke_l8/timing_debug_report.md",
+            ]
+
+
+def test_generate_l1_sweep_task_emits_commands_for_each_attention_score32_exact_partial_tree_config() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_attention_score32_exact_partial_tree_repo(repo_root)
+        second_config_path = _write_second_attention_score32_exact_partial_tree_repo(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path, second_config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/npu_blocks",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="architecture_block",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert [command["name"] for command in work_item.command_manifest] == [
+                "generate_attention_score32_exact_partial_tree_rtl_attention_score32_exact_partial_tree_smoke_c4_r2",
+                "check_attention_score32_exact_partial_tree_guard_attention_score32_exact_partial_tree_smoke_c4_r2",
+                "run_block_sweep_attention_score32_exact_partial_tree_smoke_c4_r2",
+                "extract_attention_score32_exact_partial_tree_timing_paths_attention_score32_exact_partial_tree_smoke_c4_r2",
+                "generate_attention_score32_exact_partial_tree_rtl_attention_score32_exact_partial_tree_smoke_c16_r2",
+                "check_attention_score32_exact_partial_tree_guard_attention_score32_exact_partial_tree_smoke_c16_r2",
+                "run_block_sweep_attention_score32_exact_partial_tree_smoke_c16_r2",
+                "extract_attention_score32_exact_partial_tree_timing_paths_attention_score32_exact_partial_tree_smoke_c16_r2",
+                "build_runs_index",
+                "validate",
+            ]
+            assert "attention_score32_exact_partial_tree_smoke_c4_r2/config.json" in work_item.command_manifest[0]["run"]
+            assert "attention_score32_exact_partial_tree_smoke_c16_r2/config.json" in work_item.command_manifest[4]["run"]
+            assert work_item.expected_outputs == [
+                "runs/designs/npu_blocks/attention_score32_exact_partial_tree_smoke_c4_r2/metrics.csv",
+                "runs/designs/npu_blocks/attention_score32_exact_partial_tree_smoke_c4_r2/timing_debug_report.md",
+                "runs/designs/npu_blocks/attention_score32_exact_partial_tree_smoke_c16_r2/metrics.csv",
+                "runs/designs/npu_blocks/attention_score32_exact_partial_tree_smoke_c16_r2/timing_debug_report.md",
             ]
 
 

--- a/docs/proposals/prop_l1_decoder_attention_score32_exact_partial_tree_cluster_ppa_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_exact_partial_tree_cluster_ppa_v1/evaluation_requests.json
@@ -1,0 +1,38 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_score32_exact_partial_tree_cluster_ppa_v1",
+  "source_commit_note": "Replace with the merge commit that adds the standalone exact-partial-tree guard, sweep, proposal, and L1 task-generator support before dispatch.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_score32_exact_partial_tree_cluster_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for standalone score32 exact partial trees at 2, 4, 8, and 16 clusters.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "exact_partial_tree_cluster_anchor",
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c2_r2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c4_r2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c8_r2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c16_r2/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_partial_tree_v1/sweeps/nangate45_attention_score32_exact_partial_tree_cluster_firstpass.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c2_r2/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c2_r2/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c4_r2/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c4_r2/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c8_r2/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c8_r2/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c16_r2/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c16_r2/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "measure_exact_partial_tree_cluster_cost",
+        "reason": "This isolates spatial tree fan-in cost and captures timing or placement failure as boundary evidence before any direct-link or finalizer composition claim is attempted."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "Standalone tree-only boundary baseline; direct 328-bit links, NoC/SRAM placement, and the root finalizer remain separate abstractions."
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_score32_exact_partial_tree_cluster_ppa_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_exact_partial_tree_cluster_ppa_v1/proposal.json
@@ -1,0 +1,83 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_score32_exact_partial_tree_cluster_ppa_v1",
+  "created_utc": "2026-07-27T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "title": "Score32 exact partial tree cluster PPA baseline",
+  "abstraction_layer": "architecture_block",
+  "hypothesis": "A standalone radix-2 exact-partial tree sweep can isolate cluster fan-in cost and expose placement or timing failure modes before any direct-link, NoC, SRAM, or root-finalizer composition is treated as physically grounded.",
+  "direct_comparison": {
+    "primary_question": "What Nangate45 area and timing boundary is exposed by standalone score32 exact partial trees at 2, 4, 8, and 16 clusters under a fixed first-pass 8 ns, 2500 um die, 2400 um core envelope?",
+    "candidate": "l1_decoder_attention_score32_exact_partial_tree_cluster_ppa_v1",
+    "include": [
+      "actual attention_score32_exact_partial_tree RTL generation",
+      "strict config/manifest/RTL guard before synthesis",
+      "hierarchical OpenROAD block sweeps at place densities 0.30 and 0.50",
+      "timing-summary extraction for each cluster configuration"
+    ],
+    "exclude": [
+      "no direct 328-bit link, NoC, or SRAM placement closure claim",
+      "no root finalizer or composed exact-finalized tree in this patch",
+      "no claim that the standalone tree represents full decoder-attention macro closure"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "die_area",
+      "total_power_mw",
+      "stdcell_count",
+      "timing_debug_report"
+    ]
+  },
+  "remaining_abstractions": [
+    "This item measures only the standalone exact partial reduction tree; the direct 328-bit internal links remain unclosed.",
+    "NoC transport, SRAM placement, and cluster-to-memory physical composition remain separate sources of area and timing risk.",
+    "The root finalizer is excluded here; any later composed macro must consume this as a tree-only boundary anchor, not as full-path closure evidence."
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_score32_exact_partial_tree_cluster_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for standalone score32 exact partial trees at 2, 4, 8, and 16 clusters.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "exact_partial_tree_cluster_anchor",
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c2_r2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c4_r2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c8_r2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c16_r2/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_partial_tree_v1/sweeps/nangate45_attention_score32_exact_partial_tree_cluster_firstpass.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c2_r2/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c2_r2/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c4_r2/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c4_r2/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c8_r2/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c8_r2/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c16_r2/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c16_r2/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "measure_exact_partial_tree_cluster_cost",
+        "reason": "This isolates spatial tree fan-in cost and captures timing or placement failure as boundary evidence before any direct-link or finalizer composition claim is attempted."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "Boundary evidence is valid here, especially for c16; direct 328-bit links, NoC/SRAM placement, and the root finalizer remain separate abstractions."
+    }
+  ],
+  "source_refs": [
+    "npu/rtlgen/gen_attention_score32_exact_partial_tree.py",
+    "npu/eval/check_attention_score32_exact_partial_tree_guard.py",
+    "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c2_r2/config.json",
+    "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c4_r2/config.json",
+    "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c8_r2/config.json",
+    "runs/designs/npu_blocks/attention_score32_exact_partial_tree_c16_r2/config.json",
+    "runs/campaigns/npu/attention_score32_exact_partial_tree_v1/sweeps/nangate45_attention_score32_exact_partial_tree_cluster_firstpass.json"
+  ],
+  "knowledge_refs": [
+    "npu/docs/attention_score32_exact_partial_tree_contract.md"
+  ]
+}

--- a/npu/eval/check_attention_score32_exact_partial_tree_guard.py
+++ b/npu/eval/check_attention_score32_exact_partial_tree_guard.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Strict generated RTL guard for standalone score32 exact partial trees."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+import re
+import sys
+import tempfile
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_score32_exact_partial_tree import generate
+from npu.sim.perf.attention_exact_partial import PARTIAL_LINK_BITS, PARTIAL_PAYLOAD_BITS
+
+
+_SUPPORTED_CLUSTERS = {2, 4, 8, 16}
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _resolve_selected_config(*, design_dir: Path, selected: Path | None) -> Path:
+    config_path = selected or (design_dir / "config.json")
+    config_path = config_path.resolve()
+    if not config_path.exists():
+        raise SystemExit(f"missing config: {config_path}")
+    try:
+        relative_path = config_path.relative_to(design_dir)
+    except ValueError as exc:
+        raise SystemExit(f"selected config must live under design-dir: {config_path}") from exc
+    if len(relative_path.parts) != 1:
+        raise SystemExit(f"selected config must be a direct child of design-dir, got: {relative_path.as_posix()}")
+    return config_path
+
+
+def _require(mapping: dict[str, object], key: str, expected: object, label: str) -> None:
+    if mapping.get(key) != expected:
+        raise SystemExit(f"{label} {key} must be {expected}")
+
+
+def _require_token(text: str, token: str, label: str) -> None:
+    if token not in text:
+        raise SystemExit(f"{label} missing semantic token: {token}")
+
+
+def _clog2(value: int) -> int:
+    return max(1, math.ceil(math.log2(max(2, value))))
+
+
+def _extract_module(rtl: str, module_name: str) -> str:
+    pattern = re.compile(rf"module\s+{re.escape(module_name)}\b.*?endmodule\s*", re.DOTALL)
+    match = pattern.search(rtl)
+    if match is None:
+        raise SystemExit(f"generated RTL does not define top module {module_name}")
+    return match.group(0)
+
+
+def _compare_current_generation(*, config: dict[str, object], rtl_dir: Path) -> None:
+    with tempfile.TemporaryDirectory(prefix="score32_exact_partial_tree_guard_") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        generate(config, temp_dir)
+        for relative_name in (
+            "top.v",
+            "config.json",
+            "attention_score32_exact_partial_tree_manifest.json",
+        ):
+            generated_text = (temp_dir / relative_name).read_text(encoding="utf-8")
+            current_text = (rtl_dir / relative_name).read_text(encoding="utf-8")
+            if generated_text != current_text:
+                raise SystemExit(f"generated RTL artifacts do not match current generator output: {relative_name}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--design-dir", type=Path, required=True)
+    ap.add_argument("--config", type=Path, default=None)
+    args = ap.parse_args(argv)
+
+    design_dir = args.design_dir.resolve()
+    config_path = _resolve_selected_config(design_dir=design_dir, selected=args.config)
+    rtl_dir = design_dir / "verilog"
+    generated_config_path = rtl_dir / "config.json"
+    manifest_path = rtl_dir / "attention_score32_exact_partial_tree_manifest.json"
+    top_path = rtl_dir / "top.v"
+    for path in (config_path, generated_config_path, manifest_path, top_path):
+        if not path.is_file():
+            raise SystemExit(f"missing exact partial tree artifact: {path}")
+
+    config = _load_json(config_path)
+    generated_config = _load_json(generated_config_path)
+    if config != generated_config:
+        raise SystemExit("generated config does not match source config")
+
+    top_name = str(config.get("top_name") or "").strip()
+    if not top_name:
+        raise SystemExit("top_name must not be empty")
+    body = config.get("attention_score32_exact_partial_tree")
+    if not isinstance(body, dict):
+        raise SystemExit("config must contain attention_score32_exact_partial_tree object")
+    clusters = int(body.get("clusters", 0))
+    radix = int(body.get("radix", 0))
+    value_slices = int(body.get("value_slices", 0))
+    head_id_bits = int(body.get("head_id_bits", 0))
+    if clusters not in _SUPPORTED_CLUSTERS:
+        raise SystemExit("clusters must be one of 2, 4, 8, 16")
+    if clusters & (clusters - 1):
+        raise SystemExit("clusters must be a power of two")
+    if radix != 2:
+        raise SystemExit("radix must be 2 for the current exact partial tree")
+    if value_slices < 1 or value_slices > 16 or (value_slices & (value_slices - 1)):
+        raise SystemExit("value_slices must be a power of two in [1, 16]")
+    if head_id_bits < 1 or head_id_bits > 8:
+        raise SystemExit("head_id_bits must be in [1, 8]")
+
+    tree_nodes = clusters - 1
+    tree_stages = int(math.log2(clusters))
+    slice_bits = _clog2(value_slices)
+    root_index = tree_nodes - 1
+    pair_top_name = f"{top_name}__pair_node"
+
+    manifest = _load_json(manifest_path)
+    expected_manifest = {
+        "top_name": top_name,
+        "generator": "npu/rtlgen/gen_attention_score32_exact_partial_tree.py",
+        "semantic_profile": "score32_online_exact_partial_radix2_tree_v1",
+        "clusters": clusters,
+        "radix": radix,
+        "value_slices": value_slices,
+        "head_id_bits": head_id_bits,
+        "tree_stages": tree_stages,
+        "tree_nodes": tree_nodes,
+        "result_interface": "clusters_ready_valid_exact_partial_leaf_streams_to_root_stream",
+        "partial_payload_bits_per_beat": PARTIAL_PAYLOAD_BITS,
+        "partial_link_bits_per_beat": PARTIAL_LINK_BITS,
+        "equivalence_hash": False,
+        "direct_328bit_links_unclosed": True,
+        "final_divider_embodied": False,
+        "macro_eval_excludes_io_pads": True,
+    }
+    for key, expected in expected_manifest.items():
+        _require(manifest, key, expected, "generated manifest")
+
+    pair_manifest = manifest.get("submodule_manifests")
+    if not isinstance(pair_manifest, dict):
+        raise SystemExit("generated manifest must contain submodule_manifests")
+    pair_merge_manifest = pair_manifest.get("pair_merge")
+    if not isinstance(pair_merge_manifest, dict):
+        raise SystemExit("generated manifest must contain pair_merge submodule manifest")
+    _require(
+        pair_merge_manifest,
+        "generator",
+        "npu/rtlgen/gen_attention_score32_online_state_merge.py",
+        "pair-merge submodule manifest",
+    )
+    _require(
+        pair_merge_manifest,
+        "semantic_profile",
+        "score32_online_exact_partial_pair_merge_v1",
+        "pair-merge submodule manifest",
+    )
+
+    rtl = top_path.read_text(encoding="utf-8", errors="replace")
+    top_module = _extract_module(rtl, top_name)
+    top_module_body = top_module.split(");", 1)[1]
+
+    for token in (
+        f"localparam integer CLUSTERS = {clusters};",
+        f"localparam integer TREE_STAGES = {tree_stages};",
+        f"localparam integer TREE_NODES = {tree_nodes};",
+        f"localparam integer HEAD_ID_BITS = {head_id_bits};",
+        f"localparam integer VALUE_SLICES = {value_slices};",
+        f"localparam integer SLICE_BITS = {slice_bits};",
+        f"localparam integer PARTIAL_PAYLOAD_BITS = {PARTIAL_PAYLOAD_BITS};",
+        f"assign root_valid = node_valid_w[{root_index}];",
+        f"assign root_command_id = node_command_id_w[{root_index}];",
+        f"assign root_head_id = node_head_id_w[{root_index}];",
+        f"assign root_global_max = node_global_max_w[{root_index}];",
+        f"assign root_exp_sum = node_exp_sum_w[{root_index}];",
+        f"assign root_slice = node_slice_w[{root_index}];",
+        f"assign root_last = node_last_w[{root_index}];",
+        f"assign root_value = node_value_w[{root_index}];",
+        f"assign root_completed_count = node_completed_count_w[{root_index}];",
+        f"assign cycle_count = node_cycle_count_w[{root_index}];",
+        "assign protocol_error = |node_protocol_error;",
+        "wire node_valid_w [0:TREE_NODES-1];",
+        "wire node_ready_w [0:TREE_NODES-1];",
+        "wire [31:0] node_completed_count_w [0:TREE_NODES-1];",
+        "wire node_protocol_error_w [0:TREE_NODES-1];",
+    ):
+        _require_token(top_module, token, "generated RTL")
+
+    for token in (
+        f"output wire [{tree_nodes * 32 - 1}:0] node_completed_count,",
+        f"output wire [{tree_stages * 32 - 1}:0] stage_completed_count,",
+        f"output wire [{tree_nodes - 1}:0] node_protocol_error,",
+        f"output wire [{tree_stages - 1}:0] stage_protocol_error,",
+        "output wire [31:0]  cycle_count,",
+        "output wire [31:0]  root_completed_count,",
+        "output wire         protocol_error",
+    ):
+        _require_token(top_module, token, "generated RTL")
+
+    if re.search(r"^\s*reg\b", top_module_body, re.MULTILINE):
+        raise SystemExit("top module must not contain internal reg storage")
+
+    instance_indices = {int(index) for index in re.findall(rf"\bu_node_(\d+)\b", top_module)}
+    if instance_indices != set(range(tree_nodes)):
+        raise SystemExit("generated RTL must instantiate every pair node exactly once")
+    if top_module.count(f"{pair_top_name} u_node_") != tree_nodes:
+        raise SystemExit("generated RTL pair-node instance count does not match tree_nodes")
+
+    _require_token(top_module, f".out_ready(root_ready)", "generated RTL")
+    for node_index in range(tree_nodes):
+        _require_token(top_module, f".out_valid(node_valid_w[{node_index}])", "generated RTL")
+        _require_token(top_module, f".completed_count(node_completed_count_w[{node_index}])", "generated RTL")
+        _require_token(top_module, f".protocol_error(node_protocol_error_w[{node_index}])", "generated RTL")
+        if node_index == root_index:
+            _require_token(top_module, f"{pair_top_name} u_node_{node_index} (", "generated RTL")
+        else:
+            _require_token(top_module, f".out_ready(node_ready_w[{node_index}])", "generated RTL")
+        _require_token(
+            top_module,
+            f"assign node_completed_count[{node_index * 32} +: 32] = node_completed_count_w[{node_index}];",
+            "generated RTL",
+        )
+        _require_token(
+            top_module,
+            f"assign node_protocol_error[{node_index}] = node_protocol_error_w[{node_index}];",
+            "generated RTL",
+        )
+    for stage in range(tree_stages):
+        _require_token(
+            top_module,
+            f"assign stage_completed_count[{stage * 32} +: 32] =",
+            "generated RTL",
+        )
+        _require_token(
+            top_module,
+            f"assign stage_protocol_error[{stage}] =",
+            "generated RTL",
+        )
+
+    _compare_current_generation(config=config, rtl_dir=rtl_dir)
+
+    print(
+        json.dumps(
+            {
+                "design": top_name,
+                "guard": "attention_score32_exact_partial_tree_v1",
+                "clusters": clusters,
+                "tree_nodes": tree_nodes,
+                "tree_stages": tree_stages,
+                "status": "ok",
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runs/campaigns/npu/attention_score32_exact_partial_tree_v1/sweeps/nangate45_attention_score32_exact_partial_tree_cluster_firstpass.json
+++ b/runs/campaigns/npu/attention_score32_exact_partial_tree_v1/sweeps/nangate45_attention_score32_exact_partial_tree_cluster_firstpass.json
@@ -1,0 +1,21 @@
+{
+  "tag_prefix": "attention_score32_exact_partial_tree_cluster_firstpass_v1",
+  "flow_params": {
+    "CLOCK_PERIOD": [
+      8.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.3,
+      0.5
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ]
+  }
+}

--- a/tests/test_check_attention_score32_exact_partial_tree_guard.py
+++ b/tests/test_check_attention_score32_exact_partial_tree_guard.py
@@ -1,0 +1,133 @@
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_score32_exact_partial_tree import generate
+
+
+def _config_path(clusters: int) -> Path:
+    return (
+        REPO_ROOT
+        / "runs"
+        / "designs"
+        / "npu_blocks"
+        / f"attention_score32_exact_partial_tree_c{clusters}_r2"
+        / "config.json"
+    )
+
+
+def _prepare_design_dir(tmp_path: Path, *, clusters: int) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    design_dir = tmp_path / f"attention_score32_exact_partial_tree_c{clusters}_r2"
+    design_dir.mkdir()
+    config = json.loads(_config_path(clusters).read_text(encoding="utf-8"))
+    (design_dir / "config.json").write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    generate(config, design_dir / "verilog")
+    return design_dir
+
+
+def test_exact_partial_tree_guard_accepts_all_checked_in_cluster_configs(tmp_path: Path) -> None:
+    for clusters in (2, 4, 8, 16):
+        design_dir = _prepare_design_dir(tmp_path / f"case_{clusters}", clusters=clusters)
+        result = subprocess.run(
+            [
+                sys.executable,
+                "npu/eval/check_attention_score32_exact_partial_tree_guard.py",
+                "--design-dir",
+                str(design_dir),
+                "--config",
+                str(design_dir / "config.json"),
+            ],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["clusters"] == clusters
+        assert payload["tree_nodes"] == clusters - 1
+        assert payload["tree_stages"] == {2: 1, 4: 2, 8: 3, 16: 4}[clusters]
+        assert payload["status"] == "ok"
+
+
+def test_exact_partial_tree_guard_rejects_stale_generated_config(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, clusters=4)
+    config = json.loads((design_dir / "config.json").read_text(encoding="utf-8"))
+    config["attention_score32_exact_partial_tree"]["clusters"] = 8
+    (design_dir / "config.json").write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/check_attention_score32_exact_partial_tree_guard.py",
+            "--design-dir",
+            str(design_dir),
+            "--config",
+            str(design_dir / "config.json"),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "generated config does not match source config" in result.stderr
+
+
+def test_exact_partial_tree_guard_rejects_manifest_boundary_mismatch(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, clusters=8)
+    manifest_path = design_dir / "verilog" / "attention_score32_exact_partial_tree_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["direct_328bit_links_unclosed"] = False
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/check_attention_score32_exact_partial_tree_guard.py",
+            "--design-dir",
+            str(design_dir),
+            "--config",
+            str(design_dir / "config.json"),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "generated manifest direct_328bit_links_unclosed must be True" in result.stderr
+
+
+def test_exact_partial_tree_guard_rejects_top_level_internal_storage(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, clusters=16)
+    top_path = design_dir / "verilog" / "top.v"
+    text = top_path.read_text(encoding="utf-8")
+    prefix, suffix = text.rsplit("endmodule\n", 1)
+    top_path.write_text(
+        prefix + "reg [327:0] illegal_full_state_q [0:31];\nendmodule\n" + suffix,
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/check_attention_score32_exact_partial_tree_guard.py",
+            "--design-dir",
+            str(design_dir),
+            "--config",
+            str(design_dir / "config.json"),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "top module must not contain internal reg storage" in result.stderr


### PR DESCRIPTION
## Summary
- add strict generated-RTL guard for standalone score32 exact partial trees
- add L1 task-generator support for c2/c4/c8/c16 tree sweeps
- add Nangate45 first-pass sweep and linked proposal artifact

## Scope
This measures the embodied radix-2 partial reduction tree only. Direct 328-bit links, NoC/SRAM placement, and the exact root finalizer remain explicit separate boundaries.

## Verification
- `pytest -q tests/test_check_attention_score32_exact_partial_tree_guard.py tests/test_attention_score32_exact_partial_tree.py` (10 passed)
- `PYTHONPATH=$PWD/control_plane:$PWD pytest -q control_plane/control_plane/tests/test_l1_task_generator.py -k 'attention_score32_exact_partial_tree or exact_partial_tree_cluster_ppa'` (3 passed)
- `python3 scripts/validate_runs.py --skip_eval_queue`
