### PR TITLE
Add composed exact finalized tree PPA control

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -843,6 +843,56 @@ def _read_config_target(
                 },
             ],
         )
+    elif "top_name" in cfg and "attention_score32_exact_finalized_tree" in cfg:
+        top_name = str(cfg["top_name"]).strip()
+        if not top_name:
+            raise Layer1TaskGenerationError(f"top_name must not be empty in {config_path}")
+        try:
+            design_dir = str(config_path.parent.resolve().relative_to(repo_root.resolve()))
+        except ValueError as exc:
+            raise Layer1TaskGenerationError(
+                f"score32 exact finalized tree config must live under repo_root/runs/designs/...: {config_path}"
+            ) from exc
+        design_name = config_path.parent.name
+        return Layer1ConfigTarget(
+            design_kind="block",
+            design_name=design_name,
+            expected_metrics_path=block_metrics_path(design_name),
+            expected_report_paths=[f"{design_dir}/timing_debug_report.md"],
+            commands=[
+                {
+                    "name": "generate_attention_score32_exact_finalized_tree_rtl",
+                    "run": _with_oss_cad_path(
+                        "python3 npu/rtlgen/gen_attention_score32_exact_finalized_tree.py "
+                        f"--config {config_rel} --out {design_dir}/verilog"
+                    ),
+                },
+                {
+                    "name": "check_attention_score32_exact_finalized_tree_guard",
+                    "run": (
+                        "python3 npu/eval/check_attention_score32_exact_finalized_tree_guard.py "
+                        f"--design-dir {design_dir} --config {config_rel}"
+                    ),
+                },
+                {
+                    "name": "run_block_sweep",
+                    "run": _with_oss_cad_path(
+                        "python3 npu/synth/run_block_sweep.py "
+                        f"--design_dir {design_dir} --platform {{platform}} --top {top_name} "
+                        f"--sweep {{sweep_path}} --out_root {out_root} "
+                        + (f"--make_target {make_target} " if make_target else "")
+                        + "--skip_existing"
+                    ),
+                },
+                {
+                    "name": "extract_attention_score32_exact_finalized_tree_timing_paths",
+                    "run": (
+                        "python3 npu/eval/extract_openroad_timing_summary.py "
+                        f"--design-dir {design_dir} --out {design_dir}/timing_debug_report.md --max-paths 8"
+                    ),
+                },
+            ],
+        )
     elif "top_name" in cfg and "attention_score32_exact_partial_tree" in cfg:
         top_name = str(cfg["top_name"]).strip()
         if not top_name:

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -1750,6 +1750,57 @@ def _write_example_attention_score32_exact_partial_tree_repo(repo_root: Path) ->
     return str(config_path.relative_to(repo_root)), str(sweep_path.relative_to(repo_root))
 
 
+def _write_example_attention_score32_exact_finalized_tree_repo(repo_root: Path) -> tuple[str, str]:
+    design_dir = repo_root / "runs" / "designs" / "npu_blocks" / "attention_score32_exact_finalized_tree_smoke_c16_r2_l4"
+    design_dir.mkdir(parents=True, exist_ok=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_score32_exact_finalized_tree_smoke_c16_r2_l4",
+                "attention_score32_exact_finalized_tree": {
+                    "clusters": 16,
+                    "radix": 2,
+                    "value_slices": 16,
+                    "head_id_bits": 5,
+                    "divider_lanes": 4,
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    sweep_path = (
+        repo_root
+        / "runs"
+        / "campaigns"
+        / "npu"
+        / "attention_score32_exact_finalized_tree_v1"
+        / "sweeps"
+        / "nangate45_attention_score32_exact_finalized_tree_c16_lane_firstpass.json"
+    )
+    sweep_path.parent.mkdir(parents=True, exist_ok=True)
+    sweep_path.write_text(
+        json.dumps(
+            {
+                "tag_prefix": "attention_score32_exact_finalized_tree_c16_lane_firstpass_v1",
+                "flow_params": {
+                    "CLOCK_PERIOD": [8.0],
+                    "DIE_AREA": ["0 0 2500 2500"],
+                    "CORE_AREA": ["50 50 2450 2450"],
+                    "PLACE_DENSITY": [0.3, 0.5],
+                    "SYNTH_HIERARCHICAL": [1],
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return str(config_path.relative_to(repo_root)), str(sweep_path.relative_to(repo_root))
+
+
 def _write_second_attention_score32_exact_partial_tree_repo(repo_root: Path) -> str:
     design_dir = repo_root / "runs" / "designs" / "npu_blocks" / "attention_score32_exact_partial_tree_smoke_c16_r2"
     design_dir.mkdir(parents=True, exist_ok=True)
@@ -1782,6 +1833,30 @@ def _write_second_attention_score32_exact_root_finalizer_repo(repo_root: Path) -
             {
                 "top_name": "attention_score32_exact_root_finalizer_smoke_l8",
                 "attention_score32_exact_root_finalizer": {
+                    "value_slices": 16,
+                    "head_id_bits": 5,
+                    "divider_lanes": 8,
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return str(config_path.relative_to(repo_root))
+
+
+def _write_second_attention_score32_exact_finalized_tree_repo(repo_root: Path) -> str:
+    design_dir = repo_root / "runs" / "designs" / "npu_blocks" / "attention_score32_exact_finalized_tree_smoke_c16_r2_l8"
+    design_dir.mkdir(parents=True, exist_ok=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_score32_exact_finalized_tree_smoke_c16_r2_l8",
+                "attention_score32_exact_finalized_tree": {
+                    "clusters": 16,
+                    "radix": 2,
                     "value_slices": 16,
                     "head_id_bits": 5,
                     "divider_lanes": 8,
@@ -3830,6 +3905,42 @@ def test_exact_partial_tree_cluster_ppa_proposal_is_pending_merge_with_all_clust
     assert "Boundary evidence is valid here" in proposal_entry["notes"]
 
 
+def test_exact_finalized_tree_c16_lane_ppa_proposal_is_pending_merge_with_all_lane_configs() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    proposal_dir = (
+        repo_root
+        / "docs"
+        / "proposals"
+        / "prop_l1_decoder_attention_score32_exact_finalized_tree_c16_lane_ppa_v1"
+    )
+    proposal = json.loads((proposal_dir / "proposal.json").read_text(encoding="utf-8"))
+    evaluation_requests = json.loads((proposal_dir / "evaluation_requests.json").read_text(encoding="utf-8"))
+
+    item_id = "l1_decoder_attention_score32_exact_finalized_tree_c16_lane_ppa_v1"
+    expected_configs = [
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l1/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l4/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l8/config.json",
+    ]
+    expected_sweep = (
+        "runs/campaigns/npu/attention_score32_exact_finalized_tree_v1/sweeps/"
+        "nangate45_attention_score32_exact_finalized_tree_c16_lane_firstpass.json"
+    )
+    proposal_entry = {entry["item_id"]: entry for entry in proposal["required_evaluations"]}[item_id]
+    request_entry = {entry["item_id"]: entry for entry in evaluation_requests["requested_items"]}[item_id]
+
+    assert proposal["abstraction_layer"] == "architecture_block"
+    assert proposal_entry["status"] == "pending_implementation_merge"
+    assert request_entry["status"] == "pending_implementation_merge"
+    assert proposal_entry["configs"] == expected_configs
+    assert request_entry["configs"] == expected_configs
+    assert proposal_entry["sweep_path"] == expected_sweep
+    assert request_entry["sweep_path"] == expected_sweep
+    assert "non-additive PPA" in proposal["hypothesis"]
+    assert "full decoder composition remain unclosed" in proposal_entry["notes"]
+
+
 def test_generate_l1_sweep_task_checked_in_service_requests_gate_and_refresh_release() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"
@@ -4763,6 +4874,54 @@ def test_generate_l1_sweep_task_emits_commands_for_each_attention_score32_exact_
                 "runs/designs/npu_blocks/attention_score32_exact_partial_tree_smoke_c4_r2/timing_debug_report.md",
                 "runs/designs/npu_blocks/attention_score32_exact_partial_tree_smoke_c16_r2/metrics.csv",
                 "runs/designs/npu_blocks/attention_score32_exact_partial_tree_smoke_c16_r2/timing_debug_report.md",
+            ]
+
+
+def test_generate_l1_sweep_task_emits_commands_for_each_attention_score32_exact_finalized_tree_config() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_attention_score32_exact_finalized_tree_repo(repo_root)
+        second_config_path = _write_second_attention_score32_exact_finalized_tree_repo(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path, second_config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/npu_blocks",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="architecture_block",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert [command["name"] for command in work_item.command_manifest] == [
+                "generate_attention_score32_exact_finalized_tree_rtl_attention_score32_exact_finalized_tree_smoke_c16_r2_l4",
+                "check_attention_score32_exact_finalized_tree_guard_attention_score32_exact_finalized_tree_smoke_c16_r2_l4",
+                "run_block_sweep_attention_score32_exact_finalized_tree_smoke_c16_r2_l4",
+                "extract_attention_score32_exact_finalized_tree_timing_paths_attention_score32_exact_finalized_tree_smoke_c16_r2_l4",
+                "generate_attention_score32_exact_finalized_tree_rtl_attention_score32_exact_finalized_tree_smoke_c16_r2_l8",
+                "check_attention_score32_exact_finalized_tree_guard_attention_score32_exact_finalized_tree_smoke_c16_r2_l8",
+                "run_block_sweep_attention_score32_exact_finalized_tree_smoke_c16_r2_l8",
+                "extract_attention_score32_exact_finalized_tree_timing_paths_attention_score32_exact_finalized_tree_smoke_c16_r2_l8",
+                "build_runs_index",
+                "validate",
+            ]
+            assert "attention_score32_exact_finalized_tree_smoke_c16_r2_l4/config.json" in work_item.command_manifest[0]["run"]
+            assert "attention_score32_exact_finalized_tree_smoke_c16_r2_l8/config.json" in work_item.command_manifest[4]["run"]
+            assert work_item.expected_outputs == [
+                "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_smoke_c16_r2_l4/metrics.csv",
+                "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_smoke_c16_r2_l4/timing_debug_report.md",
+                "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_smoke_c16_r2_l8/metrics.csv",
+                "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_smoke_c16_r2_l8/timing_debug_report.md",
             ]
 
 

--- a/docs/proposals/prop_l1_decoder_attention_score32_exact_finalized_tree_c16_lane_ppa_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_exact_finalized_tree_c16_lane_ppa_v1/evaluation_requests.json
@@ -1,0 +1,38 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_score32_exact_finalized_tree_c16_lane_ppa_v1",
+  "source_commit_note": "Replace with the merge commit that adds the composed exact-finalized-tree configs, strict guard, sweep, and L1 task-generator support before dispatch.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_score32_exact_finalized_tree_c16_lane_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the composed c16 score32 exact finalized tree at divider lanes 1, 2, 4, and 8.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "exact_finalized_tree_c16_lane_anchor",
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l1/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l4/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_finalized_tree_v1/sweeps/nangate45_attention_score32_exact_finalized_tree_c16_lane_firstpass.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l1/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l1/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l2/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l2/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l4/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l4/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l8/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "measure_exact_finalized_tree_c16_lane_cost",
+        "reason": "This measures the composed tree plus embodied finalizer cost directly, capturing non-additive PPA before transport or decoder-level closure work."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "Composed c16 tree plus finalizer PPA only; 16 external leaf streams, direct 328-bit transport, NoC and SRAM placement, and full decoder composition remain unclosed."
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_score32_exact_finalized_tree_c16_lane_ppa_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_exact_finalized_tree_c16_lane_ppa_v1/proposal.json
@@ -1,0 +1,84 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_score32_exact_finalized_tree_c16_lane_ppa_v1",
+  "created_utc": "2026-07-27T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "title": "Score32 exact finalized-tree c16 lane PPA baseline",
+  "abstraction_layer": "architecture_block",
+  "hypothesis": "A composed c16 exact-partial tree plus embodied root finalizer sweep will expose the non-additive PPA cost of the integrated control path across 1/2/4/8 divider lanes before any transport or full-decoder closure claims are made.",
+  "direct_comparison": {
+    "primary_question": "What Nangate45 area and timing tradeoff comes from the composed 16-cluster score32 exact finalized tree when divider lanes vary across 1, 2, 4, and 8 under a fixed first-pass 8 ns, 2500 um die, 2450 um core envelope?",
+    "candidate": "l1_decoder_attention_score32_exact_finalized_tree_c16_lane_ppa_v1",
+    "include": [
+      "actual attention_score32_exact_finalized_tree RTL generation",
+      "strict config, manifest, regeneration, and wiring guard before synthesis",
+      "hierarchical OpenROAD block sweeps at place densities 0.30 and 0.50",
+      "timing-summary extraction for each composed lane configuration"
+    ],
+    "exclude": [
+      "no closure claim for 16 external leaf streams or direct 328-bit transport",
+      "no NoC or SRAM placement closure claim",
+      "no claim that this composed macro closes the full decoder attention path"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "die_area",
+      "total_power_mw",
+      "stdcell_count",
+      "timing_debug_report"
+    ]
+  },
+  "remaining_abstractions": [
+    "This item measures only the composed c16 tree plus finalizer non-additive PPA; 16 external leaf streams and direct 328-bit transport remain unclosed.",
+    "NoC placement, SRAM placement, and macro-to-macro transport are still open physical risks outside this block-only measurement.",
+    "Full decoder composition remains unclosed, so later integrated conclusions must treat this as a component anchor rather than path closure evidence."
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_score32_exact_finalized_tree_c16_lane_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the composed c16 score32 exact finalized tree at divider lanes 1, 2, 4, and 8.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "exact_finalized_tree_c16_lane_anchor",
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l1/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l4/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_finalized_tree_v1/sweeps/nangate45_attention_score32_exact_finalized_tree_c16_lane_firstpass.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l1/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l1/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l2/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l2/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l4/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l4/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l8/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "measure_exact_finalized_tree_c16_lane_cost",
+        "reason": "This measures the composed tree plus embodied finalizer cost directly, capturing non-additive PPA before transport or decoder-level closure work."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "This is a composed c16 tree plus finalizer PPA probe only; external leaf streams, direct 328-bit transport, NoC and SRAM placement, and full decoder composition remain unclosed."
+    }
+  ],
+  "source_refs": [
+    "npu/rtlgen/gen_attention_score32_exact_finalized_tree.py",
+    "npu/eval/check_attention_score32_exact_finalized_tree_guard.py",
+    "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l1/config.json",
+    "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l2/config.json",
+    "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l4/config.json",
+    "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_c16_r2_l8/config.json",
+    "runs/campaigns/npu/attention_score32_exact_finalized_tree_v1/sweeps/nangate45_attention_score32_exact_finalized_tree_c16_lane_firstpass.json"
+  ],
+  "knowledge_refs": [
+    "npu/docs/attention_score32_exact_partial_tree_contract.md",
+    "npu/docs/attention_score32_exact_root_finalizer_contract.md"
+  ]
+}

--- a/npu/eval/check_attention_score32_exact_finalized_tree_guard.py
+++ b/npu/eval/check_attention_score32_exact_finalized_tree_guard.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Strict generated RTL guard for composed score32 exact finalized trees."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+import re
+import sys
+import tempfile
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_score32_exact_finalized_tree import generate
+from npu.sim.perf.attention_exact_partial import (
+    FINAL_LINK_BITS,
+    FINAL_PAYLOAD_BITS,
+    PARTIAL_LINK_BITS,
+    PARTIAL_PAYLOAD_BITS,
+)
+
+
+_SUPPORTED_CLUSTERS = {2, 4, 8, 16}
+_SUPPORTED_LANES = {1, 2, 4, 8}
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _resolve_selected_config(*, design_dir: Path, selected: Path | None) -> Path:
+    config_path = selected or (design_dir / "config.json")
+    config_path = config_path.resolve()
+    if not config_path.exists():
+        raise SystemExit(f"missing config: {config_path}")
+    try:
+        relative_path = config_path.relative_to(design_dir)
+    except ValueError as exc:
+        raise SystemExit(f"selected config must live under design-dir: {config_path}") from exc
+    if len(relative_path.parts) != 1:
+        raise SystemExit(f"selected config must be a direct child of design-dir, got: {relative_path.as_posix()}")
+    return config_path
+
+
+def _require(mapping: dict[str, object], key: str, expected: object, label: str) -> None:
+    if mapping.get(key) != expected:
+        raise SystemExit(f"{label} {key} must be {expected}")
+
+
+def _require_token(text: str, token: str, label: str) -> None:
+    if token not in text:
+        raise SystemExit(f"{label} missing semantic token: {token}")
+
+
+def _clog2(value: int) -> int:
+    return max(1, math.ceil(math.log2(max(2, value))))
+
+
+def _extract_module(rtl: str, module_name: str) -> str:
+    pattern = re.compile(rf"module\s+{re.escape(module_name)}\b.*?endmodule\s*", re.DOTALL)
+    match = pattern.search(rtl)
+    if match is None:
+        raise SystemExit(f"generated RTL does not define module {module_name}")
+    return match.group(0)
+
+
+def _strip_comments(text: str) -> str:
+    no_block = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    return re.sub(r"//.*", "", no_block)
+
+
+def _contains_operator_division(text: str) -> bool:
+    stripped = _strip_comments(text)
+    return re.search(r"(?<![*/])/(?![/*])", stripped) is not None
+
+
+def _compare_current_generation(*, config: dict[str, object], rtl_dir: Path) -> None:
+    with tempfile.TemporaryDirectory(prefix="score32_exact_finalized_tree_guard_") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        generate(config, temp_dir)
+        for relative_name in (
+            "top.v",
+            "config.json",
+            "attention_score32_exact_finalized_tree_manifest.json",
+        ):
+            generated_text = (temp_dir / relative_name).read_text(encoding="utf-8")
+            current_text = (rtl_dir / relative_name).read_text(encoding="utf-8")
+            if generated_text != current_text:
+                raise SystemExit(f"generated RTL artifacts do not match current generator output: {relative_name}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--design-dir", type=Path, required=True)
+    ap.add_argument("--config", type=Path, default=None)
+    args = ap.parse_args(argv)
+
+    design_dir = args.design_dir.resolve()
+    config_path = _resolve_selected_config(design_dir=design_dir, selected=args.config)
+    rtl_dir = design_dir / "verilog"
+    generated_config_path = rtl_dir / "config.json"
+    manifest_path = rtl_dir / "attention_score32_exact_finalized_tree_manifest.json"
+    top_path = rtl_dir / "top.v"
+    for path in (config_path, generated_config_path, manifest_path, top_path):
+        if not path.is_file():
+            raise SystemExit(f"missing exact finalized tree artifact: {path}")
+
+    config = _load_json(config_path)
+    generated_config = _load_json(generated_config_path)
+    if config != generated_config:
+        raise SystemExit("generated config does not match source config")
+
+    top_name = str(config.get("top_name") or "").strip()
+    if not top_name:
+        raise SystemExit("top_name must not be empty")
+    body = config.get("attention_score32_exact_finalized_tree")
+    if not isinstance(body, dict):
+        raise SystemExit("config must contain attention_score32_exact_finalized_tree object")
+    clusters = int(body.get("clusters", 0))
+    radix = int(body.get("radix", 0))
+    value_slices = int(body.get("value_slices", 0))
+    head_id_bits = int(body.get("head_id_bits", 0))
+    divider_lanes = int(body.get("divider_lanes", 0))
+    if clusters not in _SUPPORTED_CLUSTERS:
+        raise SystemExit("clusters must be one of 2, 4, 8, 16")
+    if clusters & (clusters - 1):
+        raise SystemExit("clusters must be a power of two")
+    if radix != 2:
+        raise SystemExit("radix must be 2 for the current exact finalized tree")
+    if value_slices < 1 or value_slices > 16 or (value_slices & (value_slices - 1)):
+        raise SystemExit("value_slices must be a power of two in [1, 16]")
+    if head_id_bits < 1 or head_id_bits > 8:
+        raise SystemExit("head_id_bits must be in [1, 8]")
+    if divider_lanes not in _SUPPORTED_LANES:
+        raise SystemExit("divider_lanes must be one of 1, 2, 4, 8")
+
+    tree_nodes = clusters - 1
+    tree_stages = int(math.log2(clusters))
+    slice_bits = _clog2(value_slices)
+    tree_top_name = f"{top_name}__partial_tree"
+    finalizer_top_name = f"{top_name}__root_finalizer"
+    pair_top_name = f"{tree_top_name}__pair_node"
+
+    manifest = _load_json(manifest_path)
+    expected_manifest = {
+        "top_name": top_name,
+        "generator": "npu/rtlgen/gen_attention_score32_exact_finalized_tree.py",
+        "semantic_profile": "score32_online_exact_finalized_radix2_tree_v1",
+        "clusters": clusters,
+        "radix": radix,
+        "value_slices": value_slices,
+        "head_id_bits": head_id_bits,
+        "divider_lanes": divider_lanes,
+        "tree_stages": tree_stages,
+        "tree_nodes": tree_nodes,
+        "result_interface": "clusters_ready_valid_exact_partial_leaf_streams_to_exact_finalized_root_stream",
+        "partial_payload_bits_per_beat": PARTIAL_PAYLOAD_BITS,
+        "partial_link_bits_per_beat": PARTIAL_LINK_BITS,
+        "final_payload_bits_per_beat": FINAL_PAYLOAD_BITS,
+        "final_link_bits_per_beat": FINAL_LINK_BITS,
+        "equivalence_hash": False,
+        "direct_328bit_links_unclosed": True,
+        "final_divider_embodied": True,
+        "macro_eval_excludes_io_pads": True,
+    }
+    for key, expected in expected_manifest.items():
+        _require(manifest, key, expected, "generated manifest")
+
+    submanifests = manifest.get("submodule_manifests")
+    if not isinstance(submanifests, dict):
+        raise SystemExit("generated manifest must contain submodule_manifests")
+    tree_manifest = submanifests.get("partial_tree")
+    if not isinstance(tree_manifest, dict):
+        raise SystemExit("generated manifest must contain partial_tree submodule manifest")
+    finalizer_manifest = submanifests.get("root_finalizer")
+    if not isinstance(finalizer_manifest, dict):
+        raise SystemExit("generated manifest must contain root_finalizer submodule manifest")
+
+    expected_tree_manifest = {
+        "top_name": tree_top_name,
+        "generator": "npu/rtlgen/gen_attention_score32_exact_partial_tree.py",
+        "semantic_profile": "score32_online_exact_partial_radix2_tree_v1",
+        "clusters": clusters,
+        "radix": radix,
+        "value_slices": value_slices,
+        "head_id_bits": head_id_bits,
+        "tree_stages": tree_stages,
+        "tree_nodes": tree_nodes,
+        "result_interface": "clusters_ready_valid_exact_partial_leaf_streams_to_root_stream",
+        "partial_payload_bits_per_beat": PARTIAL_PAYLOAD_BITS,
+        "partial_link_bits_per_beat": PARTIAL_LINK_BITS,
+        "equivalence_hash": False,
+        "direct_328bit_links_unclosed": True,
+        "final_divider_embodied": False,
+        "macro_eval_excludes_io_pads": True,
+    }
+    for key, expected in expected_tree_manifest.items():
+        _require(tree_manifest, key, expected, "partial-tree submodule manifest")
+
+    pair_manifest = tree_manifest.get("submodule_manifests")
+    if not isinstance(pair_manifest, dict):
+        raise SystemExit("partial-tree submodule manifest must contain submodule_manifests")
+    pair_merge_manifest = pair_manifest.get("pair_merge")
+    if not isinstance(pair_merge_manifest, dict):
+        raise SystemExit("partial-tree submodule manifest must contain pair_merge manifest")
+    _require(
+        pair_merge_manifest,
+        "top_name",
+        pair_top_name,
+        "pair-merge submodule manifest",
+    )
+    _require(
+        pair_merge_manifest,
+        "generator",
+        "npu/rtlgen/gen_attention_score32_online_state_merge.py",
+        "pair-merge submodule manifest",
+    )
+    _require(
+        pair_merge_manifest,
+        "semantic_profile",
+        "score32_online_exact_partial_pair_merge_v1",
+        "pair-merge submodule manifest",
+    )
+
+    expected_finalizer_manifest = {
+        "top_name": finalizer_top_name,
+        "generator": "npu/rtlgen/gen_attention_score32_exact_root_finalizer.py",
+        "semantic_profile": "score32_online_exact_root_finalizer_iterdiv_v1",
+        "value_slices": value_slices,
+        "head_id_bits": head_id_bits,
+        "divider_lanes": divider_lanes,
+        "physical_divider_lanes": divider_lanes,
+        "divider_groups_per_beat": 8 // divider_lanes,
+        "divider_iterations_per_group": 57,
+        "divider_cycles_per_beat": (8 // divider_lanes) * 57,
+        "input_value_bits_per_beat": 328,
+        "output_value_bits_per_beat": 320,
+        "result_interface": "ready_valid_exact_finalized_slice_stream",
+        "protocol_error_conditions": ["last_semantics", "exp_sum_zero", "final_value_overflow"],
+        "final_divider_embodied": True,
+        "equivalence_hash": False,
+    }
+    for key, expected in expected_finalizer_manifest.items():
+        _require(finalizer_manifest, key, expected, "root-finalizer submodule manifest")
+
+    rtl = top_path.read_text(encoding="utf-8", errors="replace")
+    tree_module = _extract_module(rtl, tree_top_name)
+    finalizer_module = _extract_module(rtl, finalizer_top_name)
+    top_module = _extract_module(rtl, top_name)
+    top_module_body = top_module.split(");", 1)[1]
+
+    for token in (
+        f"input  wire [{clusters - 1}:0] leaf_valid,",
+        f"output wire [{clusters - 1}:0] leaf_ready,",
+        "output wire         root_valid,",
+        "input  wire         root_ready,",
+        "output wire [15:0]  root_command_id,",
+        f"output wire [{head_id_bits - 1}:0] root_head_id,",
+        f"output wire [{slice_bits - 1}:0] root_slice,",
+        "output wire [319:0] root_value,",
+        "output wire [31:0]  cycle_count,",
+        "output wire [31:0]  root_completed_count,",
+        "output wire [31:0]  finalizer_accepted_count,",
+        "output wire [31:0]  tree_root_completed_count,",
+        f"output wire [{tree_nodes * 32 - 1}:0] node_completed_count,",
+        f"output wire [{tree_stages * 32 - 1}:0] stage_completed_count,",
+        f"output wire [{tree_nodes - 1}:0] node_protocol_error,",
+        f"output wire [{tree_stages - 1}:0] stage_protocol_error,",
+        "output wire         tree_protocol_error,",
+        "output wire         finalizer_protocol_error,",
+        "output wire         protocol_error",
+        "wire tree_root_valid;",
+        "wire tree_root_ready;",
+        "wire [15:0] tree_root_command_id;",
+        f"wire [{head_id_bits - 1}:0] tree_root_head_id;",
+        "wire signed [31:0] tree_root_global_max;",
+        "wire [32:0] tree_root_exp_sum;",
+        f"wire [{slice_bits - 1}:0] tree_root_slice;",
+        "wire tree_root_last;",
+        "wire [327:0] tree_root_value;",
+        "wire [31:0] tree_cycle_count;",
+        "wire [31:0] tree_root_completed_count_w;",
+        "wire [31:0] finalizer_accepted_count_w;",
+        "wire [31:0] finalizer_completed_count_w;",
+        "wire [31:0] finalizer_cycle_count_w;",
+        "assign cycle_count = finalizer_cycle_count_w;",
+        "assign root_completed_count = finalizer_completed_count_w;",
+        "assign finalizer_accepted_count = finalizer_accepted_count_w;",
+        "assign tree_root_completed_count = tree_root_completed_count_w;",
+        "assign protocol_error = tree_protocol_error | finalizer_protocol_error;",
+        f"{tree_top_name} u_tree (",
+        ".root_valid(tree_root_valid),",
+        ".root_ready(tree_root_ready),",
+        ".root_command_id(tree_root_command_id),",
+        ".root_head_id(tree_root_head_id),",
+        ".root_global_max(tree_root_global_max),",
+        ".root_exp_sum(tree_root_exp_sum),",
+        ".root_slice(tree_root_slice),",
+        ".root_last(tree_root_last),",
+        ".root_value(tree_root_value),",
+        ".cycle_count(tree_cycle_count),",
+        ".root_completed_count(tree_root_completed_count_w),",
+        ".node_completed_count(node_completed_count),",
+        ".stage_completed_count(stage_completed_count),",
+        ".node_protocol_error(node_protocol_error),",
+        ".stage_protocol_error(stage_protocol_error),",
+        ".protocol_error(tree_protocol_error)",
+        f"{finalizer_top_name} u_finalizer (",
+        ".in_valid(tree_root_valid),",
+        ".in_ready(tree_root_ready),",
+        ".in_command_id(tree_root_command_id),",
+        ".in_head_id(tree_root_head_id),",
+        ".in_exp_sum(tree_root_exp_sum),",
+        ".in_slice(tree_root_slice),",
+        ".in_last(tree_root_last),",
+        ".in_value(tree_root_value),",
+        ".out_valid(root_valid),",
+        ".out_ready(root_ready),",
+        ".out_command_id(root_command_id),",
+        ".out_head_id(root_head_id),",
+        ".out_slice(root_slice),",
+        ".out_last(root_last),",
+        ".out_value(root_value),",
+        ".accepted_count(finalizer_accepted_count_w),",
+        ".completed_count(finalizer_completed_count_w),",
+        ".cycle_count(finalizer_cycle_count_w),",
+        ".protocol_error(finalizer_protocol_error)",
+    ):
+        _require_token(top_module, token, "generated RTL")
+
+    if re.search(r"^\s*reg\b", top_module_body, re.MULTILINE):
+        raise SystemExit("top module must not contain internal reg storage")
+    if re.search(r"^\s*always\b", top_module_body, re.MULTILINE):
+        raise SystemExit("top module must not contain sequential or combinational always blocks")
+
+    instance_indices = {int(index) for index in re.findall(rf"\bu_node_(\d+)\b", tree_module)}
+    if instance_indices != set(range(tree_nodes)):
+        raise SystemExit("generated RTL must instantiate every pair node exactly once")
+    if tree_module.count(f"{pair_top_name} u_node_") != tree_nodes:
+        raise SystemExit("generated RTL pair-node instance count does not match tree_nodes")
+
+    for token in (
+        f"localparam integer CLUSTERS = {clusters};",
+        f"localparam integer TREE_STAGES = {tree_stages};",
+        f"localparam integer TREE_NODES = {tree_nodes};",
+        f"localparam integer HEAD_ID_BITS = {head_id_bits};",
+        f"localparam integer VALUE_SLICES = {value_slices};",
+        f"localparam integer SLICE_BITS = {slice_bits};",
+        f"localparam integer PARTIAL_PAYLOAD_BITS = {PARTIAL_PAYLOAD_BITS};",
+        "assign protocol_error = |node_protocol_error;",
+        "wire node_valid_w [0:TREE_NODES-1];",
+        "wire node_ready_w [0:TREE_NODES-1];",
+        "wire [31:0] node_completed_count_w [0:TREE_NODES-1];",
+        "wire node_protocol_error_w [0:TREE_NODES-1];",
+    ):
+        _require_token(tree_module, token, "generated RTL")
+
+    for token in (
+        f"localparam integer DIVIDER_LANES = {divider_lanes};",
+        "localparam integer DIVIDE_ITERATIONS = 57;",
+        "localparam integer DIVIDEND_BITS = 57;",
+        "assign in_ready = (state_q == IDLE) && !out_valid_q;",
+        "assign out_valid = out_valid_q;",
+        "assign protocol_error = protocol_error_q;",
+        "accepted_count <= accepted_count + 1'b1;",
+        "completed_count <= completed_count + 1'b1;",
+        "if (out_valid_q && out_ready) begin",
+        "rounded_dividend =",
+        "state_q <= DIVIDE;",
+        "div_bit_count_q <= DIVIDE_ITERATIONS[5:0];",
+    ):
+        _require_token(finalizer_module, token, "generated finalizer RTL")
+    if _contains_operator_division(finalizer_module):
+        raise SystemExit("generated finalizer RTL must not contain combinational division operators")
+
+    _compare_current_generation(config=config, rtl_dir=rtl_dir)
+
+    print(
+        json.dumps(
+            {
+                "design": top_name,
+                "guard": "attention_score32_exact_finalized_tree_v1",
+                "clusters": clusters,
+                "divider_lanes": divider_lanes,
+                "tree_nodes": tree_nodes,
+                "tree_stages": tree_stages,
+                "status": "ok",
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runs/campaigns/npu/attention_score32_exact_finalized_tree_v1/sweeps/nangate45_attention_score32_exact_finalized_tree_c16_lane_firstpass.json
+++ b/runs/campaigns/npu/attention_score32_exact_finalized_tree_v1/sweeps/nangate45_attention_score32_exact_finalized_tree_c16_lane_firstpass.json
@@ -1,0 +1,21 @@
+{
+  "tag_prefix": "attention_score32_exact_finalized_tree_c16_lane_firstpass_v1",
+  "flow_params": {
+    "CLOCK_PERIOD": [
+      8.0
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "PLACE_DENSITY": [
+      0.3,
+      0.5
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ]
+  }
+}

--- a/tests/test_check_attention_score32_exact_finalized_tree_guard.py
+++ b/tests/test_check_attention_score32_exact_finalized_tree_guard.py
@@ -1,0 +1,114 @@
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_score32_exact_finalized_tree import generate
+
+
+def _config_path(lanes: int) -> Path:
+    return (
+        REPO_ROOT
+        / "runs"
+        / "designs"
+        / "npu_blocks"
+        / f"attention_score32_exact_finalized_tree_c16_r2_l{lanes}"
+        / "config.json"
+    )
+
+
+def _prepare_design_dir(tmp_path: Path, *, lanes: int) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    design_dir = tmp_path / f"attention_score32_exact_finalized_tree_c16_r2_l{lanes}"
+    design_dir.mkdir()
+    config = json.loads(_config_path(lanes).read_text(encoding="utf-8"))
+    (design_dir / "config.json").write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    generate(config, design_dir / "verilog")
+    return design_dir
+
+
+def _run_guard(design_dir: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/check_attention_score32_exact_finalized_tree_guard.py",
+            "--design-dir",
+            str(design_dir),
+            "--config",
+            str(design_dir / "config.json"),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_exact_finalized_tree_guard_accepts_all_checked_in_lane_configs(tmp_path: Path) -> None:
+    for lanes in (1, 2, 4, 8):
+        design_dir = _prepare_design_dir(tmp_path / f"case_{lanes}", lanes=lanes)
+        result = _run_guard(design_dir)
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["divider_lanes"] == lanes
+        assert payload["clusters"] == 16
+        assert payload["tree_nodes"] == 15
+        assert payload["tree_stages"] == 4
+        assert payload["status"] == "ok"
+
+
+def test_exact_finalized_tree_guard_rejects_stale_generated_top(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, lanes=4)
+    top_path = design_dir / "verilog" / "top.v"
+    top_path.write_text(top_path.read_text(encoding="utf-8") + "\n// stale artifact drift\n", encoding="utf-8")
+
+    result = _run_guard(design_dir)
+    assert result.returncode != 0
+    assert "generated RTL artifacts do not match current generator output: top.v" in result.stderr
+
+
+def test_exact_finalized_tree_guard_rejects_manifest_boundary_mismatch(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, lanes=2)
+    manifest_path = design_dir / "verilog" / "attention_score32_exact_finalized_tree_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["direct_328bit_links_unclosed"] = False
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    result = _run_guard(design_dir)
+    assert result.returncode != 0
+    assert "generated manifest direct_328bit_links_unclosed must be True" in result.stderr
+
+
+def test_exact_finalized_tree_guard_rejects_tree_to_finalizer_wiring_mismatch(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, lanes=8)
+    top_path = design_dir / "verilog" / "top.v"
+    text = top_path.read_text(encoding="utf-8")
+    top_path.write_text(
+        text.replace(".in_value(tree_root_value),", ".in_value(root_value),"),
+        encoding="utf-8",
+    )
+
+    result = _run_guard(design_dir)
+    assert result.returncode != 0
+    assert "generated RTL missing semantic token: .in_value(tree_root_value)," in result.stderr
+
+
+def test_exact_finalized_tree_guard_rejects_combinational_divide_in_finalizer(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, lanes=1)
+    top_path = design_dir / "verilog" / "top.v"
+    text = top_path.read_text(encoding="utf-8")
+    module_name = "attention_score32_exact_finalized_tree_c16_r2_l1__root_finalizer"
+    pattern = re.compile(rf"(module\s+{re.escape(module_name)}\b.*?)(endmodule\s*)", re.DOTALL)
+    match = pattern.search(text)
+    assert match is not None
+    finalizer_with_divide = match.group(1) + "  wire [31:0] bad_div = 32'd8 / 32'd2;\n" + match.group(2)
+    top_path.write_text(text[: match.start()] + finalizer_with_divide + text[match.end() :], encoding="utf-8")
+
+    result = _run_guard(design_dir)
+    assert result.returncode != 0
+    assert "generated finalizer RTL must not contain combinational division operators" in result.stderr


### PR DESCRIPTION
## Summary
- add strict generated-RTL guard for the composed c16 exact partial tree plus root finalizer
- add L1 task-generator support for lane 1/2/4/8 composed sweeps
- add Nangate45 first-pass sweep and linked proposal artifact

## Scope
This directly measures non-additive tree-plus-finalizer PPA. The 16 external leaf streams, direct 328-bit transport, NoC/SRAM placement, and full decoder composition remain explicit open boundaries.

## Functional evidence
Full c16, 32-head RTL probes pass for all lane counts with the same exact output hash. Measured drain cycles are 234674, 118279, 59577, and 30724 for lanes 1, 2, 4, and 8.

## Verification
- `pytest -q tests/test_check_attention_score32_exact_finalized_tree_guard.py tests/test_attention_score32_exact_finalized_tree.py` (14 passed)
- `PYTHONPATH=$PWD/control_plane:$PWD pytest -q control_plane/control_plane/tests/test_l1_task_generator.py -k 'attention_score32_exact_finalized_tree or exact_finalized_tree_c16_lane_ppa'` (2 passed)
- `python3 scripts/validate_runs.py --skip_eval_queue`
