### PR TITLE
Add ordered banked exact finalizer tree

### DIFF
--- a/npu/docs/attention_score32_exact_banked_finalized_tree_contract.md
+++ b/npu/docs/attention_score32_exact_banked_finalized_tree_contract.md
@@ -1,0 +1,80 @@
+# Score32 Exact Banked Finalized Tree Contract
+
+This phase keeps the exact radix-2 partial tree and replaces the single
+throughput abstraction at the root with an ordered bank of identical iterative
+finalizers.
+
+## Workload Shape
+
+- A full Llama7B layer wave is `32 heads x 16 value slices = 512` finalized
+  root beats.
+- With `16` clusters, the leaf side still carries `8192` exact-partial beats
+  for that full wave.
+- The emitted root beat order remains exact slice order inside each head and
+  exact head order across the full wave.
+
+## Ordering Contract
+
+- Tree root beats are dispatched to finalizer banks in deterministic
+  round-robin order.
+- Dispatch never scans for an alternate ready bank. If the selected bank is
+  busy, the tree root stalls in place.
+- An explicit FIFO stores only issued bank IDs, one entry per accepted beat.
+- Only the bank named at the FIFO head may see `out_ready` or drive the top
+- level root output.
+- Output order therefore matches tree-root acceptance order even under
+  arbitrary top-level backpressure.
+
+## Timing Boundary
+
+- The iterative divider still performs `57` divide iterations per lane-8 beat.
+- Measured RTL timing is not `57` cycles/beat:
+  - accept at cycle `0`
+  - output handshake earliest at cycle `58`
+  - next re-accept earliest at cycle `59`
+- The service boundary for bank wrap is therefore `59` banks, not `57` or `58`.
+- Bank counts `57`, `58`, and `59` are all checked because:
+  - `57` proves the divide-iteration count alone is insufficient
+  - `58` proves the extra OUTPUT state still leaves a wrap bubble
+  - `59` is the first wrap-free point for saturated lane-8 service with no
+    output stall
+
+## Recorded Full-Wave Evidence
+
+- Source generator: `npu/eval/probe_attention_score32_exact_banked_finalized_tree.py`
+- Source command form:
+  `python npu/eval/probe_attention_score32_exact_banked_finalized_tree.py --clusters 16 --heads 32 --divider-lanes 8 --finalizer-banks <B> --saturated --root-ready-pattern 1 --json`
+- Full-wave exact output hash for all rows below:
+  `027dd06c1e4e1bc77636eb4041aa7efd4fd6e55a090b337a6d33f78da89f65bd`
+
+| banks | first out | last out | interval cycles | cycles/beat |
+| --- | ---: | ---: | ---: | ---: |
+| 1 | 62 | 30211 | 30149 | 59.0 |
+| 57 | 62 | 589 | 527 | 1.031311 |
+| 58 | 62 | 581 | 519 | 1.015656 |
+| 59 | 62 | 573 | 511 | 1.0 |
+| 64 | 62 | 573 | 511 | 1.0 |
+
+- These measurements are kept here so direct full-512 RTL evidence remains in
+  the checked-in contract without forcing CI to recompile every large bank
+  count on every run.
+
+## Remaining Abstractions
+
+- The tree still uses direct `328`-bit exact-partial leaf/root payload links.
+- No NoC closure is claimed for those links.
+- No SRAM closure is claimed for those links.
+- The design still reuses the existing single-entry iterative finalizer macro.
+- No full-head monolithic state register is introduced at the root; only a
+  compact bank-ID FIFO, aggregate counters, and compact bank masks are exposed.
+
+## Reporting Contract
+
+- Manifest service fields must distinguish:
+  - divide iterations per group
+  - earliest output latency
+  - earliest re-accept interval
+- Probe reports must compare every RTL output beat to the exact reference
+  stream and its hash, not just counts.
+- Saturated service claims must be stated from measured RTL cycles, not from
+  divide-iteration counts alone.

--- a/npu/docs/attention_score32_exact_root_finalizer_contract.md
+++ b/npu/docs/attention_score32_exact_root_finalizer_contract.md
@@ -7,7 +7,11 @@ Phase C closes the semantic boundary that phase B left open: the radix-2 exact-p
 - Input beat: `command_id`, `head_id`, `slice`, `last`, shared `exp_sum[32:0]`, and 8 signed `S41` numerators packed into 328 payload bits.
 - Output beat: `command_id`, `head_id`, `slice`, `last`, and 8 signed `S40` finalized values packed into 320 payload bits.
 - Arithmetic: symmetric rounding of `abs(numerator) * 65535 / exp_sum` with sign restore, no combinational `/`, sequential restoring division only.
-- Physical divider lanes: `1/2/4/8`, with ideal standalone service of `456/228/114/57` divide cycles per beat.
+- Physical divider lanes: `1/2/4/8`.
+- Timing terms are distinct:
+  - divide iterations per beat: `456/228/114/57`
+  - earliest output latency per beat: `457/229/115/58`
+  - earliest re-accept interval per beat: `458/230/116/59`
 - Protocol errors: sticky error on `exp_sum == 0`; metadata/last-semantics errors propagate from the tree and are also surfaced at the wrapper boundary.
 
 ## Composition Boundary
@@ -28,5 +32,7 @@ Phase C closes the semantic boundary that phase B left open: the radix-2 exact-p
 ## Reporting Contract
 
 - Probe output must distinguish theoretical `32`-head service accounting from measured workload.
+- Probe output must also distinguish divide iterations from output latency and
+  from re-accept interval.
 - Measured composed-tree evidence is authoritative for first output, last output, drain cycles, accepted/output counts, and root output interval.
 - Standalone divider-cycle figures are ideal service references only; they are not a claim about full-tree initiation interval under backpressure.

--- a/npu/eval/check_attention_score32_exact_banked_finalized_tree_guard.py
+++ b/npu/eval/check_attention_score32_exact_banked_finalized_tree_guard.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Strict generated RTL guard for banked score32 exact finalized trees."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+import re
+import sys
+import tempfile
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_score32_exact_banked_finalized_tree import generate
+from npu.sim.perf.attention_exact_partial import (
+    FINAL_LINK_BITS,
+    FINAL_PAYLOAD_BITS,
+    PARTIAL_LINK_BITS,
+    PARTIAL_PAYLOAD_BITS,
+    exact_banked_finalized_tree_service_manifest,
+)
+
+_SUPPORTED_CLUSTERS = {2, 4, 8, 16}
+_SUPPORTED_LANES = {1, 2, 4, 8}
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _resolve_selected_config(*, design_dir: Path, selected: Path | None) -> Path:
+    config_path = selected or (design_dir / "config.json")
+    config_path = config_path.resolve()
+    if not config_path.exists():
+        raise SystemExit(f"missing config: {config_path}")
+    try:
+        relative_path = config_path.relative_to(design_dir)
+    except ValueError as exc:
+        raise SystemExit(f"selected config must live under design-dir: {config_path}") from exc
+    if len(relative_path.parts) != 1:
+        raise SystemExit(f"selected config must be a direct child of design-dir, got: {relative_path.as_posix()}")
+    return config_path
+
+
+def _require(mapping: dict[str, object], key: str, expected: object, label: str) -> None:
+    if mapping.get(key) != expected:
+        raise SystemExit(f"{label} {key} must be {expected}")
+
+
+def _require_token(text: str, token: str, label: str) -> None:
+    if token not in text:
+        raise SystemExit(f"{label} missing semantic token: {token}")
+
+
+def _clog2(value: int) -> int:
+    return max(1, math.ceil(math.log2(max(2, value))))
+
+
+def _extract_module(rtl: str, module_name: str) -> str:
+    pattern = re.compile(rf"module\s+{re.escape(module_name)}\b.*?endmodule\s*", re.DOTALL)
+    match = pattern.search(rtl)
+    if match is None:
+        raise SystemExit(f"generated RTL does not define module {module_name}")
+    return match.group(0)
+
+
+def _strip_comments(text: str) -> str:
+    no_block = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    return re.sub(r"//.*", "", no_block)
+
+
+def _contains_operator_division(text: str) -> bool:
+    stripped = _strip_comments(text)
+    return re.search(r"(?<![*/])/(?![/*])", stripped) is not None
+
+
+def _compare_current_generation(*, config: dict[str, object], rtl_dir: Path) -> None:
+    with tempfile.TemporaryDirectory(prefix="score32_exact_banked_finalized_tree_guard_") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        generate(config, temp_dir)
+        for relative_name in (
+            "top.v",
+            "config.json",
+            "attention_score32_exact_banked_finalized_tree_manifest.json",
+        ):
+            generated_text = (temp_dir / relative_name).read_text(encoding="utf-8")
+            current_text = (rtl_dir / relative_name).read_text(encoding="utf-8")
+            if generated_text != current_text:
+                raise SystemExit(f"generated RTL artifacts do not match current generator output: {relative_name}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--design-dir", type=Path, required=True)
+    ap.add_argument("--config", type=Path, default=None)
+    args = ap.parse_args(argv)
+
+    design_dir = args.design_dir.resolve()
+    config_path = _resolve_selected_config(design_dir=design_dir, selected=args.config)
+    rtl_dir = design_dir / "verilog"
+    generated_config_path = rtl_dir / "config.json"
+    manifest_path = rtl_dir / "attention_score32_exact_banked_finalized_tree_manifest.json"
+    top_path = rtl_dir / "top.v"
+    for path in (config_path, generated_config_path, manifest_path, top_path):
+        if not path.is_file():
+            raise SystemExit(f"missing banked exact finalized tree artifact: {path}")
+
+    config = _load_json(config_path)
+    generated_config = _load_json(generated_config_path)
+    if config != generated_config:
+        raise SystemExit("generated config does not match source config")
+
+    top_name = str(config.get("top_name") or "").strip()
+    if not top_name:
+        raise SystemExit("top_name must not be empty")
+    body = config.get("attention_score32_exact_banked_finalized_tree")
+    if not isinstance(body, dict):
+        raise SystemExit("config must contain attention_score32_exact_banked_finalized_tree object")
+
+    clusters = int(body.get("clusters", 0))
+    radix = int(body.get("radix", 0))
+    value_slices = int(body.get("value_slices", 0))
+    head_id_bits = int(body.get("head_id_bits", 0))
+    divider_lanes = int(body.get("divider_lanes", 0))
+    finalizer_banks = int(body.get("finalizer_banks", 0))
+    if clusters not in _SUPPORTED_CLUSTERS:
+        raise SystemExit("clusters must be one of 2, 4, 8, 16")
+    if radix != 2:
+        raise SystemExit("radix must be 2 for the current banked exact finalized tree")
+    if value_slices < 1 or value_slices > 16 or (value_slices & (value_slices - 1)):
+        raise SystemExit("value_slices must be a power of two in [1, 16]")
+    if head_id_bits < 1 or head_id_bits > 8:
+        raise SystemExit("head_id_bits must be in [1, 8]")
+    if divider_lanes not in _SUPPORTED_LANES:
+        raise SystemExit("divider_lanes must be one of 1, 2, 4, 8")
+    if finalizer_banks < 1 or finalizer_banks > 64:
+        raise SystemExit("finalizer_banks must be in [1, 64]")
+
+    tree_nodes = clusters - 1
+    tree_stages = int(math.log2(clusters))
+    slice_bits = _clog2(value_slices)
+    bank_id_bits = _clog2(finalizer_banks)
+    tree_top_name = f"{top_name}__partial_tree"
+    finalizer_top_name = f"{top_name}__root_finalizer"
+    service_manifest = exact_banked_finalized_tree_service_manifest(
+        clusters=clusters,
+        heads=32,
+        divider_lanes=divider_lanes,
+        finalizer_banks=finalizer_banks,
+    )
+
+    manifest = _load_json(manifest_path)
+    expected_manifest = {
+        "top_name": top_name,
+        "generator": "npu/rtlgen/gen_attention_score32_exact_banked_finalized_tree.py",
+        "semantic_profile": "score32_online_exact_banked_finalized_radix2_tree_v1",
+        "clusters": clusters,
+        "radix": radix,
+        "value_slices": value_slices,
+        "head_id_bits": head_id_bits,
+        "divider_lanes": divider_lanes,
+        "finalizer_banks": finalizer_banks,
+        "tree_stages": tree_stages,
+        "tree_nodes": tree_nodes,
+        "result_interface": "clusters_ready_valid_exact_partial_leaf_streams_to_ordered_banked_exact_finalized_root_stream",
+        "partial_payload_bits_per_beat": PARTIAL_PAYLOAD_BITS,
+        "partial_link_bits_per_beat": PARTIAL_LINK_BITS,
+        "final_payload_bits_per_beat": FINAL_PAYLOAD_BITS,
+        "final_link_bits_per_beat": FINAL_LINK_BITS,
+        "order_fifo_depth": finalizer_banks,
+        "order_fifo_entry_bits": bank_id_bits,
+        "order_fifo_storage_bits": finalizer_banks * bank_id_bits,
+        "ordering_contract": "single_bank_id_fifo_exact_issue_order_one_beat_per_entry",
+        "actual_finalizer_accept_interval_cycles": service_manifest["per_bank_accept_interval_cycles"],
+        "direct_328bit_links_unclosed": True,
+        "final_divider_embodied": True,
+        "noc_closure": False,
+        "sram_closure": False,
+        "macro_eval_excludes_io_pads": True,
+        "equivalence_hash": False,
+    }
+    for key, expected in expected_manifest.items():
+        _require(manifest, key, expected, "generated manifest")
+
+    submanifests = manifest.get("submodule_manifests")
+    if not isinstance(submanifests, dict):
+        raise SystemExit("generated manifest must contain submodule_manifests")
+    tree_manifest = submanifests.get("partial_tree")
+    if not isinstance(tree_manifest, dict):
+        raise SystemExit("generated manifest must contain partial_tree submodule manifest")
+    finalizer_manifest = submanifests.get("root_finalizer")
+    if not isinstance(finalizer_manifest, dict):
+        raise SystemExit("generated manifest must contain root_finalizer submodule manifest")
+    _require(tree_manifest, "top_name", tree_top_name, "partial-tree submodule manifest")
+    expected_finalizer_manifest = {
+        "top_name": finalizer_top_name,
+        "generator": "npu/rtlgen/gen_attention_score32_exact_root_finalizer.py",
+        "semantic_profile": "score32_online_exact_root_finalizer_iterdiv_v1",
+        "value_slices": value_slices,
+        "head_id_bits": head_id_bits,
+        "divider_lanes": divider_lanes,
+        "physical_divider_lanes": divider_lanes,
+        "divider_groups_per_beat": 8 // divider_lanes,
+        "divider_iterations_per_group": 57,
+        "divider_cycles_per_beat": (8 // divider_lanes) * 57,
+        "output_latency_cycles_per_beat": ((8 // divider_lanes) * 57) + 1,
+        "accept_interval_cycles_per_beat": ((8 // divider_lanes) * 57) + 2,
+        "input_value_bits_per_beat": 328,
+        "output_value_bits_per_beat": 320,
+        "result_interface": "ready_valid_exact_finalized_slice_stream",
+        "protocol_error_conditions": ["last_semantics", "exp_sum_zero", "final_value_overflow"],
+        "final_divider_embodied": True,
+        "equivalence_hash": False,
+    }
+    for key, expected in expected_finalizer_manifest.items():
+        _require(finalizer_manifest, key, expected, "root-finalizer submodule manifest")
+
+    rtl = top_path.read_text(encoding="utf-8", errors="replace")
+    tree_module = _extract_module(rtl, tree_top_name)
+    finalizer_module = _extract_module(rtl, finalizer_top_name)
+    top_module = _extract_module(rtl, top_name)
+
+    if len(re.findall(rf"\bmodule\s+{re.escape(finalizer_top_name)}\b", rtl)) != 1:
+        raise SystemExit("generated RTL must contain exactly one root finalizer module definition")
+    if top_module.count(f"{finalizer_top_name} u_finalizer_bank_") != finalizer_banks:
+        raise SystemExit("generated RTL finalizer instance count does not match finalizer_banks")
+
+    for token in (
+        f"output wire [{finalizer_banks - 1}:0] bank_protocol_error,",
+        f"output wire [{finalizer_banks - 1}:0] bank_outstanding,",
+        "output wire [31:0]  order_fifo_occupancy,",
+        "output wire [31:0]  order_fifo_high_watermark,",
+        "output wire [31:0]  order_enqueued_count,",
+        "output wire [31:0]  order_dequeued_count,",
+        "output wire [31:0]  dispatch_stall_cycles,",
+        "output wire [31:0]  dispatch_bank_id,",
+        "output wire [31:0]  head_bank_id,",
+        "output wire         order_protocol_error,",
+        "wire order_fifo_dequeue_fire_w = root_valid_r && root_ready;",
+        "wire order_fifo_enqueue_ready_w = !order_fifo_full_w || order_fifo_dequeue_fire_w;",
+        "wire tree_root_ready_w = dispatch_bank_in_ready_r && order_fifo_enqueue_ready_w;",
+        "order_fifo_mem[order_fifo_tail_q] <= dispatch_bank_q;",
+        "bank_outstanding_q[dispatch_bank_q] <= 1'b1;",
+        "bank_outstanding_q[order_fifo_head_bank_id_w] <= 1'b0;",
+        "dispatch_stall_cycles_q <= dispatch_stall_cycles_q + 1'b1;",
+        "order_protocol_error_q <= 1'b1;",
+    ):
+        _require_token(top_module, token, "generated RTL")
+
+    _require_token(tree_module, "assign protocol_error = |node_protocol_error;", "generated tree RTL")
+    _require_token(finalizer_module, "localparam integer DIVIDE_ITERATIONS = 57;", "generated finalizer RTL")
+    _require_token(finalizer_module, "assign in_ready = (state_q == IDLE) && !out_valid_q;", "generated finalizer RTL")
+    if _contains_operator_division(finalizer_module):
+        raise SystemExit("generated finalizer RTL must not contain combinational division operators")
+
+    _compare_current_generation(config=config, rtl_dir=rtl_dir)
+
+    print(
+        json.dumps(
+            {
+                "design": top_name,
+                "guard": "attention_score32_exact_banked_finalized_tree_v1",
+                "clusters": clusters,
+                "divider_lanes": divider_lanes,
+                "finalizer_banks": finalizer_banks,
+                "tree_nodes": tree_nodes,
+                "tree_stages": tree_stages,
+                "status": "ok",
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/check_attention_score32_exact_finalized_tree_guard.py
+++ b/npu/eval/check_attention_score32_exact_finalized_tree_guard.py
@@ -237,6 +237,8 @@ def main(argv: list[str] | None = None) -> int:
         "divider_groups_per_beat": 8 // divider_lanes,
         "divider_iterations_per_group": 57,
         "divider_cycles_per_beat": (8 // divider_lanes) * 57,
+        "output_latency_cycles_per_beat": ((8 // divider_lanes) * 57) + 1,
+        "accept_interval_cycles_per_beat": ((8 // divider_lanes) * 57) + 2,
         "input_value_bits_per_beat": 328,
         "output_value_bits_per_beat": 320,
         "result_interface": "ready_valid_exact_finalized_slice_stream",

--- a/npu/eval/check_attention_score32_exact_root_finalizer_guard.py
+++ b/npu/eval/check_attention_score32_exact_root_finalizer_guard.py
@@ -95,6 +95,8 @@ def main(argv: list[str] | None = None) -> int:
         "divider_groups_per_beat": 8 // divider_lanes,
         "divider_iterations_per_group": 57,
         "divider_cycles_per_beat": (8 // divider_lanes) * 57,
+        "output_latency_cycles_per_beat": ((8 // divider_lanes) * 57) + 1,
+        "accept_interval_cycles_per_beat": ((8 // divider_lanes) * 57) + 2,
         "input_value_bits_per_beat": 328,
         "output_value_bits_per_beat": 320,
         "result_interface": "ready_valid_exact_finalized_slice_stream",

--- a/npu/eval/probe_attention_score32_exact_banked_finalized_tree.py
+++ b/npu/eval/probe_attention_score32_exact_banked_finalized_tree.py
@@ -1,0 +1,774 @@
+#!/usr/bin/env python3
+"""Probe the exact-partial reduction tree with ordered banked root finalizers."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_score32_exact_banked_finalized_tree import generate as generate_tree
+from npu.sim.perf.attention_exact_partial import (
+    ExactPartialBeat,
+    exact_banked_finalized_tree_service_manifest,
+    finalize_partial_beats,
+    finalizer_accept_interval_cycles,
+    finalizer_cycles_per_beat,
+    merge_balanced_partial_streams,
+    pack_numerators,
+    partial_stream_from_blocks,
+    simulate_exact_banked_finalizer,
+    unpack_final_values,
+)
+
+JsonDict = dict[str, Any]
+
+_ROOT_RE = re.compile(
+    r"ROOT_RESULT cmd=(\d+) head=(\d+) slice=(\d+) last=(\d+) value=([0-9a-fA-F]+) cycle=(\d+)"
+)
+_LEAF_RE = re.compile(r"LEAF_SUMMARY leaf=(\d+) accepted=(\d+) issued=(\d+)")
+_NODE_RE = re.compile(r"NODE_SUMMARY stage=(\d+) node=(\d+) count=(\d+) error=(\d+)")
+_STAGE_RE = re.compile(r"STAGE_SUMMARY stage=(\d+) count=(\d+) error=(\d+)")
+_FINALIZER_RE = re.compile(
+    r"FINALIZER_SUMMARY accepted=(\d+) completed=(\d+) protocol_error=(\d+) tree_root_completed=(\d+) tree_protocol_error=(\d+) order_protocol_error=(\d+) fifo_high_watermark=(\d+) dispatch_stall=(\d+)"
+)
+_SUMMARY_RE = re.compile(
+    r"SUMMARY outputs=(\d+) dut_cycle=(\d+) tb_cycle=(\d+) first=(\d+) last=(\d+) protocol_error=(\d+) root_completed=(\d+)"
+)
+
+
+def _tool(name: str) -> str:
+    path = shutil.which(name)
+    if path:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    if fallback.exists():
+        return str(fallback)
+    raise RuntimeError(f"required tool unavailable: {name}")
+
+
+def _hash(value: object) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def _commands(heads: int) -> tuple[dict[str, int], ...]:
+    head_count = int(heads)
+    if head_count < 1 or head_count > 32:
+        raise ValueError("heads must be in [1, 32]")
+    return tuple({"command_id": 0x5A00 + head_index, "head_id": head_index} for head_index in range(head_count))
+
+
+def _signed_literal(value: int, bits: int) -> str:
+    return f"-{bits}'sd{abs(value)}" if value < 0 else f"{bits}'sd{value}"
+
+
+def _score_rows(leaf: int, command_index: int) -> tuple[tuple[int, ...], ...]:
+    return tuple(
+        tuple(
+            ((leaf * 43 + command_index * 29 + block * 17 + lane * 11) % 255) - 127 + (14 if lane == block else 0)
+            for lane in range(8)
+        )
+        for block in range(3)
+    )
+
+
+def _value_blocks(leaf: int, command_index: int) -> tuple[tuple[tuple[tuple[int, ...], ...], ...], ...]:
+    return tuple(
+        tuple(
+            tuple(
+                tuple(
+                    ((leaf * 59 + command_index * 31 + block * 23 + value_slice * 13 + row * 7 + lane * 5) % 255)
+                    - 127
+                    for lane in range(8)
+                )
+                for row in range(8)
+            )
+            for value_slice in range(16)
+        )
+        for block in range(3)
+    )
+
+
+def _leaf_stream(leaf: int, *, heads: int) -> tuple[ExactPartialBeat, ...]:
+    beats: list[ExactPartialBeat] = []
+    for command_index, command in enumerate(_commands(heads)):
+        beats.extend(
+            partial_stream_from_blocks(
+                command_id=int(command["command_id"]),
+                head_id=int(command["head_id"]),
+                score_rows=_score_rows(leaf, command_index),
+                value_blocks=_value_blocks(leaf, command_index),
+            )
+        )
+    return tuple(beats)
+
+
+def _shape(clusters: int) -> list[list[int]]:
+    level_sizes: list[list[int]] = []
+    next_index = 0
+    width = clusters // 2
+    while width:
+        level_sizes.append(list(range(next_index, next_index + width)))
+        next_index += width
+        width //= 2
+    return level_sizes
+
+
+def _default_ready_pattern() -> tuple[bool, ...]:
+    return tuple(((cycle % 5) != 2) and (((cycle + 3) % 11) != 7) for cycle in range(64))
+
+
+def _expected(
+    clusters: int,
+    *,
+    heads: int,
+    divider_lanes: int,
+    finalizer_banks: int,
+    output_ready_pattern: tuple[bool, ...],
+) -> dict[str, object]:
+    leaves = [_leaf_stream(leaf, heads=heads) for leaf in range(clusters)]
+    merged = merge_balanced_partial_streams(leaves)
+    finalized = finalize_partial_beats(merged)
+    root_rows = [
+        {
+            "command_id": beat.command_id,
+            "head_id": beat.head_id,
+            "slice": beat.slice_index,
+            "last": beat.last,
+            "value": list(beat.values),
+        }
+        for beat in finalized
+    ]
+    levels = _shape(clusters)
+    total_results = len(root_rows)
+    leaf_rows = [
+        [
+            {
+                "command_id": beat.command_id,
+                "head_id": beat.head_id,
+                "slice": beat.slice_index,
+                "last": beat.last,
+                "global_max": beat.max_score,
+                "exp_sum": beat.exp_sum,
+                "value": list(beat.numerators),
+            }
+            for beat in leaf
+        ]
+        for leaf in leaves
+    ]
+    finalizer_reference = simulate_exact_banked_finalizer(
+        merged,
+        divider_lanes=divider_lanes,
+        finalizer_banks=finalizer_banks,
+        output_ready_pattern=output_ready_pattern,
+    )
+    return {
+        "heads": heads,
+        "leaves": leaf_rows,
+        "root": root_rows,
+        "leaf_hash": _hash(leaf_rows),
+        "root_hash": _hash(root_rows),
+        "leaf_accept_count": [total_results] * clusters,
+        "node_completed_count": [total_results] * (clusters - 1),
+        "stage_completed_count": [len(level) * total_results for level in levels],
+        "node_protocol_error": [False] * (clusters - 1),
+        "stage_protocol_error": [False] * len(levels),
+        "banked_finalizer_reference": finalizer_reference,
+    }
+
+
+def _config(clusters: int, divider_lanes: int, finalizer_banks: int) -> dict[str, object]:
+    return {
+        "top_name": f"attention_score32_exact_banked_finalized_tree_c{clusters}_r2_l{divider_lanes}_b{finalizer_banks}",
+        "attention_score32_exact_banked_finalized_tree": {
+            "clusters": clusters,
+            "radix": 2,
+            "value_slices": 16,
+            "head_id_bits": 5,
+            "divider_lanes": divider_lanes,
+            "finalizer_banks": finalizer_banks,
+        },
+    }
+
+
+def _ready_mem_init(pattern: tuple[bool, ...]) -> str:
+    return "\n".join(
+        f"    root_ready_mem[{index}] = 1'b{1 if ready else 0};" for index, ready in enumerate(pattern)
+    )
+
+
+def _saturated_drive_blocks(clusters: int) -> tuple[str, str]:
+    combinational_lines = []
+    sequential_lines = []
+    for leaf in range(clusters):
+        combinational_lines.extend(
+            [
+                f"      if (leaf_issue[{leaf}] < TOTAL_RESULTS) begin",
+                f"        leaf_valid[{leaf}] = 1'b1;",
+                f"        leaf_command_id[({leaf} * 16) +: 16] = leaf_cmd_mem[({leaf} * TOTAL_RESULTS) + leaf_issue[{leaf}]];",
+                f"        leaf_head_id[({leaf} * 5) +: 5] = leaf_head_mem[({leaf} * TOTAL_RESULTS) + leaf_issue[{leaf}]];",
+                f"        leaf_global_max[({leaf} * 32) +: 32] = leaf_max_mem[({leaf} * TOTAL_RESULTS) + leaf_issue[{leaf}]];",
+                f"        leaf_exp_sum[({leaf} * 33) +: 33] = leaf_sum_mem[({leaf} * TOTAL_RESULTS) + leaf_issue[{leaf}]];",
+                f"        leaf_slice[({leaf} * 4) +: 4] = leaf_slice_mem[({leaf} * TOTAL_RESULTS) + leaf_issue[{leaf}]];",
+                f"        leaf_last[{leaf}] = leaf_last_mem[({leaf} * TOTAL_RESULTS) + leaf_issue[{leaf}]];",
+                f"        leaf_value[({leaf} * 328) +: 328] = leaf_value_mem[({leaf} * TOTAL_RESULTS) + leaf_issue[{leaf}]];",
+                "      end",
+            ]
+        )
+        sequential_lines.extend(
+            [
+                f"      if (leaf_valid[{leaf}] && leaf_ready[{leaf}]) begin",
+                f"        leaf_accept_count[{leaf}] <= leaf_accept_count[{leaf}] + 1;",
+                f"        leaf_issue[{leaf}] <= leaf_issue[{leaf}] + 1;",
+                "      end",
+            ]
+        )
+    return "\n".join(combinational_lines), "\n".join(sequential_lines)
+
+
+def _skewed_drive_blocks(clusters: int) -> tuple[str, str]:
+    combinational_lines = []
+    sequential_lines = []
+    for leaf in range(clusters):
+        combinational_lines.extend(
+            [
+                f"      if (leaf_pending[{leaf}]) begin",
+                f"        leaf_valid[{leaf}] = 1'b1;",
+                f"        leaf_command_id[({leaf} * 16) +: 16] = leaf_cmd_mem[({leaf} * TOTAL_RESULTS) + leaf_issue[{leaf}]];",
+                f"        leaf_head_id[({leaf} * 5) +: 5] = leaf_head_mem[({leaf} * TOTAL_RESULTS) + leaf_issue[{leaf}]];",
+                f"        leaf_global_max[({leaf} * 32) +: 32] = leaf_max_mem[({leaf} * TOTAL_RESULTS) + leaf_issue[{leaf}]];",
+                f"        leaf_exp_sum[({leaf} * 33) +: 33] = leaf_sum_mem[({leaf} * TOTAL_RESULTS) + leaf_issue[{leaf}]];",
+                f"        leaf_slice[({leaf} * 4) +: 4] = leaf_slice_mem[({leaf} * TOTAL_RESULTS) + leaf_issue[{leaf}]];",
+                f"        leaf_last[{leaf}] = leaf_last_mem[({leaf} * TOTAL_RESULTS) + leaf_issue[{leaf}]];",
+                f"        leaf_value[({leaf} * 328) +: 328] = leaf_value_mem[({leaf} * TOTAL_RESULTS) + leaf_issue[{leaf}]];",
+                "      end",
+            ]
+        )
+        sequential_lines.extend(
+            [
+                f"      if (!leaf_pending[{leaf}] && leaf_issue[{leaf}] < TOTAL_RESULTS) begin",
+                f"        if ((((cycle + {leaf * 3}) % (3 + ({leaf} % 5))) != 0) && (((cycle + leaf_issue[{leaf}] + {leaf}) % 7) != 1)) begin",
+                f"          leaf_pending[{leaf}] <= 1'b1;",
+                "        end",
+                "      end",
+                f"      if (leaf_pending[{leaf}] && leaf_ready[{leaf}]) begin",
+                f"        leaf_pending[{leaf}] <= 1'b0;",
+                f"        leaf_accept_count[{leaf}] <= leaf_accept_count[{leaf}] + 1;",
+                f"        leaf_issue[{leaf}] <= leaf_issue[{leaf}] + 1;",
+                "      end",
+            ]
+        )
+    return "\n".join(combinational_lines), "\n".join(sequential_lines)
+
+
+def _testbench(
+    *,
+    top_name: str,
+    clusters: int,
+    heads: int,
+    divider_lanes: int,
+    finalizer_banks: int,
+    expected: dict[str, object],
+    saturated: bool,
+    output_ready_pattern: tuple[bool, ...],
+) -> str:
+    leaf_rows = expected["leaves"]
+    total_results = len(expected["root"])
+    mem_depth = clusters * total_results
+    leaf_init: list[str] = []
+    for leaf in range(clusters):
+        rows = leaf_rows[leaf]
+        for beat_index, beat in enumerate(rows):
+            flat_index = (leaf * total_results) + beat_index
+            leaf_init.append(
+                f"    leaf_cmd_mem[{flat_index}] = 16'h{int(beat['command_id']):04x}; "
+                f"leaf_head_mem[{flat_index}] = 5'd{int(beat['head_id'])}; "
+                f"leaf_max_mem[{flat_index}] = {_signed_literal(int(beat['global_max']), 32)}; "
+                f"leaf_sum_mem[{flat_index}] = 33'd{int(beat['exp_sum'])}; "
+                f"leaf_slice_mem[{flat_index}] = 4'd{int(beat['slice'])}; "
+                f"leaf_last_mem[{flat_index}] = 1'b{1 if beat['last'] else 0}; "
+                f"leaf_value_mem[{flat_index}] = 328'h{pack_numerators(beat['value']):082x};"
+            )
+
+    drive_comb, drive_seq = (
+        _saturated_drive_blocks(clusters) if saturated else _skewed_drive_blocks(clusters)
+    )
+    leaf_accept_displays = [
+        f'        $display("LEAF_SUMMARY leaf={leaf} accepted=%0d issued=%0d", leaf_accept_count[{leaf}], leaf_issue[{leaf}]);'
+        for leaf in range(clusters)
+    ]
+    node_stage_displays = []
+    stage_levels = _shape(clusters)
+    for stage, indices in enumerate(stage_levels):
+        for node_index in indices:
+            node_stage_displays.append(
+                f'        $display("NODE_SUMMARY stage={stage} node={node_index} count=%0d error=%0d", '
+                f"node_completed_count[{node_index * 32} +: 32], node_protocol_error[{node_index}]);"
+            )
+    stage_displays = [
+        f'        $display("STAGE_SUMMARY stage={stage} count=%0d error=%0d", '
+        f"stage_completed_count[{stage * 32} +: 32], stage_protocol_error[{stage}]);"
+        for stage in range(len(stage_levels))
+    ]
+    timeout_cycles = max(
+        5000,
+        (clusters * total_results * 4) + (total_results * (finalizer_accept_interval_cycles(divider_lanes) + 8)),
+    )
+
+    return f"""`timescale 1ns/1ps
+module tb;
+  localparam integer CLUSTERS = {clusters};
+  localparam integer HEADS = {heads};
+  localparam integer TOTAL_RESULTS = {total_results};
+  localparam integer MEM_DEPTH = {mem_depth};
+  localparam integer ROOT_READY_PATTERN_LEN = {len(output_ready_pattern)};
+  reg clk = 0, rst_n = 0;
+  reg [CLUSTERS-1:0] leaf_valid;
+  wire [CLUSTERS-1:0] leaf_ready;
+  reg [(CLUSTERS*16)-1:0] leaf_command_id;
+  reg [(CLUSTERS*5)-1:0] leaf_head_id;
+  reg [(CLUSTERS*32)-1:0] leaf_global_max;
+  reg [(CLUSTERS*33)-1:0] leaf_exp_sum;
+  reg [(CLUSTERS*4)-1:0] leaf_slice;
+  reg [CLUSTERS-1:0] leaf_last;
+  reg [(CLUSTERS*328)-1:0] leaf_value;
+  wire root_valid;
+  reg root_ready;
+  reg root_ready_mem [0:ROOT_READY_PATTERN_LEN-1];
+  wire [15:0] root_command_id;
+  wire [4:0] root_head_id;
+  wire [3:0] root_slice;
+  wire root_last;
+  wire [319:0] root_value;
+  wire [31:0] cycle_count;
+  wire [31:0] root_completed_count;
+  wire [31:0] finalizer_accepted_count;
+  wire [31:0] tree_root_completed_count;
+  wire [31:0] order_fifo_occupancy;
+  wire [31:0] order_fifo_high_watermark;
+  wire [31:0] order_enqueued_count;
+  wire [31:0] order_dequeued_count;
+  wire [31:0] dispatch_stall_cycles;
+  wire [31:0] dispatch_bank_id;
+  wire [31:0] head_bank_id;
+  wire [{(clusters - 1) * 32 - 1}:0] node_completed_count;
+  wire [{int(math.log2(clusters)) * 32 - 1}:0] stage_completed_count;
+  wire [{clusters - 2}:0] node_protocol_error;
+  wire [{int(math.log2(clusters)) - 1}:0] stage_protocol_error;
+  wire [{finalizer_banks - 1}:0] bank_protocol_error;
+  wire [{finalizer_banks - 1}:0] bank_outstanding;
+  wire tree_protocol_error;
+  wire order_protocol_error;
+  wire finalizer_protocol_error;
+  wire protocol_error;
+
+  reg [15:0] leaf_cmd_mem [0:MEM_DEPTH-1];
+  reg [4:0] leaf_head_mem [0:MEM_DEPTH-1];
+  reg signed [31:0] leaf_max_mem [0:MEM_DEPTH-1];
+  reg [32:0] leaf_sum_mem [0:MEM_DEPTH-1];
+  reg [3:0] leaf_slice_mem [0:MEM_DEPTH-1];
+  reg leaf_last_mem [0:MEM_DEPTH-1];
+  reg [327:0] leaf_value_mem [0:MEM_DEPTH-1];
+  reg leaf_pending [0:CLUSTERS-1];
+  reg [31:0] leaf_issue [0:CLUSTERS-1];
+  reg [31:0] leaf_accept_count [0:CLUSTERS-1];
+  integer init_index;
+  integer cycle = 0;
+  integer root_seen = 0;
+  integer first_output_cycle = -1;
+  integer last_output_cycle = -1;
+  reg pending_summary = 0;
+  integer leaf_index;
+
+  always #5 clk = ~clk;
+
+  {top_name} dut (
+      .clk(clk),
+      .rst_n(rst_n),
+      .leaf_valid(leaf_valid),
+      .leaf_ready(leaf_ready),
+      .leaf_command_id(leaf_command_id),
+      .leaf_head_id(leaf_head_id),
+      .leaf_global_max(leaf_global_max),
+      .leaf_exp_sum(leaf_exp_sum),
+      .leaf_slice(leaf_slice),
+      .leaf_last(leaf_last),
+      .leaf_value(leaf_value),
+      .root_valid(root_valid),
+      .root_ready(root_ready),
+      .root_command_id(root_command_id),
+      .root_head_id(root_head_id),
+      .root_slice(root_slice),
+      .root_last(root_last),
+      .root_value(root_value),
+      .cycle_count(cycle_count),
+      .root_completed_count(root_completed_count),
+      .finalizer_accepted_count(finalizer_accepted_count),
+      .tree_root_completed_count(tree_root_completed_count),
+      .order_fifo_occupancy(order_fifo_occupancy),
+      .order_fifo_high_watermark(order_fifo_high_watermark),
+      .order_enqueued_count(order_enqueued_count),
+      .order_dequeued_count(order_dequeued_count),
+      .dispatch_stall_cycles(dispatch_stall_cycles),
+      .dispatch_bank_id(dispatch_bank_id),
+      .head_bank_id(head_bank_id),
+      .node_completed_count(node_completed_count),
+      .stage_completed_count(stage_completed_count),
+      .node_protocol_error(node_protocol_error),
+      .stage_protocol_error(stage_protocol_error),
+      .bank_protocol_error(bank_protocol_error),
+      .bank_outstanding(bank_outstanding),
+      .tree_protocol_error(tree_protocol_error),
+      .order_protocol_error(order_protocol_error),
+      .finalizer_protocol_error(finalizer_protocol_error),
+      .protocol_error(protocol_error)
+  );
+
+  always @* begin
+    leaf_valid = {{CLUSTERS{{1'b0}}}};
+    leaf_command_id = {{(CLUSTERS*16){{1'b0}}}};
+    leaf_head_id = {{(CLUSTERS*5){{1'b0}}}};
+    leaf_global_max = {{(CLUSTERS*32){{1'b0}}}};
+    leaf_exp_sum = {{(CLUSTERS*33){{1'b0}}}};
+    leaf_slice = {{(CLUSTERS*4){{1'b0}}}};
+    leaf_last = {{CLUSTERS{{1'b0}}}};
+    leaf_value = {{(CLUSTERS*328){{1'b0}}}};
+    root_ready = root_ready_mem[cycle % ROOT_READY_PATTERN_LEN];
+{drive_comb}
+  end
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      cycle <= 0;
+      root_seen <= 0;
+      first_output_cycle <= -1;
+      last_output_cycle <= -1;
+      pending_summary <= 1'b0;
+      for (leaf_index = 0; leaf_index < CLUSTERS; leaf_index = leaf_index + 1) begin
+        leaf_pending[leaf_index] <= 1'b0;
+        leaf_issue[leaf_index] <= 32'd0;
+        leaf_accept_count[leaf_index] <= 32'd0;
+      end
+    end else begin
+      cycle <= cycle + 1;
+{drive_seq}
+      if (root_valid && root_ready) begin
+        $display("ROOT_RESULT cmd=%0d head=%0d slice=%0d last=%0d value=%080x cycle=%0d",
+                 root_command_id, root_head_id, root_slice, root_last, root_value, cycle);
+        if (first_output_cycle < 0) first_output_cycle <= cycle;
+        last_output_cycle <= cycle;
+        root_seen <= root_seen + 1;
+        if (root_seen + 1 == TOTAL_RESULTS) pending_summary <= 1'b1;
+      end
+      if (pending_summary) begin
+{chr(10).join(leaf_accept_displays)}
+{chr(10).join(node_stage_displays)}
+{chr(10).join(stage_displays)}
+        $display("FINALIZER_SUMMARY accepted=%0d completed=%0d protocol_error=%0d tree_root_completed=%0d tree_protocol_error=%0d order_protocol_error=%0d fifo_high_watermark=%0d dispatch_stall=%0d",
+                 finalizer_accepted_count, root_completed_count, finalizer_protocol_error, tree_root_completed_count, tree_protocol_error, order_protocol_error, order_fifo_high_watermark, dispatch_stall_cycles);
+        $display("SUMMARY outputs=%0d dut_cycle=%0d tb_cycle=%0d first=%0d last=%0d protocol_error=%0d root_completed=%0d",
+                 root_seen, cycle_count, cycle, first_output_cycle, last_output_cycle, protocol_error, root_completed_count);
+        #1 $finish;
+      end
+      if (cycle > {timeout_cycles}) $fatal(1, "timeout");
+    end
+  end
+
+  initial begin
+    for (init_index = 0; init_index < MEM_DEPTH; init_index = init_index + 1) begin
+      leaf_cmd_mem[init_index] = 16'd0;
+      leaf_head_mem[init_index] = 5'd0;
+      leaf_max_mem[init_index] = 32'sd0;
+      leaf_sum_mem[init_index] = 33'd0;
+      leaf_slice_mem[init_index] = 4'd0;
+      leaf_last_mem[init_index] = 1'b0;
+      leaf_value_mem[init_index] = 328'd0;
+    end
+{_ready_mem_init(output_ready_pattern)}
+{chr(10).join(leaf_init)}
+    repeat (3) @(posedge clk);
+    @(negedge clk);
+    rst_n = 1'b1;
+  end
+endmodule
+"""
+
+
+def build_report(
+    clusters: int = 16,
+    heads: int = 32,
+    divider_lanes: int = 8,
+    finalizer_banks: int = 59,
+    *,
+    saturated: bool = False,
+    output_ready_pattern: tuple[bool, ...] | None = None,
+) -> JsonDict:
+    ready_pattern = output_ready_pattern or _default_ready_pattern()
+    expected = _expected(
+        clusters,
+        heads=heads,
+        divider_lanes=divider_lanes,
+        finalizer_banks=finalizer_banks,
+        output_ready_pattern=ready_pattern,
+    )
+    with tempfile.TemporaryDirectory(
+        prefix=f"score32_exact_banked_finalized_tree_c{clusters}_l{divider_lanes}_b{finalizer_banks}_"
+    ) as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        generate_tree(_config(clusters, divider_lanes, finalizer_banks), temp_dir / "rtl")
+        tb_path = temp_dir / "tb.sv"
+        top_name = str(_config(clusters, divider_lanes, finalizer_banks)["top_name"])
+        tb_path.write_text(
+            _testbench(
+                top_name=top_name,
+                clusters=clusters,
+                heads=heads,
+                divider_lanes=divider_lanes,
+                finalizer_banks=finalizer_banks,
+                expected=expected,
+                saturated=saturated,
+                output_ready_pattern=ready_pattern,
+            ),
+            encoding="utf-8",
+        )
+
+        simv = temp_dir / "simv"
+        compiled = subprocess.run(
+            [
+                _tool("iverilog"),
+                "-g2012",
+                "-s",
+                "tb",
+                "-o",
+                str(simv),
+                str(temp_dir / "rtl" / "top.v"),
+                str(tb_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=900,
+        )
+        if compiled.returncode:
+            raise RuntimeError(f"iverilog failed:\n{compiled.stderr}")
+        run = subprocess.run([_tool("vvp"), str(simv)], capture_output=True, text=True, timeout=900)
+        if run.returncode:
+            raise RuntimeError(f"simulation failed:\n{run.stdout}\n{run.stderr}")
+
+    observed_root: list[dict[str, object]] = []
+    leaf_summary: list[int] = [0] * clusters
+    node_count = clusters - 1
+    stage_count = int(math.log2(clusters))
+    node_completed_count: list[int] = [0] * node_count
+    node_protocol_error: list[bool] = [False] * node_count
+    stage_completed_count: list[int] = [0] * stage_count
+    stage_protocol_error: list[bool] = [False] * stage_count
+    finalizer_summary: dict[str, object] | None = None
+    summary: dict[str, object] | None = None
+    for line in run.stdout.splitlines():
+        stripped = line.strip()
+        if match := _ROOT_RE.fullmatch(stripped):
+            observed_root.append(
+                {
+                    "command_id": int(match.group(1)),
+                    "head_id": int(match.group(2)),
+                    "slice": int(match.group(3)),
+                    "last": bool(int(match.group(4))),
+                    "value": list(unpack_final_values(int(match.group(5), 16))),
+                    "cycle": int(match.group(6)),
+                }
+            )
+        elif match := _LEAF_RE.fullmatch(stripped):
+            leaf = int(match.group(1))
+            leaf_summary[leaf] = int(match.group(2))
+            if int(match.group(3)) != int(match.group(2)):
+                raise RuntimeError(f"leaf issue/accept mismatch in leaf {leaf}: {stripped}")
+        elif match := _NODE_RE.fullmatch(stripped):
+            node = int(match.group(2))
+            node_completed_count[node] = int(match.group(3))
+            node_protocol_error[node] = bool(int(match.group(4)))
+        elif match := _STAGE_RE.fullmatch(stripped):
+            stage = int(match.group(1))
+            stage_completed_count[stage] = int(match.group(2))
+            stage_protocol_error[stage] = bool(int(match.group(3)))
+        elif match := _FINALIZER_RE.fullmatch(stripped):
+            finalizer_summary = {
+                "accepted": int(match.group(1)),
+                "completed": int(match.group(2)),
+                "finalizer_protocol_error": bool(int(match.group(3))),
+                "tree_root_completed": int(match.group(4)),
+                "tree_protocol_error": bool(int(match.group(5))),
+                "order_protocol_error": bool(int(match.group(6))),
+                "fifo_high_watermark": int(match.group(7)),
+                "dispatch_stall_cycles": int(match.group(8)),
+            }
+        elif match := _SUMMARY_RE.fullmatch(stripped):
+            summary = {
+                "outputs": int(match.group(1)),
+                "dut_cycle": int(match.group(2)),
+                "tb_cycle": int(match.group(3)),
+                "first_output_cycle": int(match.group(4)),
+                "last_output_cycle": int(match.group(5)),
+                "protocol_error": bool(int(match.group(6))),
+                "root_completed_count": int(match.group(7)),
+            }
+    if summary is None or finalizer_summary is None:
+        raise RuntimeError("summary missing from banked finalized tree probe")
+
+    observed_rows = [{key: value for key, value in row.items() if key != "cycle"} for row in observed_root]
+    root_hash = _hash(observed_rows)
+    expected_hash = str(expected["root_hash"])
+    first_output_cycle = int(summary["first_output_cycle"])
+    last_output_cycle = int(summary["last_output_cycle"])
+    output_interval_cycles = max(0, last_output_cycle - first_output_cycle)
+    interval_beats = max(0, int(summary["outputs"]) - 1)
+    measured_workload_manifest = exact_banked_finalized_tree_service_manifest(
+        clusters=clusters,
+        heads=heads,
+        divider_lanes=divider_lanes,
+        finalizer_banks=finalizer_banks,
+    )
+    measured_workload_manifest.update(
+        {
+            "measured_heads": heads,
+            "leaf_accepts_per_leaf": len(expected["root"]),
+            "total_leaf_beats": clusters * len(expected["root"]),
+            "root_outputs": len(expected["root"]),
+            "first_output_cycle": first_output_cycle,
+            "last_output_cycle": last_output_cycle,
+            "drain_cycles": int(summary["tb_cycle"]),
+            "measured_root_output_interval_beats": interval_beats,
+            "measured_root_output_interval_cycles": output_interval_cycles,
+            "measured_root_output_interval_beats_per_cycle": (
+                round(interval_beats / output_interval_cycles, 6) if output_interval_cycles else 0.0
+            ),
+            "measured_root_output_interval_cycles_per_beat": (
+                round(output_interval_cycles / interval_beats, 6) if interval_beats else 0.0
+            ),
+            "protocol_error": bool(summary["protocol_error"]),
+            "saturated_leaf_mode": bool(saturated),
+            "root_ready_pattern_length": len(ready_pattern),
+        }
+    )
+    passed = (
+        observed_rows == expected["root"]
+        and leaf_summary == expected["leaf_accept_count"]
+        and node_completed_count == expected["node_completed_count"]
+        and stage_completed_count == expected["stage_completed_count"]
+        and node_protocol_error == expected["node_protocol_error"]
+        and stage_protocol_error == expected["stage_protocol_error"]
+        and bool(summary["protocol_error"]) is False
+        and bool(finalizer_summary["finalizer_protocol_error"]) is False
+        and bool(finalizer_summary["tree_protocol_error"]) is False
+        and bool(finalizer_summary["order_protocol_error"]) is False
+        and int(summary["outputs"]) == len(expected["root"])
+        and int(summary["root_completed_count"]) == len(expected["root"])
+        and int(finalizer_summary["accepted"]) == len(expected["root"])
+        and int(finalizer_summary["tree_root_completed"]) == len(expected["root"])
+        and root_hash == expected_hash
+    )
+    return {
+        "clusters": clusters,
+        "divider_lanes": divider_lanes,
+        "finalizer_banks": finalizer_banks,
+        "heads": heads,
+        "saturated": saturated,
+        "passed": passed,
+        "expected_root_hash": expected_hash,
+        "observed_root_hash": root_hash,
+        "outputs": len(observed_rows),
+        "first_output_cycle": first_output_cycle,
+        "last_output_cycle": last_output_cycle,
+        "drain_cycles": int(summary["tb_cycle"]),
+        "dut_cycle": int(summary["dut_cycle"]),
+        "leaf_accept_count": leaf_summary,
+        "node_completed_count": node_completed_count,
+        "node_protocol_error": node_protocol_error,
+        "stage_completed_count": stage_completed_count,
+        "stage_protocol_error": stage_protocol_error,
+        "finalizer_accepted_count": int(finalizer_summary["accepted"]),
+        "finalizer_completed_count": int(finalizer_summary["completed"]),
+        "tree_root_completed_count": int(finalizer_summary["tree_root_completed"]),
+        "tree_protocol_error": bool(finalizer_summary["tree_protocol_error"]),
+        "order_protocol_error": bool(finalizer_summary["order_protocol_error"]),
+        "finalizer_protocol_error": bool(finalizer_summary["finalizer_protocol_error"]),
+        "protocol_error": bool(summary["protocol_error"]),
+        "order_fifo_high_watermark": int(finalizer_summary["fifo_high_watermark"]),
+        "dispatch_stall_cycles": int(finalizer_summary["dispatch_stall_cycles"]),
+        "measured_workload_manifest": measured_workload_manifest,
+        "theoretical_full_llama_service_manifest": exact_banked_finalized_tree_service_manifest(
+            clusters=clusters,
+            heads=32,
+            divider_lanes=divider_lanes,
+            finalizer_banks=finalizer_banks,
+        ),
+        "banked_finalizer_reference": expected["banked_finalizer_reference"],
+        "ideal_divider_cycles_per_beat": finalizer_cycles_per_beat(divider_lanes),
+        "per_bank_accept_interval_cycles": finalizer_accept_interval_cycles(divider_lanes),
+        "observed_rows": observed_rows,
+    }
+
+
+def _pattern_from_bits(bits: str) -> tuple[bool, ...]:
+    cleaned = bits.strip()
+    if not cleaned or any(ch not in {"0", "1"} for ch in cleaned):
+        raise ValueError("root_ready_pattern must be a non-empty bit string")
+    return tuple(ch == "1" for ch in cleaned)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--clusters", type=int, default=16)
+    parser.add_argument("--heads", type=int, default=32)
+    parser.add_argument("--divider-lanes", type=int, default=8)
+    parser.add_argument("--finalizer-banks", type=int, default=59)
+    parser.add_argument("--saturated", action="store_true")
+    parser.add_argument("--root-ready-pattern", type=str, default="")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    ready_pattern = _pattern_from_bits(args.root_ready_pattern) if args.root_ready_pattern else None
+    report = build_report(
+        clusters=args.clusters,
+        heads=args.heads,
+        divider_lanes=args.divider_lanes,
+        finalizer_banks=args.finalizer_banks,
+        saturated=args.saturated,
+        output_ready_pattern=ready_pattern,
+    )
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(
+            json.dumps(
+                {
+                    "clusters": report["clusters"],
+                    "divider_lanes": report["divider_lanes"],
+                    "finalizer_banks": report["finalizer_banks"],
+                    "heads": report["heads"],
+                    "saturated": report["saturated"],
+                    "passed": report["passed"],
+                    "outputs": report["outputs"],
+                    "first_output_cycle": report["first_output_cycle"],
+                    "last_output_cycle": report["last_output_cycle"],
+                    "drain_cycles": report["drain_cycles"],
+                    "observed_root_hash": report["observed_root_hash"],
+                },
+                sort_keys=True,
+            )
+        )
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/rtlgen/gen_attention_score32_exact_banked_finalized_tree.py
+++ b/npu/rtlgen/gen_attention_score32_exact_banked_finalized_tree.py
@@ -1,0 +1,656 @@
+#!/usr/bin/env python3
+"""Generate a radix-2 exact-reduction tree with ordered banked root finalizers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_score32_exact_partial_tree import generate as generate_tree
+from npu.rtlgen.gen_attention_score32_exact_root_finalizer import generate as generate_finalizer
+from npu.sim.perf.attention_exact_partial import (
+    FINAL_LINK_BITS,
+    FINAL_PAYLOAD_BITS,
+    PARTIAL_LINK_BITS,
+    PARTIAL_PAYLOAD_BITS,
+    exact_banked_finalized_tree_service_manifest,
+)
+
+JsonDict = dict[str, Any]
+
+
+def _load(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit(f"config must decode to a JSON object: {path}")
+    return payload
+
+
+def _clog2(value: int) -> int:
+    return max(1, math.ceil(math.log2(max(2, value))))
+
+
+def _validate(config: JsonDict) -> JsonDict:
+    top_name = str(config.get("top_name") or "").strip()
+    body = config.get("attention_score32_exact_banked_finalized_tree")
+    if not top_name or not isinstance(body, dict):
+        raise SystemExit("config requires top_name and attention_score32_exact_banked_finalized_tree")
+
+    clusters = int(body.get("clusters", 16))
+    radix = int(body.get("radix", 2))
+    value_slices = int(body.get("value_slices", 16))
+    head_id_bits = int(body.get("head_id_bits", 5))
+    divider_lanes = int(body.get("divider_lanes", 8))
+    finalizer_banks = int(body.get("finalizer_banks", 1))
+    if clusters < 2 or clusters > 16 or (clusters & (clusters - 1)):
+        raise SystemExit("clusters must be a power of two in [2, 16]")
+    if radix != 2:
+        raise SystemExit("banked exact finalized tree only implements radix=2")
+    if value_slices < 1 or value_slices > 16 or (value_slices & (value_slices - 1)):
+        raise SystemExit("value_slices must be a power of two in [1, 16]")
+    if head_id_bits < 1 or head_id_bits > 8:
+        raise SystemExit("head_id_bits must be in [1, 8]")
+    if divider_lanes not in {1, 2, 4, 8}:
+        raise SystemExit("divider_lanes must be one of 1, 2, 4, 8")
+    if finalizer_banks < 1 or finalizer_banks > 64:
+        raise SystemExit("finalizer_banks must be in [1, 64]")
+    return {
+        "top_name": top_name,
+        "clusters": clusters,
+        "radix": radix,
+        "value_slices": value_slices,
+        "head_id_bits": head_id_bits,
+        "divider_lanes": divider_lanes,
+        "finalizer_banks": finalizer_banks,
+    }
+
+
+def _bank_literal(index: int, width: int) -> str:
+    return f"{width}'d{index}"
+
+
+def _wrap_increment_fn(*, name: str, width: int, limit: int) -> str:
+    return f"""  function automatic [{width - 1}:0] {name};
+    input [{width - 1}:0] value;
+    begin
+      if (value == {width}'d{limit - 1}) begin
+        {name} = {width}'d0;
+      end else begin
+        {name} = value + {width}'d1;
+      end
+    end
+  endfunction
+"""
+
+
+def _zext_expr(*, pad_expr: str, signal_expr: str) -> str:
+    return "{{(" + pad_expr + "){1'b0}}, " + signal_expr + "}"
+
+
+def _dispatch_case(*, banks: int, bank_id_bits: int) -> str:
+    lines = ["  always @* begin", "    dispatch_bank_in_ready_r = 1'b0;"]
+    lines.append("    case (dispatch_bank_q)")
+    for bank in range(banks):
+        lines.append(
+            f"      {_bank_literal(bank, bank_id_bits)}: begin "
+            f"dispatch_bank_in_ready_r = bank_in_ready_w[{bank}]; end"
+        )
+    lines.append("      default: begin dispatch_bank_in_ready_r = 1'b0; end")
+    lines.append("    endcase")
+    lines.append("  end")
+    return "\n".join(lines)
+
+
+def _root_mux_case(*, banks: int, bank_id_bits: int, head_id_bits: int, slice_bits: int) -> str:
+    lines = [
+        "  always @* begin",
+        "    root_valid_r = 1'b0;",
+        "    root_command_id_r = 16'd0;",
+        f"    root_head_id_r = {{{head_id_bits}{{1'b0}}}};",
+        f"    root_slice_r = {{{slice_bits}{{1'b0}}}};",
+        "    root_last_r = 1'b0;",
+        "    root_value_r = 320'd0;",
+        "    head_bank_outstanding_r = 1'b0;",
+        "    case (order_fifo_head_bank_id_w)",
+    ]
+    for bank in range(banks):
+        lines.extend(
+            [
+                f"      {_bank_literal(bank, bank_id_bits)}: begin",
+                f"        root_valid_r = bank_out_valid_w[{bank}];",
+                f"        root_command_id_r = bank_out_command_id_w[{bank}];",
+                f"        root_head_id_r = bank_out_head_id_w[{bank}];",
+                f"        root_slice_r = bank_out_slice_w[{bank}];",
+                f"        root_last_r = bank_out_last_w[{bank}];",
+                f"        root_value_r = bank_out_value_w[{bank}];",
+                f"        head_bank_outstanding_r = bank_outstanding_q[{bank}];",
+                "      end",
+            ]
+        )
+    lines.append("      default: begin end")
+    lines.append("    endcase")
+    lines.append("  end")
+    return "\n".join(lines)
+
+
+def _bank_assigns(*, banks: int, bank_id_bits: int) -> str:
+    lines: list[str] = []
+    for bank in range(banks):
+        lines.append(
+            f"  assign bank_issue_w[{bank}] = tree_root_valid && tree_root_ready_w && (dispatch_bank_q == {_bank_literal(bank, bank_id_bits)});"
+        )
+        lines.append(
+            f"  assign bank_out_ready_w[{bank}] = root_ready && order_fifo_has_entry_w && (order_fifo_head_bank_id_w == {_bank_literal(bank, bank_id_bits)});"
+        )
+    return "\n".join(lines)
+
+
+def _bank_instances(*, finalizer_top_name: str, banks: int, head_id_bits: int, slice_bits: int) -> str:
+    blocks: list[str] = []
+    for bank in range(banks):
+        blocks.append(
+            f"""  {finalizer_top_name} u_finalizer_bank_{bank} (
+      .clk(clk),
+      .rst_n(rst_n),
+      .in_valid(bank_issue_w[{bank}]),
+      .in_ready(bank_in_ready_w[{bank}]),
+      .in_command_id(tree_root_command_id),
+      .in_head_id(tree_root_head_id),
+      .in_exp_sum(tree_root_exp_sum),
+      .in_slice(tree_root_slice),
+      .in_last(tree_root_last),
+      .in_value(tree_root_value),
+      .out_valid(bank_out_valid_w[{bank}]),
+      .out_ready(bank_out_ready_w[{bank}]),
+      .out_command_id(bank_out_command_id_w[{bank}]),
+      .out_head_id(bank_out_head_id_w[{bank}]),
+      .out_slice(bank_out_slice_w[{bank}]),
+      .out_last(bank_out_last_w[{bank}]),
+      .out_value(bank_out_value_w[{bank}]),
+      .accepted_count(bank_accepted_count_w[{bank}]),
+      .completed_count(bank_completed_count_w[{bank}]),
+      .cycle_count(bank_cycle_count_w[{bank}]),
+      .protocol_error(bank_protocol_error_w[{bank}])
+  );"""
+        )
+    return "\n\n".join(blocks)
+
+
+def _bank_output_assigns(*, banks: int) -> str:
+    return "\n".join(f"  assign bank_protocol_error[{bank}] = bank_protocol_error_w[{bank}];" for bank in range(banks))
+
+
+def _bank_valid_error_checks(*, banks: int) -> str:
+    lines: list[str] = []
+    for bank in range(banks):
+        lines.append(
+            f"      if (bank_out_valid_w[{bank}] && !bank_outstanding_q[{bank}]) begin\n"
+            f"        order_protocol_error_q <= 1'b1;\n"
+            f"      end"
+        )
+    return "\n".join(lines)
+
+
+def _top_pin_bits(
+    *,
+    clusters: int,
+    head_id_bits: int,
+    stages: int,
+    nodes: int,
+    slice_bits: int,
+    banks: int,
+) -> int:
+    leaf_bits = clusters * (1 + 16 + head_id_bits + 32 + 33 + slice_bits + 1 + PARTIAL_PAYLOAD_BITS + 1)
+    root_bits = 1 + 1 + 16 + head_id_bits + slice_bits + 1 + FINAL_PAYLOAD_BITS
+    monitor_bits = (
+        32
+        + 32
+        + 32
+        + 32
+        + 32
+        + 32
+        + 32
+        + 32
+        + 32
+        + 32
+        + (nodes * 32)
+        + (stages * 32)
+        + nodes
+        + stages
+        + banks
+        + banks
+        + 4
+    )
+    return 2 + leaf_bits + root_bits + monitor_bits
+
+
+def _top(
+    *,
+    top_name: str,
+    tree_top_name: str,
+    finalizer_top_name: str,
+    clusters: int,
+    value_slices: int,
+    head_id_bits: int,
+    divider_lanes: int,
+    finalizer_banks: int,
+) -> str:
+    slice_bits = _clog2(value_slices)
+    node_count = clusters - 1
+    stage_count = int(math.log2(clusters))
+    bank_id_bits = _clog2(finalizer_banks)
+    fifo_count_bits = _clog2(finalizer_banks + 1)
+    dispatch_case = _dispatch_case(banks=finalizer_banks, bank_id_bits=bank_id_bits)
+    root_mux_case = _root_mux_case(
+        banks=finalizer_banks,
+        bank_id_bits=bank_id_bits,
+        head_id_bits=head_id_bits,
+        slice_bits=slice_bits,
+    )
+    bank_assigns = _bank_assigns(banks=finalizer_banks, bank_id_bits=bank_id_bits)
+    bank_instances = _bank_instances(
+        finalizer_top_name=finalizer_top_name,
+        banks=finalizer_banks,
+        head_id_bits=head_id_bits,
+        slice_bits=slice_bits,
+    )
+    bank_output_assigns = _bank_output_assigns(banks=finalizer_banks)
+    bank_valid_error_checks = _bank_valid_error_checks(banks=finalizer_banks)
+    order_fifo_count_zext = _zext_expr(pad_expr="32-ORDER_FIFO_COUNT_BITS", signal_expr="order_fifo_count_q")
+    dispatch_bank_zext = _zext_expr(pad_expr="32-BANK_ID_BITS", signal_expr="dispatch_bank_q")
+    head_bank_zext = _zext_expr(pad_expr="32-BANK_ID_BITS", signal_expr="order_fifo_head_bank_id_w")
+    fifo_zero_literal = f"{fifo_count_bits}'d0"
+    fifo_one_literal = f"{fifo_count_bits}'d1"
+    fifo_full_literal = f"{fifo_count_bits}'d{finalizer_banks}"
+    return f"""// Auto-generated by npu/rtlgen/gen_attention_score32_exact_banked_finalized_tree.py
+module {top_name} (
+    input  wire         clk,
+    input  wire         rst_n,
+    input  wire [{clusters - 1}:0] leaf_valid,
+    output wire [{clusters - 1}:0] leaf_ready,
+    input  wire [{clusters * 16 - 1}:0] leaf_command_id,
+    input  wire [{clusters * head_id_bits - 1}:0] leaf_head_id,
+    input  wire [{clusters * 32 - 1}:0] leaf_global_max,
+    input  wire [{clusters * 33 - 1}:0] leaf_exp_sum,
+    input  wire [{clusters * slice_bits - 1}:0] leaf_slice,
+    input  wire [{clusters - 1}:0] leaf_last,
+    input  wire [{clusters * PARTIAL_PAYLOAD_BITS - 1}:0] leaf_value,
+    output wire         root_valid,
+    input  wire         root_ready,
+    output wire [15:0]  root_command_id,
+    output wire [{head_id_bits - 1}:0] root_head_id,
+    output wire [{slice_bits - 1}:0] root_slice,
+    output wire         root_last,
+    output wire [319:0] root_value,
+    output wire [31:0]  cycle_count,
+    output wire [31:0]  root_completed_count,
+    output wire [31:0]  finalizer_accepted_count,
+    output wire [31:0]  tree_root_completed_count,
+    output wire [31:0]  order_fifo_occupancy,
+    output wire [31:0]  order_fifo_high_watermark,
+    output wire [31:0]  order_enqueued_count,
+    output wire [31:0]  order_dequeued_count,
+    output wire [31:0]  dispatch_stall_cycles,
+    output wire [31:0]  dispatch_bank_id,
+    output wire [31:0]  head_bank_id,
+    output wire [{node_count * 32 - 1}:0] node_completed_count,
+    output wire [{stage_count * 32 - 1}:0] stage_completed_count,
+    output wire [{node_count - 1}:0] node_protocol_error,
+    output wire [{stage_count - 1}:0] stage_protocol_error,
+    output wire [{finalizer_banks - 1}:0] bank_protocol_error,
+    output wire [{finalizer_banks - 1}:0] bank_outstanding,
+    output wire         tree_protocol_error,
+    output wire         order_protocol_error,
+    output wire         finalizer_protocol_error,
+    output wire         protocol_error
+);
+  localparam integer PARTIAL_PAYLOAD_BITS = {PARTIAL_PAYLOAD_BITS};
+  localparam integer FINALIZER_BANKS = {finalizer_banks};
+  localparam integer BANK_ID_BITS = {bank_id_bits};
+  localparam integer ORDER_FIFO_DEPTH = {finalizer_banks};
+  localparam integer ORDER_FIFO_COUNT_BITS = {fifo_count_bits};
+
+  wire tree_root_valid;
+  wire tree_root_ready;
+  wire [15:0] tree_root_command_id;
+  wire [{head_id_bits - 1}:0] tree_root_head_id;
+  wire signed [31:0] tree_root_global_max;
+  wire [32:0] tree_root_exp_sum;
+  wire [{slice_bits - 1}:0] tree_root_slice;
+  wire tree_root_last;
+  wire [327:0] tree_root_value;
+  wire [31:0] tree_cycle_count;
+  wire [31:0] tree_root_completed_count_w;
+
+  wire bank_issue_w [0:FINALIZER_BANKS-1];
+  wire bank_in_ready_w [0:FINALIZER_BANKS-1];
+  wire bank_out_valid_w [0:FINALIZER_BANKS-1];
+  wire bank_out_ready_w [0:FINALIZER_BANKS-1];
+  wire [15:0] bank_out_command_id_w [0:FINALIZER_BANKS-1];
+  wire [{head_id_bits - 1}:0] bank_out_head_id_w [0:FINALIZER_BANKS-1];
+  wire [{slice_bits - 1}:0] bank_out_slice_w [0:FINALIZER_BANKS-1];
+  wire bank_out_last_w [0:FINALIZER_BANKS-1];
+  wire [319:0] bank_out_value_w [0:FINALIZER_BANKS-1];
+  wire [31:0] bank_accepted_count_w [0:FINALIZER_BANKS-1];
+  wire [31:0] bank_completed_count_w [0:FINALIZER_BANKS-1];
+  wire [31:0] bank_cycle_count_w [0:FINALIZER_BANKS-1];
+  wire bank_protocol_error_w [0:FINALIZER_BANKS-1];
+
+  reg [BANK_ID_BITS-1:0] dispatch_bank_q;
+  reg [BANK_ID_BITS-1:0] order_fifo_head_q;
+  reg [BANK_ID_BITS-1:0] order_fifo_tail_q;
+  reg [BANK_ID_BITS-1:0] order_fifo_mem [0:ORDER_FIFO_DEPTH-1];
+  reg [ORDER_FIFO_COUNT_BITS-1:0] order_fifo_count_q;
+  reg [FINALIZER_BANKS-1:0] bank_outstanding_q;
+  reg [31:0] cycle_count_q;
+  reg [31:0] root_completed_count_q;
+  reg [31:0] finalizer_accepted_count_q;
+  reg [31:0] order_fifo_high_watermark_q;
+  reg [31:0] order_enqueued_count_q;
+  reg [31:0] order_dequeued_count_q;
+  reg [31:0] dispatch_stall_cycles_q;
+  reg order_protocol_error_q;
+  reg dispatch_bank_in_ready_r;
+  reg root_valid_r;
+  reg [15:0] root_command_id_r;
+  reg [{head_id_bits - 1}:0] root_head_id_r;
+  reg [{slice_bits - 1}:0] root_slice_r;
+  reg root_last_r;
+  reg [319:0] root_value_r;
+  reg head_bank_outstanding_r;
+  reg [31:0] order_fifo_count_next_r;
+  integer bank_index;
+
+{_wrap_increment_fn(name="next_bank_id", width=bank_id_bits, limit=finalizer_banks)}
+  wire order_fifo_has_entry_w = (order_fifo_count_q != {fifo_zero_literal});
+  wire order_fifo_full_w = (order_fifo_count_q == {fifo_full_literal});
+  wire [BANK_ID_BITS-1:0] order_fifo_head_bank_id_w = order_fifo_mem[order_fifo_head_q];
+  wire order_fifo_dequeue_fire_w = root_valid_r && root_ready;
+  wire order_fifo_enqueue_ready_w = !order_fifo_full_w || order_fifo_dequeue_fire_w;
+  wire tree_root_ready_w = dispatch_bank_in_ready_r && order_fifo_enqueue_ready_w;
+  wire tree_root_issue_w = tree_root_valid && tree_root_ready_w;
+  wire any_bank_protocol_error_w = |bank_protocol_error;
+  wire finalizer_protocol_error_w = any_bank_protocol_error_w | order_protocol_error_q;
+
+  assign root_valid = root_valid_r;
+  assign root_command_id = root_command_id_r;
+  assign root_head_id = root_head_id_r;
+  assign root_slice = root_slice_r;
+  assign root_last = root_last_r;
+  assign root_value = root_value_r;
+  assign tree_root_ready = tree_root_ready_w;
+  assign cycle_count = cycle_count_q;
+  assign root_completed_count = root_completed_count_q;
+  assign finalizer_accepted_count = finalizer_accepted_count_q;
+  assign tree_root_completed_count = tree_root_completed_count_w;
+  assign order_fifo_occupancy = {order_fifo_count_zext};
+  assign order_fifo_high_watermark = order_fifo_high_watermark_q;
+  assign order_enqueued_count = order_enqueued_count_q;
+  assign order_dequeued_count = order_dequeued_count_q;
+  assign dispatch_stall_cycles = dispatch_stall_cycles_q;
+  assign dispatch_bank_id = {dispatch_bank_zext};
+  assign head_bank_id =
+      order_fifo_has_entry_w ? {head_bank_zext} : 32'd0;
+  assign bank_outstanding = bank_outstanding_q;
+  assign order_protocol_error = order_protocol_error_q;
+  assign finalizer_protocol_error = finalizer_protocol_error_w;
+  assign protocol_error = tree_protocol_error | finalizer_protocol_error_w;
+
+{bank_output_assigns}
+
+{dispatch_case}
+
+{root_mux_case}
+
+{bank_assigns}
+
+  {tree_top_name} u_tree (
+      .clk(clk),
+      .rst_n(rst_n),
+      .leaf_valid(leaf_valid),
+      .leaf_ready(leaf_ready),
+      .leaf_command_id(leaf_command_id),
+      .leaf_head_id(leaf_head_id),
+      .leaf_global_max(leaf_global_max),
+      .leaf_exp_sum(leaf_exp_sum),
+      .leaf_slice(leaf_slice),
+      .leaf_last(leaf_last),
+      .leaf_value(leaf_value),
+      .root_valid(tree_root_valid),
+      .root_ready(tree_root_ready),
+      .root_command_id(tree_root_command_id),
+      .root_head_id(tree_root_head_id),
+      .root_global_max(tree_root_global_max),
+      .root_exp_sum(tree_root_exp_sum),
+      .root_slice(tree_root_slice),
+      .root_last(tree_root_last),
+      .root_value(tree_root_value),
+      .cycle_count(tree_cycle_count),
+      .root_completed_count(tree_root_completed_count_w),
+      .node_completed_count(node_completed_count),
+      .stage_completed_count(stage_completed_count),
+      .node_protocol_error(node_protocol_error),
+      .stage_protocol_error(stage_protocol_error),
+      .protocol_error(tree_protocol_error)
+  );
+
+{bank_instances}
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      dispatch_bank_q <= {{BANK_ID_BITS{{1'b0}}}};
+      order_fifo_head_q <= {{BANK_ID_BITS{{1'b0}}}};
+      order_fifo_tail_q <= {{BANK_ID_BITS{{1'b0}}}};
+      order_fifo_count_q <= {{ORDER_FIFO_COUNT_BITS{{1'b0}}}};
+      bank_outstanding_q <= {{FINALIZER_BANKS{{1'b0}}}};
+      cycle_count_q <= 32'd0;
+      root_completed_count_q <= 32'd0;
+      finalizer_accepted_count_q <= 32'd0;
+      order_fifo_high_watermark_q <= 32'd0;
+      order_enqueued_count_q <= 32'd0;
+      order_dequeued_count_q <= 32'd0;
+      dispatch_stall_cycles_q <= 32'd0;
+      order_protocol_error_q <= 1'b0;
+      for (bank_index = 0; bank_index < ORDER_FIFO_DEPTH; bank_index = bank_index + 1) begin
+        order_fifo_mem[bank_index] <= {{BANK_ID_BITS{{1'b0}}}};
+      end
+    end else begin
+      cycle_count_q <= cycle_count_q + 1'b1;
+      if (tree_root_valid && !tree_root_ready_w) begin
+        dispatch_stall_cycles_q <= dispatch_stall_cycles_q + 1'b1;
+      end
+      if (!order_fifo_has_entry_w && (|bank_outstanding_q)) begin
+        order_protocol_error_q <= 1'b1;
+      end
+{bank_valid_error_checks}
+      if (tree_root_issue_w) begin
+        finalizer_accepted_count_q <= finalizer_accepted_count_q + 1'b1;
+        order_enqueued_count_q <= order_enqueued_count_q + 1'b1;
+        if (bank_outstanding_q[dispatch_bank_q]) begin
+          order_protocol_error_q <= 1'b1;
+        end
+        bank_outstanding_q[dispatch_bank_q] <= 1'b1;
+        order_fifo_mem[order_fifo_tail_q] <= dispatch_bank_q;
+      end
+      if (order_fifo_dequeue_fire_w) begin
+        root_completed_count_q <= root_completed_count_q + 1'b1;
+        order_dequeued_count_q <= order_dequeued_count_q + 1'b1;
+        if (!order_fifo_has_entry_w) begin
+          order_protocol_error_q <= 1'b1;
+        end
+        if (!head_bank_outstanding_r) begin
+          order_protocol_error_q <= 1'b1;
+        end
+        bank_outstanding_q[order_fifo_head_bank_id_w] <= 1'b0;
+      end
+
+      order_fifo_count_next_r = {order_fifo_count_zext};
+      case ({{tree_root_issue_w, order_fifo_dequeue_fire_w}})
+        2'b10: begin
+          order_fifo_tail_q <= next_bank_id(order_fifo_tail_q);
+          order_fifo_count_q <= order_fifo_count_q + {fifo_one_literal};
+          order_fifo_count_next_r = {order_fifo_count_zext} + 32'd1;
+        end
+        2'b01: begin
+          order_fifo_head_q <= next_bank_id(order_fifo_head_q);
+          order_fifo_count_q <= order_fifo_count_q - {fifo_one_literal};
+          order_fifo_count_next_r = {order_fifo_count_zext} - 32'd1;
+        end
+        2'b11: begin
+          order_fifo_head_q <= next_bank_id(order_fifo_head_q);
+          order_fifo_tail_q <= next_bank_id(order_fifo_tail_q);
+          order_fifo_count_next_r = {order_fifo_count_zext};
+        end
+        default: begin
+          order_fifo_count_next_r = {order_fifo_count_zext};
+        end
+      endcase
+      if (tree_root_issue_w) begin
+        dispatch_bank_q <= next_bank_id(dispatch_bank_q);
+      end
+      if (order_fifo_count_next_r > order_fifo_high_watermark_q) begin
+        order_fifo_high_watermark_q <= order_fifo_count_next_r;
+      end
+    end
+  end
+endmodule
+"""
+
+
+def generate(config: JsonDict, out_dir: Path) -> None:
+    params = _validate(json.loads(json.dumps(config)))
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    tree_top_name = f"{params['top_name']}__partial_tree"
+    finalizer_top_name = f"{params['top_name']}__root_finalizer"
+    with tempfile.TemporaryDirectory(prefix="score32_exact_banked_finalized_tree_") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        generate_tree(
+            {
+                "top_name": tree_top_name,
+                "attention_score32_exact_partial_tree": {
+                    "clusters": int(params["clusters"]),
+                    "radix": int(params["radix"]),
+                    "value_slices": int(params["value_slices"]),
+                    "head_id_bits": int(params["head_id_bits"]),
+                },
+            },
+            temp_dir / "tree",
+        )
+        generate_finalizer(
+            {
+                "top_name": finalizer_top_name,
+                "attention_score32_exact_root_finalizer": {
+                    "value_slices": int(params["value_slices"]),
+                    "head_id_bits": int(params["head_id_bits"]),
+                    "divider_lanes": int(params["divider_lanes"]),
+                },
+            },
+            temp_dir / "finalizer",
+        )
+        tree_rtl = (temp_dir / "tree" / "top.v").read_text(encoding="utf-8")
+        finalizer_rtl = (temp_dir / "finalizer" / "top.v").read_text(encoding="utf-8")
+        tree_manifest = json.loads(
+            (temp_dir / "tree" / "attention_score32_exact_partial_tree_manifest.json").read_text(encoding="utf-8")
+        )
+        finalizer_manifest = json.loads(
+            (temp_dir / "finalizer" / "attention_score32_exact_root_finalizer_manifest.json").read_text(
+                encoding="utf-8"
+            )
+        )
+
+    top_text = _top(
+        top_name=str(params["top_name"]),
+        tree_top_name=tree_top_name,
+        finalizer_top_name=finalizer_top_name,
+        clusters=int(params["clusters"]),
+        value_slices=int(params["value_slices"]),
+        head_id_bits=int(params["head_id_bits"]),
+        divider_lanes=int(params["divider_lanes"]),
+        finalizer_banks=int(params["finalizer_banks"]),
+    )
+    (out_dir / "top.v").write_text(tree_rtl + "\n\n" + finalizer_rtl + "\n\n" + top_text, encoding="utf-8")
+    (out_dir / "config.json").write_text(json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    clusters = int(params["clusters"])
+    banks = int(params["finalizer_banks"])
+    node_count = clusters - 1
+    stage_count = int(math.log2(clusters))
+    slice_bits = _clog2(int(params["value_slices"]))
+    bank_id_bits = _clog2(banks)
+    service_manifest = exact_banked_finalized_tree_service_manifest(
+        clusters=clusters,
+        heads=32,
+        divider_lanes=int(params["divider_lanes"]),
+        finalizer_banks=banks,
+    )
+    manifest = {
+        "version": 1,
+        "top_name": params["top_name"],
+        "generator": "npu/rtlgen/gen_attention_score32_exact_banked_finalized_tree.py",
+        "semantic_profile": "score32_online_exact_banked_finalized_radix2_tree_v1",
+        "clusters": clusters,
+        "radix": int(params["radix"]),
+        "value_slices": int(params["value_slices"]),
+        "head_id_bits": int(params["head_id_bits"]),
+        "divider_lanes": int(params["divider_lanes"]),
+        "finalizer_banks": banks,
+        "tree_stages": stage_count,
+        "tree_nodes": node_count,
+        "result_interface": "clusters_ready_valid_exact_partial_leaf_streams_to_ordered_banked_exact_finalized_root_stream",
+        "partial_payload_bits_per_beat": PARTIAL_PAYLOAD_BITS,
+        "partial_link_bits_per_beat": PARTIAL_LINK_BITS,
+        "final_payload_bits_per_beat": FINAL_PAYLOAD_BITS,
+        "final_link_bits_per_beat": FINAL_LINK_BITS,
+        "order_fifo_depth": banks,
+        "order_fifo_entry_bits": bank_id_bits,
+        "order_fifo_storage_bits": banks * bank_id_bits,
+        "order_fifo_count_bits": _clog2(banks + 1),
+        "ordering_contract": "single_bank_id_fifo_exact_issue_order_one_beat_per_entry",
+        "actual_finalizer_accept_interval_cycles": service_manifest["per_bank_accept_interval_cycles"],
+        "direct_328bit_links_unclosed": True,
+        "final_divider_embodied": True,
+        "noc_closure": False,
+        "sram_closure": False,
+        "macro_eval_excludes_io_pads": True,
+        "equivalence_hash": False,
+        "service_model": service_manifest,
+        "top_pin_estimate_bits": _top_pin_bits(
+            clusters=clusters,
+            head_id_bits=int(params["head_id_bits"]),
+            stages=stage_count,
+            nodes=node_count,
+            slice_bits=slice_bits,
+            banks=banks,
+        ),
+        "submodule_manifests": {
+            "partial_tree": tree_manifest,
+            "root_finalizer": finalizer_manifest,
+        },
+    }
+    (out_dir / "attention_score32_exact_banked_finalized_tree_manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    generate(_load(args.config), args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/rtlgen/gen_attention_score32_exact_root_finalizer.py
+++ b/npu/rtlgen/gen_attention_score32_exact_root_finalizer.py
@@ -286,6 +286,8 @@ def generate(config: dict[str, Any], out_dir: Path) -> None:
         "divider_groups_per_beat": 8 // divider_lanes,
         "divider_iterations_per_group": 57,
         "divider_cycles_per_beat": (8 // divider_lanes) * 57,
+        "output_latency_cycles_per_beat": ((8 // divider_lanes) * 57) + 1,
+        "accept_interval_cycles_per_beat": ((8 // divider_lanes) * 57) + 2,
         "input_value_bits_per_beat": 328,
         "output_value_bits_per_beat": 320,
         "result_interface": "ready_valid_exact_finalized_slice_stream",

--- a/npu/sim/perf/attention_exact_partial.py
+++ b/npu/sim/perf/attention_exact_partial.py
@@ -281,7 +281,7 @@ def simulate_exact_finalizer(
     cycle = 0
     for index, beat in enumerate(finalized):
         accept_events.append({"index": index, "cycle": cycle})
-        cycle += groups * divide_cycles
+        cycle += finalizer_output_latency_cycles(lanes)
         if ready_pattern:
             while not ready_pattern[cycle % len(ready_pattern)]:
                 cycle += 1
@@ -315,6 +315,14 @@ def finalizer_cycles_per_beat(divider_lanes: int) -> int:
     if lanes not in {1, 2, 4, 8}:
         raise ValueError("divider_lanes must be one of 1, 2, 4, 8")
     return (SLICE_LANES // lanes) * 57
+
+
+def finalizer_output_latency_cycles(divider_lanes: int) -> int:
+    return finalizer_cycles_per_beat(divider_lanes) + 1
+
+
+def finalizer_accept_interval_cycles(divider_lanes: int) -> int:
+    return finalizer_cycles_per_beat(divider_lanes) + 2
 
 
 def merge_partial_streams(
@@ -471,11 +479,148 @@ def exact_finalized_tree_service_manifest(
             "divider_groups_per_beat": SLICE_LANES // lanes,
             "divider_iterations_per_group": 57,
             "divider_cycles_per_beat": finalizer_cycles_per_beat(lanes),
+            "per_bank_output_latency_cycles": finalizer_output_latency_cycles(lanes),
+            "per_bank_accept_interval_cycles": finalizer_accept_interval_cycles(lanes),
             "root_output_bytes": ((FINAL_LINK_BITS * VALUE_SLICES * int(heads)) + 7) // 8,
             "direct_328bit_links_unclosed": True,
             "final_divider_embodied": True,
             "finalizer_boundary": "embodied",
             "future_area_sensitivity": "folded_tree_or_lane_count",
+        }
+    )
+    return manifest
+
+
+def simulate_exact_banked_finalizer(
+    stream: Iterable[ExactPartialBeat],
+    *,
+    divider_lanes: int,
+    finalizer_banks: int,
+    output_ready_pattern: Iterable[bool] | None = None,
+) -> dict[str, object]:
+    lanes = int(divider_lanes)
+    banks = int(finalizer_banks)
+    if lanes not in {1, 2, 4, 8}:
+        raise ValueError("divider_lanes must be one of 1, 2, 4, 8")
+    if banks < 1 or banks > 64:
+        raise ValueError("finalizer_banks must be in [1, 64]")
+    beats = tuple(stream)
+    finalized = tuple(finalize_partial_beat(beat) for beat in beats)
+    ready_pattern = tuple(bool(value) for value in output_ready_pattern) if output_ready_pattern is not None else ()
+    divide_cycles = finalizer_cycles_per_beat(lanes)
+    output_latency_cycles = finalizer_output_latency_cycles(lanes)
+    next_issue_index = 0
+    dispatch_bank = 0
+    cycle = 0
+    order_fifo: list[int] = []
+    high_watermark = 0
+    dispatch_stall_cycles = 0
+    bank_state = [
+        {
+            "busy_cycles_left": 0,
+            "output_pending": False,
+            "output_index": -1,
+            "accepted_count": 0,
+            "completed_count": 0,
+        }
+        for _ in range(banks)
+    ]
+    accept_events: list[dict[str, int]] = []
+    result_events: list[dict[str, int | bool]] = []
+
+    while next_issue_index < len(finalized) or order_fifo:
+        head_bank = order_fifo[0] if order_fifo else -1
+        out_ready = ready_pattern[cycle % len(ready_pattern)] if ready_pattern else True
+        dequeue_fire = bool(order_fifo and bank_state[head_bank]["output_pending"] and out_ready)
+        enqueue_ready = (len(order_fifo) < banks) or dequeue_fire
+        selected_bank_ready = (
+            next_issue_index < len(finalized)
+            and bank_state[dispatch_bank]["busy_cycles_left"] == 0
+            and not bank_state[dispatch_bank]["output_pending"]
+        )
+        enqueue_fire = bool(next_issue_index < len(finalized) and enqueue_ready and selected_bank_ready)
+        if next_issue_index < len(finalized) and not enqueue_fire:
+            dispatch_stall_cycles += 1
+
+        if dequeue_fire:
+            output_index = int(bank_state[head_bank]["output_index"])
+            beat = finalized[output_index]
+            result_events.append(
+                {
+                    "index": output_index,
+                    "cycle": cycle,
+                    "bank": head_bank,
+                    "command_id": beat.command_id,
+                    "head_id": beat.head_id,
+                    "slice": beat.slice_index,
+                    "last": beat.last,
+                }
+            )
+
+        if enqueue_fire:
+            bank_state[dispatch_bank]["busy_cycles_left"] = output_latency_cycles
+            bank_state[dispatch_bank]["output_pending"] = False
+            bank_state[dispatch_bank]["output_index"] = next_issue_index
+            bank_state[dispatch_bank]["accepted_count"] += 1
+            accept_events.append({"index": next_issue_index, "cycle": cycle, "bank": dispatch_bank})
+            order_fifo.append(dispatch_bank)
+            high_watermark = max(high_watermark, len(order_fifo))
+            next_issue_index += 1
+            dispatch_bank = (dispatch_bank + 1) % banks
+
+        if dequeue_fire:
+            bank_state[head_bank]["output_pending"] = False
+            bank_state[head_bank]["output_index"] = -1
+            bank_state[head_bank]["completed_count"] += 1
+            order_fifo.pop(0)
+
+        for state in bank_state:
+            if int(state["busy_cycles_left"]) > 0:
+                state["busy_cycles_left"] = int(state["busy_cycles_left"]) - 1
+                if int(state["busy_cycles_left"]) == 0:
+                    state["output_pending"] = True
+
+        cycle += 1
+
+    return {
+        "divider_lanes": lanes,
+        "finalizer_banks": banks,
+        "divider_cycles_per_beat": divide_cycles,
+        "per_bank_output_latency_cycles": output_latency_cycles,
+        "per_bank_accept_interval_cycles": finalizer_accept_interval_cycles(lanes),
+        "accept_events": accept_events,
+        "result_events": result_events,
+        "accepted_count": len(accept_events),
+        "completed_count": len(result_events),
+        "dispatch_stall_cycles": dispatch_stall_cycles,
+        "order_fifo_high_watermark": high_watermark,
+        "drain_cycles": cycle,
+        "bank_accepted_count": [int(state["accepted_count"]) for state in bank_state],
+        "bank_completed_count": [int(state["completed_count"]) for state in bank_state],
+    }
+
+
+def exact_banked_finalized_tree_service_manifest(
+    *,
+    clusters: int,
+    heads: int = 32,
+    divider_lanes: int = 8,
+    finalizer_banks: int = 1,
+) -> dict[str, int | bool | str]:
+    banks = int(finalizer_banks)
+    if banks < 1 or banks > 64:
+        raise ValueError("finalizer_banks must be in [1, 64]")
+    manifest = dict(exact_finalized_tree_service_manifest(clusters=clusters, heads=heads, divider_lanes=divider_lanes))
+    manifest.update(
+        {
+            "finalizer_banks": banks,
+            "order_fifo_depth": banks,
+            "order_fifo_entry_bits": max(1, (banks - 1).bit_length()),
+            "order_fifo_storage_bits": banks * max(1, (banks - 1).bit_length()),
+            "ordering_contract": "round_robin_dispatch_fifo_retire",
+            "per_bank_output_latency_cycles": finalizer_output_latency_cycles(divider_lanes),
+            "per_bank_accept_interval_cycles": finalizer_accept_interval_cycles(divider_lanes),
+            "minimum_banks_for_wrap_free_lane8_service": finalizer_accept_interval_cycles(8),
         }
     )
     return manifest
@@ -496,7 +641,10 @@ __all__ = [
     "VALUE_SLICES",
     "exact_partial_tree_service_manifest",
     "exact_finalized_tree_service_manifest",
+    "exact_banked_finalized_tree_service_manifest",
     "finalizer_cycles_per_beat",
+    "finalizer_output_latency_cycles",
+    "finalizer_accept_interval_cycles",
     "finalize_partial_beat",
     "finalize_partial_beats",
     "finalize_partial_stream",
@@ -509,6 +657,7 @@ __all__ = [
     "partial_stream_from_blocks",
     "pack_final_values",
     "simulate_exact_finalizer",
+    "simulate_exact_banked_finalizer",
     "unpack_final_values",
     "unpack_numerators",
 ]

--- a/runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b1/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b1/config.json
@@ -1,0 +1,11 @@
+{
+  "attention_score32_exact_banked_finalized_tree": {
+    "clusters": 16,
+    "divider_lanes": 8,
+    "finalizer_banks": 1,
+    "head_id_bits": 5,
+    "radix": 2,
+    "value_slices": 16
+  },
+  "top_name": "attention_score32_exact_banked_finalized_tree_c16_r2_l8_b1"
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b16/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b16/config.json
@@ -1,0 +1,11 @@
+{
+  "attention_score32_exact_banked_finalized_tree": {
+    "clusters": 16,
+    "divider_lanes": 8,
+    "finalizer_banks": 16,
+    "head_id_bits": 5,
+    "radix": 2,
+    "value_slices": 16
+  },
+  "top_name": "attention_score32_exact_banked_finalized_tree_c16_r2_l8_b16"
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b32/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b32/config.json
@@ -1,0 +1,11 @@
+{
+  "attention_score32_exact_banked_finalized_tree": {
+    "clusters": 16,
+    "divider_lanes": 8,
+    "finalizer_banks": 32,
+    "head_id_bits": 5,
+    "radix": 2,
+    "value_slices": 16
+  },
+  "top_name": "attention_score32_exact_banked_finalized_tree_c16_r2_l8_b32"
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b57/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b57/config.json
@@ -1,0 +1,11 @@
+{
+  "attention_score32_exact_banked_finalized_tree": {
+    "clusters": 16,
+    "divider_lanes": 8,
+    "finalizer_banks": 57,
+    "head_id_bits": 5,
+    "radix": 2,
+    "value_slices": 16
+  },
+  "top_name": "attention_score32_exact_banked_finalized_tree_c16_r2_l8_b57"
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b58/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b58/config.json
@@ -1,0 +1,11 @@
+{
+  "attention_score32_exact_banked_finalized_tree": {
+    "clusters": 16,
+    "divider_lanes": 8,
+    "finalizer_banks": 58,
+    "head_id_bits": 5,
+    "radix": 2,
+    "value_slices": 16
+  },
+  "top_name": "attention_score32_exact_banked_finalized_tree_c16_r2_l8_b58"
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b59/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b59/config.json
@@ -1,0 +1,11 @@
+{
+  "attention_score32_exact_banked_finalized_tree": {
+    "clusters": 16,
+    "divider_lanes": 8,
+    "finalizer_banks": 59,
+    "head_id_bits": 5,
+    "radix": 2,
+    "value_slices": 16
+  },
+  "top_name": "attention_score32_exact_banked_finalized_tree_c16_r2_l8_b59"
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b64/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b64/config.json
@@ -1,0 +1,11 @@
+{
+  "attention_score32_exact_banked_finalized_tree": {
+    "clusters": 16,
+    "divider_lanes": 8,
+    "finalizer_banks": 64,
+    "head_id_bits": 5,
+    "radix": 2,
+    "value_slices": 16
+  },
+  "top_name": "attention_score32_exact_banked_finalized_tree_c16_r2_l8_b64"
+}

--- a/tests/test_attention_exact_partial.py
+++ b/tests/test_attention_exact_partial.py
@@ -11,7 +11,9 @@ from npu.sim.perf.attention_exact_partial import (
     finalize_partial_beat,
     finalize_partial_beats,
     finalize_partial_stream,
+    finalizer_accept_interval_cycles,
     finalizer_cycles_per_beat,
+    finalizer_output_latency_cycles,
     merge_balanced_partial_streams,
     merge_partial_beats,
     merge_partial_streams,
@@ -177,6 +179,8 @@ def test_exact_finalized_tree_service_manifest_is_consistent() -> None:
     assert manifest["final_link_bits_per_beat"] == FINAL_LINK_BITS == 346
     assert manifest["divider_lanes"] == 8
     assert manifest["divider_cycles_per_beat"] == 57
+    assert manifest["per_bank_output_latency_cycles"] == 58
+    assert manifest["per_bank_accept_interval_cycles"] == 59
     assert manifest["direct_328bit_links_unclosed"] is True
     assert manifest["final_divider_embodied"] is True
 
@@ -248,8 +252,14 @@ def test_exact_finalizer_cycle_reference_scales_with_lane_count() -> None:
     assert finalizer_cycles_per_beat(8) == 57
     assert finalizer_cycles_per_beat(4) == 114
     assert finalizer_cycles_per_beat(1) == 456
+    assert finalizer_output_latency_cycles(8) == 58
+    assert finalizer_output_latency_cycles(4) == 115
+    assert finalizer_output_latency_cycles(1) == 457
+    assert finalizer_accept_interval_cycles(8) == 59
+    assert finalizer_accept_interval_cycles(4) == 116
+    assert finalizer_accept_interval_cycles(1) == 458
     assert lane8["accepted_count"] == 2
     assert lane8["completed_count"] == 2
-    assert lane8["first_output_cycle"] == 57
-    assert lane4["first_output_cycle"] == 114
-    assert lane1["first_output_cycle"] == 456
+    assert lane8["first_output_cycle"] == 58
+    assert lane4["first_output_cycle"] == 115
+    assert lane1["first_output_cycle"] == 457

--- a/tests/test_attention_score32_exact_banked_finalized_tree.py
+++ b/tests/test_attention_score32_exact_banked_finalized_tree.py
@@ -1,0 +1,295 @@
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval.probe_attention_score32_exact_banked_finalized_tree import build_report
+from npu.rtlgen.gen_attention_score32_exact_banked_finalized_tree import generate
+from npu.sim.perf.attention_exact_partial import (
+    ExactPartialBeat,
+    merge_balanced_partial_streams,
+    partial_stream_from_blocks,
+    simulate_exact_banked_finalizer,
+)
+
+
+def _rtl_tools_available() -> bool:
+    return bool(shutil.which("iverilog") and shutil.which("vvp") and shutil.which("verilator"))
+
+
+def _tool(name: str) -> str:
+    path = shutil.which(name)
+    if path:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    if fallback.exists():
+        return str(fallback)
+    raise RuntimeError(f"required tool unavailable: {name}")
+
+
+def _config(finalizer_banks: int, *, clusters: int = 16, divider_lanes: int = 8) -> dict[str, object]:
+    return {
+        "top_name": f"attention_score32_exact_banked_finalized_tree_c{clusters}_r2_l{divider_lanes}_b{finalizer_banks}",
+        "attention_score32_exact_banked_finalized_tree": {
+            "clusters": clusters,
+            "radix": 2,
+            "value_slices": 16,
+            "head_id_bits": 5,
+            "divider_lanes": divider_lanes,
+            "finalizer_banks": finalizer_banks,
+        },
+    }
+
+
+def _commands(heads: int) -> tuple[dict[str, int], ...]:
+    return tuple({"command_id": 0x5A00 + head_index, "head_id": head_index} for head_index in range(heads))
+
+
+def _score_rows(leaf: int, command_index: int) -> tuple[tuple[int, ...], ...]:
+    return tuple(
+        tuple(
+            ((leaf * 43 + command_index * 29 + block * 17 + lane * 11) % 255) - 127 + (14 if lane == block else 0)
+            for lane in range(8)
+        )
+        for block in range(3)
+    )
+
+
+def _value_blocks(leaf: int, command_index: int) -> tuple[tuple[tuple[tuple[int, ...], ...], ...], ...]:
+    return tuple(
+        tuple(
+            tuple(
+                tuple(
+                    ((leaf * 59 + command_index * 31 + block * 23 + value_slice * 13 + row * 7 + lane * 5) % 255)
+                    - 127
+                    for lane in range(8)
+                )
+                for row in range(8)
+            )
+            for value_slice in range(16)
+        )
+        for block in range(3)
+    )
+
+
+def _leaf_stream(leaf: int, *, heads: int) -> tuple[ExactPartialBeat, ...]:
+    beats: list[ExactPartialBeat] = []
+    for command_index, command in enumerate(_commands(heads)):
+        beats.extend(
+            partial_stream_from_blocks(
+                command_id=int(command["command_id"]),
+                head_id=int(command["head_id"]),
+                score_rows=_score_rows(leaf, command_index),
+                value_blocks=_value_blocks(leaf, command_index),
+            )
+        )
+    return tuple(beats)
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="RTL tools unavailable")
+def test_banked_finalized_tree_manifest_and_verilator_lint(tmp_path: Path) -> None:
+    cfg = _config(59, clusters=16, divider_lanes=8)
+    generate(cfg, tmp_path / "rtl")
+
+    manifest = json.loads(
+        (tmp_path / "rtl" / "attention_score32_exact_banked_finalized_tree_manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert manifest["finalizer_banks"] == 59
+    assert manifest["order_fifo_depth"] == 59
+    assert manifest["actual_finalizer_accept_interval_cycles"] == 59
+    assert manifest["service_model"]["minimum_banks_for_wrap_free_lane8_service"] == 59
+    assert manifest["direct_328bit_links_unclosed"] is True
+    assert manifest["final_divider_embodied"] is True
+    assert manifest["noc_closure"] is False
+    assert manifest["sram_closure"] is False
+
+    lint = subprocess.run(
+        [
+            _tool("verilator"),
+            "--lint-only",
+            "--top-module",
+            str(cfg["top_name"]),
+            str(tmp_path / "rtl" / "top.v"),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert lint.returncode == 0, lint.stderr
+
+
+def test_banked_finalized_tree_rejects_invalid_bank_counts(tmp_path: Path) -> None:
+    for banks in (0, 65):
+        with pytest.raises(SystemExit, match="finalizer_banks must be in \\[1, 64\\]"):
+            generate(_config(banks), tmp_path / f"rtl_{banks}")
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="RTL tools unavailable")
+@pytest.mark.parametrize("finalizer_banks", [1, 16, 32, 57, 58, 59, 64])
+def test_banked_finalized_tree_small_probe_all_checked_in_bank_counts(finalizer_banks: int) -> None:
+    report = build_report(clusters=2, heads=1, divider_lanes=8, finalizer_banks=finalizer_banks)
+
+    assert report["passed"] is True
+    assert report["outputs"] == 16
+    assert report["finalizer_accepted_count"] == 16
+    assert report["tree_root_completed_count"] == 16
+    assert report["per_bank_accept_interval_cycles"] == 59
+    assert report["measured_workload_manifest"]["minimum_banks_for_wrap_free_lane8_service"] == 59
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="RTL tools unavailable")
+@pytest.mark.parametrize("finalizer_banks", [1, 59])
+def test_banked_finalized_tree_full_c16_heads32_exact_regression(finalizer_banks: int) -> None:
+    report = build_report(
+        clusters=16,
+        heads=32,
+        divider_lanes=8,
+        finalizer_banks=finalizer_banks,
+        saturated=True,
+        output_ready_pattern=(True,),
+    )
+
+    assert report["passed"] is True
+    assert report["outputs"] == 512
+    assert report["finalizer_accepted_count"] == 512
+    assert report["tree_root_completed_count"] == 512
+    assert report["leaf_accept_count"] == [512] * 16
+    assert report["measured_workload_manifest"]["measured_heads"] == 32
+    assert report["measured_workload_manifest"]["total_leaf_beats"] == 8192
+    assert report["observed_root_hash"] == "027dd06c1e4e1bc77636eb4041aa7efd4fd6e55a090b337a6d33f78da89f65bd"
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="RTL tools unavailable")
+def test_banked_finalized_tree_root_backpressure_order_stress() -> None:
+    report = build_report(
+        clusters=4,
+        heads=4,
+        divider_lanes=8,
+        finalizer_banks=57,
+        saturated=True,
+        output_ready_pattern=(True, False, True, True, False, True, False, True, True, True),
+    )
+
+    assert report["passed"] is True
+    assert report["protocol_error"] is False
+    assert report["order_protocol_error"] is False
+    assert report["finalizer_protocol_error"] is False
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="RTL tools unavailable")
+def test_banked_finalized_tree_non_power_of_two_pointer_wrap() -> None:
+    report = build_report(
+        clusters=4,
+        heads=4,
+        divider_lanes=8,
+        finalizer_banks=57,
+        saturated=True,
+        output_ready_pattern=(True,),
+    )
+
+    assert report["passed"] is True
+    assert report["outputs"] == 64
+    assert report["order_fifo_high_watermark"] <= 57
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="RTL tools unavailable")
+def test_bank59_is_first_wrap_free_lane8_point_under_saturated_no_stall() -> None:
+    bank57 = build_report(
+        clusters=2,
+        heads=5,
+        divider_lanes=8,
+        finalizer_banks=57,
+        saturated=True,
+        output_ready_pattern=(True,),
+    )
+    bank58 = build_report(
+        clusters=2,
+        heads=5,
+        divider_lanes=8,
+        finalizer_banks=58,
+        saturated=True,
+        output_ready_pattern=(True,),
+    )
+    bank59 = build_report(
+        clusters=2,
+        heads=5,
+        divider_lanes=8,
+        finalizer_banks=59,
+        saturated=True,
+        output_ready_pattern=(True,),
+    )
+    bank64 = build_report(
+        clusters=2,
+        heads=5,
+        divider_lanes=8,
+        finalizer_banks=64,
+        saturated=True,
+        output_ready_pattern=(True,),
+    )
+
+    for report in (bank57, bank58, bank59, bank64):
+        assert report["passed"] is True
+
+    interval57 = bank57["measured_workload_manifest"]["measured_root_output_interval_cycles"]
+    interval58 = bank58["measured_workload_manifest"]["measured_root_output_interval_cycles"]
+    interval59 = bank59["measured_workload_manifest"]["measured_root_output_interval_cycles"]
+    interval64 = bank64["measured_workload_manifest"]["measured_root_output_interval_cycles"]
+
+    assert interval57 > interval58 > interval59
+    assert interval59 == interval64
+
+
+def test_bank_wrap_boundary_full_wave_perf_model() -> None:
+    merged = merge_balanced_partial_streams([_leaf_stream(leaf, heads=32) for leaf in range(16)])
+    bank57 = simulate_exact_banked_finalizer(merged, divider_lanes=8, finalizer_banks=57, output_ready_pattern=(True,))
+    bank58 = simulate_exact_banked_finalizer(merged, divider_lanes=8, finalizer_banks=58, output_ready_pattern=(True,))
+    bank59 = simulate_exact_banked_finalizer(merged, divider_lanes=8, finalizer_banks=59, output_ready_pattern=(True,))
+    bank64 = simulate_exact_banked_finalizer(merged, divider_lanes=8, finalizer_banks=64, output_ready_pattern=(True,))
+
+    assert bank57["completed_count"] == 512
+    assert bank58["completed_count"] == 512
+    assert bank59["completed_count"] == 512
+    assert bank64["completed_count"] == 512
+    assert bank57["result_events"][-1]["cycle"] - bank57["result_events"][0]["cycle"] == 527
+    assert bank58["result_events"][-1]["cycle"] - bank58["result_events"][0]["cycle"] == 519
+    assert bank59["result_events"][-1]["cycle"] - bank59["result_events"][0]["cycle"] == 511
+    assert bank64["result_events"][-1]["cycle"] - bank64["result_events"][0]["cycle"] == 511
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="RTL tools unavailable")
+def test_banked_probe_script_runs_without_pythonpath() -> None:
+    env = {key: value for key, value in os.environ.items() if key != "PYTHONPATH"}
+    run = subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/probe_attention_score32_exact_banked_finalized_tree.py",
+            "--clusters",
+            "2",
+            "--heads",
+            "1",
+            "--divider-lanes",
+            "8",
+            "--finalizer-banks",
+            "59",
+            "--json",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=240,
+    )
+    assert run.returncode == 0, run.stderr
+    payload = json.loads(run.stdout)
+    assert payload["passed"] is True
+    assert payload["finalizer_banks"] == 59

--- a/tests/test_attention_score32_exact_finalized_tree.py
+++ b/tests/test_attention_score32_exact_finalized_tree.py
@@ -108,6 +108,8 @@ def test_root_finalizer_and_wrapper_manifests(tmp_path: Path) -> None:
 
     assert finalizer_manifest["divider_lanes"] == 4
     assert finalizer_manifest["divider_cycles_per_beat"] == 114
+    assert finalizer_manifest["output_latency_cycles_per_beat"] == 115
+    assert finalizer_manifest["accept_interval_cycles_per_beat"] == 116
     assert finalizer_manifest["final_divider_embodied"] is True
     assert wrapper_manifest["clusters"] == 16
     assert wrapper_manifest["divider_lanes"] == 8

--- a/tests/test_check_attention_score32_exact_banked_finalized_tree_guard.py
+++ b/tests/test_check_attention_score32_exact_banked_finalized_tree_guard.py
@@ -1,0 +1,140 @@
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_score32_exact_banked_finalized_tree import generate
+
+
+def _config_path(banks: int) -> Path:
+    return (
+        REPO_ROOT
+        / "runs"
+        / "designs"
+        / "npu_blocks"
+        / f"attention_score32_exact_banked_finalized_tree_c16_r2_l8_b{banks}"
+        / "config.json"
+    )
+
+
+def _prepare_design_dir(tmp_path: Path, *, banks: int) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    design_dir = tmp_path / f"attention_score32_exact_banked_finalized_tree_c16_r2_l8_b{banks}"
+    design_dir.mkdir()
+    config = json.loads(_config_path(banks).read_text(encoding="utf-8"))
+    (design_dir / "config.json").write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    generate(config, design_dir / "verilog")
+    return design_dir
+
+
+def _run_guard(design_dir: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/check_attention_score32_exact_banked_finalized_tree_guard.py",
+            "--design-dir",
+            str(design_dir),
+            "--config",
+            str(design_dir / "config.json"),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_banked_exact_finalized_tree_guard_accepts_all_checked_in_configs(tmp_path: Path) -> None:
+    for banks in (1, 16, 32, 57, 58, 59, 64):
+        design_dir = _prepare_design_dir(tmp_path / f"case_{banks}", banks=banks)
+        result = _run_guard(design_dir)
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["finalizer_banks"] == banks
+        assert payload["clusters"] == 16
+        assert payload["tree_nodes"] == 15
+        assert payload["tree_stages"] == 4
+        assert payload["status"] == "ok"
+
+
+def test_banked_exact_finalized_tree_guard_rejects_stale_generated_top(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, banks=59)
+    top_path = design_dir / "verilog" / "top.v"
+    top_path.write_text(top_path.read_text(encoding="utf-8") + "\n// stale artifact drift\n", encoding="utf-8")
+
+    result = _run_guard(design_dir)
+    assert result.returncode != 0
+    assert "generated RTL artifacts do not match current generator output: top.v" in result.stderr
+
+
+def test_banked_exact_finalized_tree_guard_rejects_manifest_boundary_mismatch(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, banks=58)
+    manifest_path = design_dir / "verilog" / "attention_score32_exact_banked_finalized_tree_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["actual_finalizer_accept_interval_cycles"] = 58
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    result = _run_guard(design_dir)
+    assert result.returncode != 0
+    assert "generated manifest actual_finalizer_accept_interval_cycles must be 59" in result.stderr
+
+
+def test_banked_exact_finalized_tree_guard_rejects_missing_order_fifo_token(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, banks=57)
+    top_path = design_dir / "verilog" / "top.v"
+    text = top_path.read_text(encoding="utf-8")
+    top_path.write_text(
+        text.replace(
+            "wire order_fifo_enqueue_ready_w = !order_fifo_full_w || order_fifo_dequeue_fire_w;",
+            "wire order_fifo_enqueue_ready_w = !order_fifo_full_w;",
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run_guard(design_dir)
+    assert result.returncode != 0
+    assert (
+        "generated RTL missing semantic token: wire order_fifo_enqueue_ready_w = !order_fifo_full_w || order_fifo_dequeue_fire_w;"
+        in result.stderr
+    )
+
+
+def test_banked_exact_finalized_tree_guard_rejects_finalizer_combinational_divide(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, banks=59)
+    top_path = design_dir / "verilog" / "top.v"
+    text = top_path.read_text(encoding="utf-8")
+    module_name = "attention_score32_exact_banked_finalized_tree_c16_r2_l8_b59__root_finalizer"
+    pattern = re.compile(rf"(module\s+{re.escape(module_name)}\b.*?)(endmodule\s*)", re.DOTALL)
+    match = pattern.search(text)
+    assert match is not None
+    top_path.write_text(
+        text[: match.start()] + match.group(1) + "  wire [31:0] bad_div = 32'd8 / 32'd2;\n" + match.group(2) + text[match.end() :],
+        encoding="utf-8",
+    )
+
+    result = _run_guard(design_dir)
+    assert result.returncode != 0
+    assert "generated finalizer RTL must not contain combinational division operators" in result.stderr
+
+
+def test_banked_exact_finalized_tree_guard_does_not_flag_pair_merge_division_as_finalizer_divide(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, banks=59)
+    top_path = design_dir / "verilog" / "top.v"
+    text = top_path.read_text(encoding="utf-8")
+    module_name = "attention_score32_exact_banked_finalized_tree_c16_r2_l8_b59__partial_tree__pair_node"
+    pattern = re.compile(rf"(module\s+{re.escape(module_name)}\b.*?)(endmodule\s*)", re.DOTALL)
+    match = pattern.search(text)
+    assert match is not None
+    top_path.write_text(
+        text[: match.start()] + match.group(1) + "  wire [31:0] benign_div = 32'd8 / 32'd2;\n" + match.group(2) + text[match.end() :],
+        encoding="utf-8",
+    )
+
+    result = _run_guard(design_dir)
+    assert result.returncode != 0
+    assert "generated finalizer RTL must not contain combinational division operators" not in result.stderr


### PR DESCRIPTION
## Summary
- add an ordered replicated exact-finalizer bank behind the embodied c16 partial-reduction tree
- model and guard the corrected 57-cycle divide, 58-cycle output latency, and 59-cycle re-accept interval
- prove exact full-wave equivalence and the 59-bank first wrap-free boundary

## Results
- exact output hash for b1/b57/b58/b59/b64: `027dd06c1e4e1bc77636eb4041aa7efd4fd6e55a090b337a6d33f78da89f65bd`
- b1: 59.0 cycles/beat
- b57: 1.031311 cycles/beat
- b58: 1.015656 cycles/beat
- b59: 1.0 cycle/beat
- b64: 1.0 cycle/beat

## Verification
- 68 affected exact-path tests passed
- `python scripts/validate_runs.py --skip_eval_queue` passed
- `git diff --check` passed

Physical PPA is intentionally deferred to a separate guarded remote evaluation job.
