### PR TITLE
Add banked exact finalizer PPA control

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -266,6 +266,23 @@ def _resolve_requested_entry_bool(
     return bool(entry.get(key))
 
 
+def _resolve_requested_entry_int(
+    entry: dict[str, Any] | None,
+    *,
+    key: str,
+    explicit: int,
+    default: int,
+) -> int:
+    if explicit != default:
+        return explicit
+    if not isinstance(entry, dict):
+        return explicit
+    try:
+        return int(entry.get(key, explicit))
+    except (TypeError, ValueError):
+        return explicit
+
+
 def _retry_base(item_id: str) -> str:
     return item_id.rsplit("_r", 1)[0] if "_r" in item_id else item_id
 
@@ -836,6 +853,56 @@ def _read_config_target(
                 },
                 {
                     "name": "extract_attention_score32_exact_root_finalizer_timing_paths",
+                    "run": (
+                        "python3 npu/eval/extract_openroad_timing_summary.py "
+                        f"--design-dir {design_dir} --out {design_dir}/timing_debug_report.md --max-paths 8"
+                    ),
+                },
+            ],
+        )
+    elif "top_name" in cfg and "attention_score32_exact_banked_finalized_tree" in cfg:
+        top_name = str(cfg["top_name"]).strip()
+        if not top_name:
+            raise Layer1TaskGenerationError(f"top_name must not be empty in {config_path}")
+        try:
+            design_dir = str(config_path.parent.resolve().relative_to(repo_root.resolve()))
+        except ValueError as exc:
+            raise Layer1TaskGenerationError(
+                f"score32 exact banked finalized tree config must live under repo_root/runs/designs/...: {config_path}"
+            ) from exc
+        design_name = config_path.parent.name
+        return Layer1ConfigTarget(
+            design_kind="block",
+            design_name=design_name,
+            expected_metrics_path=block_metrics_path(design_name),
+            expected_report_paths=[f"{design_dir}/timing_debug_report.md"],
+            commands=[
+                {
+                    "name": "generate_attention_score32_exact_banked_finalized_tree_rtl",
+                    "run": _with_oss_cad_path(
+                        "python3 npu/rtlgen/gen_attention_score32_exact_banked_finalized_tree.py "
+                        f"--config {config_rel} --out {design_dir}/verilog"
+                    ),
+                },
+                {
+                    "name": "check_attention_score32_exact_banked_finalized_tree_guard",
+                    "run": (
+                        "python3 npu/eval/check_attention_score32_exact_banked_finalized_tree_guard.py "
+                        f"--design-dir {design_dir} --config {config_rel} --sweep {{sweep_path}}"
+                    ),
+                },
+                {
+                    "name": "run_block_sweep",
+                    "run": _with_oss_cad_path(
+                        "python3 npu/synth/run_block_sweep.py "
+                        f"--design_dir {design_dir} --platform {{platform}} --top {top_name} "
+                        f"--sweep {{sweep_path}} --out_root {out_root} "
+                        + (f"--make_target {make_target} " if make_target else "")
+                        + "--skip_existing"
+                    ),
+                },
+                {
+                    "name": "extract_attention_score32_exact_banked_finalized_tree_timing_paths",
                     "run": (
                         "python3 npu/eval/extract_openroad_timing_summary.py "
                         f"--design-dir {design_dir} --out {design_dir}/timing_debug_report.md --max-paths 8"
@@ -1994,6 +2061,12 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
         key="requires_materialized_refs",
         explicit=request.requires_materialized_refs,
     )
+    effective_priority = _resolve_requested_entry_int(
+        requested_entry,
+        key="priority",
+        explicit=request.priority,
+        default=1,
+    )
     _validate_architecture_block_sweep_policy(
         sweep_path=(repo_root / sweep_path).resolve(),
         abstraction_layer=effective_abstraction_layer,
@@ -2129,7 +2202,7 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
         title=title,
         objective=objective,
         requested_by=request.requested_by,
-        priority=request.priority,
+        priority=effective_priority,
         platform=request.platform,
         sweep_path=sweep_path,
         config_paths=config_paths,
@@ -2188,7 +2261,7 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
         platform=request.platform,
         task_type="l1_sweep",
         state=WorkItemState.DRAFT,
-        priority=request.priority,
+        priority=effective_priority,
         source_mode="config",
     )
     transient_task_request = TaskRequest(
@@ -2199,7 +2272,7 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
         description=objective,
         layer=LayerName.LAYER1,
         flow=FlowName.OPENROAD,
-        priority=request.priority,
+        priority=effective_priority,
         request_payload=payload,
         source_commit=source_commit,
     )
@@ -2218,7 +2291,7 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
             description=objective,
             layer=LayerName.LAYER1,
             flow=FlowName.OPENROAD,
-            priority=request.priority,
+            priority=effective_priority,
             request_payload=payload,
             source_commit=source_commit,
         )
@@ -2234,7 +2307,7 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
             platform=request.platform,
             task_type="l1_sweep",
             state=initial_state,
-            priority=request.priority,
+            priority=effective_priority,
             source_mode="config",
             input_manifest=payload["task"]["inputs"],
             command_manifest=payload["task"]["commands"],
@@ -2261,11 +2334,11 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
     existing.task_request.requested_by = request.requested_by
     existing.task_request.title = title
     existing.task_request.description = objective
-    existing.task_request.priority = request.priority
+    existing.task_request.priority = effective_priority
     existing.task_request.request_payload = payload
     existing.task_request.source_commit = source_commit
 
-    existing.priority = request.priority
+    existing.priority = effective_priority
     existing.platform = request.platform
     existing.source_mode = "config"
     existing.input_manifest = payload["task"]["inputs"]

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -1801,6 +1801,58 @@ def _write_example_attention_score32_exact_finalized_tree_repo(repo_root: Path) 
     return str(config_path.relative_to(repo_root)), str(sweep_path.relative_to(repo_root))
 
 
+def _write_example_attention_score32_exact_banked_finalized_tree_repo(repo_root: Path) -> tuple[str, str]:
+    design_dir = repo_root / "runs" / "designs" / "npu_blocks" / "attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b16"
+    design_dir.mkdir(parents=True, exist_ok=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b16",
+                "attention_score32_exact_banked_finalized_tree": {
+                    "clusters": 16,
+                    "radix": 2,
+                    "value_slices": 16,
+                    "head_id_bits": 5,
+                    "divider_lanes": 8,
+                    "finalizer_banks": 16,
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    sweep_path = (
+        repo_root
+        / "runs"
+        / "campaigns"
+        / "npu"
+        / "attention_score32_exact_banked_finalized_tree_v1"
+        / "sweeps"
+        / "nangate45_attention_score32_exact_banked_finalized_tree_c16_bank_firstpass.json"
+    )
+    sweep_path.parent.mkdir(parents=True, exist_ok=True)
+    sweep_path.write_text(
+        json.dumps(
+            {
+                "tag_prefix": "attention_score32_exact_banked_finalized_tree_c16_bank_firstpass_v1",
+                "flow_params": {
+                    "CLOCK_PERIOD": [8.0],
+                    "DIE_AREA": ["0 0 2700 2700"],
+                    "CORE_AREA": ["100 100 2600 2600"],
+                    "PLACE_DENSITY": [0.3, 0.5],
+                    "SYNTH_HIERARCHICAL": [1],
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return str(config_path.relative_to(repo_root)), str(sweep_path.relative_to(repo_root))
+
+
 def _write_second_attention_score32_exact_partial_tree_repo(repo_root: Path) -> str:
     design_dir = repo_root / "runs" / "designs" / "npu_blocks" / "attention_score32_exact_partial_tree_smoke_c16_r2"
     design_dir.mkdir(parents=True, exist_ok=True)
@@ -1860,6 +1912,81 @@ def _write_second_attention_score32_exact_finalized_tree_repo(repo_root: Path) -
                     "value_slices": 16,
                     "head_id_bits": 5,
                     "divider_lanes": 8,
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return str(config_path.relative_to(repo_root))
+
+
+def _write_second_attention_score32_exact_banked_finalized_tree_repo(repo_root: Path) -> str:
+    design_dir = repo_root / "runs" / "designs" / "npu_blocks" / "attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b32"
+    design_dir.mkdir(parents=True, exist_ok=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b32",
+                "attention_score32_exact_banked_finalized_tree": {
+                    "clusters": 16,
+                    "radix": 2,
+                    "value_slices": 16,
+                    "head_id_bits": 5,
+                    "divider_lanes": 8,
+                    "finalizer_banks": 32,
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return str(config_path.relative_to(repo_root))
+
+
+def _write_third_attention_score32_exact_banked_finalized_tree_repo(repo_root: Path) -> str:
+    design_dir = repo_root / "runs" / "designs" / "npu_blocks" / "attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b59"
+    design_dir.mkdir(parents=True, exist_ok=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b59",
+                "attention_score32_exact_banked_finalized_tree": {
+                    "clusters": 16,
+                    "radix": 2,
+                    "value_slices": 16,
+                    "head_id_bits": 5,
+                    "divider_lanes": 8,
+                    "finalizer_banks": 59,
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return str(config_path.relative_to(repo_root))
+
+
+def _write_fourth_attention_score32_exact_banked_finalized_tree_repo(repo_root: Path) -> str:
+    design_dir = repo_root / "runs" / "designs" / "npu_blocks" / "attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b64"
+    design_dir.mkdir(parents=True, exist_ok=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b64",
+                "attention_score32_exact_banked_finalized_tree": {
+                    "clusters": 16,
+                    "radix": 2,
+                    "value_slices": 16,
+                    "head_id_bits": 5,
+                    "divider_lanes": 8,
+                    "finalizer_banks": 64,
                 },
             },
             indent=2,
@@ -3358,6 +3485,115 @@ def test_generate_l1_sweep_task_supports_attention_score32_exact_partial_tree_co
             }
 
 
+def test_generate_l1_sweep_task_supports_attention_score32_exact_banked_finalized_tree_configs() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_attention_score32_exact_banked_finalized_tree_repo(repo_root)
+        proposal_dir = (
+            repo_root
+            / "docs"
+            / "proposals"
+            / "prop_l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1"
+        )
+        proposal_dir.mkdir(parents=True, exist_ok=True)
+        item_id = "l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1"
+        (proposal_dir / "proposal.json").write_text(
+            json.dumps(
+                {
+                    "proposal_id": "prop_l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1",
+                    "abstraction_layer": "architecture_block",
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (proposal_dir / "evaluation_requests.json").write_text(
+            json.dumps(
+                {
+                    "proposal_id": "prop_l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1",
+                    "requested_items": [
+                        {
+                            "item_id": item_id,
+                            "task_type": "l1_sweep",
+                            "evaluation_mode": "frontier_followup",
+                            "abstraction_layer": "architecture_block",
+                            "comparison_role": "exact_banked_finalized_tree_c16_bank_anchor",
+                            "priority": 94,
+                            "expected_result": {
+                                "direction": "measure_exact_banked_finalized_tree_c16_bank_cost",
+                                "reason": "Use the merged banked wrapper to compare sub-wrap, wrap-free, and power-of-two bank counts.",
+                            },
+                        }
+                    ],
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/npu_blocks",
+                    item_id=item_id,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1",
+                    proposal_path=str(proposal_dir.relative_to(repo_root)),
+                    update_proposal_files=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert work_item.priority == 94
+            assert [command["name"] for command in work_item.command_manifest] == [
+                "generate_attention_score32_exact_banked_finalized_tree_rtl",
+                "check_attention_score32_exact_banked_finalized_tree_guard",
+                "run_block_sweep",
+                "extract_attention_score32_exact_banked_finalized_tree_timing_paths",
+                "build_runs_index",
+                "validate",
+            ]
+            assert work_item.command_manifest[0]["run"] == (
+                "export PATH=/oss-cad-suite/bin:$PATH && "
+                "python3 npu/rtlgen/gen_attention_score32_exact_banked_finalized_tree.py "
+                "--config runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b16/config.json "
+                "--out runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b16/verilog"
+            )
+            assert work_item.command_manifest[1]["run"] == (
+                "python3 npu/eval/check_attention_score32_exact_banked_finalized_tree_guard.py "
+                "--design-dir runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b16 "
+                "--config runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b16/config.json "
+                "--sweep runs/campaigns/npu/attention_score32_exact_banked_finalized_tree_v1/sweeps/"
+                "nangate45_attention_score32_exact_banked_finalized_tree_c16_bank_firstpass.json"
+            )
+            assert "--top attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b16" in work_item.command_manifest[2]["run"]
+            assert work_item.command_manifest[3]["run"] == (
+                "python3 npu/eval/extract_openroad_timing_summary.py "
+                "--design-dir runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b16 "
+                "--out runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b16/timing_debug_report.md "
+                "--max-paths 8"
+            )
+            assert work_item.expected_outputs == [
+                "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b16/metrics.csv",
+                "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b16/timing_debug_report.md",
+            ]
+            assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
+                "layer": "architecture_block"
+            }
+
+
 def test_generate_l1_sweep_task_supports_attention_hbm_replay_controller_configs() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"
@@ -3939,6 +4175,44 @@ def test_exact_finalized_tree_c16_lane_ppa_proposal_is_pending_merge_with_all_la
     assert request_entry["sweep_path"] == expected_sweep
     assert "non-additive PPA" in proposal["hypothesis"]
     assert "full decoder composition remain unclosed" in proposal_entry["notes"]
+
+
+def test_exact_banked_finalized_tree_c16_bank_ppa_proposal_is_pending_merge_with_four_bank_configs() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    proposal_dir = (
+        repo_root
+        / "docs"
+        / "proposals"
+        / "prop_l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1"
+    )
+    proposal = json.loads((proposal_dir / "proposal.json").read_text(encoding="utf-8"))
+    evaluation_requests = json.loads((proposal_dir / "evaluation_requests.json").read_text(encoding="utf-8"))
+
+    item_id = "l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1"
+    expected_configs = [
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b16/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b32/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b59/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b64/config.json",
+    ]
+    expected_sweep = (
+        "runs/campaigns/npu/attention_score32_exact_banked_finalized_tree_v1/sweeps/"
+        "nangate45_attention_score32_exact_banked_finalized_tree_c16_bank_firstpass.json"
+    )
+    proposal_entry = {entry["item_id"]: entry for entry in proposal["required_evaluations"]}[item_id]
+    request_entry = {entry["item_id"]: entry for entry in evaluation_requests["requested_items"]}[item_id]
+
+    assert proposal["abstraction_layer"] == "architecture_block"
+    assert proposal_entry["priority"] == 94
+    assert request_entry["priority"] == 94
+    assert proposal_entry["status"] == "pending_implementation_merge"
+    assert request_entry["status"] == "pending_implementation_merge"
+    assert proposal_entry["configs"] == expected_configs
+    assert request_entry["configs"] == expected_configs
+    assert proposal_entry["sweep_path"] == expected_sweep
+    assert request_entry["sweep_path"] == expected_sweep
+    assert "b59 is the first measured one-result/cycle point" in proposal["hypothesis"]
+    assert "100 um perimeter keepout" in proposal_entry["notes"]
 
 
 def test_generate_l1_sweep_task_checked_in_service_requests_gate_and_refresh_release() -> None:
@@ -4922,6 +5196,70 @@ def test_generate_l1_sweep_task_emits_commands_for_each_attention_score32_exact_
                 "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_smoke_c16_r2_l4/timing_debug_report.md",
                 "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_smoke_c16_r2_l8/metrics.csv",
                 "runs/designs/npu_blocks/attention_score32_exact_finalized_tree_smoke_c16_r2_l8/timing_debug_report.md",
+            ]
+
+
+def test_generate_l1_sweep_task_emits_commands_for_each_attention_score32_exact_banked_finalized_tree_config() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_attention_score32_exact_banked_finalized_tree_repo(repo_root)
+        second_config_path = _write_second_attention_score32_exact_banked_finalized_tree_repo(repo_root)
+        third_config_path = _write_third_attention_score32_exact_banked_finalized_tree_repo(repo_root)
+        fourth_config_path = _write_fourth_attention_score32_exact_banked_finalized_tree_repo(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path, second_config_path, third_config_path, fourth_config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/npu_blocks",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="architecture_block",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert [command["name"] for command in work_item.command_manifest] == [
+                "generate_attention_score32_exact_banked_finalized_tree_rtl_attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b16",
+                "check_attention_score32_exact_banked_finalized_tree_guard_attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b16",
+                "run_block_sweep_attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b16",
+                "extract_attention_score32_exact_banked_finalized_tree_timing_paths_attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b16",
+                "generate_attention_score32_exact_banked_finalized_tree_rtl_attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b32",
+                "check_attention_score32_exact_banked_finalized_tree_guard_attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b32",
+                "run_block_sweep_attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b32",
+                "extract_attention_score32_exact_banked_finalized_tree_timing_paths_attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b32",
+                "generate_attention_score32_exact_banked_finalized_tree_rtl_attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b59",
+                "check_attention_score32_exact_banked_finalized_tree_guard_attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b59",
+                "run_block_sweep_attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b59",
+                "extract_attention_score32_exact_banked_finalized_tree_timing_paths_attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b59",
+                "generate_attention_score32_exact_banked_finalized_tree_rtl_attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b64",
+                "check_attention_score32_exact_banked_finalized_tree_guard_attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b64",
+                "run_block_sweep_attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b64",
+                "extract_attention_score32_exact_banked_finalized_tree_timing_paths_attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b64",
+                "build_runs_index",
+                "validate",
+            ]
+            assert "attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b16/config.json" in work_item.command_manifest[0]["run"]
+            assert "attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b32/config.json" in work_item.command_manifest[4]["run"]
+            assert "attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b59/config.json" in work_item.command_manifest[8]["run"]
+            assert "attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b64/config.json" in work_item.command_manifest[12]["run"]
+            assert work_item.expected_outputs == [
+                "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b16/metrics.csv",
+                "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b16/timing_debug_report.md",
+                "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b32/metrics.csv",
+                "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b32/timing_debug_report.md",
+                "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b59/metrics.csv",
+                "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b59/timing_debug_report.md",
+                "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b64/metrics.csv",
+                "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_smoke_c16_r2_l8_b64/timing_debug_report.md",
             ]
 
 

--- a/docs/proposals/prop_l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1/evaluation_requests.json
@@ -1,0 +1,39 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1",
+  "source_commit_note": "Replace with the merge commit that adds the banked exact-finalized-tree configs, strict PPA guard, sweep, and L1 task-generator support before dispatch.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the merged c16/r2/l8 score32 exact banked finalized tree at finalizer banks 16, 32, 59, and 64.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "exact_banked_finalized_tree_c16_bank_anchor",
+      "priority": 94,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b16/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b32/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b59/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b64/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_banked_finalized_tree_v1/sweeps/nangate45_attention_score32_exact_banked_finalized_tree_c16_bank_firstpass.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b16/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b16/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b32/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b32/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b59/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b59/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b64/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b64/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "measure_exact_banked_finalized_tree_c16_bank_cost",
+        "reason": "This records the sub-wrap b16/b32 cost, the first wrap-free b59 point, and the b64 power-of-two overhead while keeping the same merged c16/r2/l8 architecture and fixed perimeter-aware envelope."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "Merged banked wrapper PPA only; 16 external leaf streams, direct 328-bit transport, NoC and SRAM placement, and full decoder composition remain unclosed."
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1/proposal.json
@@ -1,0 +1,85 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1",
+  "created_utc": "2026-07-27T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "title": "Score32 exact banked finalized-tree c16 bank PPA baseline",
+  "abstraction_layer": "architecture_block",
+  "hypothesis": "A merged c16 exact-partial tree plus ordered banked exact finalizer sweep can expose the marginal PPA cost of root-throughput scaling before any transport or full-decoder closure claims are made; b59 is the first measured one-result/cycle point and b64 quantifies the power-of-two overhead above that boundary.",
+  "direct_comparison": {
+    "primary_question": "What Nangate45 area and timing tradeoff comes from the merged c16/r2/l8 ordered banked exact finalized tree when finalizer banks vary across 16, 32, 59, and 64 under a fixed first-pass 8 ns, 2700 um die, and 2500 um square core envelope with a 100 um perimeter keepout?",
+    "candidate": "l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1",
+    "include": [
+      "actual attention_score32_exact_banked_finalized_tree RTL generation",
+      "strict config, manifest, regeneration, membership, and PPA-sweep guard before synthesis",
+      "hierarchical OpenROAD block sweeps at place densities 0.30 and 0.50",
+      "timing-summary extraction for each checked-in bank configuration"
+    ],
+    "exclude": [
+      "no closure claim for the 16 external leaf streams or direct 328-bit transport",
+      "no NoC or SRAM placement closure claim",
+      "no claim that this merged banked macro closes the full decoder attention path"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "die_area",
+      "total_power_mw",
+      "stdcell_count",
+      "timing_debug_report"
+    ]
+  },
+  "remaining_abstractions": [
+    "This item measures only the merged c16 tree plus ordered banked finalizer root; the 16 external leaf streams and direct 328-bit exact-partial transport remain unclosed.",
+    "NoC placement, SRAM placement, and macro-to-macro transport are still open physical risks outside this block-only measurement.",
+    "Full decoder composition remains unclosed, so later integrated conclusions must treat this as a component anchor rather than path closure evidence."
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the merged c16/r2/l8 score32 exact banked finalized tree at finalizer banks 16, 32, 59, and 64.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "exact_banked_finalized_tree_c16_bank_anchor",
+      "priority": 94,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b16/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b32/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b59/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b64/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_banked_finalized_tree_v1/sweeps/nangate45_attention_score32_exact_banked_finalized_tree_c16_bank_firstpass.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b16/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b16/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b32/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b32/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b59/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b59/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b64/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b64/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "measure_exact_banked_finalized_tree_c16_bank_cost",
+        "reason": "This records the sub-wrap b16/b32 cost, the first wrap-free b59 point, and the b64 power-of-two overhead while keeping the same merged c16/r2/l8 architecture and fixed perimeter-aware envelope."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "Use the merged banked wrapper only. The fixed 2700 um die with 100 um perimeter keepout retains the earlier 2500 um core span while leaving more pin-perimeter headroom for the 16 exposed leaf streams plus bank-order monitors; no DB auto-dispatch or materialization is part of this patch."
+    }
+  ],
+  "source_refs": [
+    "npu/rtlgen/gen_attention_score32_exact_banked_finalized_tree.py",
+    "npu/eval/check_attention_score32_exact_banked_finalized_tree_guard.py",
+    "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b16/config.json",
+    "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b32/config.json",
+    "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b59/config.json",
+    "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b64/config.json",
+    "runs/campaigns/npu/attention_score32_exact_banked_finalized_tree_v1/sweeps/nangate45_attention_score32_exact_banked_finalized_tree_c16_bank_firstpass.json"
+  ],
+  "knowledge_refs": [
+    "npu/docs/attention_score32_exact_banked_finalized_tree_contract.md",
+    "npu/docs/attention_score32_exact_root_finalizer_contract.md"
+  ]
+}

--- a/npu/eval/check_attention_score32_exact_banked_finalized_tree_guard.py
+++ b/npu/eval/check_attention_score32_exact_banked_finalized_tree_guard.py
@@ -26,6 +26,15 @@ from npu.sim.perf.attention_exact_partial import (
 
 _SUPPORTED_CLUSTERS = {2, 4, 8, 16}
 _SUPPORTED_LANES = {1, 2, 4, 8}
+_PPA_SWEEP_TAG_PREFIX = "attention_score32_exact_banked_finalized_tree_c16_bank_firstpass_v1"
+_PPA_SWEEP_FLOW_PARAMS = {
+    "CLOCK_PERIOD": [8.0],
+    "DIE_AREA": ["0 0 2700 2700"],
+    "CORE_AREA": ["100 100 2600 2600"],
+    "PLACE_DENSITY": [0.3, 0.5],
+    "SYNTH_HIERARCHICAL": [1],
+}
+_PPA_SWEEP_ALLOWED_BANKS = {16, 32, 59, 64}
 
 
 def _load_json(path: Path) -> dict[str, object]:
@@ -93,10 +102,33 @@ def _compare_current_generation(*, config: dict[str, object], rtl_dir: Path) -> 
                 raise SystemExit(f"generated RTL artifacts do not match current generator output: {relative_name}")
 
 
+def _validate_ppa_sweep(*, config: dict[str, object], sweep_path: Path) -> None:
+    if not sweep_path.is_file():
+        raise SystemExit(f"missing sweep: {sweep_path}")
+    sweep = _load_json(sweep_path)
+    if sweep.get("tag_prefix") != _PPA_SWEEP_TAG_PREFIX:
+        raise SystemExit(f"banked PPA sweep tag_prefix must be {_PPA_SWEEP_TAG_PREFIX}")
+    if sweep.get("flow_params") != _PPA_SWEEP_FLOW_PARAMS:
+        raise SystemExit("banked PPA sweep flow_params do not match the checked-in banked-finalized-tree contract")
+
+    body = config.get("attention_score32_exact_banked_finalized_tree")
+    if not isinstance(body, dict):
+        raise SystemExit("config must contain attention_score32_exact_banked_finalized_tree object")
+    clusters = int(body.get("clusters", 0))
+    radix = int(body.get("radix", 0))
+    divider_lanes = int(body.get("divider_lanes", 0))
+    finalizer_banks = int(body.get("finalizer_banks", 0))
+    if clusters != 16 or radix != 2 or divider_lanes != 8 or finalizer_banks not in _PPA_SWEEP_ALLOWED_BANKS:
+        raise SystemExit(
+            "banked PPA sweep membership requires c16/r2/l8 with finalizer_banks in {16, 32, 59, 64}"
+        )
+
+
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--design-dir", type=Path, required=True)
     ap.add_argument("--config", type=Path, default=None)
+    ap.add_argument("--sweep", type=Path, default=None)
     args = ap.parse_args(argv)
 
     design_dir = args.design_dir.resolve()
@@ -113,6 +145,8 @@ def main(argv: list[str] | None = None) -> int:
     generated_config = _load_json(generated_config_path)
     if config != generated_config:
         raise SystemExit("generated config does not match source config")
+    if args.sweep is not None:
+        _validate_ppa_sweep(config=config, sweep_path=args.sweep.resolve())
 
     top_name = str(config.get("top_name") or "").strip()
     if not top_name:
@@ -185,6 +219,7 @@ def main(argv: list[str] | None = None) -> int:
     }
     for key, expected in expected_manifest.items():
         _require(manifest, key, expected, "generated manifest")
+    _require(manifest, "service_model", service_manifest, "generated manifest")
 
     submanifests = manifest.get("submodule_manifests")
     if not isinstance(submanifests, dict):
@@ -256,6 +291,8 @@ def main(argv: list[str] | None = None) -> int:
     _require_token(finalizer_module, "assign in_ready = (state_q == IDLE) && !out_valid_q;", "generated finalizer RTL")
     if _contains_operator_division(finalizer_module):
         raise SystemExit("generated finalizer RTL must not contain combinational division operators")
+    if "equivalence_hash" in rtl:
+        raise SystemExit("functional datapath must not contain equivalence_hash tokens")
 
     _compare_current_generation(config=config, rtl_dir=rtl_dir)
 

--- a/runs/campaigns/npu/attention_score32_exact_banked_finalized_tree_v1/sweeps/nangate45_attention_score32_exact_banked_finalized_tree_c16_bank_firstpass.json
+++ b/runs/campaigns/npu/attention_score32_exact_banked_finalized_tree_v1/sweeps/nangate45_attention_score32_exact_banked_finalized_tree_c16_bank_firstpass.json
@@ -1,0 +1,21 @@
+{
+  "tag_prefix": "attention_score32_exact_banked_finalized_tree_c16_bank_firstpass_v1",
+  "flow_params": {
+    "CLOCK_PERIOD": [
+      8.0
+    ],
+    "DIE_AREA": [
+      "0 0 2700 2700"
+    ],
+    "CORE_AREA": [
+      "100 100 2600 2600"
+    ],
+    "PLACE_DENSITY": [
+      0.3,
+      0.5
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ]
+  }
+}

--- a/tests/test_check_attention_score32_exact_banked_finalized_tree_guard.py
+++ b/tests/test_check_attention_score32_exact_banked_finalized_tree_guard.py
@@ -33,15 +33,22 @@ def _prepare_design_dir(tmp_path: Path, *, banks: int) -> Path:
 
 
 def _run_guard(design_dir: Path) -> subprocess.CompletedProcess[str]:
+    return _run_guard_with_sweep(design_dir)
+
+
+def _run_guard_with_sweep(design_dir: Path, sweep: Path | None = None) -> subprocess.CompletedProcess[str]:
+    command = [
+        sys.executable,
+        "npu/eval/check_attention_score32_exact_banked_finalized_tree_guard.py",
+        "--design-dir",
+        str(design_dir),
+        "--config",
+        str(design_dir / "config.json"),
+    ]
+    if sweep is not None:
+        command.extend(["--sweep", str(sweep)])
     return subprocess.run(
-        [
-            sys.executable,
-            "npu/eval/check_attention_score32_exact_banked_finalized_tree_guard.py",
-            "--design-dir",
-            str(design_dir),
-            "--config",
-            str(design_dir / "config.json"),
-        ],
+        command,
         cwd=REPO_ROOT,
         check=False,
         capture_output=True,
@@ -138,3 +145,71 @@ def test_banked_exact_finalized_tree_guard_does_not_flag_pair_merge_division_as_
     result = _run_guard(design_dir)
     assert result.returncode != 0
     assert "generated finalizer RTL must not contain combinational division operators" not in result.stderr
+
+
+def test_banked_exact_finalized_tree_guard_accepts_banked_ppa_sweep_membership(tmp_path: Path) -> None:
+    sweep_path = (
+        REPO_ROOT
+        / "runs"
+        / "campaigns"
+        / "npu"
+        / "attention_score32_exact_banked_finalized_tree_v1"
+        / "sweeps"
+        / "nangate45_attention_score32_exact_banked_finalized_tree_c16_bank_firstpass.json"
+    )
+    for banks in (16, 32, 59, 64):
+        design_dir = _prepare_design_dir(tmp_path / f"ppa_case_{banks}", banks=banks)
+        result = _run_guard_with_sweep(design_dir, sweep=sweep_path)
+        assert result.returncode == 0, result.stderr
+
+
+def test_banked_exact_finalized_tree_guard_rejects_non_ppa_bank_membership_when_sweep_is_supplied(tmp_path: Path) -> None:
+    sweep_path = (
+        REPO_ROOT
+        / "runs"
+        / "campaigns"
+        / "npu"
+        / "attention_score32_exact_banked_finalized_tree_v1"
+        / "sweeps"
+        / "nangate45_attention_score32_exact_banked_finalized_tree_c16_bank_firstpass.json"
+    )
+    design_dir = _prepare_design_dir(tmp_path, banks=57)
+    result = _run_guard_with_sweep(design_dir, sweep=sweep_path)
+    assert result.returncode != 0
+    assert "banked PPA sweep membership requires c16/r2/l8 with finalizer_banks in {16, 32, 59, 64}" in result.stderr
+
+
+def test_banked_exact_finalized_tree_guard_rejects_ppa_sweep_knob_drift(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, banks=59)
+    sweep_path = tmp_path / "nangate45_attention_score32_exact_banked_finalized_tree_c16_bank_firstpass.json"
+    sweep_path.write_text(
+        json.dumps(
+            {
+                "tag_prefix": "attention_score32_exact_banked_finalized_tree_c16_bank_firstpass_v1",
+                "flow_params": {
+                    "CLOCK_PERIOD": [8.0],
+                    "DIE_AREA": ["0 0 2500 2500"],
+                    "CORE_AREA": ["50 50 2450 2450"],
+                    "PLACE_DENSITY": [0.3, 0.5],
+                    "SYNTH_HIERARCHICAL": [1],
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_guard_with_sweep(design_dir, sweep=sweep_path)
+    assert result.returncode != 0
+    assert "banked PPA sweep flow_params do not match the checked-in banked-finalized-tree contract" in result.stderr
+
+
+def test_banked_exact_finalized_tree_guard_rejects_equivalence_hash_token_in_datapath(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, banks=59)
+    top_path = design_dir / "verilog" / "top.v"
+    top_path.write_text(top_path.read_text(encoding="utf-8") + "\nwire equivalence_hash = 1'b0;\n", encoding="utf-8")
+
+    result = _run_guard(design_dir)
+    assert result.returncode != 0
+    assert "functional datapath must not contain equivalence_hash tokens" in result.stderr


### PR DESCRIPTION
## Summary
- add a guarded Nangate45 PPA sweep for the c16/r2/l8 ordered exact-finalizer bank at b16, b32, b59, and b64
- enforce fixed physical knobs, exact bank membership, regenerated RTL, service timing, and hash-free functional RTL before synthesis
- add Layer 1 task generation support with proposal-derived priority 94

## Physical envelope
All points use an 8 ns clock, a common 2700 x 2700 um die, a 2500 x 2500 um core, densities 0.30/0.50, and hierarchical synthesis. The larger perimeter avoids repeating known exposed-pin placement failures while preserving a fixed comparison envelope.

## Verification
- 13 focused guard/task-generator tests passed
- `scripts/validate_runs.py --skip_eval_queue` passed
- `git diff --check` passed

This PR does not materialize or dispatch the job.
