### PR TITLE
Recost score32 schedule with exact banked reduction

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6322,6 +6322,47 @@ def _decoder_attention_score32_schedule_wrapper_postroute_activity_power_evidenc
     }
 
 
+def _decoder_attention_score32_exact_reduction_recost_evidence(*, item_id: str) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    source_recost_json = (
+        f"{base}/decoder_attention_composed_datapath_physical_feasibility__"
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1.json"
+    )
+    banked_config = (
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b59/config.json"
+    )
+    out = f"{base}/decoder_attention_score32_exact_reduction_recost__{item_id}.json"
+    report = f"{base}/decoder_attention_score32_exact_reduction_recost__{item_id}.md"
+    return {
+        "inputs": {
+            "attention_score32_exact_reduction_recost_source_json": source_recost_json,
+            "attention_score32_exact_reduction_recost_banked_config": banked_config,
+            "attention_score32_exact_reduction_recost_out": out,
+            "attention_score32_exact_reduction_recost_report": report,
+            "attention_score32_exact_reduction_recost_scope": (
+                "Correct the obsolete 141-cycle score32 schedule-wrapper reduction assumption with the exact "
+                "ordered banked finalized-tree c16/r2/l8/b59 full-wave no-stall service contract while "
+                "preserving the source recost values explicitly and keeping reducer PPA/activity plus "
+                "328-bit transport/NoC/SRAM closure out of scope."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decoder_attention_score32_exact_reduction_recost",
+                "run": (
+                    "python3 npu/eval/audit_llm_decoder_attention_score32_exact_reduction_recost.py "
+                    f"--source-recost-json {source_recost_json} "
+                    f"--banked-config {banked_config} "
+                    f"--out {out} "
+                    f"--out-md {report}"
+                ),
+            }
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_score32_compute_activity_energy_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_attention_score32_compute_activity_energy__{item_id}.json"
@@ -11324,6 +11365,7 @@ def _build_payload(
         "decoder_attention_score32_hbm_controller_replay",
         "decoder_attention_score32_integrated_frontier_ranking",
         "decoder_attention_score32_schedule_wrapper_postroute_activity_power",
+        "decoder_attention_score32_exact_reduction_recost",
         "decoder_attention_score32_compute_activity_energy",
         "decoder_attention_score32_separated_compute_recost",
         "decoder_attention_separated_cluster_equivalence",
@@ -11627,6 +11669,8 @@ def _build_payload(
             decoder_evidence = _decoder_attention_score32_schedule_wrapper_postroute_activity_power_evidence(
                 item_id=item_id
             )
+        elif abstraction_layer_name == "decoder_attention_score32_exact_reduction_recost":
+            decoder_evidence = _decoder_attention_score32_exact_reduction_recost_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_score32_compute_activity_energy":
             decoder_evidence = _decoder_attention_score32_compute_activity_energy_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_score32_separated_compute_recost":

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7354,6 +7354,113 @@ def test_generate_l2_campaign_task_adds_attention_score32_compute_activity_energ
             )
 
 
+def test_generate_l2_campaign_task_adds_attention_score32_exact_reduction_recost_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1/proposal.json",
+                    abstraction_layer="decoder_attention_score32_exact_reduction_recost",
+                    evaluation_mode="frontier_detail",
+                    comparison_role="score32_exact_reduction_recost",
+                    paired_baseline_item_id=(
+                        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1"
+                    ),
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1"
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    priority=98,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert work_item.priority == 98
+            assert [command["name"] for command in commands[:2]] == [
+                "audit_decoder_attention_score32_exact_reduction_recost",
+                "validate_runs",
+            ]
+            assert "audit_llm_decoder_attention_score32_exact_reduction_recost.py" in run
+            assert (
+                "--source-recost-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_composed_datapath_physical_feasibility__"
+                "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1.json"
+            ) in run
+            assert (
+                "--banked-config runs/designs/npu_blocks/"
+                "attention_score32_exact_banked_finalized_tree_c16_r2_l8_b59/config.json"
+            ) in run
+            assert decoder_inputs["attention_score32_exact_reduction_recost_source_json"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_composed_datapath_physical_feasibility__"
+                "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_score32_exact_reduction_recost_banked_config"] == (
+                "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b59/config.json"
+            )
+            assert decoder_inputs["attention_score32_exact_reduction_recost_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_exact_reduction_recost__"
+                "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1.json"
+            )
+            assert decoder_inputs["attention_score32_exact_reduction_recost_scope"].startswith(
+                "Correct the obsolete 141-cycle score32 schedule-wrapper reduction assumption"
+            )
+            assert work_item.task_request.request_payload["developer_loop"] == {
+                "proposal_id": "prop_l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+                "proposal_path": "docs/proposals/prop_l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1/proposal.json",
+                "evaluation": {
+                    "mode": "frontier_detail",
+                    "expected_direction": "",
+                    "expected_reason": "",
+                },
+                "abstraction": {
+                    "layer": "decoder_attention_score32_exact_reduction_recost",
+                },
+                "comparison": {
+                    "role": "score32_exact_reduction_recost",
+                    "paired_baseline_item_id": (
+                        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1"
+                    ),
+                },
+                "dependencies": {
+                    "item_ids": [
+                        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1"
+                    ],
+                    "requires_merged_inputs": True,
+                    "requires_materialized_refs": True,
+                },
+            }
+            assert work_item.task_request.request_payload["task"]["expected_outputs"] == [
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_exact_reduction_recost__"
+                "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1.json",
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_exact_reduction_recost__"
+                "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1.md",
+            ]
+
+
 def test_generate_l2_campaign_task_adds_attention_score32_separated_compute_recost_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,38 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+  "source_commit_note": "Replace with the merge commit that contains this exact-reduction recost implementation after merge and before dispatch. Leave this request pending for manual dispatch only; it must consume merged/materialized inputs, and l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1 must not keep running against the obsolete 141-cycle reduction assumption once this correction artifact exists.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Correct the score32 schedule-wrapper Llama7B reduction schedule using the exact c16/r2/l8/b59 banked finalized-tree full-wave no-stall service contract.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_exact_reduction_recost",
+      "comparison_role": "score32_exact_reduction_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "priority": 98,
+      "revision": {
+        "reason": "obsolete_141_cycle_reduction_schedule_assumption",
+        "superseded_contract": {
+          "source_item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1",
+          "obsolete_best_requested_cross_tile_reduction_cycles": 141,
+          "replacement_cross_tile_reduction_cycles": 574
+        },
+        "blocked_downstream_item_ids": [
+          "l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1"
+        ]
+      },
+      "expected_result": {
+        "direction": "record_score32_exact_reduction_recost",
+        "reason": "Preserve the merged source contract explicitly, emit the corrected exact b59 reduction schedule, and keep the existing activity-power v1 consumer off the obsolete 141-cycle assumption until its own r2 input swap is merged."
+      },
+      "status": "pending",
+      "notes": "Manual dispatch only. Run only the new exact-reduction recost audit, commit one JSON and one Markdown artifact, and do not alter DB state or materialize new refs from this request."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1/proposal.json
@@ -1,0 +1,88 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+  "created_utc": "2026-07-28T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Score32 exact reduction schedule recost for Llama7B",
+  "abstraction_layer": "decoder_attention_score32_exact_reduction_recost",
+  "hypothesis": "The merged score32 schedule-wrapper recost still bakes in an obsolete 141-cycle cross-tile reduction assumption. Replacing only that term with the checked-in c16/r2/l8/b59 exact banked finalized-tree full-wave no-stall service contract should raise the reduction term to 574 cycles, shift per-layer and total latency accordingly, and provide the correction artifact that downstream score32 consumers must adopt before any further wrapper activity-power or integrated rerank revisions.",
+  "direct_comparison": {
+    "primary_question": "How does the score32 schedule-wrapper Llama7B row change when the obsolete 141-cycle reduction assumption is replaced by the exact c16/r2/l8/b59 full-wave banked-finalizer drain contract?",
+    "baseline": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1",
+    "include": [
+      "the merged schedule-wrapper recost JSON as the preserved source contract",
+      "the checked-in c16/r2/l8/b59 exact banked finalized-tree config",
+      "the analytical full-wave saturated service contract derived from tree stages plus exact 57/58/59 finalizer timing",
+      "compact JSON and Markdown outputs only"
+    ],
+    "exclude": [
+      "new RTL compilation or large-wave probe reruns",
+      "exact reducer PPA closure",
+      "exact reducer activity-energy closure",
+      "328-bit transport, NoC, or SRAM closure"
+    ]
+  },
+  "expected_benefit": [
+    "records the corrected reduction schedule without mutating the already-merged source artifact",
+    "preserves the obsolete 141-cycle contract explicitly so downstream consumers can be revised deliberately",
+    "forces later score32 work to adopt the exact b59 reduction schedule before claiming tighter wrapper or frontier conclusions"
+  ],
+  "risks": [
+    "this is still a schedule-only correction and does not close reducer area or activity energy",
+    "the current score32 schedule-wrapper postroute activity-power v1 item remains pointed at the obsolete source recost until a follow-on r2 consumer is merged",
+    "the 328-bit exact transport and memory hierarchy remain unclosed abstractions even after the schedule fix",
+    "producer arrival timing and overlap with the reducer are not embodied here; adding the 574-cycle drain after tile waves is a conservative serialized-stage schedule"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Correct the score32 schedule-wrapper Llama7B reduction schedule using the exact c16/r2/l8/b59 banked finalized-tree full-wave no-stall service contract.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_exact_reduction_recost",
+      "comparison_role": "score32_exact_reduction_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "priority": 98,
+      "revision": {
+        "reason": "obsolete_141_cycle_reduction_schedule_assumption",
+        "superseded_contract": {
+          "source_item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1",
+          "obsolete_best_requested_cross_tile_reduction_cycles": 141,
+          "replacement_cross_tile_reduction_cycles": 574
+        },
+        "blocked_downstream_item_ids": [
+          "l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1"
+        ]
+      },
+      "expected_result": {
+        "direction": "record_score32_exact_reduction_recost",
+        "reason": "Preserve the merged schedule-wrapper source contract explicitly, emit the corrected reduction/layer/total/latency terms from the exact b59 service model, and keep the existing activity-power v1 item off the obsolete 141-cycle assumption until its own r2 consumer revision exists."
+      },
+      "status": "pending",
+      "notes": "Manual dispatch only. This item is evidence-only, depends on merged/materialized inputs, and should land before any downstream score32 wrapper activity-power or frontier consumer is revised to read the corrected reduction artifact."
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1.json",
+    "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b59/config.json",
+    "npu/docs/attention_score32_exact_banked_finalized_tree_contract.md"
+  ],
+  "knowledge_refs": [
+    "npu/eval/audit_llm_decoder_attention_score32_exact_reduction_recost.py",
+    "npu/sim/perf/attention_exact_partial.py",
+    "control_plane/control_plane/services/l2_task_generator.py"
+  ],
+  "remaining_abstractions_after_this_step": [
+    "Exact reducer PPA remains unclosed.",
+    "Exact reducer activity energy remains unclosed.",
+    "328-bit exact transport, NoC, and SRAM composition remain unclosed.",
+    "Producer arrival timing and overlap with the reducer are not embodied here; the 574-cycle drain is still applied after tile waves as a conservative serialized-stage schedule.",
+    "The downstream score32 schedule-wrapper postroute activity-power path still needs an explicit r2 consumer revision after this artifact merges."
+  ]
+}

--- a/npu/docs/attention_score32_exact_banked_finalized_tree_contract.md
+++ b/npu/docs/attention_score32_exact_banked_finalized_tree_contract.md
@@ -47,13 +47,13 @@ finalizers.
 - Full-wave exact output hash for all rows below:
   `027dd06c1e4e1bc77636eb4041aa7efd4fd6e55a090b337a6d33f78da89f65bd`
 
-| banks | first out | last out | interval cycles | cycles/beat |
-| --- | ---: | ---: | ---: | ---: |
-| 1 | 62 | 30211 | 30149 | 59.0 |
-| 57 | 62 | 589 | 527 | 1.031311 |
-| 58 | 62 | 581 | 519 | 1.015656 |
-| 59 | 62 | 573 | 511 | 1.0 |
-| 64 | 62 | 573 | 511 | 1.0 |
+| banks | first out | last out | drain cycles | interval cycles | cycles/beat |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 1 | 62 | 30211 | 30212 | 30149 | 59.0 |
+| 57 | 62 | 589 | 590 | 527 | 1.031311 |
+| 58 | 62 | 581 | 582 | 519 | 1.015656 |
+| 59 | 62 | 573 | 574 | 511 | 1.0 |
+| 64 | 62 | 573 | 574 | 511 | 1.0 |
 
 - These measurements are kept here so direct full-512 RTL evidence remains in
   the checked-in contract without forcing CI to recompile every large bank
@@ -78,3 +78,6 @@ finalizers.
   stream and its hash, not just counts.
 - Saturated service claims must be stated from measured RTL cycles, not from
   divide-iteration counts alone.
+- `exact_no_stall_full_wave_service` means `dispatch_stall_cycles == 0`, which
+  also covers short waves where `root_beats <= finalizer_banks` even if banks
+  are still below the steady-state `59`-cycle reuse interval.

--- a/npu/eval/audit_llm_decoder_attention_score32_exact_reduction_recost.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_exact_reduction_recost.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""Recost the score32 schedule-wrapper row with the exact banked reduction schedule."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+from npu.sim.perf.attention_exact_partial import exact_banked_finalized_tree_full_wave_saturated_service
+
+JsonDict = dict[str, Any]
+
+_MODEL = "llm_decoder_attention_score32_exact_reduction_recost_v1"
+_EXPECTED_SOURCE_ITEM_ID = "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1"
+_EXPECTED_REDUCTION_CYCLES = 141
+_EXPECTED_LAYER_CYCLES = 8231
+_EXPECTED_TOTAL_CYCLES = 263392
+_EXPECTED_HEADS = 32
+_EXPECTED_LAYERS = 32
+_EXPECTED_TILE_WAVES = 8
+_EXPECTED_TILE_SERVICE_CYCLES = 986
+_EXPECTED_QKV_CYCLES = 192
+_EXPECTED_KV_WRITE_CYCLES = 10
+_EXPECTED_CLOCK_NS = 48.6509
+_RECORDED_FULL_WAVE_OUTPUT_HASH = "027dd06c1e4e1bc77636eb4041aa7efd4fd6e55a090b337a6d33f78da89f65bd"
+_RECORDED_B59_PROBE_COMMAND = (
+    "python npu/eval/probe_attention_score32_exact_banked_finalized_tree.py "
+    "--clusters 16 --heads 32 --divider-lanes 8 --finalizer-banks 59 --saturated --root-ready-pattern 1 --json"
+)
+_EXPECTED_CONFIG = {
+    "clusters": 16,
+    "radix": 2,
+    "divider_lanes": 8,
+    "finalizer_banks": 59,
+    "value_slices": 16,
+    "head_id_bits": 5,
+}
+
+
+def _load_json(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return payload
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _canonical_json_sha256(payload: Any) -> str:
+    return hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+
+
+def _portable_path(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(Path(__file__).resolve().parents[2].resolve()).as_posix()
+    except ValueError:
+        return path.resolve().as_posix()
+
+
+def _require_equal(actual: Any, expected: Any, label: str) -> None:
+    if actual != expected:
+        raise ValueError(f"{label} must be {expected!r}, got {actual!r}")
+
+
+def _as_float(value: Any, label: str) -> float:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be a finite number") from exc
+    if not math.isfinite(numeric):
+        raise ValueError(f"{label} must be a finite number")
+    return numeric
+
+
+def _validate_source_contract(payload: JsonDict) -> JsonDict:
+    diagnosis = payload.get("diagnosis")
+    if not isinstance(diagnosis, dict):
+        raise ValueError("source recost payload missing diagnosis")
+    _require_equal(diagnosis.get("decision"), "dual_stream_feasible", "source diagnosis.decision")
+    row = payload.get("best_requested")
+    if not isinstance(row, dict):
+        raise ValueError("source recost payload missing best_requested")
+    _require_equal(row.get("cross_tile_reduction_cycles"), _EXPECTED_REDUCTION_CYCLES, "source reduction cycles")
+    _require_equal(row.get("replica_recost_layer_cycles"), _EXPECTED_LAYER_CYCLES, "source layer cycles")
+    _require_equal(row.get("replica_recost_total_cycles"), _EXPECTED_TOTAL_CYCLES, "source total cycles")
+    _require_equal(row.get("total_cycles"), _EXPECTED_TOTAL_CYCLES, "source total_cycles")
+    _require_equal(row.get("layers"), _EXPECTED_LAYERS, "source layers")
+    _require_equal(row.get("tile_waves"), _EXPECTED_TILE_WAVES, "source tile_waves")
+    _require_equal(
+        row.get("replica_recost_tile_service_cycles"),
+        _EXPECTED_TILE_SERVICE_CYCLES,
+        "source tile service cycles",
+    )
+    _require_equal(row.get("tile_service_cycles"), _EXPECTED_TILE_SERVICE_CYCLES, "source tile_service_cycles")
+    _require_equal(row.get("replica_recost_qkv_cycles"), _EXPECTED_QKV_CYCLES, "source qkv cycles")
+    _require_equal(row.get("kv_write_cycles"), _EXPECTED_KV_WRITE_CYCLES, "source kv_write_cycles")
+    clock_ns = _as_float(row.get("replica_recost_clock_ns"), "source replica_recost_clock_ns")
+    _require_equal(clock_ns, _EXPECTED_CLOCK_NS, "source replica_recost_clock_ns")
+    source_latency_us = _as_float(row.get("replica_recost_latency_us"), "source replica_recost_latency_us")
+    source_throughput = 1_000_000.0 / source_latency_us
+    return {
+        "source_best_requested_original": dict(row),
+        "source_path_decision": diagnosis.get("decision"),
+        "source_best_requested_contract": {
+            "cross_tile_reduction_cycles": _EXPECTED_REDUCTION_CYCLES,
+            "replica_recost_layer_cycles": _EXPECTED_LAYER_CYCLES,
+            "replica_recost_total_cycles": _EXPECTED_TOTAL_CYCLES,
+            "total_cycles": _EXPECTED_TOTAL_CYCLES,
+            "layers": _EXPECTED_LAYERS,
+            "tile_waves": _EXPECTED_TILE_WAVES,
+            "replica_recost_tile_service_cycles": _EXPECTED_TILE_SERVICE_CYCLES,
+            "tile_service_cycles": _EXPECTED_TILE_SERVICE_CYCLES,
+            "replica_recost_qkv_cycles": _EXPECTED_QKV_CYCLES,
+            "kv_write_cycles": _EXPECTED_KV_WRITE_CYCLES,
+            "replica_recost_clock_ns": clock_ns,
+            "replica_recost_latency_us": source_latency_us,
+            "token_throughput_per_s": round(source_throughput, 12),
+        },
+    }
+
+
+def _validate_banked_config(path: Path) -> JsonDict:
+    payload = _load_json(path)
+    body = payload.get("attention_score32_exact_banked_finalized_tree")
+    if not isinstance(body, dict):
+        raise ValueError("banked config missing attention_score32_exact_banked_finalized_tree")
+    for key, expected in _EXPECTED_CONFIG.items():
+        _require_equal(body.get(key), expected, f"banked config {key}")
+    top_name = str(payload.get("top_name") or "").strip()
+    if top_name != "attention_score32_exact_banked_finalized_tree_c16_r2_l8_b59":
+        raise ValueError("banked config top_name must be attention_score32_exact_banked_finalized_tree_c16_r2_l8_b59")
+    return payload
+
+
+def build_report(args: argparse.Namespace) -> JsonDict:
+    source_path = Path(args.source_recost_json).resolve()
+    config_path = Path(args.banked_config).resolve()
+    source_payload = _load_json(source_path)
+    source_contract = _validate_source_contract(source_payload)
+    config_payload = _validate_banked_config(config_path)
+    source_best_requested_original = dict(source_contract["source_best_requested_original"])
+
+    service = exact_banked_finalized_tree_full_wave_saturated_service(
+        clusters=_EXPECTED_CONFIG["clusters"],
+        heads=_EXPECTED_HEADS,
+        divider_lanes=_EXPECTED_CONFIG["divider_lanes"],
+        finalizer_banks=_EXPECTED_CONFIG["finalizer_banks"],
+    )
+    _require_equal(service["exact_no_stall_full_wave_service"], True, "exact no-stall full-wave service")
+    _require_equal(service["first_output_cycle"], 62, "bank59 first_output_cycle")
+    _require_equal(service["last_output_cycle"], 573, "bank59 last_output_cycle")
+    _require_equal(service["drain_cycles"], 574, "bank59 drain_cycles")
+    corrected_reduction_cycles = int(service["drain_cycles"])
+    corrected_layer_cycles = (
+        _EXPECTED_TILE_WAVES * _EXPECTED_TILE_SERVICE_CYCLES
+    ) + _EXPECTED_QKV_CYCLES + _EXPECTED_KV_WRITE_CYCLES + corrected_reduction_cycles
+    corrected_total_cycles = _EXPECTED_LAYERS * corrected_layer_cycles
+    corrected_latency_us = round((corrected_total_cycles * _EXPECTED_CLOCK_NS) / 1000.0, 6)
+    corrected_throughput = round(1_000_000.0 / corrected_latency_us, 12)
+    source_latency_us = _as_float(source_best_requested_original.get("latency_us"), "source latency_us")
+    source_schedule_latency_us = _as_float(
+        source_best_requested_original.get("source_latency_us"),
+        "source source_latency_us",
+    )
+    source_base_cross_tile_reduction_cycles = source_best_requested_original.get("base_cross_tile_reduction_cycles")
+    if source_base_cross_tile_reduction_cycles is not None:
+        source_base_cross_tile_reduction_cycles = int(
+            _as_float(source_base_cross_tile_reduction_cycles, "source base_cross_tile_reduction_cycles")
+        )
+    corrected_replica_recost_latency_slowdown_vs_source = round(corrected_latency_us / source_latency_us, 12)
+    corrected_adjusted_speedup_if_feasible = round(source_schedule_latency_us / corrected_latency_us, 12)
+    corrected_best_requested = dict(source_best_requested_original)
+    corrected_field_updates: JsonDict = {
+        "cross_tile_reduction_cycles": corrected_reduction_cycles,
+        "replica_recost_layer_cycles": corrected_layer_cycles,
+        "layer_cycles": corrected_layer_cycles,
+        "replica_recost_total_cycles": corrected_total_cycles,
+        "total_cycles": corrected_total_cycles,
+        "replica_recost_latency_us": corrected_latency_us,
+        "adjusted_latency_us_if_feasible": corrected_latency_us,
+        "replica_recost_latency_slowdown_vs_source": corrected_replica_recost_latency_slowdown_vs_source,
+        "adjusted_speedup_if_feasible": corrected_adjusted_speedup_if_feasible,
+        "token_throughput_per_s": corrected_throughput,
+        "exact_reduction_replaces_legacy_component_breakdown": True,
+    }
+    if source_base_cross_tile_reduction_cycles is not None:
+        corrected_field_updates["base_cross_tile_reduction_cycles"] = corrected_reduction_cycles
+    corrected_best_requested.update(corrected_field_updates)
+    source_best_requested = source_contract["source_best_requested_contract"]
+    overridden_fields = [
+        field for field in corrected_field_updates if field in source_best_requested_original
+    ]
+    added_fields = [
+        field for field in corrected_field_updates if field not in source_best_requested_original
+    ]
+    return {
+        "version": 1,
+        "model": _MODEL,
+        "decision": "score32_exact_reduction_schedule_recost_recorded",
+        "source_revision": {
+            "source_item_id": _EXPECTED_SOURCE_ITEM_ID,
+            "source_best_requested_preserved": True,
+            "source_best_requested_field_count": len(source_best_requested_original),
+            "source_path_decision": source_contract["source_path_decision"],
+            "source_only_latency_fields_preserved": [
+                field
+                for field in ("latency_us", "source_latency_us", "unconstrained_latency_us")
+                if field in source_best_requested_original
+            ],
+            "overridden_best_requested_fields": overridden_fields,
+            "added_best_requested_fields": added_fields,
+            "legacy_component_breakdown_revision": {
+                "source_base_cross_tile_reduction_cycles": source_base_cross_tile_reduction_cycles,
+                "replacement_base_cross_tile_reduction_cycles": corrected_reduction_cycles
+                if source_base_cross_tile_reduction_cycles is not None
+                else None,
+                "historical_source_diagnostics": {
+                    field: source_best_requested_original[field]
+                    for field in (
+                        "base_cross_tile_local_cycles",
+                        "base_cross_tile_noc_cycles",
+                        "base_cross_tile_vector_cycles",
+                    )
+                    if field in source_best_requested_original
+                },
+            },
+            "obsolete_schedule_assumption": {
+                "cross_tile_reduction_cycles": _EXPECTED_REDUCTION_CYCLES,
+                "replica_recost_layer_cycles": _EXPECTED_LAYER_CYCLES,
+                "replica_recost_total_cycles": _EXPECTED_TOTAL_CYCLES,
+            },
+            "replacement_schedule_contract": {
+                "cross_tile_reduction_cycles": corrected_reduction_cycles,
+                "replica_recost_layer_cycles": corrected_layer_cycles,
+                "replica_recost_total_cycles": corrected_total_cycles,
+            },
+        },
+        "source_artifacts": {
+            "schedule_wrapper_recost_json": {
+                "path": _portable_path(source_path),
+                "file_sha256": _sha256_file(source_path),
+                "canonical_json_sha256": _canonical_json_sha256(source_payload),
+            },
+            "banked_config_json": {
+                "path": _portable_path(config_path),
+                "file_sha256": _sha256_file(config_path),
+                "canonical_json_sha256": _canonical_json_sha256(config_payload),
+            },
+        },
+        "source_contract": source_best_requested,
+        "service_contract_provenance": {
+            "analytical_function": (
+                "npu.sim.perf.attention_exact_partial.exact_banked_finalized_tree_full_wave_saturated_service"
+            ),
+            "checked_in_contract_md": "npu/docs/attention_score32_exact_banked_finalized_tree_contract.md",
+            "validated_config": {
+                "top_name": config_payload["top_name"],
+                **_EXPECTED_CONFIG,
+            },
+            "recorded_exact_output_hash": _RECORDED_FULL_WAVE_OUTPUT_HASH,
+            "recorded_probe_command": _RECORDED_B59_PROBE_COMMAND,
+            "recorded_rtl_evidence": {
+                "bank1": {"first_output_cycle": 62, "last_output_cycle": 30211, "drain_cycles": 30212},
+                "bank57": {"first_output_cycle": 62, "last_output_cycle": 589, "drain_cycles": 590},
+                "bank58": {"first_output_cycle": 62, "last_output_cycle": 581, "drain_cycles": 582},
+                "bank59": {"first_output_cycle": 62, "last_output_cycle": 573, "drain_cycles": 574},
+                "bank64": {"first_output_cycle": 62, "last_output_cycle": 573, "drain_cycles": 574},
+            },
+            "service": service,
+        },
+        "source_best_requested": source_best_requested_original,
+        "corrected_contract": {
+            "cross_tile_reduction_cycles": corrected_reduction_cycles,
+            "base_cross_tile_reduction_cycles": corrected_reduction_cycles
+            if source_base_cross_tile_reduction_cycles is not None
+            else None,
+            "replica_recost_layer_cycles": corrected_layer_cycles,
+            "replica_recost_total_cycles": corrected_total_cycles,
+            "total_cycles": corrected_total_cycles,
+            "heads": _EXPECTED_HEADS,
+            "layers": _EXPECTED_LAYERS,
+            "tile_waves": _EXPECTED_TILE_WAVES,
+            "replica_recost_tile_service_cycles": _EXPECTED_TILE_SERVICE_CYCLES,
+            "tile_service_cycles": _EXPECTED_TILE_SERVICE_CYCLES,
+            "replica_recost_qkv_cycles": _EXPECTED_QKV_CYCLES,
+            "kv_write_cycles": _EXPECTED_KV_WRITE_CYCLES,
+            "replica_recost_clock_ns": _EXPECTED_CLOCK_NS,
+            "replica_recost_latency_us": corrected_latency_us,
+            "adjusted_latency_us_if_feasible": corrected_latency_us,
+            "replica_recost_latency_slowdown_vs_source": corrected_replica_recost_latency_slowdown_vs_source,
+            "adjusted_speedup_if_feasible": corrected_adjusted_speedup_if_feasible,
+            "token_throughput_per_s": corrected_throughput,
+            "exact_reduction_replaces_legacy_component_breakdown": True,
+        },
+        "best_requested": corrected_best_requested,
+        "delta_vs_source": {
+            "cross_tile_reduction_cycles": corrected_reduction_cycles - int(source_best_requested["cross_tile_reduction_cycles"]),
+            "base_cross_tile_reduction_cycles": (
+                corrected_reduction_cycles - source_base_cross_tile_reduction_cycles
+                if source_base_cross_tile_reduction_cycles is not None
+                else None
+            ),
+            "replica_recost_layer_cycles": corrected_layer_cycles - int(source_best_requested["replica_recost_layer_cycles"]),
+            "replica_recost_total_cycles": corrected_total_cycles - int(source_best_requested["replica_recost_total_cycles"]),
+            "replica_recost_latency_us": round(
+                corrected_latency_us - _as_float(source_best_requested["replica_recost_latency_us"], "source contract latency"),
+                12,
+            ),
+            "adjusted_latency_us_if_feasible": round(
+                corrected_latency_us
+                - _as_float(
+                    source_best_requested_original.get("adjusted_latency_us_if_feasible"),
+                    "source adjusted_latency_us_if_feasible",
+                ),
+                12,
+            ),
+            "replica_recost_latency_slowdown_vs_source": round(
+                corrected_replica_recost_latency_slowdown_vs_source
+                - _as_float(
+                    source_best_requested_original.get("replica_recost_latency_slowdown_vs_source"),
+                    "source replica_recost_latency_slowdown_vs_source",
+                ),
+                12,
+            ),
+            "adjusted_speedup_if_feasible": round(
+                corrected_adjusted_speedup_if_feasible
+                - _as_float(
+                    source_best_requested_original.get("adjusted_speedup_if_feasible"),
+                    "source adjusted_speedup_if_feasible",
+                ),
+                12,
+            ),
+            "token_throughput_per_s": round(
+                corrected_throughput
+                - _as_float(
+                    source_best_requested_original.get(
+                        "token_throughput_per_s",
+                        source_best_requested["token_throughput_per_s"],
+                    ),
+                    "source token_throughput_per_s",
+                ),
+                12,
+            ),
+        },
+        "remaining_abstractions": [
+            "Exact reducer PPA remains unclosed; this recost changes schedule cycles only.",
+            "Exact reducer activity energy remains unclosed; no reduction toggle-energy closure is claimed here.",
+            "328-bit exact transport, NoC, and SRAM composition remain unclosed.",
+            "Producer arrival timing and overlap with the reducer are not embodied here; adding the 574-cycle drain after tile waves is a conservative serialized-stage schedule.",
+        ],
+        "summary": {
+            "source_reduction_cycles": int(source_best_requested["cross_tile_reduction_cycles"]),
+            "corrected_reduction_cycles": corrected_reduction_cycles,
+            "source_layer_cycles": int(source_best_requested["replica_recost_layer_cycles"]),
+            "corrected_layer_cycles": corrected_layer_cycles,
+            "source_total_cycles": int(source_best_requested["replica_recost_total_cycles"]),
+            "corrected_total_cycles": corrected_total_cycles,
+            "source_latency_us": _as_float(source_best_requested["replica_recost_latency_us"], "source summary latency"),
+            "corrected_latency_us": corrected_latency_us,
+            "source_adjusted_latency_us_if_feasible": _as_float(
+                source_best_requested_original.get("adjusted_latency_us_if_feasible"),
+                "source summary adjusted latency",
+            ),
+            "corrected_adjusted_latency_us_if_feasible": corrected_latency_us,
+            "source_adjusted_speedup_if_feasible": _as_float(
+                source_best_requested_original.get("adjusted_speedup_if_feasible"),
+                "source summary adjusted speedup",
+            ),
+            "corrected_adjusted_speedup_if_feasible": corrected_adjusted_speedup_if_feasible,
+            "source_token_throughput_per_s": _as_float(
+                source_best_requested_original.get(
+                    "token_throughput_per_s",
+                    source_best_requested["token_throughput_per_s"],
+                ),
+                "source summary token throughput",
+            ),
+            "corrected_token_throughput_per_s": corrected_throughput,
+        },
+    }
+
+
+def _build_markdown(report: JsonDict) -> str:
+    source = report["source_contract"]
+    corrected = report["corrected_contract"]
+    service = report["service_contract_provenance"]["service"]
+    lines = [
+        "# Score32 Exact Reduction Recost",
+        "",
+        f"- decision: `{report['decision']}`",
+        f"- source recost: `{report['source_artifacts']['schedule_wrapper_recost_json']['path']}`",
+        f"- banked config: `{report['source_artifacts']['banked_config_json']['path']}`",
+        f"- analytical service: `{report['service_contract_provenance']['analytical_function']}`",
+        f"- source item: `{report['source_revision']['source_item_id']}`",
+        f"- recorded exact output hash: `{report['service_contract_provenance']['recorded_exact_output_hash']}`",
+        f"- recorded probe command: `{report['service_contract_provenance']['recorded_probe_command']}`",
+        "",
+        "| metric | source | corrected |",
+        "| --- | ---: | ---: |",
+        f"| reduction cycles | {source['cross_tile_reduction_cycles']} | {corrected['cross_tile_reduction_cycles']} |",
+        f"| layer cycles | {source['replica_recost_layer_cycles']} | {corrected['replica_recost_layer_cycles']} |",
+        f"| total cycles | {source['replica_recost_total_cycles']} | {corrected['replica_recost_total_cycles']} |",
+        f"| latency us | {source['replica_recost_latency_us']:.6f} | {corrected['replica_recost_latency_us']:.6f} |",
+        (
+            f"| adjusted latency us if feasible | "
+            f"{report['source_best_requested']['adjusted_latency_us_if_feasible']:.6f} | "
+            f"{corrected['adjusted_latency_us_if_feasible']:.6f} |"
+        ),
+        f"| token/s | {source['token_throughput_per_s']:.5f} | {corrected['token_throughput_per_s']:.5f} |",
+        "",
+        "## Full-Wave Service",
+        "",
+        f"- config: `c16/r2/l8/b59`",
+        (
+            f"- no-stall full-wave root service: first `{service['first_output_cycle']}`, "
+            f"last `{service['last_output_cycle']}`, drain `{service['drain_cycles']}`, "
+            f"interval `{service['interval_cycles']}`, cycles/beat `{service['cycles_per_beat']:.6f}`, "
+            f"dispatch stall `{service['dispatch_stall_cycles']}`"
+        ),
+        (
+            f"- divider contract stays distinct: iterations `{service['divider_iterations_per_group']}`, "
+            f"output latency `{service['per_bank_output_latency_cycles']}`, "
+            f"reaccept `{service['per_bank_accept_interval_cycles']}`"
+        ),
+        (
+            "- schedule interpretation: producer arrival timing and overlap with the reducer are not "
+            "embodied here; the 574-cycle drain is applied after tile waves as a conservative "
+            "serialized-stage schedule"
+        ),
+        "",
+        "## Remaining Abstractions",
+        "",
+    ]
+    lines.extend(f"- {item}" for item in report["remaining_abstractions"])
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-recost-json", type=Path, required=True)
+    parser.add_argument("--banked-config", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    report = build_report(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    args.out_md.parent.mkdir(parents=True, exist_ok=True)
+    args.out_md.write_text(_build_markdown(report), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/sim/perf/attention_exact_partial.py
+++ b/npu/sim/perf/attention_exact_partial.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import math
+import operator
 from typing import Iterable
 
 from npu.sim.perf.attention_online import (
@@ -325,6 +326,70 @@ def finalizer_accept_interval_cycles(divider_lanes: int) -> int:
     return finalizer_cycles_per_beat(divider_lanes) + 2
 
 
+def _require_int_arg(value: object, label: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{label} must be an integer")
+    try:
+        return operator.index(value)
+    except TypeError as exc:
+        raise ValueError(f"{label} must be an integer") from exc
+
+
+def exact_banked_finalized_tree_full_wave_saturated_service(
+    *,
+    clusters: int,
+    heads: int = 32,
+    divider_lanes: int = 8,
+    finalizer_banks: int = 1,
+) -> dict[str, int | float | str | bool]:
+    cluster_count = _require_int_arg(clusters, "clusters")
+    head_count = _require_int_arg(heads, "heads")
+    lanes = _require_int_arg(divider_lanes, "divider_lanes")
+    banks = _require_int_arg(finalizer_banks, "finalizer_banks")
+    if cluster_count < 2 or cluster_count > 16 or (cluster_count & (cluster_count - 1)):
+        raise ValueError("clusters must be a power of two in [2, 16]")
+    if head_count < 1 or head_count > 32:
+        raise ValueError("heads must be in [1, 32]")
+    if lanes not in {1, 2, 4, 8}:
+        raise ValueError("divider_lanes must be one of 1, 2, 4, 8")
+    if banks < 1 or banks > 64:
+        raise ValueError("finalizer_banks must be in [1, 64]")
+
+    tree_stages = int(math.log2(cluster_count))
+    root_beats = head_count * VALUE_SLICES
+    divider_iterations = 57
+    output_latency_cycles = finalizer_output_latency_cycles(lanes)
+    accept_interval_cycles = finalizer_accept_interval_cycles(lanes)
+    first_output_cycle = tree_stages + output_latency_cycles
+    wrap_shortage_cycles = max(0, accept_interval_cycles - banks)
+    wrap_count = (root_beats - 1) // banks if root_beats > 1 else 0
+    dispatch_stall_cycles = wrap_count * wrap_shortage_cycles
+    interval_cycles = (root_beats - 1) + dispatch_stall_cycles if root_beats > 1 else 0
+    last_output_cycle = first_output_cycle + interval_cycles
+    drain_cycles = last_output_cycle + 1
+    return {
+        "service_mode": "full_wave_saturated_no_output_stall",
+        "clusters": cluster_count,
+        "tree_stages": tree_stages,
+        "heads": head_count,
+        "root_beats": root_beats,
+        "divider_lanes": lanes,
+        "finalizer_banks": banks,
+        "divider_iterations_per_group": divider_iterations,
+        "per_bank_output_latency_cycles": output_latency_cycles,
+        "per_bank_accept_interval_cycles": accept_interval_cycles,
+        "wrap_shortage_cycles_per_bank_reuse": wrap_shortage_cycles,
+        "wrap_event_count": wrap_count,
+        "dispatch_stall_cycles": dispatch_stall_cycles,
+        "first_output_cycle": first_output_cycle,
+        "last_output_cycle": last_output_cycle,
+        "interval_cycles": interval_cycles,
+        "cycles_per_beat": interval_cycles / float(max(1, root_beats - 1)),
+        "drain_cycles": drain_cycles,
+        "exact_no_stall_full_wave_service": dispatch_stall_cycles == 0,
+    }
+
+
 def merge_partial_streams(
     left: Iterable[ExactPartialBeat],
     right: Iterable[ExactPartialBeat],
@@ -642,6 +707,7 @@ __all__ = [
     "exact_partial_tree_service_manifest",
     "exact_finalized_tree_service_manifest",
     "exact_banked_finalized_tree_service_manifest",
+    "exact_banked_finalized_tree_full_wave_saturated_service",
     "finalizer_cycles_per_beat",
     "finalizer_output_latency_cycles",
     "finalizer_accept_interval_cycles",

--- a/tests/test_attention_score32_exact_banked_finalized_tree.py
+++ b/tests/test_attention_score32_exact_banked_finalized_tree.py
@@ -15,6 +15,7 @@ from npu.eval.probe_attention_score32_exact_banked_finalized_tree import build_r
 from npu.rtlgen.gen_attention_score32_exact_banked_finalized_tree import generate
 from npu.sim.perf.attention_exact_partial import (
     ExactPartialBeat,
+    exact_banked_finalized_tree_full_wave_saturated_service,
     merge_balanced_partial_streams,
     partial_stream_from_blocks,
     simulate_exact_banked_finalizer,
@@ -264,6 +265,139 @@ def test_bank_wrap_boundary_full_wave_perf_model() -> None:
     assert bank58["result_events"][-1]["cycle"] - bank58["result_events"][0]["cycle"] == 519
     assert bank59["result_events"][-1]["cycle"] - bank59["result_events"][0]["cycle"] == 511
     assert bank64["result_events"][-1]["cycle"] - bank64["result_events"][0]["cycle"] == 511
+
+
+def test_banked_finalized_tree_full_wave_saturated_service_matches_recorded_contract() -> None:
+    bank1 = exact_banked_finalized_tree_full_wave_saturated_service(
+        clusters=16,
+        heads=32,
+        divider_lanes=8,
+        finalizer_banks=1,
+    )
+    bank57 = exact_banked_finalized_tree_full_wave_saturated_service(
+        clusters=16,
+        heads=32,
+        divider_lanes=8,
+        finalizer_banks=57,
+    )
+    bank58 = exact_banked_finalized_tree_full_wave_saturated_service(
+        clusters=16,
+        heads=32,
+        divider_lanes=8,
+        finalizer_banks=58,
+    )
+    bank59 = exact_banked_finalized_tree_full_wave_saturated_service(
+        clusters=16,
+        heads=32,
+        divider_lanes=8,
+        finalizer_banks=59,
+    )
+    bank64 = exact_banked_finalized_tree_full_wave_saturated_service(
+        clusters=16,
+        heads=32,
+        divider_lanes=8,
+        finalizer_banks=64,
+    )
+
+    assert bank1["divider_iterations_per_group"] == 57
+    assert bank1["per_bank_output_latency_cycles"] == 58
+    assert bank1["per_bank_accept_interval_cycles"] == 59
+    assert bank1["first_output_cycle"] == 62
+    assert bank1["last_output_cycle"] == 30211
+    assert bank1["drain_cycles"] == 30212
+    assert bank1["interval_cycles"] == 30149
+    assert bank1["cycles_per_beat"] == pytest.approx(59.0)
+    assert bank1["dispatch_stall_cycles"] == 29638
+    assert bank1["exact_no_stall_full_wave_service"] is False
+
+    assert bank57["first_output_cycle"] == 62
+    assert bank57["last_output_cycle"] == 589
+    assert bank57["drain_cycles"] == 590
+    assert bank57["interval_cycles"] == 527
+    assert bank57["cycles_per_beat"] == pytest.approx(527 / 511)
+    assert bank57["dispatch_stall_cycles"] == 16
+    assert bank57["exact_no_stall_full_wave_service"] is False
+
+    assert bank58["first_output_cycle"] == 62
+    assert bank58["last_output_cycle"] == 581
+    assert bank58["drain_cycles"] == 582
+    assert bank58["interval_cycles"] == 519
+    assert bank58["cycles_per_beat"] == pytest.approx(519 / 511)
+    assert bank58["dispatch_stall_cycles"] == 8
+    assert bank58["exact_no_stall_full_wave_service"] is False
+
+    assert bank59["first_output_cycle"] == 62
+    assert bank59["last_output_cycle"] == 573
+    assert bank59["drain_cycles"] == 574
+    assert bank59["interval_cycles"] == 511
+    assert bank59["cycles_per_beat"] == pytest.approx(1.0)
+    assert bank59["dispatch_stall_cycles"] == 0
+    assert bank59["exact_no_stall_full_wave_service"] is True
+
+    assert bank64["first_output_cycle"] == 62
+    assert bank64["last_output_cycle"] == 573
+    assert bank64["drain_cycles"] == 574
+    assert bank64["interval_cycles"] == 511
+    assert bank64["cycles_per_beat"] == pytest.approx(1.0)
+    assert bank64["dispatch_stall_cycles"] == 0
+    assert bank64["exact_no_stall_full_wave_service"] is True
+
+
+def test_banked_finalized_tree_short_wave_no_stall_without_bank_reuse_wrap() -> None:
+    short_wave = exact_banked_finalized_tree_full_wave_saturated_service(
+        clusters=16,
+        heads=1,
+        divider_lanes=8,
+        finalizer_banks=16,
+    )
+
+    assert short_wave["root_beats"] == 16
+    assert short_wave["wrap_event_count"] == 0
+    assert short_wave["wrap_shortage_cycles_per_bank_reuse"] == 43
+    assert short_wave["dispatch_stall_cycles"] == 0
+    assert short_wave["first_output_cycle"] == 62
+    assert short_wave["last_output_cycle"] == 77
+    assert short_wave["drain_cycles"] == 78
+    assert short_wave["cycles_per_beat"] == pytest.approx(1.0)
+    assert short_wave["exact_no_stall_full_wave_service"] is True
+
+
+def test_banked_finalized_tree_full_wave_saturated_service_rejects_invalid_inputs() -> None:
+    with pytest.raises(ValueError, match="clusters must be a power of two in \\[2, 16\\]"):
+        exact_banked_finalized_tree_full_wave_saturated_service(
+            clusters=3,
+            heads=32,
+            divider_lanes=8,
+            finalizer_banks=59,
+        )
+    with pytest.raises(ValueError, match="heads must be in \\[1, 32\\]"):
+        exact_banked_finalized_tree_full_wave_saturated_service(
+            clusters=16,
+            heads=0,
+            divider_lanes=8,
+            finalizer_banks=59,
+        )
+    with pytest.raises(ValueError, match="divider_lanes must be one of 1, 2, 4, 8"):
+        exact_banked_finalized_tree_full_wave_saturated_service(
+            clusters=16,
+            heads=32,
+            divider_lanes=3,
+            finalizer_banks=59,
+        )
+    with pytest.raises(ValueError, match="finalizer_banks must be in \\[1, 64\\]"):
+        exact_banked_finalized_tree_full_wave_saturated_service(
+            clusters=16,
+            heads=32,
+            divider_lanes=8,
+            finalizer_banks=65,
+        )
+    with pytest.raises(ValueError, match="clusters must be an integer"):
+        exact_banked_finalized_tree_full_wave_saturated_service(
+            clusters=16.0,
+            heads=32,
+            divider_lanes=8,
+            finalizer_banks=59,
+        )
 
 
 @pytest.mark.skipif(not _rtl_tools_available(), reason="RTL tools unavailable")

--- a/tests/test_audit_llm_decoder_attention_score32_exact_reduction_recost.py
+++ b/tests/test_audit_llm_decoder_attention_score32_exact_reduction_recost.py
@@ -1,0 +1,219 @@
+from argparse import Namespace
+import json
+from pathlib import Path
+
+import pytest
+
+from npu.eval.audit_llm_decoder_attention_score32_exact_reduction_recost import build_report
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _inputs(tmp_path: Path) -> Namespace:
+    source_recost_json = tmp_path / "schedule_wrapper_recost.json"
+    banked_config = tmp_path / "banked_config.json"
+    _write(
+        source_recost_json,
+        {
+            "diagnosis": {"decision": "dual_stream_feasible"},
+            "best_requested": {
+                "substituted_compute_arch": "attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2",
+                "substituted_compute_variant_kind": "dual_stream_schedule_wrapper",
+                "substituted_compute_semantic_profile": "score32_exp_lut_div",
+                "replica_recost_area_fit_replica_count": 428,
+                "replica_recost_compute_area_um2": 296797456.0,
+                "replica_recost_compute_power_mw": 25979.6,
+                "measured_dual_stream_composed_power_mw": 60.7,
+                "replica_recost_macs_per_cycle": 109568,
+                "base_cross_tile_reduction_cycles": 141,
+                "base_cross_tile_local_cycles": 48,
+                "base_cross_tile_noc_cycles": 64,
+                "base_cross_tile_vector_cycles": 29,
+                "cross_tile_reduction_cycles": 141,
+                "replica_recost_layer_cycles": 8231,
+                "layer_cycles": 8231,
+                "replica_recost_total_cycles": 263392,
+                "total_cycles": 263392,
+                "layers": 32,
+                "tile_waves": 8,
+                "replica_recost_tile_service_cycles": 986,
+                "tile_service_cycles": 986,
+                "replica_recost_qkv_cycles": 192,
+                "kv_write_cycles": 10,
+                "replica_recost_clock_ns": 48.6509,
+                "replica_recost_latency_us": 12814.257853,
+                "adjusted_latency_us_if_feasible": 12814.257853,
+                "latency_us": 1575.373891,
+                "source_latency_us": 2138.84136,
+                "unconstrained_latency_us": 2133.67369,
+                "replica_recost_latency_slowdown_vs_source": 8.134106,
+                "adjusted_speedup_if_feasible": 0.16691105989405908,
+                "token_throughput_per_s": 78.038371946117,
+            },
+        },
+    )
+    _write(
+        banked_config,
+        {
+            "top_name": "attention_score32_exact_banked_finalized_tree_c16_r2_l8_b59",
+            "attention_score32_exact_banked_finalized_tree": {
+                "clusters": 16,
+                "radix": 2,
+                "value_slices": 16,
+                "head_id_bits": 5,
+                "divider_lanes": 8,
+                "finalizer_banks": 59,
+            },
+        },
+    )
+    return Namespace(source_recost_json=source_recost_json, banked_config=banked_config)
+
+
+def test_exact_reduction_recost_corrects_schedule_wrapper_contract(tmp_path: Path) -> None:
+    report = build_report(_inputs(tmp_path))
+    best = report["best_requested"]
+
+    assert report["decision"] == "score32_exact_reduction_schedule_recost_recorded"
+    assert report["source_contract"]["cross_tile_reduction_cycles"] == 141
+    assert report["source_revision"]["source_item_id"] == (
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1"
+    )
+    assert report["source_revision"]["source_best_requested_preserved"] is True
+    assert report["source_revision"]["source_best_requested_field_count"] == len(report["source_best_requested"])
+    assert report["source_revision"]["source_only_latency_fields_preserved"] == [
+        "latency_us",
+        "source_latency_us",
+        "unconstrained_latency_us",
+    ]
+    assert report["source_revision"]["overridden_best_requested_fields"] == [
+        "cross_tile_reduction_cycles",
+        "replica_recost_layer_cycles",
+        "layer_cycles",
+        "replica_recost_total_cycles",
+        "total_cycles",
+        "replica_recost_latency_us",
+        "adjusted_latency_us_if_feasible",
+        "replica_recost_latency_slowdown_vs_source",
+        "adjusted_speedup_if_feasible",
+        "token_throughput_per_s",
+        "base_cross_tile_reduction_cycles",
+    ]
+    assert report["source_revision"]["added_best_requested_fields"] == [
+        "exact_reduction_replaces_legacy_component_breakdown"
+    ]
+    assert report["source_revision"]["legacy_component_breakdown_revision"] == {
+        "source_base_cross_tile_reduction_cycles": 141,
+        "replacement_base_cross_tile_reduction_cycles": 574,
+        "historical_source_diagnostics": {
+            "base_cross_tile_local_cycles": 48,
+            "base_cross_tile_noc_cycles": 64,
+            "base_cross_tile_vector_cycles": 29,
+        },
+    }
+    assert report["source_best_requested"]["replica_recost_compute_area_um2"] == 296797456.0
+    assert report["source_best_requested"]["replica_recost_compute_power_mw"] == 25979.6
+    assert report["source_best_requested"]["measured_dual_stream_composed_power_mw"] == 60.7
+    assert report["source_best_requested"]["adjusted_latency_us_if_feasible"] == 12814.257853
+    assert report["corrected_contract"]["heads"] == 32
+    assert report["corrected_contract"]["cross_tile_reduction_cycles"] == 574
+    assert report["corrected_contract"]["base_cross_tile_reduction_cycles"] == 574
+    assert report["corrected_contract"]["replica_recost_layer_cycles"] == 8664
+    assert report["corrected_contract"]["replica_recost_total_cycles"] == 277248
+    assert report["corrected_contract"]["replica_recost_latency_us"] == 13488.364723
+    assert report["corrected_contract"]["adjusted_latency_us_if_feasible"] == 13488.364723
+    assert report["corrected_contract"]["replica_recost_latency_slowdown_vs_source"] == pytest.approx(
+        13488.364723 / 1575.373891
+    )
+    assert report["corrected_contract"]["adjusted_speedup_if_feasible"] == pytest.approx(
+        2138.84136 / 13488.364723
+    )
+    assert report["corrected_contract"]["token_throughput_per_s"] == pytest.approx(74.137971543343)
+    assert report["corrected_contract"]["exact_reduction_replaces_legacy_component_breakdown"] is True
+    assert report["service_contract_provenance"]["service"]["first_output_cycle"] == 62
+    assert report["service_contract_provenance"]["service"]["last_output_cycle"] == 573
+    assert report["service_contract_provenance"]["service"]["drain_cycles"] == 574
+    assert report["service_contract_provenance"]["service"]["interval_cycles"] == 511
+    assert report["service_contract_provenance"]["service"]["cycles_per_beat"] == pytest.approx(1.0)
+    assert report["service_contract_provenance"]["service"]["dispatch_stall_cycles"] == 0
+    assert report["service_contract_provenance"]["service"]["divider_iterations_per_group"] == 57
+    assert report["service_contract_provenance"]["service"]["per_bank_output_latency_cycles"] == 58
+    assert report["service_contract_provenance"]["service"]["per_bank_accept_interval_cycles"] == 59
+    assert report["service_contract_provenance"]["recorded_exact_output_hash"] == (
+        "027dd06c1e4e1bc77636eb4041aa7efd4fd6e55a090b337a6d33f78da89f65bd"
+    )
+    assert "--finalizer-banks 59 --saturated --root-ready-pattern 1 --json" in (
+        report["service_contract_provenance"]["recorded_probe_command"]
+    )
+    assert best["replica_recost_compute_area_um2"] == 296797456.0
+    assert best["replica_recost_compute_power_mw"] == 25979.6
+    assert best["measured_dual_stream_composed_power_mw"] == 60.7
+    assert best["replica_recost_area_fit_replica_count"] == 428
+    assert best["replica_recost_macs_per_cycle"] == 109568
+    assert best["latency_us"] == 1575.373891
+    assert best["source_latency_us"] == 2138.84136
+    assert best["unconstrained_latency_us"] == 2133.67369
+    assert best["base_cross_tile_local_cycles"] == 48
+    assert best["base_cross_tile_noc_cycles"] == 64
+    assert best["base_cross_tile_vector_cycles"] == 29
+    assert best["base_cross_tile_reduction_cycles"] == 574
+    assert best["cross_tile_reduction_cycles"] == 574
+    assert best["replica_recost_layer_cycles"] == 8664
+    assert best["layer_cycles"] == 8664
+    assert best["replica_recost_total_cycles"] == 277248
+    assert best["total_cycles"] == 277248
+    assert best["replica_recost_latency_us"] == 13488.364723
+    assert best["adjusted_latency_us_if_feasible"] == 13488.364723
+    assert best["replica_recost_latency_slowdown_vs_source"] == pytest.approx(13488.364723 / 1575.373891)
+    assert best["adjusted_speedup_if_feasible"] == pytest.approx(2138.84136 / 13488.364723)
+    assert best["token_throughput_per_s"] == pytest.approx(74.137971543343)
+    assert best["exact_reduction_replaces_legacy_component_breakdown"] is True
+    assert report["delta_vs_source"]["base_cross_tile_reduction_cycles"] == 433
+    assert report["delta_vs_source"]["cross_tile_reduction_cycles"] == 433
+    assert report["delta_vs_source"]["replica_recost_layer_cycles"] == 433
+    assert report["delta_vs_source"]["replica_recost_total_cycles"] == 13856
+    assert report["delta_vs_source"]["adjusted_latency_us_if_feasible"] == pytest.approx(674.10687)
+    assert report["delta_vs_source"]["replica_recost_latency_slowdown_vs_source"] == pytest.approx(
+        (13488.364723 / 1575.373891) - 8.134106
+    )
+    assert report["delta_vs_source"]["adjusted_speedup_if_feasible"] == pytest.approx(
+        (2138.84136 / 13488.364723) - 0.16691105989405908
+    )
+    assert report["delta_vs_source"]["token_throughput_per_s"] == pytest.approx(74.137971543343 - 78.038371946117)
+    assert report["remaining_abstractions"] == [
+        "Exact reducer PPA remains unclosed; this recost changes schedule cycles only.",
+        "Exact reducer activity energy remains unclosed; no reduction toggle-energy closure is claimed here.",
+        "328-bit exact transport, NoC, and SRAM composition remain unclosed.",
+        "Producer arrival timing and overlap with the reducer are not embodied here; adding the 574-cycle drain after tile waves is a conservative serialized-stage schedule.",
+    ]
+
+
+def test_exact_reduction_recost_rejects_non_b59_config(tmp_path: Path) -> None:
+    args = _inputs(tmp_path)
+    payload = json.loads(args.banked_config.read_text(encoding="utf-8"))
+    payload["attention_score32_exact_banked_finalized_tree"]["finalizer_banks"] = 58
+    _write(args.banked_config, payload)
+
+    with pytest.raises(ValueError, match="banked config finalizer_banks must be 59"):
+        build_report(args)
+
+
+def test_exact_reduction_recost_rejects_mismatched_source_contract(tmp_path: Path) -> None:
+    args = _inputs(tmp_path)
+    payload = json.loads(args.source_recost_json.read_text(encoding="utf-8"))
+    payload["best_requested"]["cross_tile_reduction_cycles"] = 140
+    _write(args.source_recost_json, payload)
+
+    with pytest.raises(ValueError, match="source reduction cycles must be 141"):
+        build_report(args)
+
+
+def test_exact_reduction_recost_rejects_non_finite_source_values(tmp_path: Path) -> None:
+    args = _inputs(tmp_path)
+    payload = json.loads(args.source_recost_json.read_text(encoding="utf-8"))
+    payload["best_requested"]["replica_recost_clock_ns"] = "nan"
+    _write(args.source_recost_json, payload)
+
+    with pytest.raises(ValueError, match="source replica_recost_clock_ns must be a finite number"):
+        build_report(args)


### PR DESCRIPTION
## Summary
- derive full-wave ordered bank service from the embodied tree/finalizer timing contract
- replace the obsolete serialized 141-cycle score32 reduction assumption with c16/r2/l8/b59 drain service of 574 cycles
- add a compact L2 revision audit and strict task-generator path without mutating historical evidence

## Corrected Llama7B schedule
- reduction: 141 -> 574 cycles
- layer: 8231 -> 8664 cycles
- token latency: 12814.257853 -> 13488.364723 us
- throughput: 78.0381 -> 74.1380 token/s

The audit preserves all measured source PPA/control fields. Reducer PPA, reducer activity energy, direct 328-bit transport, and producer/reducer overlap remain explicit open terms; 574 cycles is a conservative serialized-stage recost.

## Verification
- real checked-in recost input produced a 40 KB / 915-line compact report
- 7 focused service/audit tests passed
- focused L2 task-generator test passed
- `scripts/validate_runs.py --skip_eval_queue` passed
- `git diff --check` passed

This PR does not modify the DB or dispatch work.
