### PR TITLE
Add c16 exact-partial producer tree slice

### DIFF
--- a/npu/docs/attention_score32_exact_partial_producer_tree_c16_contract.md
+++ b/npu/docs/attention_score32_exact_partial_producer_tree_c16_contract.md
@@ -1,0 +1,92 @@
+# Score32 Exact Partial Producer Tree c16 Contract
+
+This is the smallest native `c16` producer-coupled exact reduction slice. It
+composes sixteen real `attention_decode_score_multivalue_cluster` producers in
+`result_mode="exact_partial"` directly into the existing
+`c16/r2/l8/b59` ordered banked exact finalized tree.
+
+## Scope
+
+- Each external command carries an explicit `head_id`.
+- The wrapper broadcasts that command to all sixteen producers. It does not
+  infer head identity from tile IDs, wave IDs, or any other proxy.
+- Each producer keeps its own score-block input stream and value-block service
+  interface.
+- The top-level producer interfaces are packed per-producer buses, but each
+  producer still preserves the full exact-partial leaf protocol:
+  `command_id`, `head_id`, signed `global_max`, unsigned `exp_sum`, `slice`,
+  `last`, and `8 x S41` numerators (`328` payload bits).
+- The wrapper feeds those sixteen producer leaves directly into the existing
+  `c16/r2/l8/b59` ordered banked exact finalized tree without functional hash
+  shortcuts in RTL.
+
+## Explicit Non-Claims
+
+- `llama_tile_cadence_unclosed = true`.
+- No claim is made that `16 clusters x 8 tile waves x 986 cycles` has been
+  mapped or closed.
+- No NoC closure is claimed for the direct `328`-bit exact-partial links.
+- No SRAM placement or PPA closure is claimed for this wrapper.
+- No full `heads=32` native RTL simulation claim is recorded here; the checked-in
+  probe stays at `1-2` heads to keep CI tractable.
+
+## Workload Assumptions
+
+- The checked-in probe workload uses `3` score blocks per head.
+- Each block carries `3` score beats into each producer `m1x8` cluster input
+  stream.
+- Heads run in explicit in-order command sequence.
+- The coupled slice preserves ready/valid backpressure equivalence end to end:
+  producer egress -> `c16` tree -> ordered banked finalizer -> finalized root
+  stream.
+
+## Root Timing Boundary
+
+- The reused banked finalized tree still inherits the iterative divider timing:
+  - divide iterations per group: `57`
+  - earliest output latency per banked beat: `58` cycles
+  - earliest re-accept interval per banked beat: `59` cycles
+- `59` banks remains the first wrap-free lane-8 point.
+
+## Comparison Baseline
+
+- The overlap benefit comparison is not producer serialization.
+- The checked-in bound is `producer_parallel_then_reducer_staged`:
+  1. run all sixteen standalone producers from cycle `0`
+  2. wait until all producer phases have drained
+  3. start a standalone `c16/r2/l8/b59` reducer/finalizer phase at that origin
+- A fully serialized `producer_fully_serialized_then_reducer_staged` number may
+  still be reported as diagnostic context only. It is not used for overlap
+  benefit.
+
+## Recorded Native Evidence
+
+- Probe:
+  `python npu/eval/probe_attention_score32_exact_partial_producer_tree_c16.py --config runs/designs/npu_blocks/attention_score32_exact_partial_producer_tree_c16_r2_l8_b59/config.json --json`
+- Date recorded: July 28, 2026
+- Checked-in timing point:
+  - heads: `2`
+  - finalized outputs: `32`
+  - exact finalized hash:
+    `69cab7d0a005e21a6a87562b2073dbf0ad358dfe2c72931340a8dc727b564e70`
+  - integrated first output cycle: `423`
+  - integrated last output cycle: `822`
+  - integrated drain cycles: `824`
+  - producer partial windows: `343-361 -> 752` first/last across the sixteen
+    producers
+  - tree dispatch stalls: `0`
+  - producer-parallel phase drain cycles: `761`
+  - staged reducer first output cycle: `823`
+  - staged reducer last output cycle: `854`
+  - producer-parallel-then-reducer bound cycles: `855`
+  - overlap savings versus producer-parallel-then-reducer: `31` cycles
+  - fully serialized diagnostic drain cycles: `11996`
+
+- Smallest smoke/backpressure point:
+  - heads: `1`
+  - exact finalized hash:
+    `d0aed81a674f7052a2fc6b1fa10fdc402d13210886180602656eae0430e4d4a3`
+  - integrated drain cycles: `448`
+
+These numbers are bounded native c16 overlap evidence only. They are not a
+full-array cadence, NoC, SRAM, or PPA closure claim.

--- a/npu/eval/check_attention_score32_exact_partial_producer_tree_c16_guard.py
+++ b/npu/eval/check_attention_score32_exact_partial_producer_tree_c16_guard.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Strict generated RTL guard for the c16 producer-coupled exact reduction slice."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import sys
+import tempfile
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_score32_exact_partial_producer_tree_c16 import generate
+from npu.sim.perf.attention_exact_partial import (
+    FINAL_LINK_BITS,
+    FINAL_PAYLOAD_BITS,
+    PARTIAL_LINK_BITS,
+    PARTIAL_PAYLOAD_BITS,
+    exact_partial_producer_tree_service_manifest,
+)
+
+_PRODUCERS = 16
+_CLUSTERS = 16
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _resolve_selected_config(*, design_dir: Path, selected: Path | None) -> Path:
+    config_path = selected or (design_dir / "config.json")
+    config_path = config_path.resolve()
+    if not config_path.exists():
+        raise SystemExit(f"missing config: {config_path}")
+    try:
+        relative_path = config_path.relative_to(design_dir)
+    except ValueError as exc:
+        raise SystemExit(f"selected config must live under design-dir: {config_path}") from exc
+    if len(relative_path.parts) != 1:
+        raise SystemExit(f"selected config must be a direct child of design-dir, got: {relative_path.as_posix()}")
+    return config_path
+
+
+def _require(mapping: dict[str, object], key: str, expected: object, label: str) -> None:
+    if mapping.get(key) != expected:
+        raise SystemExit(f"{label} {key} must be {expected}")
+
+
+def _require_token(text: str, token: str, label: str) -> None:
+    if token not in text:
+        raise SystemExit(f"{label} missing semantic token: {token}")
+
+
+def _extract_module(rtl: str, module_name: str) -> str:
+    pattern = re.compile(rf"module\s+{re.escape(module_name)}\b.*?endmodule\s*", re.DOTALL)
+    match = pattern.search(rtl)
+    if match is None:
+        raise SystemExit(f"generated RTL does not define module {module_name}")
+    return match.group(0)
+
+
+def _compare_current_generation(*, config: dict[str, object], rtl_dir: Path) -> None:
+    with tempfile.TemporaryDirectory(prefix="score32_exact_partial_producer_tree_c16_guard_") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        generate(config, temp_dir)
+        for relative_name in (
+            "top.v",
+            "config.json",
+            "attention_score32_exact_partial_producer_tree_c16_manifest.json",
+        ):
+            generated_text = (temp_dir / relative_name).read_text(encoding="utf-8")
+            current_text = (rtl_dir / relative_name).read_text(encoding="utf-8")
+            if generated_text != current_text:
+                raise SystemExit(f"generated RTL artifacts do not match current generator output: {relative_name}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--design-dir", type=Path, required=True)
+    parser.add_argument("--config", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    design_dir = args.design_dir.resolve()
+    config_path = _resolve_selected_config(design_dir=design_dir, selected=args.config)
+    rtl_dir = design_dir / "verilog"
+    generated_config_path = rtl_dir / "config.json"
+    manifest_path = rtl_dir / "attention_score32_exact_partial_producer_tree_c16_manifest.json"
+    top_path = rtl_dir / "top.v"
+    for path in (config_path, generated_config_path, manifest_path, top_path):
+        if not path.is_file():
+            raise SystemExit(f"missing producer-coupled c16 exact tree artifact: {path}")
+
+    config = _load_json(config_path)
+    generated_config = _load_json(generated_config_path)
+    if config != generated_config:
+        raise SystemExit("generated config does not match source config")
+
+    top_name = str(config.get("top_name") or "").strip()
+    body = config.get("attention_score32_exact_partial_producer_tree_c16")
+    if not top_name or not isinstance(body, dict):
+        raise SystemExit("config must contain top_name and attention_score32_exact_partial_producer_tree_c16")
+
+    producers = int(body.get("producers", 0))
+    clusters = int(body.get("clusters", 0))
+    radix = int(body.get("radix", 0))
+    max_blocks = int(body.get("max_blocks", 0))
+    value_slices = int(body.get("value_slices", 0))
+    head_id_bits = int(body.get("head_id_bits", 0))
+    divider_lanes = int(body.get("divider_lanes", 0))
+    finalizer_banks = int(body.get("finalizer_banks", 0))
+    if producers != _PRODUCERS or clusters != _CLUSTERS or radix != 2:
+        raise SystemExit("producer-coupled c16 slice must remain fixed at producers=16, clusters=16, radix=2")
+    if max_blocks < 8 or max_blocks > 16384 or (max_blocks & (max_blocks - 1)):
+        raise SystemExit("max_blocks must be a power of two in [8, 16384]")
+    if value_slices != 16:
+        raise SystemExit("value_slices must remain 16")
+    if head_id_bits < 1 or head_id_bits > 8:
+        raise SystemExit("head_id_bits must be in [1, 8]")
+    if divider_lanes != 8 or finalizer_banks != 59:
+        raise SystemExit("producer-coupled c16 slice must remain on the c16/r2/l8/b59 finalized tree")
+
+    service_model = exact_partial_producer_tree_service_manifest(
+        producers=_PRODUCERS,
+        clusters=_CLUSTERS,
+        heads=int(config.get("probe_defaults", {}).get("heads", 32)) if isinstance(config.get("probe_defaults"), dict) else 32,
+        max_blocks=max_blocks,
+        divider_lanes=divider_lanes,
+        finalizer_banks=finalizer_banks,
+    )
+    manifest = _load_json(manifest_path)
+    expected_manifest = {
+        "top_name": top_name,
+        "generator": "npu/rtlgen/gen_attention_score32_exact_partial_producer_tree_c16.py",
+        "semantic_profile": "score32_online_exact_partial_sixteen_producer_coupled_banked_tree_v1",
+        "producers": _PRODUCERS,
+        "clusters": _CLUSTERS,
+        "radix": 2,
+        "max_blocks": max_blocks,
+        "value_slices": 16,
+        "head_id_bits": head_id_bits,
+        "divider_lanes": 8,
+        "finalizer_banks": 59,
+        "producer_result_mode": "exact_partial",
+        "producer_interface": "packed_per_producer_ready_valid_score_blocks_and_value_blocks",
+        "command_schedule_contract": "in_order_head_commands_broadcast_to_all_sixteen_producers",
+        "head_mapping_contract": "explicit_head_id_no_tile_or_wave_inference",
+        "result_interface": "sixteen_exact_partial_producers_to_c16_ordered_banked_exact_finalized_tree",
+        "partial_payload_bits_per_beat": PARTIAL_PAYLOAD_BITS,
+        "partial_link_bits_per_beat": PARTIAL_LINK_BITS,
+        "final_payload_bits_per_beat": FINAL_PAYLOAD_BITS,
+        "final_link_bits_per_beat": FINAL_LINK_BITS,
+        "comparison_baseline_contract": service_model["comparison_baseline_contract"],
+        "comparison_cycle_origin": service_model["comparison_cycle_origin"],
+        "diagnostic_only_baseline": service_model["diagnostic_only_baseline"],
+        "llama_tile_cadence_unclosed": True,
+        "producer_block_workload_assumptions": service_model["producer_block_workload_assumptions"],
+        "exact_protocols": {
+            "producer_partial_protocol": service_model["producer_partial_protocol"],
+            "finalized_protocol": service_model["finalized_protocol"],
+        },
+        "remaining_abstractions": service_model["remaining_abstractions"],
+        "equivalence_hash": False,
+        "service_model": service_model,
+    }
+    for key, expected in expected_manifest.items():
+        _require(manifest, key, expected, "generated manifest")
+    if isinstance(config.get("probe_defaults"), dict):
+        _require(manifest, "checked_in_probe_defaults", config["probe_defaults"], "generated manifest")
+
+    submodule_manifests = manifest.get("submodule_manifests")
+    if not isinstance(submodule_manifests, dict):
+        raise SystemExit("generated manifest must contain submodule_manifests")
+    producer_manifest = submodule_manifests.get("producer")
+    banked_tree_manifest = submodule_manifests.get("banked_tree")
+    if not isinstance(producer_manifest, dict) or not isinstance(banked_tree_manifest, dict):
+        raise SystemExit("generated manifest must contain producer and banked_tree submodule manifests")
+    _require(submodule_manifests, "producer_instances", _PRODUCERS, "generated manifest")
+    _require(producer_manifest, "generator", "npu/rtlgen/gen_attention_decode_score_multivalue_cluster.py", "producer submodule manifest")
+    _require(producer_manifest, "result_mode", "exact_partial", "producer submodule manifest")
+    _require(producer_manifest, "result_value_bits_per_beat", 328, "producer submodule manifest")
+    _require(producer_manifest, "head_id_bits", head_id_bits, "producer submodule manifest")
+    _require(banked_tree_manifest, "generator", "npu/rtlgen/gen_attention_score32_exact_banked_finalized_tree.py", "banked-tree submodule manifest")
+    _require(banked_tree_manifest, "clusters", _CLUSTERS, "banked-tree submodule manifest")
+    _require(banked_tree_manifest, "divider_lanes", 8, "banked-tree submodule manifest")
+    _require(banked_tree_manifest, "finalizer_banks", 59, "banked-tree submodule manifest")
+    _require(banked_tree_manifest, "actual_finalizer_accept_interval_cycles", 59, "banked-tree submodule manifest")
+    banked_service = banked_tree_manifest.get("service_model")
+    if not isinstance(banked_service, dict):
+        raise SystemExit("banked-tree submodule manifest must contain service_model")
+    _require(banked_service, "divider_iterations_per_group", 57, "banked-tree service model")
+    _require(banked_service, "per_bank_output_latency_cycles", 58, "banked-tree service model")
+    _require(banked_service, "per_bank_accept_interval_cycles", 59, "banked-tree service model")
+    _require(banked_service, "minimum_banks_for_wrap_free_lane8_service", 59, "banked-tree service model")
+
+    rtl = top_path.read_text(encoding="utf-8", errors="replace")
+    producer_top_name = f"{top_name}__producer"
+    banked_tree_top_name = f"{top_name}__banked_tree"
+    top_module = _extract_module(rtl, top_name)
+    _extract_module(rtl, producer_top_name)
+    _extract_module(rtl, banked_tree_top_name)
+
+    if len(re.findall(rf"\bmodule\s+{re.escape(producer_top_name)}\b", rtl)) != 1:
+        raise SystemExit("generated RTL must contain exactly one producer module definition")
+    if len(re.findall(rf"\bmodule\s+{re.escape(banked_tree_top_name)}\b", rtl)) != 1:
+        raise SystemExit("generated RTL must contain exactly one banked-tree module definition")
+    if top_module.count(f"{producer_top_name} u_producer_") != _PRODUCERS:
+        raise SystemExit("generated RTL must instantiate the producer module exactly sixteen times")
+    if top_module.count(f"{banked_tree_top_name} u_banked_tree") != 1:
+        raise SystemExit("generated RTL must instantiate the banked finalized tree exactly once")
+
+    for token in (
+        "assign command_ready = &producer_command_ready_w;",
+        "assign producer_partial_valid = producer_result_valid_w;",
+        "assign producer_partial_ready = producer_result_ready_w;",
+        "assign producer_partial_last = producer_result_last_w;",
+        "assign tree_leaf_valid_w[0] = producer_result_valid_w[0];",
+        "assign tree_leaf_valid_w[15] = producer_result_valid_w[15];",
+        "assign tree_leaf_command_id_w[0 +: 16] = producer_result_command_id_w[0 +: 16];",
+        "assign tree_leaf_command_id_w[240 +: 16] = producer_result_command_id_w[240 +: 16];",
+        f"assign tree_leaf_head_id_w[0 +: {head_id_bits}] = producer_result_head_id_w[0 +: {head_id_bits}];",
+        f"assign tree_leaf_head_id_w[{15 * head_id_bits} +: {head_id_bits}] = producer_result_head_id_w[{15 * head_id_bits} +: {head_id_bits}];",
+        "assign tree_leaf_value_w[0 +: PARTIAL_PAYLOAD_BITS] = producer_result_value_w[0 +: PARTIAL_PAYLOAD_BITS];",
+        f"assign tree_leaf_value_w[{15 * PARTIAL_PAYLOAD_BITS} +: PARTIAL_PAYLOAD_BITS] = producer_result_value_w[{15 * PARTIAL_PAYLOAD_BITS} +: PARTIAL_PAYLOAD_BITS];",
+        "producer_leaf_stall_cycles_q[0 +: 32] <= producer_leaf_stall_cycles_q[0 +: 32] + 1'b1;",
+        f"producer_leaf_stall_cycles_q[{15 * 32} +: 32] <= producer_leaf_stall_cycles_q[{15 * 32} +: 32] + 1'b1;",
+    ):
+        _require_token(top_module, token, "generated RTL")
+
+    if "equivalence_hash" in rtl:
+        raise SystemExit("functional datapath must not contain equivalence_hash tokens")
+
+    _compare_current_generation(config=config, rtl_dir=rtl_dir)
+
+    print(
+        json.dumps(
+            {
+                "design": top_name,
+                "guard": "attention_score32_exact_partial_producer_tree_c16_v1",
+                "producers": producers,
+                "clusters": clusters,
+                "divider_lanes": divider_lanes,
+                "finalizer_banks": finalizer_banks,
+                "status": "ok",
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/probe_attention_score32_exact_partial_producer_tree_c16.py
+++ b/npu/eval/probe_attention_score32_exact_partial_producer_tree_c16.py
@@ -1,0 +1,1350 @@
+#!/usr/bin/env python3
+"""Probe the native c16 producer-coupled exact reduction slice."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_decode_score_multivalue_cluster import generate as generate_cluster
+from npu.rtlgen.gen_attention_score32_exact_partial_producer_tree_c16 import (
+    generate as generate_tree,
+)
+from npu.sim.perf.attention_exact_partial import (
+    exact_banked_finalized_tree_full_wave_saturated_service,
+    exact_partial_producer_tree_service_manifest,
+    finalize_partial_beats,
+    merge_balanced_partial_streams,
+    partial_stream_from_blocks,
+    unpack_final_values,
+)
+from npu.sim.perf.attention_online import requantize_score_row
+
+JsonDict = dict[str, Any]
+
+_PRODUCERS = 16
+_BLOCK_COUNT = 3
+_HEAD_DIM = 3
+_VALUE_SLICES = 16
+
+_COMMAND_RE = re.compile(r"COMMAND_ACCEPT idx=(\d+) cmd=(\d+) head=(\d+) cycle=(\d+)")
+_PARTIAL_RE = re.compile(
+    r"PARTIAL_RESULT producer=(\d+) cmd=(\d+) head=(\d+) slice=(\d+) last=(\d+) max=(-?\d+) sum=(\d+) value=([0-9a-fA-F]+) cycle=(\d+)"
+)
+_ROOT_RE = re.compile(
+    r"ROOT_RESULT cmd=(\d+) head=(\d+) slice=(\d+) last=(\d+) value=([0-9a-fA-F]+) cycle=(\d+)"
+)
+_SUMMARY_RE = re.compile(
+    r"SUMMARY outputs=(\d+) drain=(\d+) first_root=(-?\d+) last_root=(-?\d+) protocol_error=(\d+) "
+    r"command_accept=(\d+) command_complete=(\d+) tree_stall=(\d+) root_completed=(\d+) "
+    r"finalizer_accepted=(\d+) tree_error=(\d+) order_error=(\d+) finalizer_error=(\d+)"
+)
+_PRODUCER_SUMMARY_RE = re.compile(
+    r"PRODUCER_SUMMARY producer=(\d+) accept=(\d+) complete=(\d+) leaf_stall=(\d+) error=(\d+)"
+)
+_STANDALONE_PARTIAL_RE = re.compile(
+    r"PARTIAL_RESULT cmd=(\d+) head=(\d+) slice=(\d+) last=(\d+) max=(-?\d+) sum=(\d+) value=([0-9a-fA-F]+) cycle=(\d+)"
+)
+_STANDALONE_SUMMARY_RE = re.compile(
+    r"SUMMARY outputs=(\d+) drain=(\d+) protocol_error=(\d+) accept=(\d+) complete=(\d+)"
+)
+
+_FAKERAM_MODEL = """
+module fakeram45_2048x39 (
+    output wire [38:0] rd_out, input wire [10:0] addr_in,
+    input wire we_in, input wire [38:0] wd_in, input wire [38:0] w_mask_in,
+    input wire clk, input wire ce_in
+);
+  reg [38:0] mem [0:2047];
+  reg [10:0] addr_q;
+  reg [38:0] rd_out_q;
+  integer idx;
+  initial begin addr_q = 0; rd_out_q = 0; for (idx = 0; idx < 2048; idx = idx + 1) mem[idx] = 0; end
+  always @(posedge clk) begin
+    rd_out_q <= mem[addr_q];
+    if (ce_in) begin
+      if (we_in) for (idx = 0; idx < 39; idx = idx + 1)
+        if (w_mask_in[idx]) mem[addr_in][idx] <= wd_in[idx];
+      addr_q <= addr_in;
+    end
+  end
+  assign rd_out = rd_out_q;
+endmodule
+"""
+
+
+def _tool(name: str) -> str:
+    path = shutil.which(name)
+    if path:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    if fallback.exists():
+        return str(fallback)
+    raise RuntimeError(f"required tool unavailable: {name}")
+
+
+def _hash(value: object) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def _pack(values: list[int], bits: int) -> int:
+    mask = (1 << bits) - 1
+    return sum((int(value) & mask) << (index * bits) for index, value in enumerate(values))
+
+
+def _signed_literal(value: int, bits: int) -> str:
+    return f"-{bits}'sd{abs(value)}" if value < 0 else f"{bits}'sd{value}"
+
+
+def _default_config() -> JsonDict:
+    return {
+        "top_name": "attention_score32_exact_partial_producer_tree_c16_r2_l8_b59",
+        "attention_score32_exact_partial_producer_tree_c16": {
+            "producers": 16,
+            "clusters": 16,
+            "radix": 2,
+            "max_blocks": 16,
+            "value_slices": 16,
+            "head_id_bits": 5,
+            "divider_lanes": 8,
+            "finalizer_banks": 59,
+        },
+        "probe_defaults": {
+            "heads": 2,
+        },
+    }
+
+
+def _command_schedule(heads: int) -> tuple[dict[str, int], ...]:
+    if heads < 1 or heads > 32:
+        raise ValueError("heads must be in [1, 32]")
+    schedule = []
+    for head in range(heads):
+        multiplier, shift = ((1 << 20), 0) if head % 3 == 0 else (7 + (head * 3), 1 if head % 3 == 1 else 2)
+        schedule.append(
+            {
+                "command_id": 0x7600 + head,
+                "head_id": head,
+                "multiplier": multiplier,
+                "shift": shift,
+            }
+        )
+    return tuple(schedule)
+
+
+def _beats_for(producer: int, command_index: int) -> list[list[tuple[int, list[int]]]]:
+    blocks: list[list[tuple[int, list[int]]]] = []
+    for block in range(_BLOCK_COUNT):
+        block_beats: list[tuple[int, list[int]]] = []
+        for beat in range(_HEAD_DIM):
+            q = ((producer * 29 + command_index * 17 + block * 11 + beat * 7) % 63) - 31
+            keys = [
+                ((producer * 43 + command_index * 19 + block * 13 + beat * 5 + lane * 3) % 127) - 63
+                for lane in range(8)
+            ]
+            block_beats.append((q, keys))
+        blocks.append(block_beats)
+    return blocks
+
+
+def _values_for(producer: int, command_index: int) -> list[list[list[list[int]]]]:
+    return [
+        [
+            [
+                [
+                    ((producer * 53 + command_index * 31 + block * 17 + value_slice * 13 + row * 7 + lane * 5) % 255)
+                    - 127
+                    for lane in range(8)
+                ]
+                for row in range(8)
+            ]
+            for value_slice in range(_VALUE_SLICES)
+        ]
+        for block in range(_BLOCK_COUNT)
+    ]
+
+
+def _raw_scores(block: list[tuple[int, list[int]]]) -> list[int]:
+    return [sum(query * keys[lane] for query, keys in block) for lane in range(8)]
+
+
+def _expected(heads: int) -> JsonDict:
+    commands = _command_schedule(heads)
+    producer_rows: list[list[dict[str, object]]] = [[] for _ in range(_PRODUCERS)]
+    finalized_rows: list[dict[str, object]] = []
+    merged_rows: list[dict[str, object]] = []
+
+    for producer in range(_PRODUCERS):
+        for command_index, command in enumerate(commands):
+            score_rows = [
+                list(
+                    requantize_score_row(
+                        _raw_scores(block),
+                        multiplier=int(command["multiplier"]),
+                        shift=int(command["shift"]),
+                    )
+                )
+                for block in _beats_for(producer, command_index)
+            ]
+            partials = partial_stream_from_blocks(
+                command_id=int(command["command_id"]),
+                head_id=int(command["head_id"]),
+                score_rows=score_rows,
+                value_blocks=_values_for(producer, command_index),
+            )
+            producer_rows[producer].extend(
+                {
+                    "command_id": beat.command_id,
+                    "head_id": beat.head_id,
+                    "slice": beat.slice_index,
+                    "last": beat.last,
+                    "global_max": beat.max_score,
+                    "exp_sum": beat.exp_sum,
+                    "value": list(beat.numerators),
+                }
+                for beat in partials
+            )
+
+    for command_index, command in enumerate(commands):
+        streams = []
+        for producer in range(_PRODUCERS):
+            streams.append(
+                partial_stream_from_blocks(
+                    command_id=int(command["command_id"]),
+                    head_id=int(command["head_id"]),
+                    score_rows=[
+                        list(
+                            requantize_score_row(
+                                _raw_scores(block),
+                                multiplier=int(command["multiplier"]),
+                                shift=int(command["shift"]),
+                            )
+                        )
+                        for block in _beats_for(producer, command_index)
+                    ],
+                    value_blocks=_values_for(producer, command_index),
+                )
+            )
+        merged = merge_balanced_partial_streams(streams)
+        merged_rows.extend(
+            {
+                "command_id": beat.command_id,
+                "head_id": beat.head_id,
+                "slice": beat.slice_index,
+                "last": beat.last,
+                "global_max": beat.max_score,
+                "exp_sum": beat.exp_sum,
+                "value": list(beat.numerators),
+            }
+            for beat in merged
+        )
+        finalized_rows.extend(
+            {
+                "command_id": beat.command_id,
+                "head_id": beat.head_id,
+                "slice": beat.slice_index,
+                "last": beat.last,
+                "value": list(beat.values),
+            }
+            for beat in finalize_partial_beats(merged)
+        )
+
+    return {
+        "commands": commands,
+        "producer_rows": producer_rows,
+        "merged_rows": merged_rows,
+        "finalized_rows": finalized_rows,
+        "producer_hashes": [_hash(rows) for rows in producer_rows],
+        "merged_hash": _hash(merged_rows),
+        "final_hash": _hash(finalized_rows),
+    }
+
+
+def _config(config: JsonDict, *, heads: int) -> JsonDict:
+    merged = json.loads(json.dumps(config))
+    probe_defaults = merged.setdefault("probe_defaults", {})
+    if isinstance(probe_defaults, dict):
+        probe_defaults["heads"] = heads
+    return merged
+
+
+def _ready_init(pattern: tuple[bool, ...]) -> str:
+    return "\n".join(f"    root_ready_mem[{index}] = 1'b{1 if value else 0};" for index, value in enumerate(pattern))
+
+
+def _producer_pack_assigns() -> str:
+    lines: list[str] = []
+    for producer in range(_PRODUCERS):
+        a_lo = producer * 8
+        b_lo = producer * 64
+        addr_lo = producer * 14
+        slice_lo = producer * 4
+        matrix_lo = producer * 512
+        lines.extend(
+            [
+                f"  assign producer_input_valid[{producer}] = producer{producer}_input_valid;",
+                f"  assign producer_input_last[{producer}] = producer{producer}_input_last;",
+                f"  assign producer_input_a[{a_lo} +: 8] = producer{producer}_input_a;",
+                f"  assign producer_input_b[{b_lo} +: 64] = producer{producer}_input_b;",
+                f"  assign producer_value_read_req_ready[{producer}] = producer{producer}_value_read_req_ready;",
+                f"  assign producer_value_response_valid[{producer}] = producer{producer}_value_response_valid;",
+                f"  assign producer_value_response_address[{addr_lo} +: 14] = producer{producer}_value_response_address;",
+                f"  assign producer_value_response_slice[{slice_lo} +: 4] = producer{producer}_value_response_slice;",
+                f"  assign producer_value_response_matrix[{matrix_lo} +: 512] = producer{producer}_value_response_matrix;",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def _producer_decl_blocks() -> str:
+    lines: list[str] = []
+    for producer in range(_PRODUCERS):
+        lines.extend(
+            [
+                f"  reg producer{producer}_input_valid;",
+                f"  reg producer{producer}_input_last;",
+                f"  reg signed [7:0] producer{producer}_input_a;",
+                f"  reg signed [63:0] producer{producer}_input_b;",
+                f"  reg producer{producer}_value_read_req_ready;",
+                f"  reg producer{producer}_value_response_valid;",
+                f"  reg [13:0] producer{producer}_value_response_address;",
+                f"  reg [3:0] producer{producer}_value_response_slice;",
+                f"  reg [511:0] producer{producer}_value_response_matrix;",
+                f"  reg pending{producer} = 0;",
+                f"  reg [13:0] pending_addr{producer} = 0;",
+                f"  reg [3:0] pending_slice{producer} = 0;",
+                f"  integer pending_delay{producer} = 0;",
+                f"  integer input_index{producer} = 0;",
+                f"  integer active_cmd{producer} = 0;",
+                f"  reg signed [7:0] q_mem{producer} [0:TOTAL_BEATS-1];",
+                f"  reg [63:0] k_mem{producer} [0:TOTAL_BEATS-1];",
+                f"  reg last_mem{producer} [0:TOTAL_BEATS-1];",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def _producer_init_blocks(heads: int) -> str:
+    lines: list[str] = []
+    for producer in range(_PRODUCERS):
+        flat = [
+            beat
+            for command_index in range(heads)
+            for block in _beats_for(producer, command_index)
+            for beat in block
+        ]
+        lasts = [
+            1 if beat_index % _HEAD_DIM == (_HEAD_DIM - 1) else 0
+            for command_index in range(heads)
+            for block in _beats_for(producer, command_index)
+            for beat_index, _ in enumerate(block)
+        ]
+        for index, (q, keys) in enumerate(flat):
+            lines.append(
+                f"    q_mem{producer}[{index}] = {_signed_literal(q, 8)}; "
+                f"k_mem{producer}[{index}] = 64'h{_pack(keys, 8):016x}; "
+                f"last_mem{producer}[{index}] = 1'b{lasts[index]};"
+            )
+    return "\n".join(lines)
+
+
+def _value_init_blocks(heads: int) -> str:
+    lines: list[str] = []
+    for producer in range(_PRODUCERS):
+        for command_index in range(heads):
+            values = _values_for(producer, command_index)
+            for block in range(_BLOCK_COUNT):
+                for value_slice in range(_VALUE_SLICES):
+                    flat = [lane for row in values[block][value_slice] for lane in row]
+                    address = (((producer * heads) + command_index) * _BLOCK_COUNT + block) * _VALUE_SLICES + value_slice
+                    lines.append(f"    value_mem[{address}] = 512'h{_pack(flat, 8):0128x};")
+    return "\n".join(lines)
+
+
+def _command_init(heads: int) -> str:
+    return "\n".join(
+        f"    cmd_id_mem[{index}] = 16'h{int(command['command_id']):04x}; "
+        f"cmd_head_mem[{index}] = 5'd{int(command['head_id'])}; "
+        f"cmd_mult_mem[{index}] = 32'd{int(command['multiplier'])}; "
+        f"cmd_shift_mem[{index}] = 6'd{int(command['shift'])};"
+        for index, command in enumerate(_command_schedule(heads))
+    )
+
+
+def _comb_assigns() -> str:
+    lines = [
+        "  always @* begin",
+        "    command_valid = rst_n && issued_commands < HEADS && (((cycle + issued_commands) % 5) != 2);",
+        "    root_ready = root_ready_mem[cycle % ROOT_READY_PATTERN_LEN];",
+    ]
+    for producer in range(_PRODUCERS):
+        gate_mod = 5 + (producer % 4)
+        gate_skip = (producer * 2 + 1) % gate_mod
+        req_mod = 4 + (producer % 3)
+        req_skip = (producer + 1) % req_mod
+        lines.extend(
+            [
+                f"    producer{producer}_input_valid =",
+                f"        rst_n && input_index{producer} < (issued_commands * BEATS_PER_COMMAND)",
+                f"        && (((cycle + {producer}) % {gate_mod}) != {gate_skip});",
+                f"    producer{producer}_input_a = input_index{producer} < TOTAL_BEATS ? q_mem{producer}[input_index{producer}] : 0;",
+                f"    producer{producer}_input_b = input_index{producer} < TOTAL_BEATS ? k_mem{producer}[input_index{producer}] : 0;",
+                f"    producer{producer}_input_last = input_index{producer} < TOTAL_BEATS ? last_mem{producer}[input_index{producer}] : 0;",
+                f"    producer{producer}_value_read_req_ready = ((cycle + {producer + 1}) % {req_mod}) != {req_skip};",
+            ]
+        )
+    lines.append("  end")
+    return "\n".join(lines)
+
+
+def _seq_body(heads: int) -> str:
+    lines: list[str] = [
+        "      if (command_valid && command_ready) begin",
+        '        $display("COMMAND_ACCEPT idx=%0d cmd=%0d head=%0d cycle=%0d",',
+        "                 issued_commands, cmd_id_mem[issued_commands], cmd_head_mem[issued_commands], cycle);",
+        "        issued_commands <= issued_commands + 1;",
+    ]
+    for producer in range(_PRODUCERS):
+        lines.append(f"        active_cmd{producer} <= issued_commands;")
+    lines.append("      end")
+    for producer in range(_PRODUCERS):
+        lines.append(
+            f"      if (producer_input_valid[{producer}] && producer_input_ready[{producer}]) input_index{producer} <= input_index{producer} + 1;"
+        )
+    for producer in range(_PRODUCERS):
+        addr_lo = producer * 14
+        slice_lo = producer * 4
+        lines.extend(
+            [
+                f"      if (producer_value_read_req_valid[{producer}] && producer{producer}_value_read_req_ready) begin",
+                f'        if (pending{producer} || producer{producer}_value_response_valid) $fatal(1, "producer{producer} multiple outstanding value requests");',
+                f"        pending{producer} <= 1;",
+                f"        pending_addr{producer} <= producer_value_read_req_address[{addr_lo} +: 14];",
+                f"        pending_slice{producer} <= producer_value_read_req_slice[{slice_lo} +: 4];",
+                f"        pending_delay{producer} <= ((producer_value_read_req_address[{addr_lo} +: 14] + producer_value_read_req_slice[{slice_lo} +: 4] + active_cmd{producer} + {producer}) % 4) + 1;",
+                "      end",
+                f"      if (pending{producer}) begin",
+                f"        if (pending_delay{producer} == 0) begin",
+                f"          pending{producer} <= 0;",
+                f"          producer{producer}_value_response_valid <= 1;",
+                f"          producer{producer}_value_response_address <= pending_addr{producer};",
+                f"          producer{producer}_value_response_slice <= pending_slice{producer};",
+                f"          producer{producer}_value_response_matrix <= value_mem[((({producer} * HEADS) + active_cmd{producer}) * BLOCK_COUNT + pending_addr{producer}) * 16 + pending_slice{producer}];",
+                "        end else begin",
+                f"          pending_delay{producer} <= pending_delay{producer} - 1;",
+                "        end",
+                "      end",
+                f"      if (producer{producer}_value_response_valid && producer_value_response_ready[{producer}]) producer{producer}_value_response_valid <= 0;",
+            ]
+        )
+    for producer in range(_PRODUCERS):
+        cmd_lo = producer * 16
+        head_lo = producer * 5
+        slice_lo = producer * 4
+        sum_lo = producer * 33
+        value_lo = producer * 328
+        lines.extend(
+            [
+                f"      if (producer_partial_valid[{producer}] && producer_partial_ready[{producer}]) begin",
+                f'        $display("PARTIAL_RESULT producer={producer} cmd=%0d head=%0d slice=%0d last=%0d max=%0d sum=%0d value=%082x cycle=%0d",',
+                f"                 dut.producer_result_command_id_w[{cmd_lo} +: 16],",
+                f"                 dut.producer_result_head_id_w[{head_lo} +: 5],",
+                f"                 dut.producer_result_slice_w[{slice_lo} +: 4],",
+                f"                 dut.producer_result_last_w[{producer}],",
+                f"                 $signed(dut.producer_result_global_max_w[{producer * 32} +: 32]),",
+                f"                 dut.producer_result_exp_sum_w[{sum_lo} +: 33],",
+                f"                 dut.producer_result_value_w[{value_lo} +: 328],",
+                "                 cycle);",
+                "      end",
+            ]
+        )
+    lines.extend(
+        [
+            "      if (root_valid && root_ready) begin",
+            '        $display("ROOT_RESULT cmd=%0d head=%0d slice=%0d last=%0d value=%080x cycle=%0d",',
+            "                 root_command_id, root_head_id, root_slice, root_last, root_value, cycle);",
+            "        if (first_root_cycle < 0) first_root_cycle <= cycle;",
+            "        last_root_cycle <= cycle;",
+            "        root_seen <= root_seen + 1;",
+            "        if (root_seen + 1 == TOTAL_RESULTS) pending_summary <= 1'b1;",
+            "      end",
+            "      if (pending_summary) begin",
+            '        $display("SUMMARY outputs=%0d drain=%0d first_root=%0d last_root=%0d protocol_error=%0d command_accept=%0d command_complete=%0d tree_stall=%0d root_completed=%0d finalizer_accepted=%0d tree_error=%0d order_error=%0d finalizer_error=%0d",',
+            "                 root_seen, cycle + 1, first_root_cycle, last_root_cycle, protocol_error, command_accept_count,",
+            "                 command_completed_count, tree_dispatch_stall_cycles, tree_root_completed_count,",
+            "                 finalizer_accepted_count, tree_protocol_error, order_protocol_error, finalizer_protocol_error);",
+        ]
+    )
+    for producer in range(_PRODUCERS):
+        count_lo = producer * 32
+        lines.extend(
+            [
+                f'        $display("PRODUCER_SUMMARY producer={producer} accept=%0d complete=%0d leaf_stall=%0d error=%0d",',
+                f"                 producer_command_accept_count[{count_lo} +: 32],",
+                f"                 producer_partial_completed_count[{count_lo} +: 32],",
+                f"                 producer_leaf_stall_cycles[{count_lo} +: 32],",
+                f"                 producer_protocol_error[{producer}]);",
+            ]
+        )
+    lines.extend(
+        [
+            "        #1 $finish;",
+            "      end",
+            f'      if (cycle > {max(120000, heads * 6000)}) $fatal(1, "timeout");',
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _reset_body() -> str:
+    lines = [
+        "      cycle <= 0;",
+        "      issued_commands <= 0;",
+        "      root_seen <= 0;",
+        "      first_root_cycle <= -1;",
+        "      last_root_cycle <= -1;",
+        "      pending_summary <= 1'b0;",
+    ]
+    for producer in range(_PRODUCERS):
+        lines.extend(
+            [
+                f"      input_index{producer} <= 0;",
+                f"      active_cmd{producer} <= 0;",
+                f"      pending{producer} <= 0;",
+                f"      pending_addr{producer} <= 0;",
+                f"      pending_slice{producer} <= 0;",
+                f"      pending_delay{producer} <= 0;",
+                f"      producer{producer}_value_response_valid <= 0;",
+                f"      producer{producer}_value_response_address <= 0;",
+                f"      producer{producer}_value_response_slice <= 0;",
+                f"      producer{producer}_value_response_matrix <= 0;",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def _testbench(*, top_name: str, heads: int, output_ready_pattern: tuple[bool, ...]) -> str:
+    return f"""`timescale 1ns/1ps
+{_FAKERAM_MODEL}
+module tb;
+  localparam integer HEADS = {heads};
+  localparam integer BLOCK_COUNT = {_BLOCK_COUNT};
+  localparam integer HEAD_DIM = {_HEAD_DIM};
+  localparam integer BEATS_PER_COMMAND = BLOCK_COUNT * HEAD_DIM;
+  localparam integer TOTAL_BEATS = HEADS * BEATS_PER_COMMAND;
+  localparam integer TOTAL_RESULTS = HEADS * {_VALUE_SLICES};
+  localparam integer ROOT_READY_PATTERN_LEN = {len(output_ready_pattern)};
+  reg clk = 0, rst_n = 0;
+  integer cycle = 0;
+  integer issued_commands = 0;
+  integer root_seen = 0;
+  integer first_root_cycle = -1;
+  integer last_root_cycle = -1;
+  reg pending_summary = 0;
+
+  reg [15:0] cmd_id_mem [0:HEADS-1];
+  reg [4:0] cmd_head_mem [0:HEADS-1];
+  reg [31:0] cmd_mult_mem [0:HEADS-1];
+  reg [5:0] cmd_shift_mem [0:HEADS-1];
+  reg [511:0] value_mem [0:({_PRODUCERS} * HEADS * BLOCK_COUNT * 16)-1];
+  reg root_ready_mem [0:ROOT_READY_PATTERN_LEN-1];
+
+  reg command_valid;
+  wire command_ready;
+  wire [{_PRODUCERS - 1}:0] producer_input_valid;
+  wire [{_PRODUCERS - 1}:0] producer_input_ready;
+  wire [{_PRODUCERS - 1}:0] producer_input_last;
+  wire signed [{(_PRODUCERS * 8) - 1}:0] producer_input_a;
+  wire signed [{(_PRODUCERS * 64) - 1}:0] producer_input_b;
+  wire [{_PRODUCERS - 1}:0] producer_value_read_req_valid;
+  wire [{_PRODUCERS - 1}:0] producer_value_read_req_ready;
+  wire [{(_PRODUCERS * 14) - 1}:0] producer_value_read_req_address;
+  wire [{(_PRODUCERS * 4) - 1}:0] producer_value_read_req_slice;
+  wire [{_PRODUCERS - 1}:0] producer_value_response_valid;
+  wire [{_PRODUCERS - 1}:0] producer_value_response_ready;
+  wire [{(_PRODUCERS * 14) - 1}:0] producer_value_response_address;
+  wire [{(_PRODUCERS * 4) - 1}:0] producer_value_response_slice;
+  wire [{(_PRODUCERS * 512) - 1}:0] producer_value_response_matrix;
+  wire root_valid;
+  reg root_ready;
+  wire [15:0] root_command_id;
+  wire [4:0] root_head_id;
+  wire [3:0] root_slice;
+  wire root_last;
+  wire [319:0] root_value;
+  wire [31:0] cycle_count;
+  wire [31:0] command_accept_count;
+  wire [31:0] command_completed_count;
+  wire [{(_PRODUCERS * 32) - 1}:0] producer_command_accept_count;
+  wire [{(_PRODUCERS * 32) - 1}:0] producer_partial_completed_count;
+  wire [{(_PRODUCERS * 32) - 1}:0] producer_leaf_stall_cycles;
+  wire [{_PRODUCERS - 1}:0] producer_partial_valid;
+  wire [{_PRODUCERS - 1}:0] producer_partial_ready;
+  wire [{_PRODUCERS - 1}:0] producer_partial_last;
+  wire [31:0] tree_root_completed_count;
+  wire [31:0] finalizer_accepted_count;
+  wire [31:0] order_fifo_occupancy;
+  wire [31:0] order_fifo_high_watermark;
+  wire [31:0] order_enqueued_count;
+  wire [31:0] order_dequeued_count;
+  wire [31:0] tree_dispatch_stall_cycles;
+  wire [31:0] dispatch_bank_id;
+  wire [31:0] head_bank_id;
+  wire [(15 * 32) - 1:0] node_completed_count;
+  wire [(4 * 32) - 1:0] stage_completed_count;
+  wire [14:0] node_protocol_error;
+  wire [3:0] stage_protocol_error;
+  wire [58:0] bank_protocol_error;
+  wire [58:0] bank_outstanding;
+  wire [{_PRODUCERS - 1}:0] producer_protocol_error;
+  wire tree_protocol_error;
+  wire order_protocol_error;
+  wire finalizer_protocol_error;
+  wire protocol_error;
+
+{_producer_decl_blocks()}
+
+{_producer_pack_assigns()}
+
+  always #5 clk = ~clk;
+
+  {top_name} dut (
+      .clk(clk),
+      .rst_n(rst_n),
+      .command_valid(command_valid),
+      .command_ready(command_ready),
+      .command_id(cmd_id_mem[issued_commands]),
+      .command_head_id(cmd_head_mem[issued_commands]),
+      .command_block_count(BLOCK_COUNT),
+      .command_score_multiplier(cmd_mult_mem[issued_commands]),
+      .command_score_shift(cmd_shift_mem[issued_commands]),
+      .producer_input_valid(producer_input_valid),
+      .producer_input_ready(producer_input_ready),
+      .producer_input_last(producer_input_last),
+      .producer_input_a(producer_input_a),
+      .producer_input_b(producer_input_b),
+      .producer_value_read_req_valid(producer_value_read_req_valid),
+      .producer_value_read_req_ready(producer_value_read_req_ready),
+      .producer_value_read_req_address(producer_value_read_req_address),
+      .producer_value_read_req_slice(producer_value_read_req_slice),
+      .producer_value_response_valid(producer_value_response_valid),
+      .producer_value_response_ready(producer_value_response_ready),
+      .producer_value_response_address(producer_value_response_address),
+      .producer_value_response_slice(producer_value_response_slice),
+      .producer_value_response_matrix(producer_value_response_matrix),
+      .root_valid(root_valid),
+      .root_ready(root_ready),
+      .root_command_id(root_command_id),
+      .root_head_id(root_head_id),
+      .root_slice(root_slice),
+      .root_last(root_last),
+      .root_value(root_value),
+      .cycle_count(cycle_count),
+      .command_accept_count(command_accept_count),
+      .command_completed_count(command_completed_count),
+      .producer_command_accept_count(producer_command_accept_count),
+      .producer_partial_completed_count(producer_partial_completed_count),
+      .producer_leaf_stall_cycles(producer_leaf_stall_cycles),
+      .producer_partial_valid(producer_partial_valid),
+      .producer_partial_ready(producer_partial_ready),
+      .producer_partial_last(producer_partial_last),
+      .tree_root_completed_count(tree_root_completed_count),
+      .finalizer_accepted_count(finalizer_accepted_count),
+      .order_fifo_occupancy(order_fifo_occupancy),
+      .order_fifo_high_watermark(order_fifo_high_watermark),
+      .order_enqueued_count(order_enqueued_count),
+      .order_dequeued_count(order_dequeued_count),
+      .tree_dispatch_stall_cycles(tree_dispatch_stall_cycles),
+      .dispatch_bank_id(dispatch_bank_id),
+      .head_bank_id(head_bank_id),
+      .node_completed_count(node_completed_count),
+      .stage_completed_count(stage_completed_count),
+      .node_protocol_error(node_protocol_error),
+      .stage_protocol_error(stage_protocol_error),
+      .bank_protocol_error(bank_protocol_error),
+      .bank_outstanding(bank_outstanding),
+      .producer_protocol_error(producer_protocol_error),
+      .tree_protocol_error(tree_protocol_error),
+      .order_protocol_error(order_protocol_error),
+      .finalizer_protocol_error(finalizer_protocol_error),
+      .protocol_error(protocol_error)
+  );
+
+{_comb_assigns()}
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+{_reset_body()}
+    end else begin
+      cycle <= cycle + 1;
+{_seq_body(heads)}
+    end
+  end
+
+  initial begin
+{_command_init(heads)}
+{_producer_init_blocks(heads)}
+{_value_init_blocks(heads)}
+{_ready_init(output_ready_pattern)}
+    repeat (3) @(posedge clk);
+    @(negedge clk);
+    rst_n = 1'b1;
+  end
+endmodule
+"""
+
+
+def _run_case(config: JsonDict, *, heads: int, output_ready_pattern: tuple[bool, ...]) -> JsonDict:
+    expected = _expected(heads)
+    run_config = _config(config, heads=heads)
+    with tempfile.TemporaryDirectory(prefix=f"score32_exact_partial_producer_tree_c16_h{heads}_") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        generate_tree(run_config, temp_dir / "rtl")
+        tb_path = temp_dir / "tb.sv"
+        tb_path.write_text(
+            _testbench(
+                top_name=str(run_config["top_name"]),
+                heads=heads,
+                output_ready_pattern=output_ready_pattern,
+            ),
+            encoding="utf-8",
+        )
+        simv = temp_dir / "simv"
+        compiled = subprocess.run(
+            [
+                _tool("iverilog"),
+                "-g2012",
+                "-s",
+                "tb",
+                "-o",
+                str(simv),
+                str(temp_dir / "rtl" / "top.v"),
+                str(tb_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=1200,
+        )
+        if compiled.returncode:
+            raise RuntimeError(f"iverilog failed:\n{compiled.stderr}")
+        run = subprocess.run([_tool("vvp"), str(simv)], capture_output=True, text=True, timeout=1200)
+        if run.returncode:
+            raise RuntimeError(f"simulation failed:\n{run.stdout}\n{run.stderr}")
+
+    command_accepts: list[dict[str, int]] = []
+    partials: list[list[dict[str, object]]] = [[] for _ in range(_PRODUCERS)]
+    root_rows: list[dict[str, object]] = []
+    summary: dict[str, int] | None = None
+    producer_summaries = [{} for _ in range(_PRODUCERS)]
+    for line in run.stdout.splitlines():
+        stripped = line.strip()
+        if match := _COMMAND_RE.fullmatch(stripped):
+            command_accepts.append(
+                {
+                    "index": int(match.group(1)),
+                    "command_id": int(match.group(2)),
+                    "head_id": int(match.group(3)),
+                    "cycle": int(match.group(4)),
+                }
+            )
+        elif match := _PARTIAL_RE.fullmatch(stripped):
+            producer = int(match.group(1))
+            partials[producer].append(
+                {
+                    "command_id": int(match.group(2)),
+                    "head_id": int(match.group(3)),
+                    "slice": int(match.group(4)),
+                    "last": bool(int(match.group(5))),
+                    "global_max": int(match.group(6)),
+                    "exp_sum": int(match.group(7)),
+                    "value": int(match.group(8), 16),
+                    "cycle": int(match.group(9)),
+                }
+            )
+        elif match := _ROOT_RE.fullmatch(stripped):
+            root_rows.append(
+                {
+                    "command_id": int(match.group(1)),
+                    "head_id": int(match.group(2)),
+                    "slice": int(match.group(3)),
+                    "last": bool(int(match.group(4))),
+                    "value": list(unpack_final_values(int(match.group(5), 16))),
+                    "cycle": int(match.group(6)),
+                }
+            )
+        elif match := _SUMMARY_RE.fullmatch(stripped):
+            summary = {
+                "outputs": int(match.group(1)),
+                "drain_cycles": int(match.group(2)),
+                "first_root_cycle": int(match.group(3)),
+                "last_root_cycle": int(match.group(4)),
+                "protocol_error": int(match.group(5)),
+                "command_accept_count": int(match.group(6)),
+                "command_complete_count": int(match.group(7)),
+                "tree_dispatch_stall_cycles": int(match.group(8)),
+                "tree_root_completed_count": int(match.group(9)),
+                "finalizer_accepted_count": int(match.group(10)),
+                "tree_protocol_error": int(match.group(11)),
+                "order_protocol_error": int(match.group(12)),
+                "finalizer_protocol_error": int(match.group(13)),
+            }
+        elif match := _PRODUCER_SUMMARY_RE.fullmatch(stripped):
+            producer = int(match.group(1))
+            producer_summaries[producer] = {
+                "accept": int(match.group(2)),
+                "complete": int(match.group(3)),
+                "leaf_stall": int(match.group(4)),
+                "error": int(match.group(5)),
+            }
+    if summary is None:
+        raise RuntimeError(f"missing SUMMARY line in simulation output:\n{run.stdout}")
+
+    expected_root = expected["finalized_rows"]
+    observed_root = [
+        {
+            "command_id": row["command_id"],
+            "head_id": row["head_id"],
+            "slice": row["slice"],
+            "last": row["last"],
+            "value": row["value"],
+        }
+        for row in root_rows
+    ]
+    partial_windows = []
+    for producer in range(_PRODUCERS):
+        cycles = [int(row["cycle"]) for row in partials[producer]]
+        partial_windows.append(
+            {
+                "producer": producer,
+                "first_cycle": cycles[0] if cycles else -1,
+                "last_cycle": cycles[-1] if cycles else -1,
+                "beats": len(cycles),
+            }
+        )
+    return {
+        "heads": heads,
+        "command_accepts": command_accepts,
+        "producer_partial_windows": partial_windows,
+        "producer_partial_hashes": [
+            _hash(
+                [
+                    {
+                        "command_id": row["command_id"],
+                        "head_id": row["head_id"],
+                        "slice": row["slice"],
+                        "last": row["last"],
+                        "global_max": row["global_max"],
+                        "exp_sum": row["exp_sum"],
+                        "value": row["value"],
+                    }
+                    for row in partials[index]
+                ]
+            )
+            for index in range(_PRODUCERS)
+        ],
+        "outputs": len(root_rows),
+        "observed_root": observed_root,
+        "observed_root_hash": _hash(observed_root),
+        "expected_root_hash": expected["final_hash"],
+        "expected_outputs": len(expected_root),
+        "summary": summary,
+        "producer_summaries": producer_summaries,
+        "passed": observed_root == expected_root
+        and len(command_accepts) == heads
+        and summary["protocol_error"] == 0
+        and summary["tree_protocol_error"] == 0
+        and summary["order_protocol_error"] == 0
+        and summary["finalizer_protocol_error"] == 0
+        and all(int(item.get("error", 1)) == 0 for item in producer_summaries),
+    }
+
+
+def _standalone_testbench(*, cluster_top_name: str, producer: int, heads: int) -> str:
+    commands = _command_schedule(heads)
+    flat = [
+        beat
+        for command_index in range(heads)
+        for block in _beats_for(producer, command_index)
+        for beat in block
+    ]
+    lasts = [
+        1 if beat_index % _HEAD_DIM == (_HEAD_DIM - 1) else 0
+        for command_index in range(heads)
+        for block in _beats_for(producer, command_index)
+        for beat_index, _ in enumerate(block)
+    ]
+    cmd_init = "\n".join(
+        f"    cmd_id_mem[{index}] = 16'h{int(command['command_id']):04x}; "
+        f"cmd_head_mem[{index}] = 5'd{int(command['head_id'])}; "
+        f"cmd_mult_mem[{index}] = 32'd{int(command['multiplier'])}; "
+        f"cmd_shift_mem[{index}] = 6'd{int(command['shift'])};"
+        for index, command in enumerate(commands)
+    )
+    beat_init = "\n".join(
+        f"    q_mem[{index}] = {_signed_literal(q, 8)}; k_mem[{index}] = 64'h{_pack(keys, 8):016x}; last_mem[{index}] = 1'b{lasts[index]};"
+        for index, (q, keys) in enumerate(flat)
+    )
+    value_init = []
+    for command_index in range(heads):
+        values = _values_for(producer, command_index)
+        for block in range(_BLOCK_COUNT):
+            for value_slice in range(_VALUE_SLICES):
+                flat_values = [lane for row in values[block][value_slice] for lane in row]
+                value_init.append(
+                    f"    value_mem[{((command_index * _BLOCK_COUNT) + block) * _VALUE_SLICES + value_slice}] = 512'h{_pack(flat_values, 8):0128x};"
+                )
+    gate_mod = 5 + (producer % 4)
+    gate_skip = (producer * 2 + 1) % gate_mod
+    req_mod = 4 + (producer % 3)
+    req_skip = (producer + 1) % req_mod
+    return f"""`timescale 1ns/1ps
+{_FAKERAM_MODEL}
+module tb;
+  localparam integer HEADS = {heads};
+  localparam integer BLOCK_COUNT = {_BLOCK_COUNT};
+  localparam integer BEATS_PER_COMMAND = BLOCK_COUNT * {_HEAD_DIM};
+  localparam integer TOTAL_BEATS = HEADS * BEATS_PER_COMMAND;
+  localparam integer TOTAL_RESULTS = HEADS * {_VALUE_SLICES};
+  reg clk = 0, rst_n = 0;
+  integer cycle = 0;
+  integer issue_index = 0;
+  integer input_index = 0;
+  integer active_cmd = 0;
+  integer seen = 0;
+  reg [15:0] cmd_id_mem [0:HEADS-1];
+  reg [4:0] cmd_head_mem [0:HEADS-1];
+  reg [31:0] cmd_mult_mem [0:HEADS-1];
+  reg [5:0] cmd_shift_mem [0:HEADS-1];
+  reg signed [7:0] q_mem [0:TOTAL_BEATS-1];
+  reg [63:0] k_mem [0:TOTAL_BEATS-1];
+  reg last_mem [0:TOTAL_BEATS-1];
+  reg [511:0] value_mem [0:(HEADS*BLOCK_COUNT*16)-1];
+  reg command_valid;
+  wire command_ready;
+  reg input_valid;
+  wire input_ready;
+  reg input_last;
+  reg signed [7:0] input_a;
+  reg signed [63:0] input_b;
+  wire value_read_req_valid;
+  reg value_read_req_ready;
+  wire [13:0] value_read_req_address;
+  wire [3:0] value_read_req_slice;
+  reg value_response_valid;
+  wire value_response_ready;
+  reg [13:0] value_response_address;
+  reg [3:0] value_response_slice;
+  reg [511:0] value_response_matrix;
+  wire result_valid;
+  reg result_ready;
+  wire [15:0] result_command_id;
+  wire [4:0] result_head_id;
+  wire signed [31:0] result_global_max;
+  wire [32:0] result_exp_sum;
+  wire [3:0] result_slice;
+  wire result_last;
+  wire [327:0] result_value;
+  wire [31:0] accepted_count;
+  wire [31:0] completed_count;
+  wire [31:0] cycle_count;
+  wire protocol_error;
+  reg pending = 0;
+  reg [13:0] pending_addr = 0;
+  reg [3:0] pending_slice = 0;
+  integer pending_delay = 0;
+
+  always #5 clk = ~clk;
+
+  {cluster_top_name} dut (
+      .clk(clk),
+      .rst_n(rst_n),
+      .command_valid(command_valid),
+      .command_ready(command_ready),
+      .command_id(cmd_id_mem[issue_index]),
+      .command_head_id(cmd_head_mem[issue_index]),
+      .command_block_count(BLOCK_COUNT),
+      .command_score_multiplier(cmd_mult_mem[issue_index]),
+      .command_score_shift(cmd_shift_mem[issue_index]),
+      .input_valid(input_valid),
+      .input_ready(input_ready),
+      .input_last(input_last),
+      .input_a(input_a),
+      .input_b(input_b),
+      .value_read_req_valid(value_read_req_valid),
+      .value_read_req_ready(value_read_req_ready),
+      .value_read_req_address(value_read_req_address),
+      .value_read_req_slice(value_read_req_slice),
+      .value_response_valid(value_response_valid),
+      .value_response_ready(value_response_ready),
+      .value_response_address(value_response_address),
+      .value_response_slice(value_response_slice),
+      .value_response_matrix(value_response_matrix),
+      .result_valid(result_valid),
+      .result_ready(result_ready),
+      .result_command_id(result_command_id),
+      .result_head_id(result_head_id),
+      .result_global_max(result_global_max),
+      .result_exp_sum(result_exp_sum),
+      .result_slice(result_slice),
+      .result_last(result_last),
+      .result_value(result_value),
+      .accepted_count(accepted_count),
+      .completed_count(completed_count),
+      .cycle_count(cycle_count),
+      .protocol_error(protocol_error)
+  );
+
+  always @* begin
+    command_valid = rst_n && issue_index < HEADS && (((cycle + issue_index) % 5) != 2);
+    input_valid = rst_n && input_index < (issue_index * BEATS_PER_COMMAND) && (((cycle + {producer}) % {gate_mod}) != {gate_skip});
+    input_a = input_index < TOTAL_BEATS ? q_mem[input_index] : 0;
+    input_b = input_index < TOTAL_BEATS ? k_mem[input_index] : 0;
+    input_last = input_index < TOTAL_BEATS ? last_mem[input_index] : 0;
+    value_read_req_ready = ((cycle + {producer + 1}) % {req_mod}) != {req_skip};
+    result_ready = ((cycle + {producer}) % 6) != 4;
+  end
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      cycle <= 0;
+      issue_index <= 0;
+      input_index <= 0;
+      active_cmd <= 0;
+      seen <= 0;
+      pending <= 0;
+      pending_addr <= 0;
+      pending_slice <= 0;
+      pending_delay <= 0;
+      value_response_valid <= 0;
+      value_response_address <= 0;
+      value_response_slice <= 0;
+      value_response_matrix <= 0;
+    end else begin
+      cycle <= cycle + 1;
+      if (command_valid && command_ready) begin
+        active_cmd <= issue_index;
+        issue_index <= issue_index + 1;
+      end
+      if (input_valid && input_ready) input_index <= input_index + 1;
+      if (value_read_req_valid && value_read_req_ready) begin
+        if (pending || value_response_valid) $fatal(1, "multiple outstanding value requests");
+        pending <= 1;
+        pending_addr <= value_read_req_address;
+        pending_slice <= value_read_req_slice;
+        pending_delay <= ((value_read_req_address + value_read_req_slice + active_cmd + {producer}) % 4) + 1;
+      end
+      if (pending) begin
+        if (pending_delay == 0) begin
+          pending <= 0;
+          value_response_valid <= 1;
+          value_response_address <= pending_addr;
+          value_response_slice <= pending_slice;
+          value_response_matrix <= value_mem[((active_cmd * BLOCK_COUNT) + pending_addr) * 16 + pending_slice];
+        end else begin
+          pending_delay <= pending_delay - 1;
+        end
+      end
+      if (value_response_valid && value_response_ready) value_response_valid <= 0;
+      if (result_valid && result_ready) begin
+        $display("PARTIAL_RESULT cmd=%0d head=%0d slice=%0d last=%0d max=%0d sum=%0d value=%082x cycle=%0d",
+                 result_command_id, result_head_id, result_slice, result_last, $signed(result_global_max),
+                 result_exp_sum, result_value, cycle);
+        seen <= seen + 1;
+        if (seen + 1 == TOTAL_RESULTS) begin
+          $display("SUMMARY outputs=%0d drain=%0d protocol_error=%0d accept=%0d complete=%0d",
+                   seen + 1, cycle + 1, protocol_error, accepted_count, completed_count);
+          #1 $finish;
+        end
+      end
+      if (cycle > {max(60000, heads * 3000)}) $fatal(1, "timeout");
+    end
+  end
+
+  initial begin
+{cmd_init}
+{beat_init}
+{chr(10).join(value_init)}
+    value_response_valid = 0;
+    value_response_address = 0;
+    value_response_slice = 0;
+    value_response_matrix = 0;
+    repeat (3) @(posedge clk);
+    @(negedge clk);
+    rst_n = 1'b1;
+  end
+endmodule
+"""
+
+
+def _run_standalone_producer_case(config: JsonDict, *, producer: int, heads: int) -> JsonDict:
+    cluster_top_name = f"standalone_exact_partial_producer_{producer}"
+    cluster_config = {
+        "top_name": cluster_top_name,
+        "attention_decode_score_multivalue_cluster": {
+            "max_blocks": int(config["attention_score32_exact_partial_producer_tree_c16"]["max_blocks"]),
+            "array_n": 8,
+            "value_slices": 16,
+            "divider_impl": "iterative_restoring",
+            "score_scale_lanes_per_cycle": 1,
+            "result_mode": "exact_partial",
+            "head_id_bits": 5,
+        },
+    }
+    with tempfile.TemporaryDirectory(prefix=f"standalone_exact_partial_producer_c16_{producer}_") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        generate_cluster(cluster_config, temp_dir / "rtl")
+        tb_path = temp_dir / "tb.sv"
+        tb_path.write_text(_standalone_testbench(cluster_top_name=cluster_top_name, producer=producer, heads=heads), encoding="utf-8")
+        simv = temp_dir / "simv"
+        compiled = subprocess.run(
+            [
+                _tool("iverilog"),
+                "-g2012",
+                "-s",
+                "tb",
+                "-o",
+                str(simv),
+                str(temp_dir / "rtl" / "top.v"),
+                str(tb_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=1200,
+        )
+        if compiled.returncode:
+            raise RuntimeError(f"iverilog failed:\n{compiled.stderr}")
+        run = subprocess.run([_tool("vvp"), str(simv)], capture_output=True, text=True, timeout=1200)
+        if run.returncode:
+            raise RuntimeError(f"standalone producer simulation failed:\n{run.stdout}\n{run.stderr}")
+
+    partials: list[dict[str, object]] = []
+    summary: dict[str, int] | None = None
+    for line in run.stdout.splitlines():
+        stripped = line.strip()
+        if match := _STANDALONE_PARTIAL_RE.fullmatch(stripped):
+            partials.append(
+                {
+                    "command_id": int(match.group(1)),
+                    "head_id": int(match.group(2)),
+                    "slice": int(match.group(3)),
+                    "last": bool(int(match.group(4))),
+                    "global_max": int(match.group(5)),
+                    "exp_sum": int(match.group(6)),
+                    "value": int(match.group(7), 16),
+                    "cycle": int(match.group(8)),
+                }
+            )
+        elif match := _STANDALONE_SUMMARY_RE.fullmatch(stripped):
+            summary = {
+                "outputs": int(match.group(1)),
+                "drain_cycles": int(match.group(2)),
+                "protocol_error": int(match.group(3)),
+                "accept_count": int(match.group(4)),
+                "complete_count": int(match.group(5)),
+            }
+    if summary is None:
+        raise RuntimeError(f"missing standalone summary for producer {producer}")
+    return {
+        "producer": producer,
+        "partials": partials,
+        "summary": summary,
+    }
+
+
+def _staged_parallel_then_reducer_baseline(*, heads: int, standalone_producer_cases: list[JsonDict]) -> JsonDict:
+    producer_phase_drain_cycles = max(int(case["summary"]["drain_cycles"]) for case in standalone_producer_cases)
+    producer_phase_last_partial_cycle = max(int(case["partials"][-1]["cycle"]) for case in standalone_producer_cases)
+    reducer_service = exact_banked_finalized_tree_full_wave_saturated_service(
+        clusters=_PRODUCERS,
+        heads=heads,
+        divider_lanes=8,
+        finalizer_banks=59,
+    )
+    reducer_phase_origin_cycle = producer_phase_drain_cycles
+    return {
+        "baseline_kind": "producer_parallel_then_reducer_staged",
+        "producer_phase_origin_cycle": 0,
+        "producer_phase_last_partial_cycle": producer_phase_last_partial_cycle,
+        "producer_phase_drain_cycles": producer_phase_drain_cycles,
+        "reducer_phase_origin_cycle": reducer_phase_origin_cycle,
+        "reducer_service": reducer_service,
+        "first_output_cycle": reducer_phase_origin_cycle + int(reducer_service["first_output_cycle"]),
+        "last_output_cycle": reducer_phase_origin_cycle + int(reducer_service["last_output_cycle"]),
+        "drain_cycles": reducer_phase_origin_cycle + int(reducer_service["drain_cycles"]),
+    }
+
+
+def _fully_serialized_producer_then_reducer_diagnostic(*, heads: int, standalone_producer_cases: list[JsonDict]) -> JsonDict:
+    reducer_service = exact_banked_finalized_tree_full_wave_saturated_service(
+        clusters=_PRODUCERS,
+        heads=heads,
+        divider_lanes=8,
+        finalizer_banks=59,
+    )
+    producer_serialized_phase_drain_cycles = sum(int(case["summary"]["drain_cycles"]) for case in standalone_producer_cases)
+    return {
+        "diagnostic_kind": "producer_fully_serialized_then_reducer_staged",
+        "producer_serialized_phase_drain_cycles": producer_serialized_phase_drain_cycles,
+        "reducer_phase_origin_cycle": producer_serialized_phase_drain_cycles,
+        "first_output_cycle": producer_serialized_phase_drain_cycles + int(reducer_service["first_output_cycle"]),
+        "last_output_cycle": producer_serialized_phase_drain_cycles + int(reducer_service["last_output_cycle"]),
+        "drain_cycles": producer_serialized_phase_drain_cycles + int(reducer_service["drain_cycles"]),
+    }
+
+
+def build_report(
+    config: JsonDict | None = None,
+    *,
+    heads: int | None = None,
+    output_ready_pattern: tuple[bool, ...] | None = None,
+    include_baseline: bool = True,
+) -> JsonDict:
+    base_config = json.loads(json.dumps(config or _default_config()))
+    probe_defaults = base_config.get("probe_defaults", {})
+    resolved_heads = heads or int(probe_defaults.get("heads", 2))
+    ready_pattern = output_ready_pattern or (True, False, True, True, False, True, True, False, True, True, True, False)
+    integrated = _run_case(base_config, heads=resolved_heads, output_ready_pattern=ready_pattern)
+    standalone_cases = (
+        [_run_standalone_producer_case(base_config, producer=producer, heads=resolved_heads) for producer in range(_PRODUCERS)]
+        if include_baseline
+        else []
+    )
+    staged_baseline = (
+        _staged_parallel_then_reducer_baseline(heads=resolved_heads, standalone_producer_cases=standalone_cases)
+        if include_baseline
+        else None
+    )
+    diagnostic_serialized = (
+        _fully_serialized_producer_then_reducer_diagnostic(heads=resolved_heads, standalone_producer_cases=standalone_cases)
+        if include_baseline
+        else None
+    )
+    staged_overlap_cycles_saved = (
+        int(staged_baseline["drain_cycles"]) - int(integrated["summary"]["drain_cycles"]) if staged_baseline else None
+    )
+    baseline_protocol_ok = all(int(case["summary"]["protocol_error"]) == 0 for case in standalone_cases)
+    passed = bool(integrated["passed"] and (baseline_protocol_ok if include_baseline else True))
+    report = {
+        "decision": "score32_exact_partial_producer_tree_c16_overlap_pass"
+        if passed
+        else "score32_exact_partial_producer_tree_c16_overlap_fail",
+        "passed": passed,
+        "top_name": str(base_config["top_name"]),
+        "producers": _PRODUCERS,
+        "clusters": _PRODUCERS,
+        "heads": resolved_heads,
+        "outputs": integrated["outputs"],
+        "expected_outputs": integrated["expected_outputs"],
+        "observed_root_hash": integrated["observed_root_hash"],
+        "expected_root_hash": integrated["expected_root_hash"],
+        "command_accept_cycles": integrated["command_accepts"],
+        "producer_partial_windows": integrated["producer_partial_windows"],
+        "producer_leaf_stall_cycles": [int(item.get("leaf_stall", 0)) for item in integrated["producer_summaries"]],
+        "tree_dispatch_stall_cycles": int(integrated["summary"]["tree_dispatch_stall_cycles"]),
+        "first_output_cycle": int(integrated["summary"]["first_root_cycle"]),
+        "last_output_cycle": int(integrated["summary"]["last_root_cycle"]),
+        "integrated_drain_cycles": int(integrated["summary"]["drain_cycles"]),
+        "command_accept_count": int(integrated["summary"]["command_accept_count"]),
+        "command_complete_count": int(integrated["summary"]["command_complete_count"]),
+        "producer_command_accept_count": [int(item.get("accept", 0)) for item in integrated["producer_summaries"]],
+        "producer_partial_completed_count": [int(item.get("complete", 0)) for item in integrated["producer_summaries"]],
+        "tree_root_completed_count": int(integrated["summary"]["tree_root_completed_count"]),
+        "finalizer_accepted_count": int(integrated["summary"]["finalizer_accepted_count"]),
+        "producer_protocol_error": [bool(int(item.get("error", 0))) for item in integrated["producer_summaries"]],
+        "tree_protocol_error": bool(integrated["summary"]["tree_protocol_error"]),
+        "order_protocol_error": bool(integrated["summary"]["order_protocol_error"]),
+        "finalizer_protocol_error": bool(integrated["summary"]["finalizer_protocol_error"]),
+        "protocol_error": bool(integrated["summary"]["protocol_error"]),
+        "integrated_case": integrated,
+        "service_model": exact_partial_producer_tree_service_manifest(
+            producers=_PRODUCERS,
+            clusters=_PRODUCERS,
+            heads=resolved_heads,
+            max_blocks=int(base_config["attention_score32_exact_partial_producer_tree_c16"]["max_blocks"]),
+            divider_lanes=int(base_config["attention_score32_exact_partial_producer_tree_c16"]["divider_lanes"]),
+            finalizer_banks=int(base_config["attention_score32_exact_partial_producer_tree_c16"]["finalizer_banks"]),
+        ),
+        "baseline_included": include_baseline,
+    }
+    if staged_baseline is not None and diagnostic_serialized is not None:
+        report.update(
+            {
+                "producer_parallel_phase_last_partial_cycle": int(staged_baseline["producer_phase_last_partial_cycle"]),
+                "producer_parallel_phase_drain_cycles": int(staged_baseline["producer_phase_drain_cycles"]),
+                "staged_reducer_phase_origin_cycle": int(staged_baseline["reducer_phase_origin_cycle"]),
+                "staged_reducer_service_drain_cycles": int(staged_baseline["reducer_service"]["drain_cycles"]),
+                "staged_reducer_service_first_output_offset": int(staged_baseline["reducer_service"]["first_output_cycle"]),
+                "staged_reducer_service_last_output_offset": int(staged_baseline["reducer_service"]["last_output_cycle"]),
+                "producer_parallel_then_reducer_bound_cycles": int(staged_baseline["drain_cycles"]),
+                "producer_parallel_then_reducer_first_output_cycle": int(staged_baseline["first_output_cycle"]),
+                "producer_parallel_then_reducer_last_output_cycle": int(staged_baseline["last_output_cycle"]),
+                "producer_parallel_then_reducer_overlap_cycles_saved": int(staged_overlap_cycles_saved or 0),
+                "producer_parallel_then_reducer_overlap_fraction": (int(staged_overlap_cycles_saved or 0) / float(max(1, int(staged_baseline["drain_cycles"])))),
+                "standalone_producer_protocol_error": [bool(case["summary"]["protocol_error"]) for case in standalone_cases],
+                "producer_parallel_then_reducer_baseline": staged_baseline,
+                "producer_fully_serialized_then_reducer_diagnostic": diagnostic_serialized,
+                "standalone_producer_cases": standalone_cases,
+            }
+        )
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=None)
+    parser.add_argument("--heads", type=int, default=None)
+    parser.add_argument("--root-ready-pattern", type=str, default=None)
+    parser.add_argument("--skip-baseline", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    config = _default_config()
+    if args.config is not None:
+        config = json.loads(args.config.read_text(encoding="utf-8"))
+    pattern = None
+    if args.root_ready_pattern:
+        pattern = tuple(token.strip() in {"1", "true", "True"} for token in args.root_ready_pattern.split(","))
+        if not pattern:
+            raise SystemExit("root-ready-pattern must not be empty")
+    report = build_report(
+        config=config,
+        heads=args.heads,
+        output_ready_pattern=pattern,
+        include_baseline=not args.skip_baseline,
+    )
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        payload = {
+            "decision": report["decision"],
+            "heads": report["heads"],
+            "outputs": report["outputs"],
+            "observed_root_hash": report["observed_root_hash"],
+            "integrated_drain_cycles": report["integrated_drain_cycles"],
+            "protocol_error": report["protocol_error"],
+        }
+        if not args.skip_baseline:
+            payload.update(
+                {
+                    "producer_parallel_then_reducer_bound_cycles": report["producer_parallel_then_reducer_bound_cycles"],
+                    "producer_parallel_then_reducer_overlap_cycles_saved": report["producer_parallel_then_reducer_overlap_cycles_saved"],
+                }
+            )
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/rtlgen/gen_attention_score32_exact_partial_producer_tree_c16.py
+++ b/npu/rtlgen/gen_attention_score32_exact_partial_producer_tree_c16.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+"""Generate a c16 exact-partial producer-coupled finalized tree slice."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_decode_score_multivalue_cluster import generate as generate_cluster
+from npu.rtlgen.gen_attention_score32_exact_banked_finalized_tree import (
+    generate as generate_banked_tree,
+)
+from npu.sim.perf.attention_exact_partial import (
+    FINAL_LINK_BITS,
+    FINAL_PAYLOAD_BITS,
+    PARTIAL_LINK_BITS,
+    PARTIAL_PAYLOAD_BITS,
+    exact_partial_producer_tree_service_manifest,
+)
+
+JsonDict = dict[str, Any]
+
+_PRODUCERS = 16
+_CLUSTERS = 16
+_RADIX = 2
+_VALUE_SLICES = 16
+_DIVIDER_LANES = 8
+_FINALIZER_BANKS = 59
+
+
+def _load(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit(f"config must decode to a JSON object: {path}")
+    return payload
+
+
+def _validate(config: JsonDict) -> JsonDict:
+    top_name = str(config.get("top_name") or "").strip()
+    body = config.get("attention_score32_exact_partial_producer_tree_c16")
+    if not top_name or not isinstance(body, dict):
+        raise SystemExit("config requires top_name and attention_score32_exact_partial_producer_tree_c16")
+
+    producers = int(body.get("producers", _PRODUCERS))
+    clusters = int(body.get("clusters", _CLUSTERS))
+    radix = int(body.get("radix", _RADIX))
+    max_blocks = int(body.get("max_blocks", 16384))
+    value_slices = int(body.get("value_slices", _VALUE_SLICES))
+    head_id_bits = int(body.get("head_id_bits", 5))
+    divider_lanes = int(body.get("divider_lanes", _DIVIDER_LANES))
+    finalizer_banks = int(body.get("finalizer_banks", _FINALIZER_BANKS))
+
+    if producers != _PRODUCERS:
+        raise SystemExit("producer-coupled c16 slice currently requires producers=16")
+    if clusters != _CLUSTERS:
+        raise SystemExit("producer-coupled c16 slice currently requires clusters=16")
+    if radix != _RADIX:
+        raise SystemExit("producer-coupled c16 slice currently requires radix=2")
+    if max_blocks < 8 or max_blocks > 16384 or (max_blocks & (max_blocks - 1)):
+        raise SystemExit("max_blocks must be a power of two in [8, 16384]")
+    if value_slices != _VALUE_SLICES:
+        raise SystemExit("producer-coupled c16 slice currently requires value_slices=16")
+    if head_id_bits < 1 or head_id_bits > 8:
+        raise SystemExit("head_id_bits must be in [1, 8]")
+    if divider_lanes != _DIVIDER_LANES:
+        raise SystemExit("producer-coupled c16 slice currently requires divider_lanes=8")
+    if finalizer_banks != _FINALIZER_BANKS:
+        raise SystemExit("producer-coupled c16 slice currently requires finalizer_banks=59")
+
+    return {
+        "top_name": top_name,
+        "producers": producers,
+        "clusters": clusters,
+        "radix": radix,
+        "max_blocks": max_blocks,
+        "value_slices": value_slices,
+        "head_id_bits": head_id_bits,
+        "divider_lanes": divider_lanes,
+        "finalizer_banks": finalizer_banks,
+    }
+
+
+def _clog2(value: int) -> int:
+    return max(1, math.ceil(math.log2(max(2, value))))
+
+
+def _producer_instances(*, producer_top_name: str, head_id_bits: int) -> str:
+    blocks: list[str] = []
+    for producer in range(_PRODUCERS):
+        a_lo = producer * 8
+        b_lo = producer * 64
+        addr_lo = producer * 14
+        slice_lo = producer * 4
+        matrix_lo = producer * 512
+        cmd_lo = producer * 16
+        head_lo = producer * head_id_bits
+        max_lo = producer * 32
+        sum_lo = producer * 33
+        count_lo = producer * 32
+        value_lo = producer * PARTIAL_PAYLOAD_BITS
+        blocks.append(
+            f"""  {producer_top_name} u_producer_{producer} (
+      .clk(clk),
+      .rst_n(rst_n),
+      .command_valid(producer_command_valid_w),
+      .command_ready(producer_command_ready_w[{producer}]),
+      .command_id(command_id),
+      .command_head_id(command_head_id),
+      .command_block_count(command_block_count),
+      .command_score_multiplier(command_score_multiplier),
+      .command_score_shift(command_score_shift),
+      .input_valid(producer_input_valid[{producer}]),
+      .input_ready(producer_input_ready[{producer}]),
+      .input_last(producer_input_last[{producer}]),
+      .input_a(producer_input_a[{a_lo} +: 8]),
+      .input_b(producer_input_b[{b_lo} +: 64]),
+      .value_read_req_valid(producer_value_read_req_valid[{producer}]),
+      .value_read_req_ready(producer_value_read_req_ready[{producer}]),
+      .value_read_req_address(producer_value_read_req_address[{addr_lo} +: 14]),
+      .value_read_req_slice(producer_value_read_req_slice[{slice_lo} +: 4]),
+      .value_response_valid(producer_value_response_valid[{producer}]),
+      .value_response_ready(producer_value_response_ready[{producer}]),
+      .value_response_address(producer_value_response_address[{addr_lo} +: 14]),
+      .value_response_slice(producer_value_response_slice[{slice_lo} +: 4]),
+      .value_response_matrix(producer_value_response_matrix[{matrix_lo} +: 512]),
+      .result_valid(producer_result_valid_w[{producer}]),
+      .result_ready(producer_result_ready_w[{producer}]),
+      .result_command_id(producer_result_command_id_w[{cmd_lo} +: 16]),
+      .result_head_id(producer_result_head_id_w[{head_lo} +: {head_id_bits}]),
+      .result_global_max(producer_result_global_max_w[{max_lo} +: 32]),
+      .result_exp_sum(producer_result_exp_sum_w[{sum_lo} +: 33]),
+      .result_slice(producer_result_slice_w[{slice_lo} +: 4]),
+      .result_last(producer_result_last_w[{producer}]),
+      .result_value(producer_result_value_w[{value_lo} +: PARTIAL_PAYLOAD_BITS]),
+      .accepted_count(producer_command_accept_count_w[{count_lo} +: 32]),
+      .completed_count(producer_partial_completed_count_w[{count_lo} +: 32]),
+      .cycle_count(producer_cycle_count_w[{count_lo} +: 32]),
+      .protocol_error(producer_protocol_error_w[{producer}])
+  );"""
+        )
+    return "\n\n".join(blocks)
+
+
+def _leaf_assigns(*, head_id_bits: int) -> str:
+    lines: list[str] = []
+    for producer in range(_PRODUCERS):
+        cmd_lo = producer * 16
+        head_lo = producer * head_id_bits
+        max_lo = producer * 32
+        sum_lo = producer * 33
+        slice_lo = producer * 4
+        value_lo = producer * PARTIAL_PAYLOAD_BITS
+        lines.extend(
+            [
+                f"  assign tree_leaf_valid_w[{producer}] = producer_result_valid_w[{producer}];",
+                f"  assign producer_result_ready_w[{producer}] = tree_leaf_ready_w[{producer}];",
+                f"  assign tree_leaf_command_id_w[{cmd_lo} +: 16] = producer_result_command_id_w[{cmd_lo} +: 16];",
+                f"  assign tree_leaf_head_id_w[{head_lo} +: {head_id_bits}] = producer_result_head_id_w[{head_lo} +: {head_id_bits}];",
+                f"  assign tree_leaf_global_max_w[{max_lo} +: 32] = producer_result_global_max_w[{max_lo} +: 32];",
+                f"  assign tree_leaf_exp_sum_w[{sum_lo} +: 33] = producer_result_exp_sum_w[{sum_lo} +: 33];",
+                f"  assign tree_leaf_slice_w[{slice_lo} +: 4] = producer_result_slice_w[{slice_lo} +: 4];",
+                f"  assign tree_leaf_last_w[{producer}] = producer_result_last_w[{producer}];",
+                f"  assign tree_leaf_value_w[{value_lo} +: PARTIAL_PAYLOAD_BITS] = producer_result_value_w[{value_lo} +: PARTIAL_PAYLOAD_BITS];",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def _stall_counters() -> str:
+    lines: list[str] = []
+    for producer in range(_PRODUCERS):
+        count_lo = producer * 32
+        lines.append(
+            f"      if (producer_result_valid_w[{producer}] && !producer_result_ready_w[{producer}]) begin\n"
+            f"        producer_leaf_stall_cycles_q[{count_lo} +: 32] <= producer_leaf_stall_cycles_q[{count_lo} +: 32] + 1'b1;\n"
+            f"      end"
+        )
+    return "\n".join(lines)
+
+
+def _top(*, top_name: str, producer_top_name: str, tree_top_name: str, head_id_bits: int) -> str:
+    node_count = _CLUSTERS - 1
+    stage_count = _clog2(_CLUSTERS)
+    leaf_assigns = _leaf_assigns(head_id_bits=head_id_bits)
+    producer_instances = _producer_instances(producer_top_name=producer_top_name, head_id_bits=head_id_bits)
+    stall_counters = _stall_counters()
+    return f"""// Auto-generated by npu/rtlgen/gen_attention_score32_exact_partial_producer_tree_c16.py
+module {top_name} (
+    input  wire         clk,
+    input  wire         rst_n,
+    input  wire         command_valid,
+    output wire         command_ready,
+    input  wire [15:0]  command_id,
+    input  wire [{head_id_bits - 1}:0] command_head_id,
+    input  wire [14:0]  command_block_count,
+    input  wire [31:0]  command_score_multiplier,
+    input  wire [5:0]   command_score_shift,
+    input  wire [{_PRODUCERS - 1}:0] producer_input_valid,
+    output wire [{_PRODUCERS - 1}:0] producer_input_ready,
+    input  wire [{_PRODUCERS - 1}:0] producer_input_last,
+    input  wire signed [{(_PRODUCERS * 8) - 1}:0] producer_input_a,
+    input  wire signed [{(_PRODUCERS * 64) - 1}:0] producer_input_b,
+    output wire [{_PRODUCERS - 1}:0] producer_value_read_req_valid,
+    input  wire [{_PRODUCERS - 1}:0] producer_value_read_req_ready,
+    output wire [{(_PRODUCERS * 14) - 1}:0] producer_value_read_req_address,
+    output wire [{(_PRODUCERS * 4) - 1}:0] producer_value_read_req_slice,
+    input  wire [{_PRODUCERS - 1}:0] producer_value_response_valid,
+    output wire [{_PRODUCERS - 1}:0] producer_value_response_ready,
+    input  wire [{(_PRODUCERS * 14) - 1}:0] producer_value_response_address,
+    input  wire [{(_PRODUCERS * 4) - 1}:0] producer_value_response_slice,
+    input  wire [{(_PRODUCERS * 512) - 1}:0] producer_value_response_matrix,
+    output wire         root_valid,
+    input  wire         root_ready,
+    output wire [15:0]  root_command_id,
+    output wire [{head_id_bits - 1}:0] root_head_id,
+    output wire [3:0]   root_slice,
+    output wire         root_last,
+    output wire [319:0] root_value,
+    output wire [31:0]  cycle_count,
+    output wire [31:0]  command_accept_count,
+    output wire [31:0]  command_completed_count,
+    output wire [{(_PRODUCERS * 32) - 1}:0] producer_command_accept_count,
+    output wire [{(_PRODUCERS * 32) - 1}:0] producer_partial_completed_count,
+    output wire [{(_PRODUCERS * 32) - 1}:0] producer_leaf_stall_cycles,
+    output wire [{_PRODUCERS - 1}:0] producer_partial_valid,
+    output wire [{_PRODUCERS - 1}:0] producer_partial_ready,
+    output wire [{_PRODUCERS - 1}:0] producer_partial_last,
+    output wire [31:0]  tree_root_completed_count,
+    output wire [31:0]  finalizer_accepted_count,
+    output wire [31:0]  order_fifo_occupancy,
+    output wire [31:0]  order_fifo_high_watermark,
+    output wire [31:0]  order_enqueued_count,
+    output wire [31:0]  order_dequeued_count,
+    output wire [31:0]  tree_dispatch_stall_cycles,
+    output wire [31:0]  dispatch_bank_id,
+    output wire [31:0]  head_bank_id,
+    output wire [{(node_count * 32) - 1}:0] node_completed_count,
+    output wire [{(stage_count * 32) - 1}:0] stage_completed_count,
+    output wire [{node_count - 1}:0] node_protocol_error,
+    output wire [{stage_count - 1}:0] stage_protocol_error,
+    output wire [58:0]  bank_protocol_error,
+    output wire [58:0]  bank_outstanding,
+    output wire [{_PRODUCERS - 1}:0] producer_protocol_error,
+    output wire         tree_protocol_error,
+    output wire         order_protocol_error,
+    output wire         finalizer_protocol_error,
+    output wire         protocol_error
+);
+  localparam integer PARTIAL_PAYLOAD_BITS = {PARTIAL_PAYLOAD_BITS};
+
+  wire [{_PRODUCERS - 1}:0] producer_command_ready_w;
+  wire [{_PRODUCERS - 1}:0] producer_result_valid_w;
+  wire [{_PRODUCERS - 1}:0] producer_result_ready_w;
+  wire [{(_PRODUCERS * 16) - 1}:0] producer_result_command_id_w;
+  wire [{(_PRODUCERS * head_id_bits) - 1}:0] producer_result_head_id_w;
+  wire [{(_PRODUCERS * 32) - 1}:0] producer_result_global_max_w;
+  wire [{(_PRODUCERS * 33) - 1}:0] producer_result_exp_sum_w;
+  wire [{(_PRODUCERS * 4) - 1}:0] producer_result_slice_w;
+  wire [{_PRODUCERS - 1}:0] producer_result_last_w;
+  wire [{(_PRODUCERS * PARTIAL_PAYLOAD_BITS) - 1}:0] producer_result_value_w;
+  wire [{(_PRODUCERS * 32) - 1}:0] producer_command_accept_count_w;
+  wire [{(_PRODUCERS * 32) - 1}:0] producer_partial_completed_count_w;
+  wire [{(_PRODUCERS * 32) - 1}:0] producer_cycle_count_w;
+  wire [{_PRODUCERS - 1}:0] producer_protocol_error_w;
+  wire [31:0] tree_cycle_count_w;
+  wire [31:0] root_completed_count_w;
+  reg [31:0] cycle_count_q;
+  reg [31:0] command_accept_count_q;
+  reg [31:0] command_completed_count_q;
+  reg [{(_PRODUCERS * 32) - 1}:0] producer_leaf_stall_cycles_q;
+
+  wire command_fire_w = command_valid && command_ready;
+  wire producer_command_valid_w = command_valid && command_ready;
+  wire root_fire_w = root_valid && root_ready;
+
+  wire [{_CLUSTERS - 1}:0] tree_leaf_valid_w;
+  wire [{_CLUSTERS - 1}:0] tree_leaf_ready_w;
+  wire [{(_CLUSTERS * 16) - 1}:0] tree_leaf_command_id_w;
+  wire [{(_CLUSTERS * head_id_bits) - 1}:0] tree_leaf_head_id_w;
+  wire [{(_CLUSTERS * 32) - 1}:0] tree_leaf_global_max_w;
+  wire [{(_CLUSTERS * 33) - 1}:0] tree_leaf_exp_sum_w;
+  wire [{(_CLUSTERS * 4) - 1}:0] tree_leaf_slice_w;
+  wire [{_CLUSTERS - 1}:0] tree_leaf_last_w;
+  wire [{(_CLUSTERS * PARTIAL_PAYLOAD_BITS) - 1}:0] tree_leaf_value_w;
+
+  assign command_ready = &producer_command_ready_w;
+  assign cycle_count = cycle_count_q;
+  assign command_accept_count = command_accept_count_q;
+  assign command_completed_count = command_completed_count_q;
+  assign producer_command_accept_count = producer_command_accept_count_w;
+  assign producer_partial_completed_count = producer_partial_completed_count_w;
+  assign producer_leaf_stall_cycles = producer_leaf_stall_cycles_q;
+  assign producer_partial_valid = producer_result_valid_w;
+  assign producer_partial_ready = producer_result_ready_w;
+  assign producer_partial_last = producer_result_last_w;
+  assign producer_protocol_error = producer_protocol_error_w;
+  assign protocol_error =
+      (|producer_protocol_error_w) || tree_protocol_error || order_protocol_error || finalizer_protocol_error;
+
+{leaf_assigns}
+
+{producer_instances}
+
+  {tree_top_name} u_banked_tree (
+      .clk(clk),
+      .rst_n(rst_n),
+      .leaf_valid(tree_leaf_valid_w),
+      .leaf_ready(tree_leaf_ready_w),
+      .leaf_command_id(tree_leaf_command_id_w),
+      .leaf_head_id(tree_leaf_head_id_w),
+      .leaf_global_max(tree_leaf_global_max_w),
+      .leaf_exp_sum(tree_leaf_exp_sum_w),
+      .leaf_slice(tree_leaf_slice_w),
+      .leaf_last(tree_leaf_last_w),
+      .leaf_value(tree_leaf_value_w),
+      .root_valid(root_valid),
+      .root_ready(root_ready),
+      .root_command_id(root_command_id),
+      .root_head_id(root_head_id),
+      .root_slice(root_slice),
+      .root_last(root_last),
+      .root_value(root_value),
+      .cycle_count(tree_cycle_count_w),
+      .root_completed_count(root_completed_count_w),
+      .finalizer_accepted_count(finalizer_accepted_count),
+      .tree_root_completed_count(tree_root_completed_count),
+      .order_fifo_occupancy(order_fifo_occupancy),
+      .order_fifo_high_watermark(order_fifo_high_watermark),
+      .order_enqueued_count(order_enqueued_count),
+      .order_dequeued_count(order_dequeued_count),
+      .dispatch_stall_cycles(tree_dispatch_stall_cycles),
+      .dispatch_bank_id(dispatch_bank_id),
+      .head_bank_id(head_bank_id),
+      .node_completed_count(node_completed_count),
+      .stage_completed_count(stage_completed_count),
+      .node_protocol_error(node_protocol_error),
+      .stage_protocol_error(stage_protocol_error),
+      .bank_protocol_error(bank_protocol_error),
+      .bank_outstanding(bank_outstanding),
+      .tree_protocol_error(tree_protocol_error),
+      .order_protocol_error(order_protocol_error),
+      .finalizer_protocol_error(finalizer_protocol_error),
+      .protocol_error()
+  );
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      cycle_count_q <= 32'd0;
+      command_accept_count_q <= 32'd0;
+      command_completed_count_q <= 32'd0;
+      producer_leaf_stall_cycles_q <= {(_PRODUCERS * 32)}'d0;
+    end else begin
+      cycle_count_q <= cycle_count_q + 1'b1;
+      if (command_fire_w) begin
+        command_accept_count_q <= command_accept_count_q + 1'b1;
+      end
+      if (root_fire_w && root_last) begin
+        command_completed_count_q <= command_completed_count_q + 1'b1;
+      end
+{stall_counters}
+    end
+  end
+endmodule
+"""
+
+
+def generate(config: JsonDict, out_dir: Path) -> None:
+    params = _validate(json.loads(json.dumps(config)))
+    top_name = str(params["top_name"])
+    producer_top_name = f"{top_name}__producer"
+    tree_top_name = f"{top_name}__banked_tree"
+    head_id_bits = int(params["head_id_bits"])
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="score32_exact_partial_producer_tree_c16_") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        producer_dir = temp_dir / "producer"
+        tree_dir = temp_dir / "tree"
+        generate_cluster(
+            {
+                "top_name": producer_top_name,
+                "attention_decode_score_multivalue_cluster": {
+                    "max_blocks": int(params["max_blocks"]),
+                    "array_n": 8,
+                    "value_slices": int(params["value_slices"]),
+                    "divider_impl": "iterative_restoring",
+                    "score_scale_lanes_per_cycle": 1,
+                    "result_mode": "exact_partial",
+                    "head_id_bits": head_id_bits,
+                },
+            },
+            producer_dir,
+        )
+        generate_banked_tree(
+            {
+                "top_name": tree_top_name,
+                "attention_score32_exact_banked_finalized_tree": {
+                    "clusters": _CLUSTERS,
+                    "radix": _RADIX,
+                    "value_slices": int(params["value_slices"]),
+                    "head_id_bits": head_id_bits,
+                    "divider_lanes": int(params["divider_lanes"]),
+                    "finalizer_banks": int(params["finalizer_banks"]),
+                },
+            },
+            tree_dir,
+        )
+        producer_rtl = (producer_dir / "top.v").read_text(encoding="utf-8")
+        tree_rtl = (tree_dir / "top.v").read_text(encoding="utf-8")
+        producer_manifest = json.loads(
+            (producer_dir / "attention_decode_score_multivalue_cluster_manifest.json").read_text(encoding="utf-8")
+        )
+        tree_manifest = json.loads(
+            (tree_dir / "attention_score32_exact_banked_finalized_tree_manifest.json").read_text(encoding="utf-8")
+        )
+
+    top_text = _top(
+        top_name=top_name,
+        producer_top_name=producer_top_name,
+        tree_top_name=tree_top_name,
+        head_id_bits=head_id_bits,
+    )
+    (out_dir / "top.v").write_text(producer_rtl + "\n\n" + tree_rtl + "\n\n" + top_text, encoding="utf-8")
+    (out_dir / "config.json").write_text(json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    service_model = exact_partial_producer_tree_service_manifest(
+        producers=_PRODUCERS,
+        clusters=_CLUSTERS,
+        heads=int(config.get("probe_defaults", {}).get("heads", 32)) if isinstance(config.get("probe_defaults"), dict) else 32,
+        max_blocks=int(params["max_blocks"]),
+        divider_lanes=int(params["divider_lanes"]),
+        finalizer_banks=int(params["finalizer_banks"]),
+    )
+    manifest = {
+        "version": 1,
+        "generator": "npu/rtlgen/gen_attention_score32_exact_partial_producer_tree_c16.py",
+        "top_name": top_name,
+        "semantic_profile": "score32_online_exact_partial_sixteen_producer_coupled_banked_tree_v1",
+        "producers": _PRODUCERS,
+        "clusters": _CLUSTERS,
+        "radix": _RADIX,
+        "max_blocks": int(params["max_blocks"]),
+        "value_slices": int(params["value_slices"]),
+        "head_id_bits": head_id_bits,
+        "divider_lanes": int(params["divider_lanes"]),
+        "finalizer_banks": int(params["finalizer_banks"]),
+        "producer_result_mode": "exact_partial",
+        "producer_interface": "packed_per_producer_ready_valid_score_blocks_and_value_blocks",
+        "command_schedule_contract": "in_order_head_commands_broadcast_to_all_sixteen_producers",
+        "head_mapping_contract": "explicit_head_id_no_tile_or_wave_inference",
+        "result_interface": "sixteen_exact_partial_producers_to_c16_ordered_banked_exact_finalized_tree",
+        "partial_payload_bits_per_beat": PARTIAL_PAYLOAD_BITS,
+        "partial_link_bits_per_beat": PARTIAL_LINK_BITS,
+        "final_payload_bits_per_beat": FINAL_PAYLOAD_BITS,
+        "final_link_bits_per_beat": FINAL_LINK_BITS,
+        "comparison_baseline_contract": service_model["comparison_baseline_contract"],
+        "comparison_cycle_origin": service_model["comparison_cycle_origin"],
+        "diagnostic_only_baseline": service_model["diagnostic_only_baseline"],
+        "llama_tile_cadence_unclosed": True,
+        "producer_block_workload_assumptions": service_model["producer_block_workload_assumptions"],
+        "exact_protocols": {
+            "producer_partial_protocol": service_model["producer_partial_protocol"],
+            "finalized_protocol": service_model["finalized_protocol"],
+        },
+        "remaining_abstractions": service_model["remaining_abstractions"],
+        "equivalence_hash": False,
+        "service_model": service_model,
+        "submodule_manifests": {
+            "producer": producer_manifest,
+            "producer_instances": _PRODUCERS,
+            "banked_tree": tree_manifest,
+        },
+    }
+    if isinstance(config.get("probe_defaults"), dict):
+        manifest["checked_in_probe_defaults"] = config["probe_defaults"]
+    (out_dir / "attention_score32_exact_partial_producer_tree_c16_manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    generate(_load(args.config), args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/sim/perf/attention_exact_partial.py
+++ b/npu/sim/perf/attention_exact_partial.py
@@ -693,20 +693,30 @@ def exact_banked_finalized_tree_service_manifest(
 
 def exact_partial_producer_tree_service_manifest(
     *,
+    producers: int = 2,
+    clusters: int = 2,
     heads: int = 32,
     max_blocks: int = 16384,
     divider_lanes: int = 8,
     finalizer_banks: int = 59,
 ) -> dict[str, object]:
+    producer_count = int(producers)
+    cluster_count = int(clusters)
     head_count = int(heads)
     block_limit = int(max_blocks)
+    if producer_count < 2 or producer_count > 16 or (producer_count & (producer_count - 1)):
+        raise ValueError("producers must be a power of two in [2, 16]")
+    if cluster_count < 2 or cluster_count > 16 or (cluster_count & (cluster_count - 1)):
+        raise ValueError("clusters must be a power of two in [2, 16]")
+    if producer_count != cluster_count:
+        raise ValueError("producer-coupled exact-partial slice requires producers == clusters")
     if head_count < 1 or head_count > 32:
         raise ValueError("heads must be in [1, 32]")
     if block_limit < 8 or block_limit > 16384 or (block_limit & (block_limit - 1)):
         raise ValueError("max_blocks must be a power of two in [8, 16384]")
     manifest = dict(
         exact_banked_finalized_tree_service_manifest(
-            clusters=2,
+            clusters=cluster_count,
             heads=head_count,
             divider_lanes=divider_lanes,
             finalizer_banks=finalizer_banks,
@@ -714,8 +724,9 @@ def exact_partial_producer_tree_service_manifest(
     )
     manifest.update(
         {
-            "producers": 2,
-            "command_broadcast_mode": "same_head_broadcast_to_both_producers",
+            "producers": producer_count,
+            "clusters": cluster_count,
+            "command_broadcast_mode": f"same_head_broadcast_to_all_{producer_count}_producers",
             "head_mapping_contract": "explicit_head_id_no_tile_or_wave_inference",
             "producer_input_contract": "per_producer_ready_valid_score_blocks_and_value_blocks",
             "producer_partial_protocol": {
@@ -747,7 +758,7 @@ def exact_partial_producer_tree_service_manifest(
             "llama_tile_cadence_unclosed": True,
             "remaining_abstractions": [
                 "direct_328bit_exact_partial_links_unclosed",
-                "native_c2_overlap_only",
+                f"native_c{cluster_count}_overlap_only",
                 "llama_16cluster_8tilewave_986cycle_mapping_open",
             ],
         }

--- a/runs/designs/npu_blocks/attention_score32_exact_partial_producer_tree_c16_r2_l8_b59/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_partial_producer_tree_c16_r2_l8_b59/config.json
@@ -1,0 +1,16 @@
+{
+  "attention_score32_exact_partial_producer_tree_c16": {
+    "clusters": 16,
+    "divider_lanes": 8,
+    "finalizer_banks": 59,
+    "head_id_bits": 5,
+    "max_blocks": 16,
+    "producers": 16,
+    "radix": 2,
+    "value_slices": 16
+  },
+  "probe_defaults": {
+    "heads": 2
+  },
+  "top_name": "attention_score32_exact_partial_producer_tree_c16_r2_l8_b59"
+}

--- a/tests/test_attention_score32_exact_partial_producer_tree_c16.py
+++ b/tests/test_attention_score32_exact_partial_producer_tree_c16.py
@@ -1,0 +1,150 @@
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval.probe_attention_score32_exact_partial_producer_tree_c16 import build_report
+from npu.rtlgen.gen_attention_score32_exact_partial_producer_tree_c16 import generate
+
+_FAKERAM_MODEL = """
+module fakeram45_2048x39 (
+    output wire [38:0] rd_out, input wire [10:0] addr_in,
+    input wire we_in, input wire [38:0] wd_in, input wire [38:0] w_mask_in,
+    input wire clk, input wire ce_in
+);
+  reg [38:0] mem [0:2047];
+  reg [10:0] addr_q;
+  reg [38:0] rd_out_q;
+  integer idx;
+  initial begin addr_q = 0; rd_out_q = 0; for (idx = 0; idx < 2048; idx = idx + 1) mem[idx] = 0; end
+  always @(posedge clk) begin
+    rd_out_q <= mem[addr_q];
+    if (ce_in) begin
+      if (we_in) for (idx = 0; idx < 39; idx = idx + 1)
+        if (w_mask_in[idx]) mem[addr_in][idx] <= wd_in[idx];
+      addr_q <= addr_in;
+    end
+  end
+  assign rd_out = rd_out_q;
+endmodule
+"""
+
+
+def _rtl_tools_available() -> bool:
+    return bool(shutil.which("iverilog") and shutil.which("vvp") and shutil.which("verilator"))
+
+
+def _tool(name: str) -> str:
+    path = shutil.which(name)
+    if path:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    if fallback.exists():
+        return str(fallback)
+    raise RuntimeError(f"required tool unavailable: {name}")
+
+
+def _config_path() -> Path:
+    return (
+        REPO_ROOT
+        / "runs"
+        / "designs"
+        / "npu_blocks"
+        / "attention_score32_exact_partial_producer_tree_c16_r2_l8_b59"
+        / "config.json"
+    )
+
+
+def _load_config() -> dict[str, object]:
+    return json.loads(_config_path().read_text(encoding="utf-8"))
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="RTL tools unavailable")
+def test_exact_partial_producer_tree_c16_manifest_and_verilator_lint(tmp_path: Path) -> None:
+    config = _load_config()
+    generate(config, tmp_path / "rtl")
+    fakeram_path = tmp_path / "fakeram45_2048x39.sv"
+    fakeram_path.write_text(_FAKERAM_MODEL, encoding="utf-8")
+
+    manifest = json.loads(
+        (tmp_path / "rtl" / "attention_score32_exact_partial_producer_tree_c16_manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert manifest["producers"] == 16
+    assert manifest["clusters"] == 16
+    assert manifest["divider_lanes"] == 8
+    assert manifest["finalizer_banks"] == 59
+    assert manifest["producer_result_mode"] == "exact_partial"
+    assert manifest["producer_interface"] == "packed_per_producer_ready_valid_score_blocks_and_value_blocks"
+    assert manifest["llama_tile_cadence_unclosed"] is True
+    assert manifest["service_model"]["per_bank_accept_interval_cycles"] == 59
+
+    lint = subprocess.run(
+        [
+            _tool("verilator"),
+            "--lint-only",
+            "-Wno-WIDTHEXPAND",
+            "-Wno-WIDTHTRUNC",
+            "--top-module",
+            str(config["top_name"]),
+            str(tmp_path / "rtl" / "top.v"),
+            str(fakeram_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert lint.returncode == 0, lint.stderr
+
+
+def test_exact_partial_producer_tree_c16_rejects_non_b59_config(tmp_path: Path) -> None:
+    config = _load_config()
+    config["attention_score32_exact_partial_producer_tree_c16"]["finalizer_banks"] = 58
+    with pytest.raises(SystemExit, match="producer-coupled c16 slice currently requires finalizer_banks=59"):
+        generate(config, tmp_path / "rtl")
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="RTL tools unavailable")
+def test_exact_partial_producer_tree_c16_heads2_native_overlap_probe() -> None:
+    report = build_report(config=_load_config())
+
+    assert report["passed"] is True
+    assert report["outputs"] == 32
+    assert report["command_accept_count"] == 2
+    assert report["command_complete_count"] == 2
+    assert report["finalizer_accepted_count"] == 32
+    assert report["tree_root_completed_count"] == 32
+    assert report["observed_root_hash"] == "69cab7d0a005e21a6a87562b2073dbf0ad358dfe2c72931340a8dc727b564e70"
+    assert report["integrated_drain_cycles"] == 824
+    assert report["producer_parallel_phase_drain_cycles"] == 761
+    assert report["producer_parallel_then_reducer_bound_cycles"] == 855
+    assert report["producer_parallel_then_reducer_overlap_cycles_saved"] == 31
+    assert report["producer_fully_serialized_then_reducer_diagnostic"]["drain_cycles"] == 11996
+    assert report["protocol_error"] is False
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="RTL tools unavailable")
+def test_exact_partial_producer_tree_c16_heads1_backpressure_probe() -> None:
+    report = build_report(
+        config=_load_config(),
+        heads=1,
+        output_ready_pattern=(True, False, False, True, True, False, True, False, True, True, False, True),
+        include_baseline=False,
+    )
+
+    assert report["passed"] is True
+    assert report["outputs"] == 16
+    assert report["observed_root_hash"] == "d0aed81a674f7052a2fc6b1fa10fdc402d13210886180602656eae0430e4d4a3"
+    assert report["integrated_drain_cycles"] == 450
+    assert report["tree_dispatch_stall_cycles"] == 0
+    assert max(report["producer_leaf_stall_cycles"]) > 0
+    assert report["order_protocol_error"] is False
+    assert report["finalizer_protocol_error"] is False

--- a/tests/test_check_attention_score32_exact_partial_producer_tree_c16_guard.py
+++ b/tests/test_check_attention_score32_exact_partial_producer_tree_c16_guard.py
@@ -1,0 +1,112 @@
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_score32_exact_partial_producer_tree_c16 import generate
+
+
+def _config_path() -> Path:
+    return (
+        REPO_ROOT
+        / "runs"
+        / "designs"
+        / "npu_blocks"
+        / "attention_score32_exact_partial_producer_tree_c16_r2_l8_b59"
+        / "config.json"
+    )
+
+
+def _prepare_design_dir(tmp_path: Path) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    design_dir = tmp_path / "design"
+    design_dir.mkdir()
+    config = json.loads(_config_path().read_text(encoding="utf-8"))
+    (design_dir / "config.json").write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    generate(config, design_dir / "verilog")
+    return design_dir
+
+
+def _run_guard(design_dir: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/check_attention_score32_exact_partial_producer_tree_c16_guard.py",
+            "--design-dir",
+            str(design_dir),
+            "--config",
+            str(design_dir / "config.json"),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_exact_partial_producer_tree_c16_guard_accepts_checked_in_config(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path)
+    result = _run_guard(design_dir)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["producers"] == 16
+    assert payload["clusters"] == 16
+    assert payload["divider_lanes"] == 8
+    assert payload["finalizer_banks"] == 59
+    assert payload["status"] == "ok"
+
+
+def test_exact_partial_producer_tree_c16_guard_rejects_stale_top(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path)
+    top_path = design_dir / "verilog" / "top.v"
+    top_path.write_text(top_path.read_text(encoding="utf-8") + "\n// stale drift\n", encoding="utf-8")
+
+    result = _run_guard(design_dir)
+    assert result.returncode != 0
+    assert "generated RTL artifacts do not match current generator output: top.v" in result.stderr
+
+
+def test_exact_partial_producer_tree_c16_guard_rejects_missing_direct_leaf_wiring(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path)
+    top_path = design_dir / "verilog" / "top.v"
+    text = top_path.read_text(encoding="utf-8")
+    top_path.write_text(
+        text.replace(
+            "assign tree_leaf_value_w[4920 +: PARTIAL_PAYLOAD_BITS] = producer_result_value_w[4920 +: PARTIAL_PAYLOAD_BITS];",
+            "assign tree_leaf_value_w[4920 +: PARTIAL_PAYLOAD_BITS] = 328'd0;",
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run_guard(design_dir)
+    assert result.returncode != 0
+    assert (
+        "generated RTL missing semantic token: assign tree_leaf_value_w[4920 +: PARTIAL_PAYLOAD_BITS] = producer_result_value_w[4920 +: PARTIAL_PAYLOAD_BITS];"
+        in result.stderr
+    )
+
+
+def test_exact_partial_producer_tree_c16_guard_rejects_banked_tree_cluster_drift(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path)
+    manifest_path = design_dir / "verilog" / "attention_score32_exact_partial_producer_tree_c16_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["submodule_manifests"]["banked_tree"]["clusters"] = 8
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    result = _run_guard(design_dir)
+    assert result.returncode != 0
+    assert "banked-tree submodule manifest clusters must be 16" in result.stderr
+
+
+def test_exact_partial_producer_tree_c16_guard_rejects_equivalence_hash_token(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path)
+    top_path = design_dir / "verilog" / "top.v"
+    top_path.write_text(top_path.read_text(encoding="utf-8") + "\nwire equivalence_hash = 1'b0;\n", encoding="utf-8")
+
+    result = _run_guard(design_dir)
+    assert result.returncode != 0
+    assert "functional datapath must not contain equivalence_hash tokens" in result.stderr


### PR DESCRIPTION
## Summary

- compose sixteen real exact-partial score32 producers into the c16/r2/l8/b59 banked finalized tree
- preserve explicit head identity and packed per-producer 328-bit ready/valid leaf interfaces
- add c16 RTL/perf equivalence, backpressure evidence, strict artifact guards, and service metadata

## Scope

This closes the native c16 functional composition only. The Llama 8-wave/986-cycle mapping, NoC links, SRAM placement, full 32-head simulation, and PPA remain explicitly open.

## Evidence

- heads=2: 32 finalized outputs match the perf reference hash
- integrated drain: 824 cycles
- producer-parallel-then-reducer staged baseline: 855 cycles
- overlap benefit: 31 cycles
- heads=1 stressed backpressure case also matches exactly

## Validation

- `pytest -q` over both c16 and existing c2 producer/tree test suites: 20 passed
- `python scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`
