### PR TITLE
Add GQA8 dual-stream exact-partial producer

### DIFF
--- a/npu/docs/attention_score32_exact_partial_gqa8_dual_stream_producer_contract.md
+++ b/npu/docs/attention_score32_exact_partial_gqa8_dual_stream_producer_contract.md
@@ -1,0 +1,107 @@
+# Score32 Exact Partial GQA8 Dual-Stream Producer Contract
+
+This block is a new functional local producer slice for the 128-MAC exact
+partial path. It is intentionally separate from the historical
+`attention_score32_exact_partial_producer_tree` evidence path.
+
+## Scope
+
+- two token streams
+- eight query-head lanes per stream (`GQA8`)
+- shared score-K broadcast within each stream
+- explicit `head_base + lane` head IDs
+- pairwise exact-partial merge across the two streams
+- exact-partial output only (`328` payload bits, `419` link bits)
+
+The structural score rate is `2 streams x 8 heads x 8 token lanes = 128`
+MAC/cycle.
+
+Each stream is built from the existing real
+`attention_decode_score_multivalue_gqa_group` extended to
+`result_mode="exact_partial"`. Corresponding stream outputs are merged with the
+existing exact-partial merge stage. The functional RTL preserves the full
+partial state on every beat: `global_max`, `exp_sum`, `slice`, `last`, and
+`8 x S41` numerators.
+
+## Local-Wave Storage Contract
+
+- `max_blocks=8` is the intended local producer limit.
+- A `1024`-token tile is partitioned into `128` token blocks and distributed
+  across `53/54` datapaths and `2` token streams, so each local stream sees at
+  most `2` token blocks per wave.
+- The checked-in smoke probe uses `1` command, `2` blocks per stream, and
+  `head_dim=3`.
+- This producer emits one wave at a time. Local `53/54`-way aggregation and
+  persistent temporal accumulation across `8` waves remain outside this slice.
+
+## Remaining Abstractions
+
+- `53or54_way_global_cluster_aggregation_open`
+- `8_wave_persistent_state_open`
+- `noc_sram_ppa_open`
+
+No global reduction closure, NoC closure, SRAM banking closure, or PPA closure
+is claimed here.
+
+## Value-Memory Contract
+
+- The implemented interface is per-stream GQA-coalesced value service, reused
+  from the GQA group generator.
+- Shared K/V request coalescing is functional within each stream.
+- No claim is made about full global K/V memory closure beyond the local stream
+  interface.
+
+## Probe Evidence
+
+Recorded on July 28, 2026 with:
+
+- `python npu/eval/probe_attention_score32_exact_partial_gqa8_dual_stream_producer.py --config runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/config.json --json`
+- `python npu/eval/probe_attention_score32_exact_partial_gqa8_dual_stream_producer.py --config runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/config_heads32_native.json --json`
+- `python npu/eval/probe_attention_score32_exact_partial_gqa8_dual_stream_producer.py --config runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/config_llama_wave.json --json`
+
+Checked-in smoke point:
+
+- heads: `8`
+- command groups: `1`
+- exact-partial output beats: `128`
+- integrated drain cycles: `438`
+- command accepts/completions: `1 / 1`
+- stream accepts/completions: `[1, 1] / [1, 1]`
+- merge completions: `128`
+- result stall cycles under probe backpressure: `64`
+
+Full native point:
+
+- heads: `32`
+- command groups: `4`
+- blocks per stream: `2`
+- head_dim: `3`
+- exact-partial output beats: `512`
+- integrated drain cycles: `1736`
+- command accepts/completions: `4 / 4`
+- stream accepts/completions: `[4, 4] / [4, 4]`
+- merge completions: `512`
+- result stall cycles under probe backpressure: `255`
+
+Llama-wave functional service point:
+
+- heads: `32`
+- command groups: `5`
+- command head_bases: `[0, 8, 16, 24, 0]`
+- blocks per stream: `1`
+- head_dim: `128`
+- exact-partial output beats: `640`
+- ideal command/input/value-request/output interfaces
+- minimum modeled value-response latency
+- integrated drain cycles: `1681`
+- compared directly to `986` cycles: `+695`
+- command accepts/completions: `5 / 5`
+- stream accepts/completions: `[5, 5] / [5, 5]`
+- merge completions: `640`
+- result stall cycles: `0`
+- exact beat equivalence: pass
+- compared directly to `986` cycles as functional service evidence only
+- this is not a frontier revision
+
+Both probes compare every emitted beat against a structured Python exact-partial
+reference. No hash reduction is used in the functional comparison path.

--- a/npu/eval/check_attention_score32_exact_partial_gqa8_dual_stream_producer_guard.py
+++ b/npu/eval/check_attention_score32_exact_partial_gqa8_dual_stream_producer_guard.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Strict generated RTL guard for the dual-stream GQA8 exact-partial producer slice."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import sys
+import tempfile
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_score32_exact_partial_gqa8_dual_stream_producer import generate
+from npu.sim.perf.attention_exact_partial import (
+    PARTIAL_LINK_BITS,
+    PARTIAL_PAYLOAD_BITS,
+    exact_partial_dual_stream_gqa8_producer_service_manifest,
+)
+
+_CONFIG_KEY = "attention_score32_exact_partial_gqa8_dual_stream_producer"
+_MANIFEST_NAME = "attention_score32_exact_partial_gqa8_dual_stream_producer_manifest.json"
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _resolve_selected_config(*, design_dir: Path, selected: Path | None) -> Path:
+    config_path = selected or (design_dir / "config.json")
+    config_path = config_path.resolve()
+    if not config_path.exists():
+        raise SystemExit(f"missing config: {config_path}")
+    try:
+        relative_path = config_path.relative_to(design_dir)
+    except ValueError as exc:
+        raise SystemExit(f"selected config must live under design-dir: {config_path}") from exc
+    if len(relative_path.parts) != 1:
+        raise SystemExit(f"selected config must be a direct child of design-dir, got: {relative_path.as_posix()}")
+    return config_path
+
+
+def _require(mapping: dict[str, object], key: str, expected: object, label: str) -> None:
+    if mapping.get(key) != expected:
+        raise SystemExit(f"{label} {key} must be {expected}")
+
+
+def _require_token(text: str, token: str, label: str) -> None:
+    if token not in text:
+        raise SystemExit(f"{label} missing semantic token: {token}")
+
+
+def _extract_module(rtl: str, module_name: str) -> str:
+    pattern = re.compile(rf"module\s+{re.escape(module_name)}\b.*?endmodule\s*", re.DOTALL)
+    match = pattern.search(rtl)
+    if match is None:
+        raise SystemExit(f"generated RTL does not define module {module_name}")
+    return match.group(0)
+
+
+def _compare_current_generation(*, config: dict[str, object], rtl_dir: Path) -> None:
+    with tempfile.TemporaryDirectory(prefix="score32_exact_partial_gqa8_dual_stream_guard_") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        generate(config, temp_dir)
+        for relative_name in (
+            "top.v",
+            "config.json",
+            _MANIFEST_NAME,
+        ):
+            generated_text = (temp_dir / relative_name).read_text(encoding="utf-8")
+            current_text = (rtl_dir / relative_name).read_text(encoding="utf-8")
+            if generated_text != current_text:
+                raise SystemExit(f"generated RTL artifacts do not match current generator output: {relative_name}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--design-dir", type=Path, required=True)
+    parser.add_argument("--config", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    design_dir = args.design_dir.resolve()
+    config_path = _resolve_selected_config(design_dir=design_dir, selected=args.config)
+    rtl_dir = design_dir / "verilog"
+    generated_config_path = rtl_dir / "config.json"
+    manifest_path = rtl_dir / _MANIFEST_NAME
+    top_path = rtl_dir / "top.v"
+    for path in (config_path, generated_config_path, manifest_path, top_path):
+        if not path.is_file():
+            raise SystemExit(f"missing dual-stream exact-partial producer artifact: {path}")
+
+    config = _load_json(config_path)
+    generated_config = _load_json(generated_config_path)
+    if config != generated_config:
+        raise SystemExit("generated config does not match source config")
+
+    top_name = str(config.get("top_name") or "").strip()
+    body = config.get(_CONFIG_KEY)
+    if not top_name or not isinstance(body, dict):
+        raise SystemExit(f"config must contain top_name and {_CONFIG_KEY}")
+
+    streams = int(body.get("streams", 0))
+    query_heads_per_stream = int(body.get("query_heads_per_stream", 0))
+    max_blocks = int(body.get("max_blocks", 0))
+    value_slices = int(body.get("value_slices", 0))
+    head_id_bits = int(body.get("head_id_bits", 0))
+    if streams != 2:
+        raise SystemExit("dual-stream exact producer must remain fixed at streams=2")
+    if query_heads_per_stream != 8:
+        raise SystemExit("dual-stream exact producer must remain fixed at query_heads_per_stream=8")
+    if max_blocks < 8 or max_blocks > 16384 or (max_blocks & (max_blocks - 1)):
+        raise SystemExit("max_blocks must be a power of two in [8, 16384]")
+    if value_slices != 16:
+        raise SystemExit("value_slices must remain 16")
+    if head_id_bits != 5:
+        raise SystemExit("head_id_bits must remain 5 for explicit 32-head addressing")
+
+    probe_defaults = config.get("probe_defaults", {})
+    if not isinstance(probe_defaults, dict):
+        probe_defaults = {}
+    service_model = exact_partial_dual_stream_gqa8_producer_service_manifest(
+        heads=int(probe_defaults.get("heads", 8)),
+        max_blocks=max_blocks,
+        command_count=int(probe_defaults.get("command_count", int(probe_defaults.get("heads", 8)) // 8)),
+        blocks_per_stream=int(probe_defaults.get("blocks_per_stream", 2)),
+        head_dim=int(probe_defaults.get("head_dim", 3)),
+        head_bases=tuple(int(value) for value in probe_defaults.get("head_bases", [])) if isinstance(probe_defaults.get("head_bases"), list) else None,
+        llama_wave_reference_cycles=int(probe_defaults["llama_wave_reference_cycles"]) if "llama_wave_reference_cycles" in probe_defaults else None,
+    )
+    manifest = _load_json(manifest_path)
+    expected_manifest = {
+        "top_name": top_name,
+        "generator": "npu/rtlgen/gen_attention_score32_exact_partial_gqa8_dual_stream_producer.py",
+        "semantic_profile": "score32_exact_partial_gqa8_dual_stream_producer_v1",
+        "streams": 2,
+        "query_heads_per_stream": 8,
+        "token_lanes_per_head": 8,
+        "structural_score_macs_per_cycle": 128,
+        "max_blocks": max_blocks,
+        "value_slices": 16,
+        "head_id_bits": 5,
+        "producer_result_mode": "exact_partial",
+        "command_schedule_contract": "in_order_head_base_commands_broadcast_to_both_streams",
+        "head_mapping_contract": "explicit_head_base_plus_lane_no_tile_or_wave_inference",
+        "result_interface": "two_exact_partial_gqa8_streams_to_pairwise_exact_merge",
+        "partial_payload_bits_per_beat": PARTIAL_PAYLOAD_BITS,
+        "partial_link_bits_per_beat": PARTIAL_LINK_BITS,
+        "exact_protocols": {
+            "producer_partial_protocol": service_model["producer_partial_protocol"],
+        },
+        "remaining_abstractions": service_model["remaining_abstractions"],
+        "equivalence_hash": False,
+        "service_model": service_model,
+    }
+    for key, expected in expected_manifest.items():
+        _require(manifest, key, expected, "generated manifest")
+    if isinstance(config.get("probe_defaults"), dict):
+        _require(manifest, "checked_in_probe_defaults", config["probe_defaults"], "generated manifest")
+
+    submodule_manifests = manifest.get("submodule_manifests")
+    if not isinstance(submodule_manifests, dict):
+        raise SystemExit("generated manifest must contain submodule_manifests")
+    group_manifest = submodule_manifests.get("gqa_group")
+    merge_manifest = submodule_manifests.get("merge")
+    if not isinstance(group_manifest, dict) or not isinstance(merge_manifest, dict):
+        raise SystemExit("generated manifest must contain gqa_group and merge submodule manifests")
+    _require(group_manifest, "generator", "npu/rtlgen/gen_attention_decode_score_multivalue_gqa_group.py", "gqa_group submodule manifest")
+    _require(group_manifest, "result_mode", "exact_partial", "gqa_group submodule manifest")
+    _require(group_manifest, "head_id_bits", 5, "gqa_group submodule manifest")
+    _require(group_manifest, "parallel_query_head_clusters", 8, "gqa_group submodule manifest")
+    _require(group_manifest, "result_value_bits_per_beat", 328, "gqa_group submodule manifest")
+    cluster_manifest = group_manifest.get("submodule_manifests", {}).get("multivalue_cluster", {})
+    _require(cluster_manifest, "result_mode", "exact_partial", "embedded cluster manifest")
+    _require(cluster_manifest, "head_id_bits", 5, "embedded cluster manifest")
+    _require(cluster_manifest, "score_bank_macro_count", 56, "embedded cluster manifest")
+    _require(merge_manifest, "generator", "npu/rtlgen/gen_attention_score32_online_state_merge.py", "merge submodule manifest")
+    _require(merge_manifest, "result_interface", "ready_valid_exact_partial_slice_stream", "merge submodule manifest")
+    _require(merge_manifest, "partial_payload_bits_per_beat", 328, "merge submodule manifest")
+
+    rtl = top_path.read_text(encoding="utf-8", errors="replace")
+    group_top = f"{top_name}__group"
+    merge_top = f"{top_name}__merge"
+    top_module = _extract_module(rtl, top_name)
+    _extract_module(rtl, group_top)
+    _extract_module(rtl, merge_top)
+
+    if len(re.findall(rf"\bmodule\s+{re.escape(group_top)}\b", rtl)) != 1:
+        raise SystemExit("generated RTL must contain exactly one GQA group module definition")
+    if len(re.findall(rf"\bmodule\s+{re.escape(merge_top)}\b", rtl)) != 1:
+        raise SystemExit("generated RTL must contain exactly one exact merge module definition")
+    if top_module.count(f"{group_top} u_stream_") != 2:
+        raise SystemExit("generated RTL must instantiate the exact GQA group exactly twice")
+    if top_module.count(f"{merge_top} u_merge") != 1:
+        raise SystemExit("generated RTL must instantiate the exact merge exactly once")
+
+    for token in (
+        "input  wire [4:0] command_head_base,",
+        "input  wire signed [127:0] input_query,",
+        "input  wire signed [127:0] input_key,",
+        "output wire [1:0]   value_read_req_valid,",
+        "input  wire [1023:0] value_response_matrix,",
+        "output wire [4:0] result_head_id,",
+        "assign command_ready = command_head_base_valid_w && (&stream_command_ready_w);",
+        "assign input_ready = &stream_input_ready_w;",
+        ".command_head_base(command_head_base)",
+        ".input_query(input_query[63:0])",
+        ".input_query(input_query[127:64])",
+        ".input_key(input_key[63:0])",
+        ".input_key(input_key[127:64])",
+        ".left_head_id(stream_result_head_id_w[4:0])",
+        ".right_head_id(stream_result_head_id_w[9:5])",
+        "command_head_base[2:0] == 3'd0",
+        "result_head_id[2:0] == 3'd7",
+        "stream_result_head_w[2:0] != stream_result_head_w[5:3]",
+        "stream_partial_valid = stream_result_valid_w;",
+        "stream_partial_ready = stream_result_ready_w;",
+        "stream_partial_last = stream_result_last_w;",
+        "result_stall_cycles_q <= result_stall_cycles_q + 1'b1;",
+    ):
+        _require_token(top_module, token, "generated RTL")
+
+    for forbidden in (
+        "equivalence_hash",
+        "result_hash",
+        "finalizer",
+        "local_normalization",
+    ):
+        if forbidden in rtl:
+            raise SystemExit(f"functional datapath must not contain {forbidden} tokens")
+
+    _compare_current_generation(config=config, rtl_dir=rtl_dir)
+
+    print(
+        json.dumps(
+            {
+                "design": top_name,
+                "guard": "attention_score32_exact_partial_gqa8_dual_stream_producer_v1",
+                "streams": streams,
+                "query_heads_per_stream": query_heads_per_stream,
+                "structural_score_macs_per_cycle": 128,
+                "max_blocks": max_blocks,
+                "status": "ok",
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/probe_attention_score32_exact_partial_gqa8_dual_stream_producer.py
+++ b/npu/eval/probe_attention_score32_exact_partial_gqa8_dual_stream_producer.py
@@ -1,0 +1,873 @@
+#!/usr/bin/env python3
+"""Probe the dual-stream GQA8 exact-partial producer against a structured reference."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_score32_exact_partial_gqa8_dual_stream_producer import generate as generate_tree
+from npu.sim.perf.attention_exact_partial import (
+    exact_partial_dual_stream_gqa8_producer_service_manifest,
+    merge_partial_streams,
+    partial_stream_from_blocks,
+)
+from npu.sim.perf.attention_online import requantize_score_row
+
+JsonDict = dict[str, Any]
+
+_COMMAND_RE = re.compile(r"COMMAND_ACCEPT idx=(\d+) cmd=(\d+) head_base=(\d+) cycle=(\d+)")
+_RESULT_RE = re.compile(
+    r"RESULT cmd=(\d+) head=(\d+) slice=(\d+) last=(\d+) max=(-?\d+) sum=(\d+) value=([0-9a-fA-F]+) cycle=(\d+)"
+)
+_SUMMARY_RE = re.compile(
+    r"SUMMARY outputs=(\d+) drain=(\d+) protocol_error=(\d+) command_accept=(\d+) command_complete=(\d+) "
+    r"stream0_accept=(\d+) stream1_accept=(\d+) stream0_complete=(\d+) stream1_complete=(\d+) "
+    r"merge_complete=(\d+) result_stall=(\d+) stream0_error=(\d+) stream1_error=(\d+) merge_error=(\d+)"
+)
+
+_FAKERAM_MODEL = """
+module fakeram45_2048x39 (
+    output wire [38:0] rd_out, input wire [10:0] addr_in,
+    input wire we_in, input wire [38:0] wd_in, input wire [38:0] w_mask_in,
+    input wire clk, input wire ce_in
+);
+  reg [38:0] mem [0:2047];
+  reg [10:0] addr_q;
+  reg [38:0] rd_out_q;
+  integer idx;
+  initial begin
+    addr_q = 0;
+    rd_out_q = 0;
+    for (idx = 0; idx < 2048; idx = idx + 1) mem[idx] = 0;
+  end
+  always @(posedge clk) begin
+    rd_out_q <= mem[addr_q];
+    if (ce_in) begin
+      if (we_in) begin
+        for (idx = 0; idx < 39; idx = idx + 1) begin
+          if (w_mask_in[idx]) mem[addr_in][idx] <= wd_in[idx];
+        end
+      end
+      addr_q <= addr_in;
+    end
+  end
+  assign rd_out = rd_out_q;
+endmodule
+"""
+
+
+def _tool(name: str) -> str:
+    path = shutil.which(name)
+    if path:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    if fallback.exists():
+        return str(fallback)
+    raise RuntimeError(f"required tool unavailable: {name}")
+
+
+def _pack(values: list[int], bits: int) -> int:
+    mask = (1 << bits) - 1
+    return sum((int(value) & mask) << (index * bits) for index, value in enumerate(values))
+
+
+def _default_config() -> JsonDict:
+    return {
+        "top_name": "attention_score32_exact_partial_gqa8_dual_stream_producer_b8",
+        "attention_score32_exact_partial_gqa8_dual_stream_producer": {
+            "streams": 2,
+            "query_heads_per_stream": 8,
+            "max_blocks": 8,
+            "value_slices": 16,
+            "head_id_bits": 5,
+        },
+        "probe_defaults": {
+            "heads": 8,
+            "command_count": 1,
+            "blocks_per_stream": 2,
+            "head_dim": 3,
+        },
+    }
+
+
+def _resolve_workload(
+    config: JsonDict,
+    *,
+    heads: int | None,
+    command_count: int | None,
+    blocks_per_stream: int | None,
+    head_dim: int | None,
+    head_bases: tuple[int, ...] | None,
+) -> dict[str, object]:
+    defaults = config.get("probe_defaults", {})
+    if not isinstance(defaults, dict):
+        defaults = {}
+    resolved_heads = int(heads if heads is not None else defaults.get("heads", 8))
+    resolved_command_count = int(command_count if command_count is not None else defaults.get("command_count", resolved_heads // 8))
+    resolved_blocks_per_stream = int(blocks_per_stream if blocks_per_stream is not None else defaults.get("blocks_per_stream", 2))
+    resolved_head_dim = int(head_dim if head_dim is not None else defaults.get("head_dim", 3))
+    configured_head_bases = head_bases
+    if configured_head_bases is None and isinstance(defaults.get("head_bases"), list):
+        configured_head_bases = tuple(int(value) for value in defaults["head_bases"])
+
+    if resolved_heads < 8 or resolved_heads > 32 or resolved_heads % 8:
+        raise ValueError("heads must be a multiple of 8 in [8, 32]")
+    if resolved_command_count < 1:
+        raise ValueError("command_count must be positive")
+    if resolved_blocks_per_stream < 1 or resolved_blocks_per_stream > 8:
+        raise ValueError("blocks_per_stream must be in [1, 8]")
+    if resolved_head_dim < 1:
+        raise ValueError("head_dim must be positive")
+    if configured_head_bases is None:
+        head_groups = tuple(group * 8 for group in range(resolved_heads // 8))
+        configured_head_bases = tuple(head_groups[index % len(head_groups)] for index in range(resolved_command_count))
+    if len(configured_head_bases) != resolved_command_count:
+        raise ValueError("head_bases length must match command_count")
+    for base in configured_head_bases:
+        if base % 8 or base < 0 or base > 24:
+            raise ValueError("head_bases entries must be aligned to 8 in [0, 24]")
+    return {
+        "heads": resolved_heads,
+        "command_count": resolved_command_count,
+        "blocks_per_stream": resolved_blocks_per_stream,
+        "head_dim": resolved_head_dim,
+        "head_bases": tuple(configured_head_bases),
+        "llama_wave_reference_cycles": defaults.get("llama_wave_reference_cycles"),
+    }
+
+
+def _command_schedule(*, heads: int, command_count: int, head_bases: tuple[int, ...]) -> tuple[dict[str, int], ...]:
+    if heads < 8 or heads > 32 or heads % 8:
+        raise ValueError("heads must be a multiple of 8 in [8, 32]")
+    schedule = []
+    for group in range(command_count):
+        head_base = int(head_bases[group])
+        multiplier, shift = ((1 << 20), 0) if group % 3 == 0 else (7 + group, 1 if group % 3 == 1 else 2)
+        schedule.append(
+            {
+                "command_id": 0x7200 + group,
+                "head_base": head_base,
+                "multiplier": multiplier,
+                "shift": shift,
+            }
+    )
+    return tuple(schedule)
+
+
+def _block_beats(
+    stream: int,
+    command_index: int,
+    *,
+    blocks_per_stream: int,
+    head_dim: int,
+) -> list[list[tuple[list[int], list[int]]]]:
+    blocks: list[list[tuple[list[int], list[int]]]] = []
+    for block in range(blocks_per_stream):
+        block_beats: list[tuple[list[int], list[int]]] = []
+        for beat in range(head_dim):
+            queries = [
+                ((stream * 41 + command_index * 29 + block * 17 + beat * 11 + head * 7) % 63) - 31
+                for head in range(8)
+            ]
+            keys = [
+                ((stream * 53 + command_index * 31 + block * 19 + beat * 13 + lane * 5) % 127) - 63
+                for lane in range(8)
+            ]
+            block_beats.append((queries, keys))
+        blocks.append(block_beats)
+    return blocks
+
+
+def _values_for(stream: int, command_index: int, *, blocks_per_stream: int) -> list[list[list[list[int]]]]:
+    return [
+        [
+            [
+                [
+                    ((stream * 67 + command_index * 37 + block * 23 + value_slice * 17 + row * 11 + lane * 7) % 255)
+                    - 127
+                    for lane in range(8)
+                ]
+                for row in range(8)
+            ]
+            for value_slice in range(16)
+        ]
+        for block in range(blocks_per_stream)
+    ]
+
+
+def _raw_scores(block: list[tuple[list[int], list[int]]], head_lane: int) -> list[int]:
+    return [
+        sum(queries[head_lane] * keys[token_lane] for queries, keys in block)
+        for token_lane in range(8)
+    ]
+
+
+def _expected(workload: dict[str, object]) -> list[dict[str, object]]:
+    heads = int(workload["heads"])
+    command_count = int(workload["command_count"])
+    blocks_per_stream = int(workload["blocks_per_stream"])
+    head_dim = int(workload["head_dim"])
+    head_bases = tuple(int(value) for value in workload["head_bases"])
+    rows: list[dict[str, object]] = []
+    for command_index, command in enumerate(
+        _command_schedule(heads=heads, command_count=command_count, head_bases=head_bases)
+    ):
+        merged_per_head = []
+        for head_lane in range(8):
+            stream_partials = []
+            for stream in range(2):
+                blocks = _block_beats(stream, command_index, blocks_per_stream=blocks_per_stream, head_dim=head_dim)
+                score_rows = [
+                    list(
+                        requantize_score_row(
+                            _raw_scores(block, head_lane),
+                            multiplier=int(command["multiplier"]),
+                            shift=int(command["shift"]),
+                        )
+                    )
+                    for block in blocks
+                ]
+                stream_partials.append(
+                    partial_stream_from_blocks(
+                        command_id=int(command["command_id"]),
+                        head_id=int(command["head_base"]) + head_lane,
+                        score_rows=score_rows,
+                        value_blocks=_values_for(stream, command_index, blocks_per_stream=blocks_per_stream),
+                    )
+                )
+            merged_per_head.append(merge_partial_streams(stream_partials[0], stream_partials[1]))
+        for head_lane in range(8):
+            for beat in merged_per_head[head_lane]:
+                rows.append(
+                    {
+                        "command_id": beat.command_id,
+                        "head_id": beat.head_id,
+                        "slice": beat.slice_index,
+                        "last": beat.last,
+                        "global_max": beat.max_score,
+                        "exp_sum": beat.exp_sum,
+                        "value": list(beat.numerators),
+                    }
+                )
+    return rows
+
+
+def _testbench(
+    *,
+    top_name: str,
+    workload: dict[str, object],
+    output_ready_pattern: tuple[bool, ...],
+    stress_interfaces: bool,
+) -> str:
+    heads = int(workload["heads"])
+    command_count = int(workload["command_count"])
+    blocks_per_stream = int(workload["blocks_per_stream"])
+    head_dim = int(workload["head_dim"])
+    head_bases = tuple(int(value) for value in workload["head_bases"])
+    commands = _command_schedule(heads=heads, command_count=command_count, head_bases=head_bases)
+    beats0 = []
+    beats1 = []
+    lasts = []
+    for command_index in range(len(commands)):
+        blocks0 = _block_beats(0, command_index, blocks_per_stream=blocks_per_stream, head_dim=head_dim)
+        blocks1 = _block_beats(1, command_index, blocks_per_stream=blocks_per_stream, head_dim=head_dim)
+        for block in range(blocks_per_stream):
+            for beat in range(head_dim):
+                queries0, keys0 = blocks0[block][beat]
+                queries1, keys1 = blocks1[block][beat]
+                beats0.append((queries0, keys0))
+                beats1.append((queries1, keys1))
+                lasts.append(1 if beat == head_dim - 1 else 0)
+
+    cmd_init = "\n".join(
+        f"    cmd_id_mem[{index}] = 16'h{int(command['command_id']):04x}; "
+        f"cmd_head_base_mem[{index}] = 5'd{int(command['head_base'])}; "
+        f"cmd_mult_mem[{index}] = 32'd{int(command['multiplier'])}; "
+        f"cmd_shift_mem[{index}] = 6'd{int(command['shift'])};"
+        for index, command in enumerate(commands)
+    )
+    beat_init = "\n".join(
+        f"    query_mem[{index}] = 128'h{_pack(beats1[index][0], 8):016x}{_pack(beats0[index][0], 8):016x}; "
+        f"key_mem[{index}] = 128'h{_pack(beats1[index][1], 8):016x}{_pack(beats0[index][1], 8):016x}; "
+        f"last_mem[{index}] = 1'b{lasts[index]};"
+        for index in range(len(beats0))
+    )
+    value_init = []
+    for stream in range(2):
+        for command_index in range(len(commands)):
+            values = _values_for(stream, command_index, blocks_per_stream=blocks_per_stream)
+            for block in range(blocks_per_stream):
+                for value_slice in range(16):
+                    flat = [lane for row in values[block][value_slice] for lane in row]
+                    value_init.append(
+                        f"    value_mem[{(((stream * len(commands)) + command_index) * blocks_per_stream + block) * 16 + value_slice}] = 512'h{_pack(flat, 8):0128x};"
+                    )
+    ready_init = "\n".join(
+        f"    result_ready_mem[{index}] = 1'b{1 if value else 0};" for index, value in enumerate(output_ready_pattern)
+    )
+    total_beats = len(beats0)
+    total_results = len(commands) * 8 * 16
+    command_valid_expr = "1'b1" if not stress_interfaces else "(((cycle + issued_commands) % 5) != 2)"
+    input_valid_expr = "1'b1" if not stress_interfaces else "(((cycle + input_index) % 7) != 3)"
+    request_ready0_expr = "1'b1" if not stress_interfaces else "(((cycle + 1) % 4) != 1)"
+    request_ready1_expr = "1'b1" if not stress_interfaces else "(((cycle + 3) % 6) != 2)"
+    response_delay0_expr = "0" if not stress_interfaces else "((value_read_req_slice[3:0] + active_cmd0) % 3) + 1"
+    response_delay1_expr = (
+        "0"
+        if not stress_interfaces
+        else "((value_read_req_address[27:14] + value_read_req_slice[7:4] + active_cmd1) % 4) + 1"
+    )
+    return f"""`timescale 1ns/1ps
+module tb;
+  localparam integer HEADS = {heads};
+  localparam integer COMMAND_COUNT = {len(commands)};
+  localparam integer BLOCK_COUNT = {blocks_per_stream};
+  localparam integer HEAD_DIM = {head_dim};
+  localparam integer BEATS_PER_COMMAND = BLOCK_COUNT * HEAD_DIM;
+  localparam integer TOTAL_BEATS = {total_beats};
+  localparam integer TOTAL_RESULTS = {total_results};
+  localparam integer READY_PATTERN_LEN = {len(output_ready_pattern)};
+
+  reg clk = 0;
+  reg rst_n = 0;
+  integer cycle = 0;
+  integer issued_commands = 0;
+  integer input_index = 0;
+  integer active_cmd0 = 0;
+  integer active_cmd1 = 0;
+  integer result_seen = 0;
+  reg finish_pending = 0;
+  integer finish_drain_cycles = 0;
+
+  reg [15:0] cmd_id_mem [0:COMMAND_COUNT-1];
+  reg [4:0] cmd_head_base_mem [0:COMMAND_COUNT-1];
+  reg [31:0] cmd_mult_mem [0:COMMAND_COUNT-1];
+  reg [5:0] cmd_shift_mem [0:COMMAND_COUNT-1];
+  reg [127:0] query_mem [0:TOTAL_BEATS-1];
+  reg [127:0] key_mem [0:TOTAL_BEATS-1];
+  reg last_mem [0:TOTAL_BEATS-1];
+  reg [511:0] value_mem [0:(2*COMMAND_COUNT*BLOCK_COUNT*16)-1];
+  reg result_ready_mem [0:READY_PATTERN_LEN-1];
+
+  reg command_valid;
+  wire command_ready;
+  reg input_valid;
+  wire input_ready;
+  reg input_last;
+  reg signed [127:0] input_query;
+  reg signed [127:0] input_key;
+  wire [1:0] value_read_req_valid;
+  reg  [1:0] value_read_req_ready;
+  wire [27:0] value_read_req_address;
+  wire [7:0] value_read_req_slice;
+  reg  [1:0] value_response_valid;
+  wire [1:0] value_response_ready;
+  reg  [27:0] value_response_address;
+  reg  [7:0] value_response_slice;
+  reg  [1023:0] value_response_matrix;
+  wire result_valid;
+  reg  result_ready;
+  wire [15:0] result_command_id;
+  wire [4:0] result_head_id;
+  wire signed [31:0] result_global_max;
+  wire [32:0] result_exp_sum;
+  wire [3:0] result_slice;
+  wire result_last;
+  wire [327:0] result_value;
+  wire [31:0] cycle_count;
+  wire [31:0] command_accept_count;
+  wire [31:0] command_completed_count;
+  wire [63:0] stream_command_accept_count;
+  wire [63:0] stream_completed_count;
+  wire [1:0] stream_partial_valid;
+  wire [1:0] stream_partial_ready;
+  wire [1:0] stream_partial_last;
+  wire [31:0] merge_completed_count;
+  wire [31:0] result_stall_cycles;
+  wire [1:0] stream_protocol_error;
+  wire merge_protocol_error;
+  wire protocol_error;
+
+  reg pending0 = 0, pending1 = 0;
+  reg [13:0] pending_addr0 = 0, pending_addr1 = 0;
+  reg [3:0] pending_slice0 = 0, pending_slice1 = 0;
+  integer pending_delay0 = 0, pending_delay1 = 0;
+
+  always #5 clk = ~clk;
+
+  {top_name} dut (
+      .clk(clk),
+      .rst_n(rst_n),
+      .command_valid(command_valid),
+      .command_ready(command_ready),
+      .command_id(cmd_id_mem[issued_commands]),
+      .command_head_base(cmd_head_base_mem[issued_commands]),
+      .command_block_count(BLOCK_COUNT),
+      .command_score_multiplier(cmd_mult_mem[issued_commands]),
+      .command_score_shift(cmd_shift_mem[issued_commands]),
+      .input_valid(input_valid),
+      .input_ready(input_ready),
+      .input_last(input_last),
+      .input_query(input_query),
+      .input_key(input_key),
+      .value_read_req_valid(value_read_req_valid),
+      .value_read_req_ready(value_read_req_ready),
+      .value_read_req_address(value_read_req_address),
+      .value_read_req_slice(value_read_req_slice),
+      .value_response_valid(value_response_valid),
+      .value_response_ready(value_response_ready),
+      .value_response_address(value_response_address),
+      .value_response_slice(value_response_slice),
+      .value_response_matrix(value_response_matrix),
+      .result_valid(result_valid),
+      .result_ready(result_ready),
+      .result_command_id(result_command_id),
+      .result_head_id(result_head_id),
+      .result_global_max(result_global_max),
+      .result_exp_sum(result_exp_sum),
+      .result_slice(result_slice),
+      .result_last(result_last),
+      .result_value(result_value),
+      .cycle_count(cycle_count),
+      .command_accept_count(command_accept_count),
+      .command_completed_count(command_completed_count),
+      .stream_command_accept_count(stream_command_accept_count),
+      .stream_completed_count(stream_completed_count),
+      .stream_partial_valid(stream_partial_valid),
+      .stream_partial_ready(stream_partial_ready),
+      .stream_partial_last(stream_partial_last),
+      .merge_completed_count(merge_completed_count),
+      .result_stall_cycles(result_stall_cycles),
+      .stream_protocol_error(stream_protocol_error),
+      .merge_protocol_error(merge_protocol_error),
+      .protocol_error(protocol_error)
+  );
+
+  always @* begin
+    command_valid = rst_n && issued_commands < COMMAND_COUNT && {command_valid_expr};
+    input_valid = rst_n && input_index < (issued_commands * BEATS_PER_COMMAND) && {input_valid_expr};
+    input_query = input_index < TOTAL_BEATS ? query_mem[input_index] : 0;
+    input_key = input_index < TOTAL_BEATS ? key_mem[input_index] : 0;
+    input_last = input_index < TOTAL_BEATS ? last_mem[input_index] : 0;
+    value_read_req_ready[0] = {request_ready0_expr};
+    value_read_req_ready[1] = {request_ready1_expr};
+    result_ready = result_ready_mem[cycle % READY_PATTERN_LEN];
+  end
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      cycle <= 0;
+      issued_commands <= 0;
+      input_index <= 0;
+      active_cmd0 <= 0;
+      active_cmd1 <= 0;
+      result_seen <= 0;
+      pending0 <= 0;
+      pending1 <= 0;
+      pending_delay0 <= 0;
+      pending_delay1 <= 0;
+      finish_pending <= 0;
+      finish_drain_cycles <= 0;
+      value_response_valid <= 0;
+      value_response_address <= 0;
+      value_response_slice <= 0;
+      value_response_matrix <= 0;
+    end else begin
+      cycle <= cycle + 1;
+      if (command_valid && command_ready) begin
+        $display("COMMAND_ACCEPT idx=%0d cmd=%0d head_base=%0d cycle=%0d",
+                 issued_commands, cmd_id_mem[issued_commands], cmd_head_base_mem[issued_commands], cycle);
+        active_cmd0 <= issued_commands;
+        active_cmd1 <= issued_commands;
+        issued_commands <= issued_commands + 1;
+      end
+      if (input_valid && input_ready) begin
+        input_index <= input_index + 1;
+      end
+
+      if (value_read_req_valid[0] && value_read_req_ready[0]) begin
+        if (pending0 || value_response_valid[0]) $fatal(1, "stream0 multiple outstanding value requests");
+        pending0 <= 1;
+        pending_addr0 <= value_read_req_address[13:0];
+        pending_slice0 <= value_read_req_slice[3:0];
+        pending_delay0 <= {response_delay0_expr};
+      end
+      if (value_read_req_valid[1] && value_read_req_ready[1]) begin
+        if (pending1 || value_response_valid[1]) $fatal(1, "stream1 multiple outstanding value requests");
+        pending1 <= 1;
+        pending_addr1 <= value_read_req_address[27:14];
+        pending_slice1 <= value_read_req_slice[7:4];
+        pending_delay1 <= {response_delay1_expr};
+      end
+
+      if (pending0) begin
+        if (pending_delay0 == 0) begin
+          pending0 <= 0;
+          value_response_valid[0] <= 1;
+          value_response_address[13:0] <= pending_addr0;
+          value_response_slice[3:0] <= pending_slice0;
+          value_response_matrix[511:0] <= value_mem[((active_cmd0 * BLOCK_COUNT) + pending_addr0) * 16 + pending_slice0];
+        end else begin
+          pending_delay0 <= pending_delay0 - 1;
+        end
+      end
+      if (pending1) begin
+        if (pending_delay1 == 0) begin
+          pending1 <= 0;
+          value_response_valid[1] <= 1;
+          value_response_address[27:14] <= pending_addr1;
+          value_response_slice[7:4] <= pending_slice1;
+          value_response_matrix[1023:512] <= value_mem[(((COMMAND_COUNT + active_cmd1) * BLOCK_COUNT) + pending_addr1) * 16 + pending_slice1];
+        end else begin
+          pending_delay1 <= pending_delay1 - 1;
+        end
+      end
+      if (value_response_valid[0] && value_response_ready[0]) value_response_valid[0] <= 0;
+      if (value_response_valid[1] && value_response_ready[1]) value_response_valid[1] <= 0;
+
+      if (result_valid && result_ready) begin
+        $display("RESULT cmd=%0d head=%0d slice=%0d last=%0d max=%0d sum=%0d value=%082x cycle=%0d",
+                 result_command_id, result_head_id, result_slice, result_last, $signed(result_global_max),
+                 result_exp_sum, result_value, cycle);
+        result_seen <= result_seen + 1;
+        if (result_seen + 1 == TOTAL_RESULTS) begin
+          finish_pending <= 1'b1;
+          finish_drain_cycles <= cycle + 1;
+        end
+      end
+      if (finish_pending) begin
+        $display("SUMMARY outputs=%0d drain=%0d protocol_error=%0d command_accept=%0d command_complete=%0d stream0_accept=%0d stream1_accept=%0d stream0_complete=%0d stream1_complete=%0d merge_complete=%0d result_stall=%0d stream0_error=%0d stream1_error=%0d merge_error=%0d",
+                 result_seen, finish_drain_cycles, protocol_error, command_accept_count, command_completed_count,
+                 stream_command_accept_count[31:0], stream_command_accept_count[63:32],
+                 stream_completed_count[31:0], stream_completed_count[63:32],
+                 merge_completed_count, result_stall_cycles, stream_protocol_error[0], stream_protocol_error[1], merge_protocol_error);
+        #1 $finish;
+      end
+      if (cycle > 60000) $fatal(1, "timeout");
+    end
+  end
+
+  initial begin
+{cmd_init}
+{beat_init}
+{chr(10).join(value_init)}
+{ready_init}
+    value_response_valid = 0;
+    value_response_address = 0;
+    value_response_slice = 0;
+    value_response_matrix = 0;
+    repeat (3) @(posedge clk);
+    @(negedge clk);
+    rst_n = 1'b1;
+  end
+endmodule
+"""
+
+
+def _unpack_result_value(word: int) -> tuple[int, ...]:
+    values = []
+    mask = (1 << 41) - 1
+    for lane in range(8):
+        raw = (word >> (lane * 41)) & mask
+        if raw & (1 << 40):
+            raw -= 1 << 41
+        values.append(raw)
+    return tuple(values)
+
+
+def _run_case(
+    config: JsonDict,
+    *,
+    heads: int | None,
+    command_count: int | None,
+    blocks_per_stream: int | None,
+    head_dim: int | None,
+    head_bases: tuple[int, ...] | None,
+    output_ready_pattern: tuple[bool, ...],
+    stress_interfaces: bool,
+) -> JsonDict:
+    workload = _resolve_workload(
+        config,
+        heads=heads,
+        command_count=command_count,
+        blocks_per_stream=blocks_per_stream,
+        head_dim=head_dim,
+        head_bases=head_bases,
+    )
+    expected = _expected(workload)
+    resolved_heads = int(workload["heads"])
+    with tempfile.TemporaryDirectory(prefix=f"score32_exact_partial_dual_stream_h{heads}_") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        run_config = json.loads(json.dumps(config))
+        probe_defaults = run_config.setdefault("probe_defaults", {})
+        probe_defaults["heads"] = int(workload["heads"])
+        probe_defaults["command_count"] = int(workload["command_count"])
+        probe_defaults["blocks_per_stream"] = int(workload["blocks_per_stream"])
+        probe_defaults["head_dim"] = int(workload["head_dim"])
+        probe_defaults["head_bases"] = list(int(value) for value in workload["head_bases"])
+        generate_tree(run_config, temp_dir / "rtl")
+        tb_path = temp_dir / "tb.sv"
+        fakeram_path = temp_dir / "fakeram45_2048x39.sv"
+        tb_path.write_text(
+            _testbench(
+                top_name=str(run_config["top_name"]),
+                workload=workload,
+                output_ready_pattern=output_ready_pattern,
+                stress_interfaces=stress_interfaces,
+            ),
+            encoding="utf-8",
+        )
+        fakeram_path.write_text(_FAKERAM_MODEL, encoding="utf-8")
+        simv = temp_dir / "simv"
+        compiled = subprocess.run(
+            [
+                _tool("iverilog"),
+                "-g2012",
+                "-s",
+                "tb",
+                "-o",
+                str(simv),
+                str(temp_dir / "rtl" / "top.v"),
+                str(fakeram_path),
+                str(tb_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=900,
+        )
+        if compiled.returncode:
+            raise RuntimeError(f"iverilog failed:\n{compiled.stderr}")
+        run = subprocess.run([_tool("vvp"), str(simv)], capture_output=True, text=True, timeout=900)
+        if run.returncode:
+            raise RuntimeError(f"simulation failed:\n{run.stdout}\n{run.stderr}")
+
+    command_accepts: list[dict[str, int]] = []
+    observed: list[dict[str, object]] = []
+    summary: dict[str, int] | None = None
+    for line in run.stdout.splitlines():
+        stripped = line.strip()
+        if match := _COMMAND_RE.fullmatch(stripped):
+            command_accepts.append(
+                {
+                    "index": int(match.group(1)),
+                    "command_id": int(match.group(2)),
+                    "head_base": int(match.group(3)),
+                    "cycle": int(match.group(4)),
+                }
+            )
+        elif match := _RESULT_RE.fullmatch(stripped):
+            observed.append(
+                {
+                    "command_id": int(match.group(1)),
+                    "head_id": int(match.group(2)),
+                    "slice": int(match.group(3)),
+                    "last": bool(int(match.group(4))),
+                    "global_max": int(match.group(5)),
+                    "exp_sum": int(match.group(6)),
+                    "value": list(_unpack_result_value(int(match.group(7), 16))),
+                    "cycle": int(match.group(8)),
+                }
+            )
+        elif match := _SUMMARY_RE.fullmatch(stripped):
+            summary = {
+                "outputs": int(match.group(1)),
+                "drain_cycles": int(match.group(2)),
+                "protocol_error": int(match.group(3)),
+                "command_accept_count": int(match.group(4)),
+                "command_complete_count": int(match.group(5)),
+                "stream0_accept_count": int(match.group(6)),
+                "stream1_accept_count": int(match.group(7)),
+                "stream0_complete_count": int(match.group(8)),
+                "stream1_complete_count": int(match.group(9)),
+                "merge_complete_count": int(match.group(10)),
+                "result_stall_cycles": int(match.group(11)),
+                "stream0_protocol_error": int(match.group(12)),
+                "stream1_protocol_error": int(match.group(13)),
+                "merge_protocol_error": int(match.group(14)),
+            }
+    if summary is None:
+        raise RuntimeError(f"missing SUMMARY line in simulation output:\n{run.stdout}")
+
+    observed_rows = [
+        {
+            "command_id": row["command_id"],
+            "head_id": row["head_id"],
+            "slice": row["slice"],
+            "last": row["last"],
+            "global_max": row["global_max"],
+            "exp_sum": row["exp_sum"],
+            "value": row["value"],
+        }
+        for row in observed
+    ]
+    return {
+        "heads": resolved_heads,
+        "commands": int(workload["command_count"]),
+        "blocks_per_stream": int(workload["blocks_per_stream"]),
+        "head_dim": int(workload["head_dim"]),
+        "head_bases": list(int(value) for value in workload["head_bases"]),
+        "command_accepts": command_accepts,
+        "outputs": len(observed_rows),
+        "observed_rows": observed_rows,
+        "expected_rows": expected,
+        "summary": summary,
+        "interface_mode": "stress" if stress_interfaces else "ideal",
+        "passed": observed_rows == expected
+        and summary["protocol_error"] == 0
+        and summary["stream0_protocol_error"] == 0
+        and summary["stream1_protocol_error"] == 0
+        and summary["merge_protocol_error"] == 0,
+    }
+
+
+def build_report(
+    config: JsonDict | None = None,
+    *,
+    heads: int | None = None,
+    command_count: int | None = None,
+    blocks_per_stream: int | None = None,
+    head_dim: int | None = None,
+    head_bases: tuple[int, ...] | None = None,
+    output_ready_pattern: tuple[bool, ...] | None = None,
+    stress_interfaces: bool | None = None,
+) -> JsonDict:
+    base_config = json.loads(json.dumps(config or _default_config()))
+    configured_mode = base_config.get("probe_defaults", {}).get("interface_mode", "stress")
+    use_stress = bool(stress_interfaces if stress_interfaces is not None else configured_mode != "ideal")
+    ready_pattern = output_ready_pattern or (
+        (True, False, True, True, False, True, False, True, True, True, False, True)
+        if use_stress
+        else (True,)
+    )
+    result = _run_case(
+        base_config,
+        heads=heads,
+        command_count=command_count,
+        blocks_per_stream=blocks_per_stream,
+        head_dim=head_dim,
+        head_bases=head_bases,
+        output_ready_pattern=ready_pattern,
+        stress_interfaces=use_stress,
+    )
+    reference_cycles = base_config.get("probe_defaults", {}).get("llama_wave_reference_cycles")
+    reference_delta = None
+    if isinstance(reference_cycles, int):
+        reference_delta = int(result["summary"]["drain_cycles"]) - reference_cycles
+    return {
+        "decision": "score32_exact_partial_dual_stream_gqa8_pass" if result["passed"] else "score32_exact_partial_dual_stream_gqa8_fail",
+        "passed": bool(result["passed"]),
+        "top_name": str(base_config["top_name"]),
+        "heads": int(result["heads"]),
+        "commands": result["commands"],
+        "blocks_per_stream": int(result["blocks_per_stream"]),
+        "head_dim": int(result["head_dim"]),
+        "head_bases": result["head_bases"],
+        "outputs": result["outputs"],
+        "expected_outputs": len(result["expected_rows"]),
+        "command_accept_cycles": result["command_accepts"],
+        "integrated_drain_cycles": int(result["summary"]["drain_cycles"]),
+        "command_accept_count": int(result["summary"]["command_accept_count"]),
+        "command_complete_count": int(result["summary"]["command_complete_count"]),
+        "stream_command_accept_count": [
+            int(result["summary"]["stream0_accept_count"]),
+            int(result["summary"]["stream1_accept_count"]),
+        ],
+        "stream_complete_count": [
+            int(result["summary"]["stream0_complete_count"]),
+            int(result["summary"]["stream1_complete_count"]),
+        ],
+        "merge_complete_count": int(result["summary"]["merge_complete_count"]),
+        "result_stall_cycles": int(result["summary"]["result_stall_cycles"]),
+        "interface_mode": result["interface_mode"],
+        "llama_wave_reference_cycles": reference_cycles,
+        "llama_wave_drain_delta_vs_986": reference_delta,
+        "stream_protocol_error": [
+            bool(result["summary"]["stream0_protocol_error"]),
+            bool(result["summary"]["stream1_protocol_error"]),
+        ],
+        "merge_protocol_error": bool(result["summary"]["merge_protocol_error"]),
+        "protocol_error": bool(result["summary"]["protocol_error"]),
+        "observed_rows": result["observed_rows"],
+        "expected_rows": result["expected_rows"],
+        "service_model": exact_partial_dual_stream_gqa8_producer_service_manifest(
+            heads=int(result["heads"]),
+            max_blocks=int(base_config["attention_score32_exact_partial_gqa8_dual_stream_producer"]["max_blocks"]),
+            command_count=int(result["commands"]),
+            blocks_per_stream=int(result["blocks_per_stream"]),
+            head_dim=int(result["head_dim"]),
+            head_bases=tuple(int(value) for value in result["head_bases"]),
+            llama_wave_reference_cycles=reference_cycles if isinstance(reference_cycles, int) else None,
+        ),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=None)
+    parser.add_argument("--heads", type=int, default=None)
+    parser.add_argument("--command-count", type=int, default=None)
+    parser.add_argument("--blocks-per-stream", type=int, default=None)
+    parser.add_argument("--head-dim", type=int, default=None)
+    parser.add_argument("--head-bases", type=str, default=None)
+    parser.add_argument("--result-ready-pattern", type=str, default=None)
+    parser.add_argument("--ideal-interfaces", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    config = _default_config()
+    if args.config is not None:
+        config = json.loads(args.config.read_text(encoding="utf-8"))
+    pattern = None
+    if args.result_ready_pattern:
+        pattern = tuple(token.strip() in {"1", "true", "True"} for token in args.result_ready_pattern.split(","))
+        if not pattern:
+            raise SystemExit("result-ready-pattern must not be empty")
+    head_bases = None
+    if args.head_bases:
+        head_bases = tuple(int(token.strip()) for token in args.head_bases.split(",") if token.strip())
+        if not head_bases:
+            raise SystemExit("head-bases must not be empty")
+    report = build_report(
+        config=config,
+        heads=args.heads,
+        command_count=args.command_count,
+        blocks_per_stream=args.blocks_per_stream,
+        head_dim=args.head_dim,
+        head_bases=head_bases,
+        output_ready_pattern=pattern,
+        stress_interfaces=False if args.ideal_interfaces else None,
+    )
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(
+            json.dumps(
+                {
+                    "decision": report["decision"],
+                    "heads": report["heads"],
+                    "commands": report["commands"],
+                    "outputs": report["outputs"],
+                    "integrated_drain_cycles": report["integrated_drain_cycles"],
+                    "protocol_error": report["protocol_error"],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/rtlgen/gen_attention_decode_score_multivalue_gqa_array.py
+++ b/npu/rtlgen/gen_attention_decode_score_multivalue_gqa_array.py
@@ -39,6 +39,8 @@ def _validate(config: dict[str, Any]) -> dict[str, int | str]:
     divider_impl = str(body.get("divider_impl", "iterative_restoring")).strip()
     query_heads_per_kv = int(body.get("query_heads_per_kv", 8))
     group_count = int(body.get("group_count", 0))
+    result_mode = str(body.get("result_mode", "normalized")).strip().lower()
+    head_id_bits = int(body.get("head_id_bits", 5))
 
     if max_blocks < 8 or max_blocks > 16384 or max_blocks & (max_blocks - 1):
         raise SystemExit("max_blocks must be a power of two in [8, 16384]")
@@ -54,18 +56,11 @@ def _validate(config: dict[str, Any]) -> dict[str, int | str]:
         raise SystemExit("query_heads_per_kv must be 8 for Llama7B GQA8")
     if group_count not in _SUPPORTED_GROUP_COUNTS:
         raise SystemExit("group_count must be exactly one of 1, 2, or 4")
+    if result_mode not in {"normalized", "exact_partial"}:
+        raise SystemExit("result_mode must be normalized or exact_partial")
+    if head_id_bits < 1 or head_id_bits > 8:
+        raise SystemExit("head_id_bits must be in [1, 8]")
 
-    body.update(
-        {
-            "max_blocks": max_blocks,
-            "array_n": array_n,
-            "value_slices": value_slices,
-            "score_scale_lanes_per_cycle": scale_lanes,
-            "divider_impl": divider_impl,
-            "query_heads_per_kv": query_heads_per_kv,
-            "group_count": group_count,
-        }
-    )
     return {
         "top_name": top_name,
         "max_blocks": max_blocks,
@@ -75,6 +70,8 @@ def _validate(config: dict[str, Any]) -> dict[str, int | str]:
         "divider_impl": divider_impl,
         "query_heads_per_kv": query_heads_per_kv,
         "group_count": group_count,
+        "result_mode": result_mode,
+        "head_id_bits": head_id_bits,
     }
 
 
@@ -83,9 +80,25 @@ def _slice(name: str, index: int, width: int) -> str:
     return f"{name}[{lo + width - 1}:{lo}]"
 
 
-def _group_instances(group_top: str, group_count: int) -> str:
+def _group_instances(
+    group_top: str,
+    group_count: int,
+    *,
+    partial_mode: bool,
+    head_id_bits: int,
+    result_value_bits: int,
+) -> str:
     instances = []
     for group in range(group_count):
+        command_head_base_port = ""
+        result_head_id_port = ""
+        if partial_mode:
+            command_head_base_port = (
+                f"\n      .command_head_base({_slice('command_head_base', group, head_id_bits)}),"
+            )
+            result_head_id_port = (
+                f"\n      .result_head_id({_slice('result_head_id', group, head_id_bits)}),"
+            )
         instances.append(
             f"""  {group_top} u_group_{group} (
       .clk(clk),
@@ -93,7 +106,7 @@ def _group_instances(group_top: str, group_count: int) -> str:
       .command_valid(command_valid && command_ready),
       .command_ready(child_command_ready[{group}]),
       .command_id(command_id),
-      .command_block_count(command_block_count),
+      .command_block_count(command_block_count),{command_head_base_port}
       .command_score_multiplier(command_score_multiplier),
       .command_score_shift(command_score_shift),
       .input_valid(input_valid && input_ready),
@@ -113,12 +126,13 @@ def _group_instances(group_top: str, group_count: int) -> str:
       .result_valid(result_valid[{group}]),
       .result_ready(result_ready[{group}]),
       .result_head({_slice("result_head", group, 3)}),
+      {result_head_id_port}
       .result_command_id({_slice("result_command_id", group, 16)}),
       .result_global_max({_slice("result_global_max", group, 32)}),
       .result_exp_sum({_slice("result_exp_sum", group, 33)}),
       .result_slice({_slice("result_slice", group, 4)}),
       .result_last(result_last[{group}]),
-      .result_value({_slice("result_value", group, 320)}),
+      .result_value({_slice("result_value", group, result_value_bits)}),
       .accepted_count({_slice("accepted_count", group, 32)}),
       .completed_count({_slice("completed_count", group, 32)}),
       .cycle_count({_slice("cycle_count", group, 32)}),
@@ -128,15 +142,22 @@ def _group_instances(group_top: str, group_count: int) -> str:
     return "\n\n".join(instances)
 
 
-def _wrapper(*, top_name: str, group_top: str, group_count: int) -> str:
+def _wrapper(*, top_name: str, group_top: str, group_count: int, partial_mode: bool, head_id_bits: int) -> str:
     total_query_bits = group_count * 64
     total_result_heads = group_count * 3
     total_result_commands = group_count * 16
     total_result_max = group_count * 32
     total_result_sums = group_count * 33
     total_result_slices = group_count * 4
-    total_result_values = group_count * 320
+    result_value_bits = 328 if partial_mode else 320
+    total_result_values = group_count * result_value_bits
     total_counter_bits = group_count * 32
+    command_head_base_port = (
+        f"\n    input  wire [{group_count * head_id_bits - 1}:0] command_head_base," if partial_mode else ""
+    )
+    result_head_id_port = (
+        f"\n    output wire [{group_count * head_id_bits - 1}:0] result_head_id," if partial_mode else ""
+    )
     return f"""// Auto-generated by npu/rtlgen/gen_attention_decode_score_multivalue_gqa_array.py
 module {top_name} (
     input  wire                         clk,
@@ -144,7 +165,7 @@ module {top_name} (
     input  wire                         command_valid,
     output wire                         command_ready,
     input  wire [15:0]                  command_id,
-    input  wire [14:0]                  command_block_count,
+    input  wire [14:0]                  command_block_count,{command_head_base_port}
     input  wire [31:0]                  command_score_multiplier,
     input  wire [5:0]                   command_score_shift,
     input  wire                         input_valid,
@@ -164,6 +185,7 @@ module {top_name} (
     output wire [{group_count - 1}:0]   result_valid,
     input  wire [{group_count - 1}:0]   result_ready,
     output wire [{total_result_heads - 1}:0] result_head,
+{result_head_id_port}
     output wire [{total_result_commands - 1}:0] result_command_id,
     output wire signed [{total_result_max - 1}:0] result_global_max,
     output wire [{total_result_sums - 1}:0] result_exp_sum,
@@ -189,10 +211,10 @@ module {top_name} (
   wire input_ready_all = &child_input_ready;
 
   assign command_ready = command_ready_all;
-  assign input_ready = input_ready_all;
-  assign protocol_error = |child_protocol_error;
+    assign input_ready = input_ready_all;
+    assign protocol_error = |child_protocol_error;
 
-{_group_instances(group_top, group_count)}
+{_group_instances(group_top, group_count, partial_mode=partial_mode, head_id_bits=head_id_bits, result_value_bits=result_value_bits)}
 endmodule
 """
 
@@ -216,6 +238,8 @@ def generate(config: dict[str, Any], out_dir: Path) -> None:
                     "divider_impl": str(params["divider_impl"]),
                     "score_scale_lanes_per_cycle": int(params["score_scale_lanes_per_cycle"]),
                     "query_heads_per_kv": int(params["query_heads_per_kv"]),
+                    "result_mode": str(params["result_mode"]),
+                    "head_id_bits": int(params["head_id_bits"]),
                 },
             },
             group_dir,
@@ -227,7 +251,18 @@ def generate(config: dict[str, Any], out_dir: Path) -> None:
             )
         )
 
-    rtl = group_rtl + "\n\n" + _wrapper(top_name=top_name, group_top=group_top, group_count=group_count) + "\n"
+    rtl = (
+        group_rtl
+        + "\n\n"
+        + _wrapper(
+            top_name=top_name,
+            group_top=group_top,
+            group_count=group_count,
+            partial_mode=str(params["result_mode"]) == "exact_partial",
+            head_id_bits=int(params["head_id_bits"]),
+        )
+        + "\n"
+    )
     (out_dir / "top.v").write_text(rtl, encoding="utf-8")
     (out_dir / "config.json").write_text(json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     manifest = {
@@ -235,6 +270,8 @@ def generate(config: dict[str, Any], out_dir: Path) -> None:
         "generator": "npu/rtlgen/gen_attention_decode_score_multivalue_gqa_array.py",
         "top_name": top_name,
         "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_array_v1",
+        "result_mode": str(params["result_mode"]),
+        "head_id_bits": int(params["head_id_bits"]),
         "max_blocks": int(params["max_blocks"]),
         "score_tile_array_n": int(params["array_n"]),
         "score_scale_lanes_per_cycle": int(params["score_scale_lanes_per_cycle"]),
@@ -250,7 +287,7 @@ def generate(config: dict[str, Any], out_dir: Path) -> None:
         "serialization": "none",
         "no_serialization": True,
         "result_beats_per_command_per_group": 128,
-        "result_value_bits_per_beat": 320,
+        "result_value_bits_per_beat": 328 if str(params["result_mode"]) == "exact_partial" else 320,
         "submodule_manifests": {"gqa_group": group_manifest},
     }
     (out_dir / "attention_decode_score_multivalue_gqa_array_manifest.json").write_text(

--- a/npu/rtlgen/gen_attention_decode_score_multivalue_gqa_group.py
+++ b/npu/rtlgen/gen_attention_decode_score_multivalue_gqa_group.py
@@ -39,6 +39,8 @@ def _validate(config: dict[str, Any]) -> dict[str, int | str]:
     divider_impl = str(body.get("divider_impl", "iterative_restoring")).strip()
     query_heads_per_kv = int(body.get("query_heads_per_kv", 8))
     parallel_lanes = int(body.get("parallel_query_head_lanes", query_heads_per_kv))
+    result_mode = str(body.get("result_mode", "normalized")).strip().lower()
+    head_id_bits = int(body.get("head_id_bits", 5))
 
     if max_blocks < 8 or max_blocks > 16384 or max_blocks & (max_blocks - 1):
         raise SystemExit("max_blocks must be a power of two in [8, 16384]")
@@ -54,17 +56,11 @@ def _validate(config: dict[str, Any]) -> dict[str, int | str]:
         raise SystemExit("query_heads_per_kv must be 8 for Llama7B GQA8")
     if parallel_lanes not in {1, 2, 4, 8} or query_heads_per_kv % parallel_lanes:
         raise SystemExit("parallel_query_head_lanes must be one of 1,2,4,8 and divide query_heads_per_kv")
+    if result_mode not in {"normalized", "exact_partial"}:
+        raise SystemExit("result_mode must be normalized or exact_partial")
+    if head_id_bits < 1 or head_id_bits > 8:
+        raise SystemExit("head_id_bits must be in [1, 8]")
 
-    body.update(
-        {
-            "max_blocks": max_blocks,
-            "array_n": array_n,
-            "value_slices": value_slices,
-            "score_scale_lanes_per_cycle": scale_lanes,
-            "divider_impl": divider_impl,
-            "query_heads_per_kv": query_heads_per_kv,
-        }
-    )
     return {
         "top_name": top_name,
         "max_blocks": max_blocks,
@@ -74,6 +70,8 @@ def _validate(config: dict[str, Any]) -> dict[str, int | str]:
         "divider_impl": divider_impl,
         "query_heads_per_kv": query_heads_per_kv,
         "parallel_query_head_lanes": parallel_lanes,
+        "result_mode": result_mode,
+        "head_id_bits": head_id_bits,
     }
 
 
@@ -90,9 +88,20 @@ def _match_expr(name: str, width: int, count: int) -> str:
     return " && ".join(f"({_bus_slice(name, idx, width)} == {base})" for idx in range(1, count))
 
 
-def _result_mux_cases(query_heads_per_kv: int) -> str:
+def _result_mux_cases(
+    query_heads_per_kv: int,
+    *,
+    result_value_bits: int,
+    partial_mode: bool,
+    head_id_bits: int,
+) -> str:
     cases: list[str] = []
     for head in range(query_heads_per_kv):
+        head_id_assign = ""
+        if partial_mode:
+            head_id_assign = (
+                f"\n        result_head_id = {_bus_slice('child_result_head_id_bus', head, head_id_bits)};"
+            )
         cases.append(
             f"""      3'd{head}: begin
         result_command_id = {_bus_slice("child_result_command_id_bus", head, 16)};
@@ -100,7 +109,7 @@ def _result_mux_cases(query_heads_per_kv: int) -> str:
         result_exp_sum = {_bus_slice("child_result_exp_sum_bus", head, 33)};
         result_slice = {_bus_slice("child_result_slice_bus", head, 4)};
         result_last = child_result_last[{head}];
-        result_value = {_bus_slice("child_result_value_bus", head, 320)};
+        result_value = {_bus_slice("child_result_value_bus", head, result_value_bits)};{head_id_assign}
       end"""
         )
     return "\n".join(cases)
@@ -113,9 +122,23 @@ def _result_ready_assigns(query_heads_per_kv: int, *, selector: str = "result_he
     return "\n".join(assigns)
 
 
-def _cluster_instances(cluster_top: str, query_heads_per_kv: int) -> str:
+def _cluster_instances(
+    cluster_top: str,
+    query_heads_per_kv: int,
+    *,
+    result_value_bits: int,
+    partial_mode: bool,
+    head_id_bits: int,
+) -> str:
     instances: list[str] = []
     for head in range(query_heads_per_kv):
+        command_head_port = ""
+        result_head_port = ""
+        if partial_mode:
+            command_head_port = f"\n      .command_head_id(command_head_base + {head_id_bits}'d{head}),"
+            result_head_port = (
+                f"\n      .result_head_id({_bus_slice('child_result_head_id_bus', head, head_id_bits)}),"
+            )
         instances.append(
             f"""  {cluster_top} u_head_{head} (
       .clk(clk),
@@ -123,7 +146,7 @@ def _cluster_instances(cluster_top: str, query_heads_per_kv: int) -> str:
       .command_valid(command_valid && command_ready),
       .command_ready(child_command_ready[{head}]),
       .command_id(command_id),
-      .command_block_count(command_block_count),
+      .command_block_count(command_block_count),{command_head_port}
       .command_score_multiplier(command_score_multiplier),
       .command_score_shift(command_score_shift),
       .input_valid(input_valid && input_ready),
@@ -145,9 +168,9 @@ def _cluster_instances(cluster_top: str, query_heads_per_kv: int) -> str:
       .result_command_id({_bus_slice("child_result_command_id_bus", head, 16)}),
       .result_global_max({_bus_slice("child_result_global_max_bus", head, 32)}),
       .result_exp_sum({_bus_slice("child_result_exp_sum_bus", head, 33)}),
-      .result_slice({_bus_slice("child_result_slice_bus", head, 4)}),
+      .result_slice({_bus_slice("child_result_slice_bus", head, 4)}),{result_head_port}
       .result_last(child_result_last[{head}]),
-      .result_value({_bus_slice("child_result_value_bus", head, 320)}),
+      .result_value({_bus_slice("child_result_value_bus", head, result_value_bits)}),
       .accepted_count({_bus_slice("child_accepted_count_bus", head, 32)}),
       .completed_count({_bus_slice("child_completed_count_bus", head, 32)}),
       .cycle_count({_bus_slice("child_cycle_count_bus", head, 32)}),
@@ -157,9 +180,26 @@ def _cluster_instances(cluster_top: str, query_heads_per_kv: int) -> str:
     return "\n\n".join(instances)
 
 
-def _folded_cluster_instances(cluster_top: str, parallel_lanes: int) -> str:
+def _folded_cluster_instances(
+    cluster_top: str,
+    parallel_lanes: int,
+    *,
+    result_value_bits: int,
+    partial_mode: bool,
+    head_id_bits: int,
+) -> str:
     instances: list[str] = []
     for lane in range(parallel_lanes):
+        command_head_port = ""
+        result_head_port = ""
+        if partial_mode:
+            command_head_port = (
+                "\n      .command_head_id("
+                f"child_command_head_base + ((wave_q * PARALLEL_QUERY_HEAD_LANES) + {head_id_bits}'d{lane})),"
+            )
+            result_head_port = (
+                f"\n      .result_head_id({_bus_slice('child_result_head_id_bus', lane, head_id_bits)}),"
+            )
         instances.append(
             f"""  wire signed [7:0] lane_input_query_{lane} =
       input_query[((wave_q * PARALLEL_QUERY_HEAD_LANES + {lane}) * 8) +: 8];
@@ -170,7 +210,7 @@ def _folded_cluster_instances(cluster_top: str, parallel_lanes: int) -> str:
       .command_valid(child_command_valid),
       .command_ready(child_command_ready[{lane}]),
       .command_id(child_command_id),
-      .command_block_count(child_command_block_count),
+      .command_block_count(child_command_block_count),{command_head_port}
       .command_score_multiplier(child_command_score_multiplier),
       .command_score_shift(child_command_score_shift),
       .input_valid(input_valid && input_ready),
@@ -192,9 +232,9 @@ def _folded_cluster_instances(cluster_top: str, parallel_lanes: int) -> str:
       .result_command_id({_bus_slice("child_result_command_id_bus", lane, 16)}),
       .result_global_max({_bus_slice("child_result_global_max_bus", lane, 32)}),
       .result_exp_sum({_bus_slice("child_result_exp_sum_bus", lane, 33)}),
-      .result_slice({_bus_slice("child_result_slice_bus", lane, 4)}),
+      .result_slice({_bus_slice("child_result_slice_bus", lane, 4)}),{result_head_port}
       .result_last(child_result_last[{lane}]),
-      .result_value({_bus_slice("child_result_value_bus", lane, 320)}),
+      .result_value({_bus_slice("child_result_value_bus", lane, result_value_bits)}),
       .accepted_count({_bus_slice("child_accepted_count_bus", lane, 32)}),
       .completed_count({_bus_slice("child_completed_count_bus", lane, 32)}),
       .cycle_count({_bus_slice("child_cycle_count_bus", lane, 32)}),
@@ -208,11 +248,43 @@ def _wrapper(*, top_name: str, params: dict[str, int | str], cluster_top: str) -
     max_blocks = int(params["max_blocks"])
     value_slices = int(params["value_slices"])
     query_heads_per_kv = int(params["query_heads_per_kv"])
+    partial_mode = str(params["result_mode"]) == "exact_partial"
+    head_id_bits = int(params["head_id_bits"])
+    result_value_bits = 328 if partial_mode else 320
     addr_bits = 14
     slice_bits = _clog2(value_slices)
     head_bits = _clog2(query_heads_per_kv)
     addr_match = _match_expr("child_value_read_req_address_bus", addr_bits, query_heads_per_kv)
     slice_match = _match_expr("child_value_read_req_slice_bus", slice_bits, query_heads_per_kv)
+    command_head_base_port = (
+        f"\n    input  wire [{head_id_bits - 1}:0] command_head_base," if partial_mode else ""
+    )
+    result_head_id_port = (
+        f"\n    output reg  [{head_id_bits - 1}:0] result_head_id," if partial_mode else ""
+    )
+    active_head_base_decl = (
+        f"\n  reg [HEAD_ID_BITS-1:0] active_command_head_base_q;" if partial_mode else ""
+    )
+    child_result_head_id_decl = (
+        f"\n  wire [QUERY_HEADS_PER_KV*HEAD_ID_BITS-1:0] child_result_head_id_bus;" if partial_mode else ""
+    )
+    active_head_base_reset = (
+        "\n      active_command_head_base_q <= {HEAD_ID_BITS{1'b0}};" if partial_mode else ""
+    )
+    active_head_base_accept = (
+        "\n        active_command_head_base_q <= command_head_base;" if partial_mode else ""
+    )
+    head_id_default = f"\n    result_head_id = {head_id_bits}'d0;" if partial_mode else ""
+    head_id_default_case = (
+        f"\n        result_head_id = {head_id_bits}'d0;" if partial_mode else ""
+    )
+    head_id_check = (
+        "\n        if (result_head_id != (active_command_head_base_q + result_head_q)) begin\n"
+        "          protocol_error_q <= 1'b1;\n"
+        "        end"
+        if partial_mode
+        else ""
+    )
     return f"""// Auto-generated by npu/rtlgen/gen_attention_decode_score_multivalue_gqa_group.py
 module {top_name} (
     input  wire         clk,
@@ -220,7 +292,7 @@ module {top_name} (
     input  wire         command_valid,
     output wire         command_ready,
     input  wire [15:0]  command_id,
-    input  wire [14:0]  command_block_count,
+    input  wire [14:0]  command_block_count,{command_head_base_port}
     input  wire [31:0]  command_score_multiplier,
     input  wire [5:0]   command_score_shift,
     input  wire         input_valid,
@@ -240,12 +312,13 @@ module {top_name} (
     output wire         result_valid,
     input  wire         result_ready,
     output wire [{head_bits - 1}:0] result_head,
+{result_head_id_port}
     output reg  [15:0]  result_command_id,
     output reg  signed [31:0] result_global_max,
     output reg  [32:0]  result_exp_sum,
     output reg  [{slice_bits - 1}:0] result_slice,
     output reg          result_last,
-    output reg  [319:0] result_value,
+    output reg  [{result_value_bits - 1}:0] result_value,
     output reg  [31:0]  accepted_count,
     output reg  [31:0]  completed_count,
     output reg  [31:0]  cycle_count,
@@ -254,11 +327,12 @@ module {top_name} (
   localparam integer MAX_BLOCKS = {max_blocks};
   localparam integer VALUE_SLICES = {value_slices};
   localparam integer QUERY_HEADS_PER_KV = {query_heads_per_kv};
+  localparam integer HEAD_ID_BITS = {head_id_bits};
 
   reg command_active_q;
   reg [{head_bits - 1}:0] result_head_q;
   reg [{slice_bits - 1}:0] expected_slice_q;
-  reg protocol_error_q;
+  reg protocol_error_q;{active_head_base_decl}
 
   wire [QUERY_HEADS_PER_KV-1:0] child_command_ready;
   wire [QUERY_HEADS_PER_KV-1:0] child_input_ready;
@@ -276,7 +350,7 @@ module {top_name} (
   wire [QUERY_HEADS_PER_KV*32-1:0] child_result_global_max_bus;
   wire [QUERY_HEADS_PER_KV*33-1:0] child_result_exp_sum_bus;
   wire [QUERY_HEADS_PER_KV*{slice_bits}-1:0] child_result_slice_bus;
-  wire [QUERY_HEADS_PER_KV*320-1:0] child_result_value_bus;
+  wire [QUERY_HEADS_PER_KV*{result_value_bits}-1:0] child_result_value_bus;{child_result_head_id_decl}
   wire [QUERY_HEADS_PER_KV*32-1:0] child_accepted_count_bus;
   wire [QUERY_HEADS_PER_KV*32-1:0] child_completed_count_bus;
   wire [QUERY_HEADS_PER_KV*32-1:0] child_cycle_count_bus;
@@ -317,28 +391,28 @@ module {top_name} (
     result_exp_sum = 33'd0;
     result_slice = {slice_bits}'d0;
     result_last = 1'b0;
-    result_value = 320'd0;
+    result_value = {result_value_bits}'d0;{head_id_default}
     case (result_head_q)
-{_result_mux_cases(query_heads_per_kv)}
+{_result_mux_cases(query_heads_per_kv, result_value_bits=result_value_bits, partial_mode=partial_mode, head_id_bits=head_id_bits)}
       default: begin
         result_command_id = 16'd0;
         result_global_max = 32'sd0;
         result_exp_sum = 33'd0;
         result_slice = {slice_bits}'d0;
         result_last = 1'b0;
-        result_value = 320'd0;
+        result_value = {result_value_bits}'d0;{head_id_default_case}
       end
     endcase
   end
 
-{_cluster_instances(cluster_top, query_heads_per_kv)}
+{_cluster_instances(cluster_top, query_heads_per_kv, result_value_bits=result_value_bits, partial_mode=partial_mode, head_id_bits=head_id_bits)}
 
   always @(posedge clk or negedge rst_n) begin
     if (!rst_n) begin
       command_active_q <= 1'b0;
       result_head_q <= {head_bits}'d0;
       expected_slice_q <= {slice_bits}'d0;
-      protocol_error_q <= 1'b0;
+      protocol_error_q <= 1'b0;{active_head_base_reset}
       accepted_count <= 32'd0;
       completed_count <= 32'd0;
       cycle_count <= 32'd0;
@@ -353,6 +427,7 @@ module {top_name} (
         command_active_q <= 1'b1;
         result_head_q <= {head_bits}'d0;
         expected_slice_q <= {slice_bits}'d0;
+{active_head_base_accept}
         accepted_count <= accepted_count + 1'b1;
       end
 
@@ -360,6 +435,7 @@ module {top_name} (
         if (result_slice != expected_slice_q) begin
           protocol_error_q <= 1'b1;
         end
+{head_id_check}
         if (expected_slice_q == VALUE_SLICES - 1) begin
           if (!result_last) begin
             protocol_error_q <= 1'b1;
@@ -389,6 +465,9 @@ def _folded_wrapper(*, top_name: str, params: dict[str, int | str], cluster_top:
     value_slices = int(params["value_slices"])
     query_heads_per_kv = int(params["query_heads_per_kv"])
     parallel_lanes = int(params["parallel_query_head_lanes"])
+    partial_mode = str(params["result_mode"]) == "exact_partial"
+    head_id_bits = int(params["head_id_bits"])
+    result_value_bits = 328 if partial_mode else 320
     waves = query_heads_per_kv // parallel_lanes
     addr_bits = 14
     slice_bits = _clog2(value_slices)
@@ -396,6 +475,41 @@ def _folded_wrapper(*, top_name: str, params: dict[str, int | str], cluster_top:
     wave_bits = _clog2(waves)
     addr_match = _match_expr("child_value_read_req_address_bus", addr_bits, parallel_lanes)
     slice_match = _match_expr("child_value_read_req_slice_bus", slice_bits, parallel_lanes)
+    command_head_base_port = (
+        f"\n    input  wire [{head_id_bits - 1}:0] command_head_base," if partial_mode else ""
+    )
+    result_head_id_port = (
+        f"\n    output reg  [{head_id_bits - 1}:0] result_head_id," if partial_mode else ""
+    )
+    active_head_base_decl = (
+        f"\n  reg [HEAD_ID_BITS-1:0] active_command_head_base_q;" if partial_mode else ""
+    )
+    child_head_id_decl = (
+        f"\n  wire [PARALLEL_QUERY_HEAD_LANES*HEAD_ID_BITS-1:0] child_result_head_id_bus;" if partial_mode else ""
+    )
+    child_command_head_base_decl = (
+        "\n  wire [HEAD_ID_BITS-1:0] child_command_head_base =\n"
+        "      command_active_q ? active_command_head_base_q : command_head_base;"
+        if partial_mode
+        else ""
+    )
+    active_head_base_reset = (
+        "\n      active_command_head_base_q <= {HEAD_ID_BITS{1'b0}};" if partial_mode else ""
+    )
+    active_head_base_accept = (
+        "\n        active_command_head_base_q <= command_head_base;" if partial_mode else ""
+    )
+    head_id_default = f"\n    result_head_id = {head_id_bits}'d0;" if partial_mode else ""
+    head_id_default_case = (
+        f"\n        result_head_id = {head_id_bits}'d0;" if partial_mode else ""
+    )
+    head_id_check = (
+        "\n        if (result_head_id != (active_command_head_base_q + result_head)) begin\n"
+        "          protocol_error_q <= 1'b1;\n"
+        "        end"
+        if partial_mode
+        else ""
+    )
     return f"""// Auto-generated folded GQA wrapper by npu/rtlgen/gen_attention_decode_score_multivalue_gqa_group.py
 module {top_name} (
     input  wire         clk,
@@ -403,7 +517,7 @@ module {top_name} (
     input  wire         command_valid,
     output wire         command_ready,
     input  wire [15:0]  command_id,
-    input  wire [14:0]  command_block_count,
+    input  wire [14:0]  command_block_count,{command_head_base_port}
     input  wire [31:0]  command_score_multiplier,
     input  wire [5:0]   command_score_shift,
     input  wire         input_valid,
@@ -423,12 +537,13 @@ module {top_name} (
     output wire         result_valid,
     input  wire         result_ready,
     output wire [2:0]   result_head,
+{result_head_id_port}
     output reg  [15:0]  result_command_id,
     output reg  signed [31:0] result_global_max,
     output reg  [32:0]  result_exp_sum,
     output reg  [{slice_bits - 1}:0] result_slice,
     output reg          result_last,
-    output reg  [319:0] result_value,
+    output reg  [{result_value_bits - 1}:0] result_value,
     output reg  [31:0]  accepted_count,
     output reg  [31:0]  completed_count,
     output reg  [31:0]  cycle_count,
@@ -439,6 +554,7 @@ module {top_name} (
   localparam integer QUERY_HEADS_PER_KV = {query_heads_per_kv};
   localparam integer PARALLEL_QUERY_HEAD_LANES = {parallel_lanes};
   localparam integer QUERY_HEAD_WAVES = {waves};
+  localparam integer HEAD_ID_BITS = {head_id_bits};
 
   reg command_active_q;
   reg launch_pending_q;
@@ -449,7 +565,7 @@ module {top_name} (
   reg [14:0] active_block_count_q;
   reg [31:0] active_score_multiplier_q;
   reg [5:0] active_score_shift_q;
-  reg protocol_error_q;
+  reg protocol_error_q;{active_head_base_decl}
 
   wire [PARALLEL_QUERY_HEAD_LANES-1:0] child_command_ready;
   wire [PARALLEL_QUERY_HEAD_LANES-1:0] child_input_ready;
@@ -467,7 +583,7 @@ module {top_name} (
   wire [PARALLEL_QUERY_HEAD_LANES*32-1:0] child_result_global_max_bus;
   wire [PARALLEL_QUERY_HEAD_LANES*33-1:0] child_result_exp_sum_bus;
   wire [PARALLEL_QUERY_HEAD_LANES*{slice_bits}-1:0] child_result_slice_bus;
-  wire [PARALLEL_QUERY_HEAD_LANES*320-1:0] child_result_value_bus;
+  wire [PARALLEL_QUERY_HEAD_LANES*{result_value_bits}-1:0] child_result_value_bus;{child_head_id_decl}
   wire [PARALLEL_QUERY_HEAD_LANES*32-1:0] child_accepted_count_bus;
   wire [PARALLEL_QUERY_HEAD_LANES*32-1:0] child_completed_count_bus;
   wire [PARALLEL_QUERY_HEAD_LANES*32-1:0] child_cycle_count_bus;
@@ -481,6 +597,7 @@ module {top_name} (
   wire [31:0] child_command_score_multiplier =
       command_active_q ? active_score_multiplier_q : command_score_multiplier;
   wire [5:0] child_command_score_shift = command_active_q ? active_score_shift_q : command_score_shift;
+{child_command_head_base_decl}
   wire any_value_req_valid = |child_value_read_req_valid;
   wire all_value_req_valid = &child_value_read_req_valid;
   wire value_req_addr_match = {addr_match};
@@ -514,21 +631,21 @@ module {top_name} (
     result_exp_sum = 33'd0;
     result_slice = {slice_bits}'d0;
     result_last = 1'b0;
-    result_value = 320'd0;
+    result_value = {result_value_bits}'d0;{head_id_default}
     case (result_lane_q)
-{_result_mux_cases(parallel_lanes)}
+{_result_mux_cases(parallel_lanes, result_value_bits=result_value_bits, partial_mode=partial_mode, head_id_bits=head_id_bits)}
       default: begin
         result_command_id = 16'd0;
         result_global_max = 32'sd0;
         result_exp_sum = 33'd0;
         result_slice = {slice_bits}'d0;
         result_last = 1'b0;
-        result_value = 320'd0;
+        result_value = {result_value_bits}'d0;{head_id_default_case}
       end
     endcase
   end
 
-{_folded_cluster_instances(cluster_top, parallel_lanes)}
+{_folded_cluster_instances(cluster_top, parallel_lanes, result_value_bits=result_value_bits, partial_mode=partial_mode, head_id_bits=head_id_bits)}
 
   always @(posedge clk or negedge rst_n) begin
     if (!rst_n) begin
@@ -541,7 +658,7 @@ module {top_name} (
       active_block_count_q <= 15'd0;
       active_score_multiplier_q <= 32'd0;
       active_score_shift_q <= 6'd0;
-      protocol_error_q <= 1'b0;
+      protocol_error_q <= 1'b0;{active_head_base_reset}
       accepted_count <= 32'd0;
       completed_count <= 32'd0;
       cycle_count <= 32'd0;
@@ -562,6 +679,7 @@ module {top_name} (
         active_block_count_q <= command_block_count;
         active_score_multiplier_q <= command_score_multiplier;
         active_score_shift_q <= command_score_shift;
+{active_head_base_accept}
         accepted_count <= accepted_count + 1'b1;
       end
 
@@ -573,6 +691,7 @@ module {top_name} (
         if (result_slice != expected_slice_q) begin
           protocol_error_q <= 1'b1;
         end
+{head_id_check}
         if (expected_slice_q == VALUE_SLICES - 1) begin
           if (!result_last) begin
             protocol_error_q <= 1'b1;
@@ -620,6 +739,8 @@ def generate(config: dict[str, Any], out_dir: Path) -> None:
                     "value_slices": int(params["value_slices"]),
                     "divider_impl": str(params["divider_impl"]),
                     "score_scale_lanes_per_cycle": int(params["score_scale_lanes_per_cycle"]),
+                    "result_mode": str(params["result_mode"]),
+                    "head_id_bits": int(params["head_id_bits"]),
                 },
             },
             cluster_dir,
@@ -643,6 +764,8 @@ def generate(config: dict[str, Any], out_dir: Path) -> None:
             if parallel_lanes == int(params["query_heads_per_kv"])
             else "decode_m1x8_shared_score_16x8d_value_iterdiv_gqa8_folded_group_v1"
         ),
+        "result_mode": str(params["result_mode"]),
+        "head_id_bits": int(params["head_id_bits"]),
         "query_heads_per_kv": int(params["query_heads_per_kv"]),
         "max_blocks": int(params["max_blocks"]),
         "score_tile_array_n": int(params["array_n"]),
@@ -661,7 +784,7 @@ def generate(config: dict[str, Any], out_dir: Path) -> None:
         ),
         "internal_value_reads_per_block_per_head": int(params["value_slices"]),
         "result_beats_per_command": int(params["query_heads_per_kv"]) * int(params["value_slices"]),
-        "result_value_bits_per_beat": 320,
+        "result_value_bits_per_beat": 328 if str(params["result_mode"]) == "exact_partial" else 320,
         "submodule_manifests": {
             "multivalue_cluster": cluster_manifest,
         },

--- a/npu/rtlgen/gen_attention_score32_exact_partial_gqa8_dual_stream_producer.py
+++ b/npu/rtlgen/gen_attention_score32_exact_partial_gqa8_dual_stream_producer.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Generate a dual-stream GQA8 exact-partial producer slice."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_decode_score_multivalue_gqa_group import generate as generate_group
+from npu.rtlgen.gen_attention_score32_online_state_merge import generate as generate_merge
+from npu.sim.perf.attention_exact_partial import (
+    HEAD_ID_BITS,
+    PARTIAL_LINK_BITS,
+    PARTIAL_PAYLOAD_BITS,
+    exact_partial_dual_stream_gqa8_producer_service_manifest,
+)
+
+JsonDict = dict[str, Any]
+
+_STREAMS = 2
+_QUERY_HEADS_PER_STREAM = 8
+_VALUE_SLICES = 16
+_ARRAY_N = 8
+_CONFIG_KEY = "attention_score32_exact_partial_gqa8_dual_stream_producer"
+_MANIFEST_NAME = "attention_score32_exact_partial_gqa8_dual_stream_producer_manifest.json"
+
+
+def _load(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit(f"config must decode to a JSON object: {path}")
+    return payload
+
+
+def _validate(config: JsonDict) -> JsonDict:
+    top_name = str(config.get("top_name") or "").strip()
+    body = config.get(_CONFIG_KEY)
+    if not top_name or not isinstance(body, dict):
+        raise SystemExit(f"config requires top_name and {_CONFIG_KEY}")
+
+    streams = int(body.get("streams", _STREAMS))
+    query_heads_per_stream = int(body.get("query_heads_per_stream", _QUERY_HEADS_PER_STREAM))
+    max_blocks = int(body.get("max_blocks", 8))
+    value_slices = int(body.get("value_slices", _VALUE_SLICES))
+    head_id_bits = int(body.get("head_id_bits", HEAD_ID_BITS))
+
+    if streams != _STREAMS:
+        raise SystemExit("dual-stream exact producer currently requires streams=2")
+    if query_heads_per_stream != _QUERY_HEADS_PER_STREAM:
+        raise SystemExit("dual-stream exact producer currently requires query_heads_per_stream=8")
+    if max_blocks < 8 or max_blocks > 16384 or (max_blocks & (max_blocks - 1)):
+        raise SystemExit("max_blocks must be a power of two in [8, 16384]")
+    if value_slices != _VALUE_SLICES:
+        raise SystemExit("dual-stream exact producer currently requires value_slices=16")
+    if head_id_bits != HEAD_ID_BITS:
+        raise SystemExit("dual-stream exact producer currently requires head_id_bits=5")
+
+    return {
+        "top_name": top_name,
+        "streams": streams,
+        "query_heads_per_stream": query_heads_per_stream,
+        "max_blocks": max_blocks,
+        "value_slices": value_slices,
+        "head_id_bits": head_id_bits,
+    }
+
+
+def _slice(name: str, index: int, width: int) -> str:
+    lo = index * width
+    return f"{name}[{lo + width - 1}:{lo}]"
+
+
+def _group_instances(group_top: str, head_id_bits: int) -> str:
+    blocks: list[str] = []
+    for stream in range(_STREAMS):
+        blocks.append(
+            f"""  {group_top} u_stream_{stream} (
+      .clk(clk),
+      .rst_n(rst_n),
+      .command_valid(command_valid && command_ready),
+      .command_ready(stream_command_ready_w[{stream}]),
+      .command_id(command_id),
+      .command_block_count(command_block_count),
+      .command_head_base(command_head_base),
+      .command_score_multiplier(command_score_multiplier),
+      .command_score_shift(command_score_shift),
+      .input_valid(input_valid && input_ready),
+      .input_ready(stream_input_ready_w[{stream}]),
+      .input_last(input_last),
+      .input_query({_slice("input_query", stream, 64)}),
+      .input_key({_slice("input_key", stream, 64)}),
+      .value_read_req_valid(value_read_req_valid[{stream}]),
+      .value_read_req_ready(value_read_req_ready[{stream}]),
+      .value_read_req_address({_slice("value_read_req_address", stream, 14)}),
+      .value_read_req_slice({_slice("value_read_req_slice", stream, 4)}),
+      .value_response_valid(value_response_valid[{stream}]),
+      .value_response_ready(value_response_ready[{stream}]),
+      .value_response_address({_slice("value_response_address", stream, 14)}),
+      .value_response_slice({_slice("value_response_slice", stream, 4)}),
+      .value_response_matrix({_slice("value_response_matrix", stream, 512)}),
+      .result_valid(stream_result_valid_w[{stream}]),
+      .result_ready(stream_result_ready_w[{stream}]),
+      .result_head({_slice("stream_result_head_w", stream, 3)}),
+      .result_head_id({_slice("stream_result_head_id_w", stream, head_id_bits)}),
+      .result_command_id({_slice("stream_result_command_id_w", stream, 16)}),
+      .result_global_max({_slice("stream_result_global_max_w", stream, 32)}),
+      .result_exp_sum({_slice("stream_result_exp_sum_w", stream, 33)}),
+      .result_slice({_slice("stream_result_slice_w", stream, 4)}),
+      .result_last(stream_result_last_w[{stream}]),
+      .result_value({_slice("stream_result_value_w", stream, PARTIAL_PAYLOAD_BITS)}),
+      .accepted_count({_slice("stream_command_accept_count_w", stream, 32)}),
+      .completed_count({_slice("stream_completed_count_w", stream, 32)}),
+      .cycle_count({_slice("stream_cycle_count_w", stream, 32)}),
+      .protocol_error(stream_protocol_error_w[{stream}])
+  );"""
+        )
+    return "\n\n".join(blocks)
+
+
+def _top(*, top_name: str, group_top: str, merge_top: str, head_id_bits: int) -> str:
+    return f"""// Auto-generated by npu/rtlgen/gen_attention_score32_exact_partial_gqa8_dual_stream_producer.py
+module {top_name} (
+    input  wire         clk,
+    input  wire         rst_n,
+    input  wire         command_valid,
+    output wire         command_ready,
+    input  wire [15:0]  command_id,
+    input  wire [{head_id_bits - 1}:0] command_head_base,
+    input  wire [14:0]  command_block_count,
+    input  wire [31:0]  command_score_multiplier,
+    input  wire [5:0]   command_score_shift,
+    input  wire         input_valid,
+    output wire         input_ready,
+    input  wire         input_last,
+    input  wire signed [127:0] input_query,
+    input  wire signed [127:0] input_key,
+    output wire [1:0]   value_read_req_valid,
+    input  wire [1:0]   value_read_req_ready,
+    output wire [27:0]  value_read_req_address,
+    output wire [7:0]   value_read_req_slice,
+    input  wire [1:0]   value_response_valid,
+    output wire [1:0]   value_response_ready,
+    input  wire [27:0]  value_response_address,
+    input  wire [7:0]   value_response_slice,
+    input  wire [1023:0] value_response_matrix,
+    output wire         result_valid,
+    input  wire         result_ready,
+    output wire [15:0]  result_command_id,
+    output wire [{head_id_bits - 1}:0] result_head_id,
+    output wire signed [31:0] result_global_max,
+    output wire [32:0]  result_exp_sum,
+    output wire [3:0]   result_slice,
+    output wire         result_last,
+    output wire [327:0] result_value,
+    output wire [31:0]  cycle_count,
+    output wire [31:0]  command_accept_count,
+    output wire [31:0]  command_completed_count,
+    output wire [63:0]  stream_command_accept_count,
+    output wire [63:0]  stream_completed_count,
+    output wire [1:0]   stream_partial_valid,
+    output wire [1:0]   stream_partial_ready,
+    output wire [1:0]   stream_partial_last,
+    output wire [31:0]  merge_completed_count,
+    output wire [31:0]  result_stall_cycles,
+    output wire [1:0]   stream_protocol_error,
+    output wire         merge_protocol_error,
+    output wire         protocol_error
+);
+  localparam integer PARTIAL_PAYLOAD_BITS = {PARTIAL_PAYLOAD_BITS};
+  localparam integer HEAD_ID_BITS = {head_id_bits};
+
+  wire [1:0] stream_command_ready_w;
+  wire [1:0] stream_input_ready_w;
+  wire [1:0] stream_result_valid_w;
+  wire [1:0] stream_result_ready_w;
+  wire [5:0] stream_result_head_w;
+  wire [9:0] stream_result_head_id_w;
+  wire [31:0] stream_result_command_id_w;
+  wire [63:0] stream_result_global_max_w;
+  wire [65:0] stream_result_exp_sum_w;
+  wire [7:0] stream_result_slice_w;
+  wire [1:0] stream_result_last_w;
+  wire [655:0] stream_result_value_w;
+  wire [63:0] stream_command_accept_count_w;
+  wire [63:0] stream_completed_count_w;
+  wire [63:0] stream_cycle_count_w;
+  wire [1:0] stream_protocol_error_w;
+
+  wire command_head_base_valid_w = (command_head_base[2:0] == 3'd0) && (command_head_base <= 5'd24);
+  wire command_fire_w = command_valid && command_ready;
+  wire merge_fire_w = result_valid && result_ready;
+
+  reg [31:0] cycle_count_q;
+  reg [31:0] command_accept_count_q;
+  reg [31:0] command_completed_count_q;
+  reg [31:0] result_stall_cycles_q;
+  reg protocol_error_q;
+
+  assign command_ready = command_head_base_valid_w && (&stream_command_ready_w);
+  assign input_ready = &stream_input_ready_w;
+  assign cycle_count = cycle_count_q;
+  assign command_accept_count = command_accept_count_q;
+  assign command_completed_count = command_completed_count_q;
+  assign stream_command_accept_count = stream_command_accept_count_w;
+  assign stream_completed_count = stream_completed_count_w;
+  assign stream_partial_valid = stream_result_valid_w;
+  assign stream_partial_ready = stream_result_ready_w;
+  assign stream_partial_last = stream_result_last_w;
+  assign result_stall_cycles = result_stall_cycles_q;
+  assign stream_protocol_error = stream_protocol_error_w;
+  assign protocol_error = protocol_error_q || (|stream_protocol_error_w) || merge_protocol_error;
+
+{_group_instances(group_top, head_id_bits)}
+
+  {merge_top} u_merge (
+      .clk(clk),
+      .rst_n(rst_n),
+      .left_valid(stream_result_valid_w[0]),
+      .left_ready(stream_result_ready_w[0]),
+      .left_command_id(stream_result_command_id_w[15:0]),
+      .left_head_id(stream_result_head_id_w[4:0]),
+      .left_global_max(stream_result_global_max_w[31:0]),
+      .left_exp_sum(stream_result_exp_sum_w[32:0]),
+      .left_slice(stream_result_slice_w[3:0]),
+      .left_last(stream_result_last_w[0]),
+      .left_value(stream_result_value_w[327:0]),
+      .right_valid(stream_result_valid_w[1]),
+      .right_ready(stream_result_ready_w[1]),
+      .right_command_id(stream_result_command_id_w[31:16]),
+      .right_head_id(stream_result_head_id_w[9:5]),
+      .right_global_max(stream_result_global_max_w[63:32]),
+      .right_exp_sum(stream_result_exp_sum_w[65:33]),
+      .right_slice(stream_result_slice_w[7:4]),
+      .right_last(stream_result_last_w[1]),
+      .right_value(stream_result_value_w[655:328]),
+      .out_valid(result_valid),
+      .out_ready(result_ready),
+      .out_command_id(result_command_id),
+      .out_head_id(result_head_id),
+      .out_global_max(result_global_max),
+      .out_exp_sum(result_exp_sum),
+      .out_slice(result_slice),
+      .out_last(result_last),
+      .out_value(result_value),
+      .completed_count(merge_completed_count),
+      .cycle_count(),
+      .protocol_error(merge_protocol_error)
+  );
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      cycle_count_q <= 32'd0;
+      command_accept_count_q <= 32'd0;
+      command_completed_count_q <= 32'd0;
+      result_stall_cycles_q <= 32'd0;
+      protocol_error_q <= 1'b0;
+    end else begin
+      cycle_count_q <= cycle_count_q + 1'b1;
+      if (command_fire_w) begin
+        command_accept_count_q <= command_accept_count_q + 1'b1;
+      end
+      if (result_valid && !result_ready) begin
+        result_stall_cycles_q <= result_stall_cycles_q + 1'b1;
+      end
+      if (merge_fire_w && result_last && (result_head_id[2:0] == 3'd7)) begin
+        command_completed_count_q <= command_completed_count_q + 1'b1;
+      end
+      if (command_valid && (&stream_command_ready_w) && !command_head_base_valid_w) begin
+        protocol_error_q <= 1'b1;
+      end
+      if ((stream_result_valid_w[0] && stream_result_valid_w[1]) && (stream_result_head_w[2:0] != stream_result_head_w[5:3])) begin
+        protocol_error_q <= 1'b1;
+      end
+    end
+  end
+endmodule
+"""
+
+
+def generate(config: JsonDict, out_dir: Path) -> None:
+    params = _validate(json.loads(json.dumps(config)))
+    top_name = str(params["top_name"])
+    group_top = f"{top_name}__group"
+    merge_top = f"{top_name}__merge"
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="score32_exact_partial_dual_stream_gqa8_") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        group_dir = temp_dir / "group"
+        merge_dir = temp_dir / "merge"
+        generate_group(
+            {
+                "top_name": group_top,
+                "attention_decode_score_multivalue_gqa_group": {
+                    "max_blocks": int(params["max_blocks"]),
+                    "array_n": _ARRAY_N,
+                    "value_slices": int(params["value_slices"]),
+                    "divider_impl": "iterative_restoring",
+                    "score_scale_lanes_per_cycle": 1,
+                    "query_heads_per_kv": int(params["query_heads_per_stream"]),
+                    "parallel_query_head_lanes": int(params["query_heads_per_stream"]),
+                    "result_mode": "exact_partial",
+                    "head_id_bits": int(params["head_id_bits"]),
+                },
+            },
+            group_dir,
+        )
+        generate_merge(
+            {
+                "top_name": merge_top,
+                "attention_score32_online_state_merge": {
+                    "value_slices": int(params["value_slices"]),
+                    "head_id_bits": int(params["head_id_bits"]),
+                },
+            },
+            merge_dir,
+        )
+        group_rtl = (group_dir / "top.v").read_text(encoding="utf-8")
+        merge_rtl = (merge_dir / "top.v").read_text(encoding="utf-8")
+        group_manifest = json.loads(
+            (group_dir / "attention_decode_score_multivalue_gqa_group_manifest.json").read_text(encoding="utf-8")
+        )
+        merge_manifest = json.loads(
+            (merge_dir / "attention_score32_online_state_merge_manifest.json").read_text(encoding="utf-8")
+        )
+
+    top_text = _top(
+        top_name=top_name,
+        group_top=group_top,
+        merge_top=merge_top,
+        head_id_bits=int(params["head_id_bits"]),
+    )
+    (out_dir / "top.v").write_text(group_rtl + "\n\n" + merge_rtl + "\n\n" + top_text + "\n", encoding="utf-8")
+    (out_dir / "config.json").write_text(json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    probe_defaults = config.get("probe_defaults", {})
+    if not isinstance(probe_defaults, dict):
+        probe_defaults = {}
+    service_model = exact_partial_dual_stream_gqa8_producer_service_manifest(
+        heads=int(probe_defaults.get("heads", 8)),
+        max_blocks=int(params["max_blocks"]),
+        command_count=int(probe_defaults.get("command_count", int(probe_defaults.get("heads", 8)) // 8)),
+        blocks_per_stream=int(probe_defaults.get("blocks_per_stream", 2)),
+        head_dim=int(probe_defaults.get("head_dim", 3)),
+        head_bases=tuple(int(value) for value in probe_defaults.get("head_bases", [])) if isinstance(probe_defaults.get("head_bases"), list) else None,
+        llama_wave_reference_cycles=int(probe_defaults["llama_wave_reference_cycles"]) if "llama_wave_reference_cycles" in probe_defaults else None,
+    )
+    manifest = {
+        "version": 1,
+        "generator": "npu/rtlgen/gen_attention_score32_exact_partial_gqa8_dual_stream_producer.py",
+        "top_name": top_name,
+        "semantic_profile": "score32_exact_partial_gqa8_dual_stream_producer_v1",
+        "streams": 2,
+        "query_heads_per_stream": 8,
+        "token_lanes_per_head": 8,
+        "structural_score_macs_per_cycle": 128,
+        "max_blocks": int(params["max_blocks"]),
+        "value_slices": int(params["value_slices"]),
+        "head_id_bits": int(params["head_id_bits"]),
+        "producer_result_mode": "exact_partial",
+        "command_schedule_contract": "in_order_head_base_commands_broadcast_to_both_streams",
+        "head_mapping_contract": "explicit_head_base_plus_lane_no_tile_or_wave_inference",
+        "result_interface": "two_exact_partial_gqa8_streams_to_pairwise_exact_merge",
+        "partial_payload_bits_per_beat": PARTIAL_PAYLOAD_BITS,
+        "partial_link_bits_per_beat": PARTIAL_LINK_BITS,
+        "exact_protocols": {
+            "producer_partial_protocol": service_model["producer_partial_protocol"],
+        },
+        "remaining_abstractions": service_model["remaining_abstractions"],
+        "equivalence_hash": False,
+        "service_model": service_model,
+        "submodule_manifests": {
+            "gqa_group": group_manifest,
+            "merge": merge_manifest,
+        },
+    }
+    if isinstance(config.get("probe_defaults"), dict):
+        manifest["checked_in_probe_defaults"] = config["probe_defaults"]
+    (out_dir / _MANIFEST_NAME).write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    generate(_load(args.config), args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/sim/perf/attention_exact_partial.py
+++ b/npu/sim/perf/attention_exact_partial.py
@@ -766,6 +766,91 @@ def exact_partial_producer_tree_service_manifest(
     return manifest
 
 
+def exact_partial_dual_stream_gqa8_producer_service_manifest(
+    *,
+    heads: int = 32,
+    max_blocks: int = 8,
+    command_count: int | None = None,
+    blocks_per_stream: int = 2,
+    head_dim: int = 3,
+    head_bases: tuple[int, ...] | None = None,
+    llama_wave_reference_cycles: int | None = None,
+) -> dict[str, object]:
+    head_count = int(heads)
+    block_limit = int(max_blocks)
+    resolved_command_count = int(command_count if command_count is not None else head_count // 8)
+    resolved_blocks_per_stream = int(blocks_per_stream)
+    resolved_head_dim = int(head_dim)
+    if head_count < 8 or head_count > 32 or head_count % 8:
+        raise ValueError("heads must be a multiple of 8 in [8, 32]")
+    if block_limit < 8 or block_limit > 16384 or (block_limit & (block_limit - 1)):
+        raise ValueError("max_blocks must be a power of two in [8, 16384]")
+    if resolved_command_count < 1:
+        raise ValueError("command_count must be positive")
+    if resolved_blocks_per_stream < 1 or resolved_blocks_per_stream > block_limit:
+        raise ValueError("blocks_per_stream must be in [1, max_blocks]")
+    if resolved_head_dim < 1:
+        raise ValueError("head_dim must be positive")
+    if head_bases is None:
+        bases = tuple((group % (head_count // 8)) * 8 for group in range(resolved_command_count))
+    else:
+        bases = tuple(int(value) for value in head_bases)
+    if len(bases) != resolved_command_count:
+        raise ValueError("head_bases length must match command_count")
+    if any(base < 0 or base > 24 or base % 8 for base in bases):
+        raise ValueError("head_bases entries must be aligned to 8 in [0, 24]")
+    cadence_reference = {
+        "reference_cycles": int(llama_wave_reference_cycles),
+        "interpretation": "functional_service_evidence_only_no_frontier_revision",
+    } if llama_wave_reference_cycles is not None else None
+    return {
+        "streams": 2,
+        "query_heads_per_stream": 8,
+        "query_head_groups": head_count // 8,
+        "token_lanes_per_head": 8,
+        "structural_score_macs_per_cycle": 2 * 8 * 8,
+        "command_broadcast_mode": "same_head_base_broadcast_to_both_stream_groups",
+        "head_mapping_contract": "explicit_head_base_plus_lane_no_tile_or_wave_inference",
+        "producer_input_contract": "packed_dual_stream_query_key_atomic_ready_valid",
+        "value_memory_contract": "per_stream_gqa_coalesced_value_reads",
+        "output_schedule_contract": "serialized_head_then_slice_exact_partial_stream",
+        "producer_partial_protocol": {
+            "command_id_bits": 16,
+            "head_id_bits": HEAD_ID_BITS,
+            "global_max_bits": SCORE_BITS,
+            "exp_sum_bits": EXP_SUM_BITS,
+            "slice_index_bits": SLICE_INDEX_BITS,
+            "partial_payload_bits_per_beat": PARTIAL_PAYLOAD_BITS,
+            "partial_link_bits_per_beat": PARTIAL_LINK_BITS,
+        },
+        "producer_block_workload_assumptions": {
+            "command_block_count_range": [1, block_limit],
+            "probe_command_count": resolved_command_count,
+            "per_wave_local_block_ceiling_per_stream": 2,
+            "persistent_local_reducer_waves": 8,
+            "probe_blocks_per_stream": resolved_blocks_per_stream,
+            "probe_head_dim": resolved_head_dim,
+            "probe_head_bases": list(bases),
+            "probe_total_heads": head_count,
+            "probe_token_streams": 2,
+            "multiple_head_groups_run_in_order": True,
+            "head_base_alignment_bits": 3,
+            "global_tile_tokens": 1024,
+            "global_tile_token_blocks": 128,
+            "worst_loaded_jobs_per_datapath_upper_bound": 5,
+        },
+        "comparison_baseline_contract": "python_structured_exact_partial_stream_reference",
+        "comparison_cycle_origin": "cycle0_on_atomic_dual_stream_input_issue",
+        "diagnostic_only_baseline": "none",
+        "llama_wave_functional_service_reference": cadence_reference,
+        "remaining_abstractions": [
+            "53or54_way_global_cluster_aggregation_open",
+            "8_wave_persistent_state_open",
+            "noc_sram_ppa_open",
+        ],
+    }
+
+
 __all__ = [
     "EXACT_STATE_BYTES_PER_CLUSTER_32_HEADS",
     "ExactFinalizedBeat",
@@ -783,6 +868,7 @@ __all__ = [
     "exact_finalized_tree_service_manifest",
     "exact_banked_finalized_tree_service_manifest",
     "exact_partial_producer_tree_service_manifest",
+    "exact_partial_dual_stream_gqa8_producer_service_manifest",
     "exact_banked_finalized_tree_full_wave_saturated_service",
     "finalizer_cycles_per_beat",
     "finalizer_output_latency_cycles",

--- a/runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/config.json
@@ -1,0 +1,16 @@
+{
+  "attention_score32_exact_partial_gqa8_dual_stream_producer": {
+    "streams": 2,
+    "query_heads_per_stream": 8,
+    "head_id_bits": 5,
+    "max_blocks": 8,
+    "value_slices": 16
+  },
+  "probe_defaults": {
+    "heads": 8,
+    "command_count": 1,
+    "blocks_per_stream": 2,
+    "head_dim": 3
+  },
+  "top_name": "attention_score32_exact_partial_gqa8_dual_stream_producer_b8"
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/config_heads32_native.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/config_heads32_native.json
@@ -1,0 +1,16 @@
+{
+  "attention_score32_exact_partial_gqa8_dual_stream_producer": {
+    "streams": 2,
+    "query_heads_per_stream": 8,
+    "head_id_bits": 5,
+    "max_blocks": 8,
+    "value_slices": 16
+  },
+  "probe_defaults": {
+    "heads": 32,
+    "command_count": 4,
+    "blocks_per_stream": 2,
+    "head_dim": 3
+  },
+  "top_name": "attention_score32_exact_partial_gqa8_dual_stream_producer_b8"
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/config_llama_wave.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/config_llama_wave.json
@@ -1,0 +1,19 @@
+{
+  "attention_score32_exact_partial_gqa8_dual_stream_producer": {
+    "streams": 2,
+    "query_heads_per_stream": 8,
+    "head_id_bits": 5,
+    "max_blocks": 8,
+    "value_slices": 16
+  },
+  "probe_defaults": {
+    "heads": 32,
+    "command_count": 5,
+    "blocks_per_stream": 1,
+    "head_dim": 128,
+    "head_bases": [0, 8, 16, 24, 0],
+    "interface_mode": "ideal",
+    "llama_wave_reference_cycles": 986
+  },
+  "top_name": "attention_score32_exact_partial_gqa8_dual_stream_producer_b8"
+}

--- a/tests/test_attention_score32_exact_partial_gqa8_dual_stream_producer.py
+++ b/tests/test_attention_score32_exact_partial_gqa8_dual_stream_producer.py
@@ -1,0 +1,244 @@
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval.probe_attention_score32_exact_partial_gqa8_dual_stream_producer import build_report
+from npu.rtlgen.gen_attention_score32_exact_partial_gqa8_dual_stream_producer import generate
+
+_FAKERAM_MODEL = """
+module fakeram45_2048x39 (
+    output wire [38:0] rd_out, input wire [10:0] addr_in,
+    input wire we_in, input wire [38:0] wd_in, input wire [38:0] w_mask_in,
+    input wire clk, input wire ce_in
+);
+  reg [38:0] mem [0:2047];
+  reg [10:0] addr_q;
+  reg [38:0] rd_out_q;
+  integer idx;
+  initial begin
+    addr_q = 0;
+    rd_out_q = 0;
+    for (idx = 0; idx < 2048; idx = idx + 1) mem[idx] = 0;
+  end
+  always @(posedge clk) begin
+    rd_out_q <= mem[addr_q];
+    if (ce_in) begin
+      if (we_in) begin
+        for (idx = 0; idx < 39; idx = idx + 1) begin
+          if (w_mask_in[idx]) mem[addr_in][idx] <= wd_in[idx];
+        end
+      end
+      addr_q <= addr_in;
+    end
+  end
+  assign rd_out = rd_out_q;
+endmodule
+"""
+
+
+def _rtl_tools_available() -> bool:
+    return bool(shutil.which("iverilog") and shutil.which("vvp") and shutil.which("verilator"))
+
+
+def _tool(name: str) -> str:
+    path = shutil.which(name)
+    if path:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    if fallback.exists():
+        return str(fallback)
+    raise RuntimeError(f"required tool unavailable: {name}")
+
+
+def _config_path(name: str = "config.json") -> Path:
+    return (
+        REPO_ROOT
+        / "runs"
+        / "designs"
+        / "npu_blocks"
+        / "attention_score32_exact_partial_gqa8_dual_stream_producer_b8"
+        / name
+    )
+
+
+def _load_config(name: str = "config.json") -> dict[str, object]:
+    return json.loads(_config_path(name).read_text(encoding="utf-8"))
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="RTL tools unavailable")
+def test_exact_partial_gqa8_dual_stream_producer_manifest_and_verilator_lint(tmp_path: Path) -> None:
+    config = _load_config()
+    generate(config, tmp_path / "rtl")
+    fakeram_path = tmp_path / "fakeram45_2048x39.sv"
+    fakeram_path.write_text(_FAKERAM_MODEL, encoding="utf-8")
+
+    manifest = json.loads(
+        (tmp_path / "rtl" / "attention_score32_exact_partial_gqa8_dual_stream_producer_manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert manifest["streams"] == 2
+    assert manifest["query_heads_per_stream"] == 8
+    assert manifest["token_lanes_per_head"] == 8
+    assert manifest["structural_score_macs_per_cycle"] == 128
+    assert manifest["max_blocks"] == 8
+    assert manifest["value_slices"] == 16
+    assert manifest["head_id_bits"] == 5
+    assert manifest["producer_result_mode"] == "exact_partial"
+    assert manifest["checked_in_probe_defaults"] == {
+        "heads": 8,
+        "command_count": 1,
+        "blocks_per_stream": 2,
+        "head_dim": 3,
+    }
+    assert manifest["service_model"]["producer_block_workload_assumptions"] == {
+        "command_block_count_range": [1, 8],
+        "probe_command_count": 1,
+        "per_wave_local_block_ceiling_per_stream": 2,
+        "persistent_local_reducer_waves": 8,
+        "probe_blocks_per_stream": 2,
+        "probe_head_dim": 3,
+        "probe_head_bases": [0],
+        "probe_total_heads": 8,
+        "probe_token_streams": 2,
+        "multiple_head_groups_run_in_order": True,
+        "head_base_alignment_bits": 3,
+        "global_tile_tokens": 1024,
+        "global_tile_token_blocks": 128,
+        "worst_loaded_jobs_per_datapath_upper_bound": 5,
+    }
+    assert manifest["remaining_abstractions"] == [
+        "53or54_way_global_cluster_aggregation_open",
+        "8_wave_persistent_state_open",
+        "noc_sram_ppa_open",
+    ]
+    assert manifest["submodule_manifests"]["gqa_group"]["result_mode"] == "exact_partial"
+    assert manifest["submodule_manifests"]["gqa_group"]["result_value_bits_per_beat"] == 328
+    assert (
+        manifest["submodule_manifests"]["gqa_group"]["submodule_manifests"]["multivalue_cluster"]["result_mode"]
+        == "exact_partial"
+    )
+    assert manifest["submodule_manifests"]["merge"]["result_interface"] == "ready_valid_exact_partial_slice_stream"
+
+    lint = subprocess.run(
+        [
+            _tool("verilator"),
+            "--lint-only",
+            "-Wno-WIDTHEXPAND",
+            "-Wno-WIDTHTRUNC",
+            "--top-module",
+            str(config["top_name"]),
+            str(tmp_path / "rtl" / "top.v"),
+            str(fakeram_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert lint.returncode == 0, lint.stderr
+
+
+def test_exact_partial_gqa8_dual_stream_producer_rejects_too_small_max_blocks(tmp_path: Path) -> None:
+    config = _load_config()
+    config["attention_score32_exact_partial_gqa8_dual_stream_producer"]["max_blocks"] = 4
+    with pytest.raises(SystemExit, match="max_blocks must be a power of two in \\[8, 16384\\]"):
+        generate(config, tmp_path / "rtl")
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="RTL tools unavailable")
+def test_exact_partial_gqa8_dual_stream_producer_small_probe_matches_reference() -> None:
+    report = build_report(config=_load_config())
+
+    assert report["passed"] is True
+    assert report["outputs"] == 128
+    assert report["expected_outputs"] == 128
+    assert report["commands"] == 1
+    assert report["command_accept_count"] == 1
+    assert report["command_complete_count"] == 1
+    assert report["stream_command_accept_count"] == [1, 1]
+    assert report["stream_complete_count"] == [1, 1]
+    assert report["merge_complete_count"] == 128
+    assert report["integrated_drain_cycles"] == 438
+    assert report["result_stall_cycles"] == 64
+    assert report["protocol_error"] is False
+    assert report["stream_protocol_error"] == [False, False]
+    assert report["merge_protocol_error"] is False
+    assert report["observed_rows"] == report["expected_rows"]
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="RTL tools unavailable")
+def test_exact_partial_gqa8_dual_stream_producer_backpressure_and_skew_stress() -> None:
+    report = build_report(
+        config=_load_config(),
+        heads=8,
+        output_ready_pattern=(True, False, True, False, True, True, False, True, True, False, True, True, False, True),
+    )
+
+    assert report["passed"] is True
+    assert report["outputs"] == 128
+    assert report["commands"] == 1
+    assert report["integrated_drain_cycles"] == 445
+    assert report["command_accept_count"] == 1
+    assert report["command_complete_count"] == 1
+    assert report["merge_complete_count"] == 128
+    assert report["result_stall_cycles"] == 71
+    assert report["protocol_error"] is False
+    assert report["stream_protocol_error"] == [False, False]
+    assert report["merge_protocol_error"] is False
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="RTL tools unavailable")
+def test_exact_partial_gqa8_dual_stream_producer_full_heads32_probe() -> None:
+    report = build_report(config=_load_config("config_heads32_native.json"))
+
+    assert report["passed"] is True
+    assert report["outputs"] == 512
+    assert report["expected_outputs"] == 512
+    assert report["commands"] == 4
+    assert report["command_accept_count"] == 4
+    assert report["command_complete_count"] == 4
+    assert report["stream_command_accept_count"] == [4, 4]
+    assert report["stream_complete_count"] == [4, 4]
+    assert report["merge_complete_count"] == 512
+    assert report["integrated_drain_cycles"] == 1736
+    assert report["result_stall_cycles"] == 255
+    assert report["protocol_error"] is False
+    assert report["stream_protocol_error"] == [False, False]
+    assert report["merge_protocol_error"] is False
+    assert report["observed_rows"] == report["expected_rows"]
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="RTL tools unavailable")
+def test_exact_partial_gqa8_dual_stream_producer_llama_wave_probe() -> None:
+    report = build_report(config=_load_config("config_llama_wave.json"))
+
+    assert report["passed"] is True
+    assert report["heads"] == 32
+    assert report["commands"] == 5
+    assert report["blocks_per_stream"] == 1
+    assert report["head_dim"] == 128
+    assert report["head_bases"] == [0, 8, 16, 24, 0]
+    assert report["outputs"] == 640
+    assert report["expected_outputs"] == 640
+    assert report["interface_mode"] == "ideal"
+    assert report["integrated_drain_cycles"] == 1681
+    assert report["command_accept_count"] == 5
+    assert report["command_complete_count"] == 5
+    assert report["stream_command_accept_count"] == [5, 5]
+    assert report["stream_complete_count"] == [5, 5]
+    assert report["merge_complete_count"] == 640
+    assert report["result_stall_cycles"] == 0
+    assert report["llama_wave_reference_cycles"] == 986
+    assert report["llama_wave_drain_delta_vs_986"] == 695
+    assert report["protocol_error"] is False
+    assert report["stream_protocol_error"] == [False, False]
+    assert report["merge_protocol_error"] is False
+    assert report["observed_rows"] == report["expected_rows"]

--- a/tests/test_check_attention_score32_exact_partial_gqa8_dual_stream_producer_guard.py
+++ b/tests/test_check_attention_score32_exact_partial_gqa8_dual_stream_producer_guard.py
@@ -1,0 +1,111 @@
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_score32_exact_partial_gqa8_dual_stream_producer import generate
+
+
+def _config_path(name: str = "config.json") -> Path:
+    return (
+        REPO_ROOT
+        / "runs"
+        / "designs"
+        / "npu_blocks"
+        / "attention_score32_exact_partial_gqa8_dual_stream_producer_b8"
+        / name
+    )
+
+
+def _prepare_design_dir(tmp_path: Path, *, config_name: str) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    design_dir = tmp_path / config_name.replace(".json", "")
+    design_dir.mkdir()
+    config = json.loads(_config_path(config_name).read_text(encoding="utf-8"))
+    (design_dir / config_name).write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    generate(config, design_dir / "verilog")
+    return design_dir
+
+
+def _run_guard(design_dir: Path, *, config_name: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/check_attention_score32_exact_partial_gqa8_dual_stream_producer_guard.py",
+            "--design-dir",
+            str(design_dir),
+            "--config",
+            str(design_dir / config_name),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_exact_partial_gqa8_dual_stream_producer_guard_accepts_checked_in_configs(tmp_path: Path) -> None:
+    for config_name in ("config.json", "config_heads32_native.json", "config_llama_wave.json"):
+        design_dir = _prepare_design_dir(tmp_path / config_name.replace(".json", ""), config_name=config_name)
+        result = _run_guard(design_dir, config_name=config_name)
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "ok"
+        assert payload["streams"] == 2
+        assert payload["query_heads_per_stream"] == 8
+        assert payload["structural_score_macs_per_cycle"] == 128
+        assert payload["max_blocks"] == 8
+        assert payload["design"] == "attention_score32_exact_partial_gqa8_dual_stream_producer_b8"
+
+
+def test_exact_partial_gqa8_dual_stream_producer_guard_rejects_stale_top(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, config_name="config.json")
+    top_path = design_dir / "verilog" / "top.v"
+    top_path.write_text(top_path.read_text(encoding="utf-8") + "\n// stale drift\n", encoding="utf-8")
+
+    result = _run_guard(design_dir, config_name="config.json")
+    assert result.returncode != 0
+    assert "generated RTL artifacts do not match current generator output: top.v" in result.stderr
+
+
+def test_exact_partial_gqa8_dual_stream_producer_guard_rejects_manifest_result_mode_drift(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, config_name="config.json")
+    manifest_path = design_dir / "verilog" / "attention_score32_exact_partial_gqa8_dual_stream_producer_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["submodule_manifests"]["gqa_group"]["result_mode"] = "normalized"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    result = _run_guard(design_dir, config_name="config.json")
+    assert result.returncode != 0
+    assert "gqa_group submodule manifest result_mode must be exact_partial" in result.stderr
+
+
+def test_exact_partial_gqa8_dual_stream_producer_guard_rejects_missing_completion_token(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, config_name="config.json")
+    top_path = design_dir / "verilog" / "top.v"
+    text = top_path.read_text(encoding="utf-8")
+    top_path.write_text(
+        text.replace(
+            "if (merge_fire_w && result_last && (result_head_id[2:0] == 3'd7)) begin",
+            "if (merge_fire_w && result_last) begin",
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run_guard(design_dir, config_name="config.json")
+    assert result.returncode != 0
+    assert "generated RTL missing semantic token: result_head_id[2:0] == 3'd7" in result.stderr
+
+
+def test_exact_partial_gqa8_dual_stream_producer_guard_rejects_equivalence_hash_token(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, config_name="config.json")
+    top_path = design_dir / "verilog" / "top.v"
+    top_path.write_text(top_path.read_text(encoding="utf-8") + "\nwire equivalence_hash = 1'b0;\n", encoding="utf-8")
+
+    result = _run_guard(design_dir, config_name="config.json")
+    assert result.returncode != 0
+    assert "functional datapath must not contain equivalence_hash tokens" in result.stderr


### PR DESCRIPTION
## Summary

- extend the GQA8 score group/array generators with an exact-partial result mode and explicit head IDs
- add a functional two-stream GQA8 producer with 128 structural score MAC/cycle and exact pairwise merge
- add structured RTL/perf equivalence probes, protocol guards, configs, and the evidence contract
- separate ideal-interface service timing from randomized backpressure stress

## Result

The Llama-wave workload distributes 256 paired-token/GQA jobs over 53 or 54 datapaths, so the worst-loaded producer executes five commands. With ideal external interfaces, the functional producer drains in 1,681 cycles, 695 cycles above the current 986-cycle arithmetic frontier assumption. This is functional service evidence, not a frontier promotion or PPA claim.

## Validation

`PYTHONPATH=control_plane:. pytest -q tests/test_attention_score32_exact_partial_gqa8_dual_stream_producer.py tests/test_check_attention_score32_exact_partial_gqa8_dual_stream_producer_guard.py tests/test_attention_score32_exact_partial_producer_tree.py tests/test_attention_score32_exact_partial_producer_tree_c16.py tests/test_attention_decode_score_multivalue_gqa_group.py tests/test_attention_decode_score_multivalue_gqa_array.py --maxfail=1`

44 tests passed.
