### PR TITLE
Revise score32 exact hierarchy cadence

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_v1/proposal.json
@@ -1,0 +1,70 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_score32_local_temporal_reducer_v1",
+  "created_utc": "2026-07-28T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "title": "Functional 53/54-way score32 local reducer with eight-wave persistent state",
+  "abstraction_layer": "decoder_attention_score32_local_temporal_reducer",
+  "hypothesis": "A staged exact-partial reducer can combine 53 or 54 functional producer streams per global cluster and retain one exact local aggregate across eight tile waves before the existing c16 global reduction, but its service cadence and PPA must be measured before the Llama7B frontier can be revised.",
+  "direct_comparison": {
+    "primary_question": "Can the local exact hierarchy consume the functional producer outputs, preserve exact online-state semantics across eight waves, and operate within the service budget needed by the Llama7B attention schedule?",
+    "baselines": [
+      "l1_decoder_attention_score32_exact_partial_dual_stream_producer_ppa_v1",
+      "attention_score32_exact_partial_producer_tree_c16_r2_l8_b59"
+    ],
+    "candidate": "l1_decoder_attention_score32_local_temporal_reducer_ppa_v1",
+    "include": [
+      "53-input and 54-input staged ready/valid exact-partial reduction",
+      "persistent local exact state across exactly eight waves",
+      "structured RTL/perf equivalence for every output beat",
+      "ideal-interface service and separate randomized backpressure evidence"
+    ],
+    "exclude": [
+      "producer fan-in NoC and SRAM physical closure",
+      "global c16 integration PPA",
+      "Llama7B frontier promotion from functional simulation alone"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "stdcell_area_um2",
+      "total_power_mw",
+      "ideal_service_cycles",
+      "functional_exact_partial_protocol",
+      "eight_wave_persistence"
+    ]
+  },
+  "remaining_abstractions": [
+    "Producer-to-local-reducer NoC and SRAM banking remain open.",
+    "The global c16 reducer must be composed after local temporal aggregation.",
+    "The 986-cycle arithmetic point is not sustained by the current functional producer."
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_score32_local_temporal_reducer_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the functional 53/54-way staged exact-partial local reducer with eight-wave persistent state after implementation merge.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_score32_local_temporal_reducer",
+      "comparison_role": "functional_local_hierarchy_anchor",
+      "paired_baseline_item_id": "l1_decoder_attention_score32_exact_partial_dual_stream_producer_ppa_v1",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "close_local_exact_reduction_and_temporal_state",
+        "reason": "The producer measurement alone cannot establish tile cadence without the local reducer and eight-wave persistent state."
+      },
+      "status": "pending_implementation_merge"
+    }
+  ],
+  "source_refs": [
+    "npu/eval/audit_llm_decoder_attention_score32_exact_hierarchy_cadence_r2.py",
+    "npu/eval/probe_attention_score32_exact_partial_gqa8_dual_stream_producer.py",
+    "runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/config_llama_wave.json"
+  ],
+  "knowledge_refs": [
+    "npu/docs/generated/llama7b_score32_exact_hierarchy_cadence_audit_v2.md",
+    "npu/docs/attention_score32_exact_partial_gqa8_dual_stream_producer_contract.md",
+    "docs/architecture/llama7b_attention_abstraction_closure_plan.md"
+  ]
+}

--- a/npu/docs/generated/llama7b_score32_exact_hierarchy_cadence_audit_v2.json
+++ b/npu/docs/generated/llama7b_score32_exact_hierarchy_cadence_audit_v2.json
@@ -1,0 +1,348 @@
+{
+  "arithmetically_reproduced_frontier": {
+    "global_distribution": {
+      "clusters_with_53_datapaths": 8,
+      "clusters_with_54_datapaths": 8,
+      "conservative_per_cluster_macs_per_cycle": 6784
+    },
+    "measured_wrapper_best_row": {
+      "critical_path_ns": 48.6509,
+      "param_hash": "78fa1b5e",
+      "row_index": 1,
+      "stdcell_area_um2": 693452.0,
+      "tag": "attention_dual_stream_schedule_wrapper_score32_exp_lut",
+      "total_power_mw": 60.7
+    },
+    "subtile_pipeline_reconstruction": {
+      "aux_memory_span_cycles": 688,
+      "compute_mode": "dual_mac",
+      "hbm_exposed_cycles": 815,
+      "normalize_strategy": "online_correction",
+      "pipeline_attention_cycles": 986,
+      "prefetch_distance": 3,
+      "subtile_aux_memory_cycles": 86,
+      "subtile_count": 8,
+      "subtile_hbm_cycles": 163,
+      "subtile_qk_cycles": 78,
+      "subtile_stats_cycles": 15,
+      "subtile_value_cycles": 78,
+      "trace": [
+        {
+          "aux_release_cycle": 0,
+          "hbm_ready_cycle": 0,
+          "qk_done_cycle": 78,
+          "qk_start_cycle": 0,
+          "stats_done_cycle": 93,
+          "stats_start_cycle": 78,
+          "subtile": 0,
+          "value_done_cycle": 171,
+          "value_start_cycle": 93
+        },
+        {
+          "aux_release_cycle": 86,
+          "hbm_ready_cycle": 0,
+          "qk_done_cycle": 164,
+          "qk_start_cycle": 86,
+          "stats_done_cycle": 179,
+          "stats_start_cycle": 164,
+          "subtile": 1,
+          "value_done_cycle": 257,
+          "value_start_cycle": 179
+        },
+        {
+          "aux_release_cycle": 172,
+          "hbm_ready_cycle": 0,
+          "qk_done_cycle": 250,
+          "qk_start_cycle": 172,
+          "stats_done_cycle": 265,
+          "stats_start_cycle": 250,
+          "subtile": 2,
+          "value_done_cycle": 343,
+          "value_start_cycle": 265
+        },
+        {
+          "aux_release_cycle": 258,
+          "hbm_ready_cycle": 163,
+          "qk_done_cycle": 336,
+          "qk_start_cycle": 258,
+          "stats_done_cycle": 351,
+          "stats_start_cycle": 336,
+          "subtile": 3,
+          "value_done_cycle": 429,
+          "value_start_cycle": 351
+        },
+        {
+          "aux_release_cycle": 344,
+          "hbm_ready_cycle": 326,
+          "qk_done_cycle": 422,
+          "qk_start_cycle": 344,
+          "stats_done_cycle": 437,
+          "stats_start_cycle": 422,
+          "subtile": 4,
+          "value_done_cycle": 515,
+          "value_start_cycle": 437
+        },
+        {
+          "aux_release_cycle": 430,
+          "hbm_ready_cycle": 489,
+          "qk_done_cycle": 567,
+          "qk_start_cycle": 489,
+          "stats_done_cycle": 582,
+          "stats_start_cycle": 567,
+          "subtile": 5,
+          "value_done_cycle": 660,
+          "value_start_cycle": 582
+        },
+        {
+          "aux_release_cycle": 516,
+          "hbm_ready_cycle": 652,
+          "qk_done_cycle": 730,
+          "qk_start_cycle": 652,
+          "stats_done_cycle": 745,
+          "stats_start_cycle": 730,
+          "subtile": 6,
+          "value_done_cycle": 823,
+          "value_start_cycle": 745
+        },
+        {
+          "aux_release_cycle": 602,
+          "hbm_ready_cycle": 815,
+          "qk_done_cycle": 893,
+          "qk_start_cycle": 815,
+          "stats_done_cycle": 908,
+          "stats_start_cycle": 893,
+          "subtile": 7,
+          "value_done_cycle": 986,
+          "value_start_cycle": 908
+        }
+      ]
+    },
+    "tile_work": {
+      "qk_cycles": 619,
+      "qk_macs": 4194304,
+      "stats_cycles": 116,
+      "value_cycles": 619,
+      "value_macs": 4194304
+    },
+    "wrapper_config": {
+      "array_m": 8,
+      "array_n": 8,
+      "clusters": 2,
+      "k_unroll": 1,
+      "semantic_profile": "score32_exp_lut_div",
+      "streams": 2,
+      "wrapper_cluster_macs_per_cycle": 128,
+      "wrapper_total_macs_per_cycle": 256
+    }
+  },
+  "decision": "score32_986_cycle_arithmetic_not_sustained_by_functional_exact_producer",
+  "exact_hierarchy_gap": {
+    "block_protocol": {
+      "placeholder_c16_config_max_blocks": 16,
+      "placeholder_eight_wave_blocks_per_head_if_one_command": 1024,
+      "placeholder_eight_wave_shortfall_blocks": 1008,
+      "placeholder_per_wave_blocks_per_head": 128,
+      "placeholder_per_wave_shortfall_blocks": 112,
+      "placeholder_shortfall_is_diagnostic_only": true,
+      "tokens_per_block": 8
+    },
+    "exact_c16_slice": {
+      "frontier_ratio": 856,
+      "producer_score_tile_array_m": 1,
+      "producer_score_tile_array_n": 8,
+      "producers": 16,
+      "semantics_only_not_frontier_cadence": true,
+      "slice_macs_per_cycle": 128
+    },
+    "measured_wrapper_classification": {
+      "deterministic_stimulus_not_full_token_replay": true,
+      "functional_exact_partial_protocol_present": false,
+      "ppa_outputs_exposed_directly": true,
+      "seed_lfsr_and_stream_buffers_present": true,
+      "structural_density_anchor_only": true
+    },
+    "required_exact_hierarchy": {
+      "functional_producer_block_distribution_per_wave": {
+        "distribution_for_53_datapaths": {
+          "datapaths": 53,
+          "datapaths_with_4_jobs": 9,
+          "datapaths_with_5_jobs": 44,
+          "paired_gqa_jobs": 256,
+          "worst_loaded_commands": 5
+        },
+        "distribution_for_54_datapaths": {
+          "datapaths": 54,
+          "datapaths_with_4_jobs": 14,
+          "datapaths_with_5_jobs": 40,
+          "paired_gqa_jobs": 256,
+          "worst_loaded_commands": 5
+        },
+        "gqa_groups": 4,
+        "paired_gqa_jobs_per_wave": 256,
+        "paired_token_blocks": 64,
+        "producer_blocks_per_stream_per_command": 1,
+        "producer_command_contract": "one_paired_token_block_times_one_gqa8_head_group",
+        "token_blocks_per_1024_token_tile": 128,
+        "token_streams_per_producer": 2
+      },
+      "local_grouping": "53_or_54_real_128mac_wrapper_cluster_partial_producers_per_global_cluster",
+      "local_merge_counts": {
+        "clusters_with_53_datapaths": 8,
+        "clusters_with_54_datapaths": 8,
+        "global_merges_per_beat": 15,
+        "merges_per_53_datapath_cluster": 52,
+        "merges_per_54_datapath_cluster": 53,
+        "total_local_merges_per_beat": 840
+      },
+      "next_unmeasured_block": "local_exact_partial_reducer_and_temporal_state_across_8_waves",
+      "real_partial_producers": 856,
+      "selected_temporal_accumulation_boundary": "per_wave_producer_emission_then_local_53_54_way_reduction_then_persistent_local_state_across_8_waves_then_one_c16_global_exact_reduction",
+      "single_c16_global_exact_reduction_after_local_aggregation": true
+    }
+  },
+  "functional_producer_revision": {
+    "interpretation": {
+      "limitation": "ideal external interfaces remove injected stalls, but the five-command functional producer still serializes input and exact-partial output service",
+      "measured_service_excess_cycles": 695,
+      "measured_service_ratio": 1.704868,
+      "reference_986_cycles_sustained": false,
+      "required_next_measurement": "functional 53/54-way local exact reducer with persistent state across eight waves"
+    },
+    "mapping": {
+      "distribution_for_53_datapaths": {
+        "datapaths": 53,
+        "datapaths_with_4_jobs": 9,
+        "datapaths_with_5_jobs": 44,
+        "paired_gqa_jobs": 256,
+        "worst_loaded_commands": 5
+      },
+      "distribution_for_54_datapaths": {
+        "datapaths": 54,
+        "datapaths_with_4_jobs": 14,
+        "datapaths_with_5_jobs": 40,
+        "paired_gqa_jobs": 256,
+        "worst_loaded_commands": 5
+      },
+      "gqa_groups": 4,
+      "paired_gqa_jobs_per_wave": 256,
+      "paired_token_blocks": 64,
+      "producer_blocks_per_stream_per_command": 1,
+      "producer_command_contract": "one_paired_token_block_times_one_gqa8_head_group",
+      "token_blocks_per_1024_token_tile": 128,
+      "token_streams_per_producer": 2
+    },
+    "measured_service": {
+      "blocks_per_stream": 1,
+      "commands": 5,
+      "head_bases": [
+        0,
+        8,
+        16,
+        24,
+        0
+      ],
+      "head_dim": 128,
+      "heads": 32,
+      "integrated_drain_cycles": 1681,
+      "interface_mode": "ideal",
+      "llama_wave_drain_delta_vs_986": 695,
+      "llama_wave_reference_cycles": 986,
+      "outputs": 640,
+      "passed": true,
+      "result_stall_cycles": 0
+    }
+  },
+  "model": "llm_decoder_attention_score32_exact_hierarchy_cadence_audit_v2",
+  "next_l1_contract": {
+    "arithmetic_reference_cycles": 986,
+    "completed_functional_block": "functional_2stream_gqa8_128mac_exact_partial_producer",
+    "global_c16_reduction_after_local_aggregation": true,
+    "measured_ideal_service_cycles": 1681,
+    "next_required_block": "functional_53_54_way_local_exact_reducer_with_8_wave_persistent_state",
+    "reference_sustained": false
+  },
+  "non_claims": [
+    "Do not promote the 986-cycle tile service point.",
+    "The 1681-cycle result is ideal-interface functional simulation, not PPA or full producer-plus-NoC timing.",
+    "No throughput revision is valid until the local reducer, persistent eight-wave state, and global c16 path are composed."
+  ],
+  "source_artifacts": {
+    "attention_online_source_py": {
+      "file_sha256": "1ac278e6fc4c85adcda4fe7af9709d66f4e9a4eca2fbe6de9061e9b86f95b36b",
+      "path": "npu/sim/perf/attention_online.py"
+    },
+    "composed_generator_py": {
+      "file_sha256": "92ebf07ae0e6a6f69bb508bb3f3952e86ccfb46e7c814d8fa3014d43509290f4",
+      "path": "npu/rtlgen/gen_attention_dual_stream_composed.py"
+    },
+    "exact_c16_config_json": {
+      "canonical_json_sha256": "24bfd12623867f96f87cf495354eadda2a146486d191f71f4e8153ba99a3df99",
+      "file_sha256": "8c55bd897be58145f1347f2329064b8915e9c9317f60e3d33842bcf84b437d12",
+      "path": "runs/designs/npu_blocks/attention_score32_exact_partial_producer_tree_c16_r2_l8_b59/config.json"
+    },
+    "exact_c16_generator_py": {
+      "file_sha256": "af0ba50382c849ea78f06cd85c3538e559c22a4b67997e1437111200213da81f",
+      "path": "npu/rtlgen/gen_attention_score32_exact_partial_producer_tree_c16.py"
+    },
+    "functional_producer_config_json": {
+      "canonical_json_sha256": "6dd6027f9ecf2a4e4a9f3494e5994e0a46c2dab056eb2a5b7838315649f787e0",
+      "file_sha256": "b63ccb6c9c92faa7c87a89bc27309458c7d48ce5ce28017605058136ce3b52d2",
+      "path": "runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/config_llama_wave.json"
+    },
+    "functional_producer_probe_py": {
+      "file_sha256": "239cc2a82d5b822c2471de95e38821712deb20abc450cf2e96ed0ab5a601bdfb",
+      "path": "npu/eval/probe_attention_score32_exact_partial_gqa8_dual_stream_producer.py"
+    },
+    "producer_cluster_generator_py": {
+      "file_sha256": "bf8a200beaf4ef5fdfd69326e6f08c70b890510965a1e529a877ee11a3490328",
+      "path": "npu/rtlgen/gen_attention_decode_score_multivalue_cluster.py"
+    },
+    "schedule_wrapper_generator_py": {
+      "file_sha256": "1080577e739c4bae657388c7d2a34277e6f1c3fd7a4624dcf8eecd0b216ae3ca",
+      "path": "npu/rtlgen/gen_attention_dual_stream_schedule_wrapper.py"
+    },
+    "schedule_wrapper_recost_json": {
+      "canonical_json_sha256": "497552e34ab153946bf5cbf792e6a1e8e4a5fe0e4976a9d63d2ed006ea699859",
+      "file_sha256": "34ab51abb4e3f30af0e827a8ea8fc1ec008039e2ddbdbce3de81713173fe08d6",
+      "path": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1.json"
+    },
+    "subtile_pipeline_generator_py": {
+      "file_sha256": "b63ab335f1c4644d59c11f6ba77df808f19e65a5b568250d975efe4067f3c270",
+      "path": "npu/eval/estimate_llm_decoder_attention_kv_subtile_pipeline_schedule.py"
+    },
+    "subtile_pipeline_json": {
+      "canonical_json_sha256": "945c6bc0ceda06c3f5e3061366d236d69b27aaf57af0aafe36d59bd944317e9a",
+      "file_sha256": "9d010ef3f93f757a019ae9fca3869488321646ce25ac062b6efdbd9d5aff0249",
+      "path": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_subtile_pipeline_schedule__l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1.json"
+    },
+    "wrapper_config_json": {
+      "canonical_json_sha256": "39bce3be932284ddf261a427d31b577fafbafe10000a6a772da06cd8ad584af5",
+      "file_sha256": "7fa3cbf33c3620a5207ca3440f8cac177fc5f9c42d917410427db88c5da0a45c",
+      "path": "runs/designs/npu_blocks/attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2/config.json"
+    },
+    "wrapper_metrics_csv": {
+      "file_sha256": "5bcb2215deeeeef101b3095aa28a5b2de5210594e315550add0c874dca08e876",
+      "path": "runs/designs/npu_blocks/attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2/metrics.csv",
+      "selected_row_index": 1,
+      "selected_row_sha256": "48ba314dc87924dad8ed2ba8f39ef6f55544a9f1eab9b3dca1e0392569eb7236"
+    }
+  },
+  "source_contract": {
+    "active_global_clusters": 16,
+    "cross_tile_reduction_cycles": 141,
+    "frontier_macs_per_cycle": 109568,
+    "kv_write_cycles": 10,
+    "qkv_cycles": 192,
+    "sequence_length": 131072,
+    "source_decision": "dual_stream_feasible",
+    "source_item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1",
+    "tile_count": 128,
+    "tile_service_cycles": 986,
+    "tile_tokens": 1024,
+    "tile_waves": 8,
+    "total_cycles": 263392,
+    "wrapper_cluster_datapaths": 856,
+    "wrapper_count": 428
+  },
+  "version": 2
+}

--- a/npu/docs/generated/llama7b_score32_exact_hierarchy_cadence_audit_v2.md
+++ b/npu/docs/generated/llama7b_score32_exact_hierarchy_cadence_audit_v2.md
@@ -1,0 +1,41 @@
+# Score32 Exact Hierarchy Cadence Audit R2
+
+- decision: `score32_986_cycle_arithmetic_not_sustained_by_functional_exact_producer`
+- historical arithmetic reference: `986` cycles
+- functional ideal-interface service: `1681` cycles
+- excess: `+695` cycles
+
+## Corrected Mapping
+
+- token blocks/tile: `128`
+- paired token blocks: `64`
+- GQA8 groups: `4`
+- paired GQA jobs/wave: `256`
+- 53 datapaths: `44` carry 5 jobs, `9` carry 4
+- 54 datapaths: `40` carry 5 jobs, `14` carry 4
+
+A producer command covers one paired token block for one GQA8 head group. The prior stream-level 1/2-block assignment did not account for all four GQA groups and is superseded by this mapping.
+
+## Functional Evidence
+
+- commands on the worst-loaded datapath: `5`
+- head bases: `[0, 8, 16, 24, 0]`
+- head dimension: `128`
+- exact-partial output beats: `640`
+- interface mode: `ideal`
+- result stalls: `0`
+- measured/reference ratio: `1.704868`
+
+The functional producer does not sustain the 986-cycle arithmetic point even with ideal external interfaces. The current frontier must remain unpromoted.
+
+## Next Measurement
+
+- functional 53/54-way local exact reduction
+- persistent local exact state across eight waves
+- one global c16 exact reduction after local aggregation
+
+## Non-Claims
+
+- Do not promote the 986-cycle tile service point.
+- The 1681-cycle result is ideal-interface functional simulation, not PPA or full producer-plus-NoC timing.
+- No throughput revision is valid until the local reducer, persistent eight-wave state, and global c16 path are composed.

--- a/npu/eval/audit_llm_decoder_attention_score32_exact_hierarchy_cadence_r2.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_exact_hierarchy_cadence_r2.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Revise the score32 cadence audit with functional GQA8 producer evidence."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval.audit_llm_decoder_attention_score32_exact_hierarchy_cadence import (
+    _build_report as build_v1_report,
+)
+from npu.eval.probe_attention_score32_exact_partial_gqa8_dual_stream_producer import (
+    build_report as build_producer_report,
+)
+
+JsonDict = dict[str, Any]
+
+_MODEL = "llm_decoder_attention_score32_exact_hierarchy_cadence_audit_v2"
+_DECISION = "score32_986_cycle_arithmetic_not_sustained_by_functional_exact_producer"
+_TOKEN_BLOCKS = 128
+_GQA_GROUPS = 4
+_TOKEN_STREAMS = 2
+_PAIRED_TOKEN_BLOCKS = _TOKEN_BLOCKS // _TOKEN_STREAMS
+_PAIRED_GQA_JOBS = _PAIRED_TOKEN_BLOCKS * _GQA_GROUPS
+_REFERENCE_CYCLES = 986
+_MEASURED_CYCLES = 1681
+
+
+def _load_json(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return payload
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _portable(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.resolve().as_posix()
+
+
+def _job_distribution(datapaths: int) -> JsonDict:
+    jobs_per_datapath = _PAIRED_GQA_JOBS // datapaths
+    extra_jobs = _PAIRED_GQA_JOBS % datapaths
+    return {
+        "datapaths": datapaths,
+        "paired_gqa_jobs": _PAIRED_GQA_JOBS,
+        "datapaths_with_5_jobs": extra_jobs,
+        "datapaths_with_4_jobs": datapaths - extra_jobs,
+        "worst_loaded_commands": math.ceil(_PAIRED_GQA_JOBS / datapaths),
+    }
+
+
+def _build_report(args: argparse.Namespace) -> JsonDict:
+    base = build_v1_report(args)
+    producer_config_path = Path(args.functional_producer_config).resolve()
+    producer_config = _load_json(producer_config_path)
+    producer = build_producer_report(config=producer_config)
+
+    expected = {
+        "passed": True,
+        "heads": 32,
+        "commands": 5,
+        "blocks_per_stream": 1,
+        "head_dim": 128,
+        "head_bases": [0, 8, 16, 24, 0],
+        "outputs": 640,
+        "interface_mode": "ideal",
+        "integrated_drain_cycles": _MEASURED_CYCLES,
+        "result_stall_cycles": 0,
+        "llama_wave_reference_cycles": _REFERENCE_CYCLES,
+        "llama_wave_drain_delta_vs_986": _MEASURED_CYCLES - _REFERENCE_CYCLES,
+    }
+    for key, value in expected.items():
+        if producer.get(key) != value:
+            raise ValueError(f"functional producer {key} must be {value!r}, got {producer.get(key)!r}")
+
+    distribution_53 = _job_distribution(53)
+    distribution_54 = _job_distribution(54)
+    if distribution_53["datapaths_with_5_jobs"] != 44 or distribution_54["datapaths_with_5_jobs"] != 40:
+        raise ValueError("unexpected paired GQA job distribution")
+
+    base["version"] = 2
+    base["model"] = _MODEL
+    base["decision"] = _DECISION
+    base["functional_producer_revision"] = {
+        "mapping": {
+            "token_blocks_per_1024_token_tile": _TOKEN_BLOCKS,
+            "token_streams_per_producer": _TOKEN_STREAMS,
+            "paired_token_blocks": _PAIRED_TOKEN_BLOCKS,
+            "gqa_groups": _GQA_GROUPS,
+            "paired_gqa_jobs_per_wave": _PAIRED_GQA_JOBS,
+            "distribution_for_53_datapaths": distribution_53,
+            "distribution_for_54_datapaths": distribution_54,
+            "producer_command_contract": "one_paired_token_block_times_one_gqa8_head_group",
+            "producer_blocks_per_stream_per_command": 1,
+        },
+        "measured_service": {
+            key: producer[key]
+            for key in (
+                "passed",
+                "heads",
+                "commands",
+                "blocks_per_stream",
+                "head_dim",
+                "head_bases",
+                "outputs",
+                "interface_mode",
+                "integrated_drain_cycles",
+                "result_stall_cycles",
+                "llama_wave_reference_cycles",
+                "llama_wave_drain_delta_vs_986",
+            )
+        },
+        "interpretation": {
+            "reference_986_cycles_sustained": False,
+            "measured_service_excess_cycles": _MEASURED_CYCLES - _REFERENCE_CYCLES,
+            "measured_service_ratio": round(_MEASURED_CYCLES / _REFERENCE_CYCLES, 6),
+            "limitation": (
+                "ideal external interfaces remove injected stalls, but the five-command functional "
+                "producer still serializes input and exact-partial output service"
+            ),
+            "required_next_measurement": (
+                "functional 53/54-way local exact reducer with persistent state across eight waves"
+            ),
+        },
+    }
+    base["exact_hierarchy_gap"]["required_exact_hierarchy"][
+        "functional_producer_block_distribution_per_wave"
+    ] = base["functional_producer_revision"]["mapping"]
+    base["next_l1_contract"] = {
+        "completed_functional_block": "functional_2stream_gqa8_128mac_exact_partial_producer",
+        "measured_ideal_service_cycles": _MEASURED_CYCLES,
+        "arithmetic_reference_cycles": _REFERENCE_CYCLES,
+        "reference_sustained": False,
+        "next_required_block": "functional_53_54_way_local_exact_reducer_with_8_wave_persistent_state",
+        "global_c16_reduction_after_local_aggregation": True,
+    }
+    base["non_claims"] = [
+        "Do not promote the 986-cycle tile service point.",
+        "The 1681-cycle result is ideal-interface functional simulation, not PPA or full producer-plus-NoC timing.",
+        "No throughput revision is valid until the local reducer, persistent eight-wave state, and global c16 path are composed.",
+    ]
+    base["source_artifacts"]["functional_producer_config_json"] = {
+        "path": _portable(producer_config_path),
+        "file_sha256": _sha256(producer_config_path),
+        "canonical_json_sha256": hashlib.sha256(
+            json.dumps(producer_config, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest(),
+    }
+    base["source_artifacts"]["functional_producer_probe_py"] = {
+        "path": _portable(Path(args.functional_producer_probe)),
+        "file_sha256": _sha256(Path(args.functional_producer_probe)),
+    }
+    return base
+
+
+def _build_markdown(report: JsonDict) -> str:
+    revision = report["functional_producer_revision"]
+    mapping = revision["mapping"]
+    measured = revision["measured_service"]
+    interpretation = revision["interpretation"]
+    d53 = mapping["distribution_for_53_datapaths"]
+    d54 = mapping["distribution_for_54_datapaths"]
+    lines = [
+        "# Score32 Exact Hierarchy Cadence Audit R2",
+        "",
+        f"- decision: `{report['decision']}`",
+        f"- historical arithmetic reference: `{measured['llama_wave_reference_cycles']}` cycles",
+        f"- functional ideal-interface service: `{measured['integrated_drain_cycles']}` cycles",
+        f"- excess: `+{measured['llama_wave_drain_delta_vs_986']}` cycles",
+        "",
+        "## Corrected Mapping",
+        "",
+        f"- token blocks/tile: `{mapping['token_blocks_per_1024_token_tile']}`",
+        f"- paired token blocks: `{mapping['paired_token_blocks']}`",
+        f"- GQA8 groups: `{mapping['gqa_groups']}`",
+        f"- paired GQA jobs/wave: `{mapping['paired_gqa_jobs_per_wave']}`",
+        f"- 53 datapaths: `{d53['datapaths_with_5_jobs']}` carry 5 jobs, `{d53['datapaths_with_4_jobs']}` carry 4",
+        f"- 54 datapaths: `{d54['datapaths_with_5_jobs']}` carry 5 jobs, `{d54['datapaths_with_4_jobs']}` carry 4",
+        "",
+        "A producer command covers one paired token block for one GQA8 head group. The prior stream-level "
+        "1/2-block assignment did not account for all four GQA groups and is superseded by this mapping.",
+        "",
+        "## Functional Evidence",
+        "",
+        f"- commands on the worst-loaded datapath: `{measured['commands']}`",
+        f"- head bases: `{measured['head_bases']}`",
+        f"- head dimension: `{measured['head_dim']}`",
+        f"- exact-partial output beats: `{measured['outputs']}`",
+        f"- interface mode: `{measured['interface_mode']}`",
+        f"- result stalls: `{measured['result_stall_cycles']}`",
+        f"- measured/reference ratio: `{interpretation['measured_service_ratio']}`",
+        "",
+        "The functional producer does not sustain the 986-cycle arithmetic point even with ideal external "
+        "interfaces. The current frontier must remain unpromoted.",
+        "",
+        "## Next Measurement",
+        "",
+        "- functional 53/54-way local exact reduction",
+        "- persistent local exact state across eight waves",
+        "- one global c16 exact reduction after local aggregation",
+        "",
+        "## Non-Claims",
+        "",
+    ]
+    lines.extend(f"- {claim}" for claim in report["non_claims"])
+    return "\n".join(lines) + "\n"
+
+
+def _default(relative: str) -> Path:
+    return REPO_ROOT / relative
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source-recost-json",
+        type=Path,
+        default=_default(
+            "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+            "decoder_attention_composed_datapath_physical_feasibility__"
+            "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1.json"
+        ),
+    )
+    parser.add_argument(
+        "--wrapper-config",
+        type=Path,
+        default=_default("runs/designs/npu_blocks/attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2/config.json"),
+    )
+    parser.add_argument(
+        "--wrapper-metrics",
+        type=Path,
+        default=_default("runs/designs/npu_blocks/attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2/metrics.csv"),
+    )
+    parser.add_argument(
+        "--exact-c16-config",
+        type=Path,
+        default=_default("runs/designs/npu_blocks/attention_score32_exact_partial_producer_tree_c16_r2_l8_b59/config.json"),
+    )
+    parser.add_argument(
+        "--subtile-pipeline-generator",
+        type=Path,
+        default=_default("npu/eval/estimate_llm_decoder_attention_kv_subtile_pipeline_schedule.py"),
+    )
+    parser.add_argument(
+        "--schedule-wrapper-generator",
+        type=Path,
+        default=_default("npu/rtlgen/gen_attention_dual_stream_schedule_wrapper.py"),
+    )
+    parser.add_argument(
+        "--composed-generator",
+        type=Path,
+        default=_default("npu/rtlgen/gen_attention_dual_stream_composed.py"),
+    )
+    parser.add_argument(
+        "--exact-c16-generator",
+        type=Path,
+        default=_default("npu/rtlgen/gen_attention_score32_exact_partial_producer_tree_c16.py"),
+    )
+    parser.add_argument(
+        "--producer-cluster-generator",
+        type=Path,
+        default=_default("npu/rtlgen/gen_attention_decode_score_multivalue_cluster.py"),
+    )
+    parser.add_argument(
+        "--attention-online-source",
+        type=Path,
+        default=_default("npu/sim/perf/attention_online.py"),
+    )
+    parser.add_argument(
+        "--functional-producer-config",
+        type=Path,
+        default=_default(
+            "runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/"
+            "config_llama_wave.json"
+        ),
+    )
+    parser.add_argument(
+        "--functional-producer-probe",
+        type=Path,
+        default=_default("npu/eval/probe_attention_score32_exact_partial_gqa8_dual_stream_producer.py"),
+    )
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    report = _build_report(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    args.out_md.parent.mkdir(parents=True, exist_ok=True)
+    args.out_md.write_text(_build_markdown(report), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_audit_llm_decoder_attention_score32_exact_hierarchy_cadence_r2.py
+++ b/tests/test_audit_llm_decoder_attention_score32_exact_hierarchy_cadence_r2.py
@@ -1,0 +1,89 @@
+from argparse import Namespace
+from pathlib import Path
+
+from npu.eval.audit_llm_decoder_attention_score32_exact_hierarchy_cadence_r2 import (
+    _build_markdown,
+    _build_report,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _args(tmp_path: Path) -> Namespace:
+    return Namespace(
+        source_recost_json=REPO_ROOT
+        / "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1.json",
+        wrapper_config=REPO_ROOT
+        / "runs/designs/npu_blocks/attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2/config.json",
+        wrapper_metrics=REPO_ROOT
+        / "runs/designs/npu_blocks/attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2/metrics.csv",
+        exact_c16_config=REPO_ROOT
+        / "runs/designs/npu_blocks/attention_score32_exact_partial_producer_tree_c16_r2_l8_b59/config.json",
+        subtile_pipeline_generator=REPO_ROOT
+        / "npu/eval/estimate_llm_decoder_attention_kv_subtile_pipeline_schedule.py",
+        schedule_wrapper_generator=REPO_ROOT / "npu/rtlgen/gen_attention_dual_stream_schedule_wrapper.py",
+        composed_generator=REPO_ROOT / "npu/rtlgen/gen_attention_dual_stream_composed.py",
+        exact_c16_generator=REPO_ROOT
+        / "npu/rtlgen/gen_attention_score32_exact_partial_producer_tree_c16.py",
+        producer_cluster_generator=REPO_ROOT
+        / "npu/rtlgen/gen_attention_decode_score_multivalue_cluster.py",
+        attention_online_source=REPO_ROOT / "npu/sim/perf/attention_online.py",
+        functional_producer_config=REPO_ROOT
+        / "runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/config_llama_wave.json",
+        functional_producer_probe=REPO_ROOT
+        / "npu/eval/probe_attention_score32_exact_partial_gqa8_dual_stream_producer.py",
+        out=tmp_path / "audit.json",
+        out_md=tmp_path / "audit.md",
+    )
+
+
+def test_r2_uses_paired_gqa_jobs_and_measured_ideal_service(tmp_path: Path) -> None:
+    report = _build_report(_args(tmp_path))
+
+    assert report["decision"] == "score32_986_cycle_arithmetic_not_sustained_by_functional_exact_producer"
+    revision = report["functional_producer_revision"]
+    assert revision["mapping"] == {
+        "token_blocks_per_1024_token_tile": 128,
+        "token_streams_per_producer": 2,
+        "paired_token_blocks": 64,
+        "gqa_groups": 4,
+        "paired_gqa_jobs_per_wave": 256,
+        "distribution_for_53_datapaths": {
+            "datapaths": 53,
+            "paired_gqa_jobs": 256,
+            "datapaths_with_5_jobs": 44,
+            "datapaths_with_4_jobs": 9,
+            "worst_loaded_commands": 5,
+        },
+        "distribution_for_54_datapaths": {
+            "datapaths": 54,
+            "paired_gqa_jobs": 256,
+            "datapaths_with_5_jobs": 40,
+            "datapaths_with_4_jobs": 14,
+            "worst_loaded_commands": 5,
+        },
+        "producer_command_contract": "one_paired_token_block_times_one_gqa8_head_group",
+        "producer_blocks_per_stream_per_command": 1,
+    }
+    measured = revision["measured_service"]
+    assert measured["passed"] is True
+    assert measured["interface_mode"] == "ideal"
+    assert measured["commands"] == 5
+    assert measured["integrated_drain_cycles"] == 1681
+    assert measured["result_stall_cycles"] == 0
+    assert measured["llama_wave_drain_delta_vs_986"] == 695
+    assert revision["interpretation"]["reference_986_cycles_sustained"] is False
+    assert report["next_l1_contract"]["next_required_block"] == (
+        "functional_53_54_way_local_exact_reducer_with_8_wave_persistent_state"
+    )
+
+
+def test_r2_markdown_blocks_frontier_promotion(tmp_path: Path) -> None:
+    report = _build_report(_args(tmp_path))
+    markdown = _build_markdown(report)
+
+    assert "paired GQA jobs/wave: `256`" in markdown
+    assert "53 datapaths: `44` carry 5 jobs, `9` carry 4" in markdown
+    assert "functional ideal-interface service: `1681` cycles" in markdown
+    assert "current frontier must remain unpromoted" in markdown


### PR DESCRIPTION
## Summary

- preserve the historical 986-cycle cadence audit and add an R2 functional-evidence overlay
- correct producer assignment to 256 paired token-block/GQA8 jobs per wave
- record the measured five-command ideal-interface producer service of 1,681 cycles
- add the proposal linkage for the 53/54-way local reducer with eight-wave persistent state

## Decision

The 986-cycle arithmetic point is not sustained by the current functional producer. The 53-datapath clusters assign five jobs to 44 datapaths and four to nine; the 54-datapath clusters assign five jobs to 40 datapaths and four to 14. Even with injected interface stalls removed, the worst-loaded functional producer needs 1,681 cycles, 695 above the arithmetic reference.

This blocks frontier promotion until the local reducer, persistent temporal state, and global c16 path are composed.

## Validation

`PYTHONPATH=control_plane:. pytest -q tests/test_audit_llm_decoder_attention_score32_exact_hierarchy_cadence_r2.py tests/test_audit_llm_decoder_attention_score32_exact_hierarchy_cadence.py --maxfail=1`

5 tests passed.
