### PR TITLE
Prepare local reducer PPA boundary job

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -1541,6 +1541,67 @@ def _read_config_target(
                 },
             ],
         )
+    elif "top_name" in cfg and "attention_score32_exact_local_temporal_reducer_physical_harness" in cfg:
+        top_name = str(cfg["top_name"]).strip()
+        if not top_name:
+            raise Layer1TaskGenerationError(f"top_name must not be empty in {config_path}")
+        try:
+            design_dir = str(config_path.parent.resolve().relative_to(repo_root.resolve()))
+        except ValueError as exc:
+            raise Layer1TaskGenerationError(
+                "score32 exact local temporal reducer physical harness config must live under "
+                f"repo_root/runs/designs/...: {config_path}"
+            ) from exc
+        design_name = config_path.parent.name
+        return Layer1ConfigTarget(
+            design_kind="block",
+            design_name=design_name,
+            expected_metrics_path=block_metrics_path(design_name),
+            expected_report_paths=[f"{design_dir}/timing_debug_report.md"],
+            commands=[
+                {
+                    "name": "generate_attention_score32_exact_local_temporal_reducer_physical_harness_rtl",
+                    "run": _with_oss_cad_path(
+                        (
+                            "python3 npu/rtlgen/gen_attention_score32_exact_local_temporal_reducer_physical_harness.py "
+                            f"--config {config_rel} "
+                            f"--out {design_dir}/verilog"
+                        )
+                    ),
+                },
+                {
+                    "name": "check_attention_score32_exact_local_temporal_reducer_physical_harness_guard",
+                    "run": (
+                        "python3 npu/eval/check_attention_score32_exact_local_temporal_reducer_physical_harness_guard.py "
+                        f"--design-dir {design_dir}"
+                    ),
+                },
+                {
+                    "name": "run_block_sweep",
+                    "run": _with_oss_cad_path(
+                        (
+                            "python3 npu/synth/run_block_sweep.py "
+                            f"--design_dir {design_dir} "
+                            "--platform {platform} "
+                            f"--top {top_name} "
+                            f"--sweep {{sweep_path}} "
+                            f"--out_root {out_root} "
+                            + (f"--make_target {make_target} " if make_target else "")
+                            + "--skip_existing"
+                        )
+                    ),
+                },
+                {
+                    "name": "extract_attention_score32_exact_local_temporal_reducer_physical_harness_timing_paths",
+                    "run": (
+                        "python3 npu/eval/extract_openroad_timing_summary.py "
+                        f"--design-dir {design_dir} "
+                        f"--out {design_dir}/timing_debug_report.md "
+                        "--max-paths 8"
+                    ),
+                },
+            ],
+        )
     elif "top_name" in cfg and "attention_hbm_replay_controller" in cfg:
         top_name = str(cfg["top_name"]).strip()
         if not top_name:

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -724,6 +724,70 @@ def _write_example_attention_command_dispatch_repo(repo_root: Path) -> tuple[str
     )
 
 
+def _write_example_attention_score32_exact_local_temporal_reducer_physical_harness_repo(
+    repo_root: Path,
+) -> tuple[str, str]:
+    design_dir = (
+        repo_root
+        / "runs"
+        / "designs"
+        / "npu_blocks"
+        / "attention_score32_exact_local_temporal_reducer_physical_harness_p53_reducer_w8"
+    )
+    design_dir.mkdir(parents=True, exist_ok=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_score32_exact_local_temporal_reducer_physical_harness_p53_reducer_w8",
+                "attention_score32_exact_local_temporal_reducer_physical_harness": {
+                    "producers": 53,
+                    "mode": "reducer",
+                    "waves": 8,
+                },
+                "report_links": {
+                    "proposal_id": "prop_l1_decoder_attention_score32_local_temporal_reducer_v1",
+                    "proposal_path": "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_v1/proposal.json",
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    sweep_path = (
+        repo_root
+        / "runs"
+        / "campaigns"
+        / "npu"
+        / "attention_score32_local_temporal_reducer_v1"
+        / "sweeps"
+        / "nangate45_attention_score32_local_temporal_reducer_physical_harness_boundary.json"
+    )
+    sweep_path.parent.mkdir(parents=True, exist_ok=True)
+    sweep_path.write_text(
+        json.dumps(
+            {
+                "tag_prefix": "attention_score32_local_temporal_reducer_physical_harness_boundary_v1",
+                "flow_params": {
+                    "CLOCK_PERIOD": [8.0, 10.0],
+                    "DIE_AREA": ["0 0 2200 2200"],
+                    "CORE_AREA": ["80 80 2120 2120"],
+                    "PLACE_DENSITY": [0.35],
+                    "SYNTH_HIERARCHICAL": [1],
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return (
+        str(config_path.relative_to(repo_root)),
+        str(sweep_path.relative_to(repo_root)),
+    )
+
+
 def _write_example_attention_schedule_wrapper_repo(repo_root: Path) -> tuple[str, str]:
     design_dir = repo_root / "runs" / "designs" / "npu_blocks" / "attention_dual_stream_schedule_wrapper_smoke_c2"
     design_dir.mkdir(parents=True, exist_ok=True)
@@ -1641,6 +1705,38 @@ def _write_second_attention_command_dispatch_repo(repo_root: Path) -> str:
                     "wave_id_bits": 8,
                     "base_token_bits": 14,
                     "max_inflight_per_cluster": 4,
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return str(config_path.relative_to(repo_root))
+
+
+def _write_second_attention_score32_exact_local_temporal_reducer_physical_harness_repo(repo_root: Path) -> str:
+    design_dir = (
+        repo_root
+        / "runs"
+        / "designs"
+        / "npu_blocks"
+        / "attention_score32_exact_local_temporal_reducer_physical_harness_p54_source_only_w8"
+    )
+    design_dir.mkdir(parents=True, exist_ok=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_score32_exact_local_temporal_reducer_physical_harness_p54_source_only_w8",
+                "attention_score32_exact_local_temporal_reducer_physical_harness": {
+                    "producers": 54,
+                    "mode": "source_only",
+                    "waves": 8,
+                },
+                "report_links": {
+                    "proposal_id": "prop_l1_decoder_attention_score32_local_temporal_reducer_v1",
+                    "proposal_path": "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_v1/proposal.json",
                 },
             },
             indent=2,
@@ -5052,6 +5148,108 @@ def test_generate_l1_sweep_task_supports_multi_attention_command_dispatch_config
                 "runs/designs/npu_blocks/attention_command_dispatch_smoke/timing_debug_report.md",
                 "runs/designs/npu_blocks/attention_command_dispatch_c16_q32/metrics.csv",
                 "runs/designs/npu_blocks/attention_command_dispatch_c16_q32/timing_debug_report.md",
+            ]
+
+
+def test_generate_l1_sweep_task_supports_multi_attention_score32_exact_local_temporal_reducer_physical_harness_configs() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_attention_score32_exact_local_temporal_reducer_physical_harness_repo(
+            repo_root
+        )
+        second_config_path = _write_second_attention_score32_exact_local_temporal_reducer_physical_harness_repo(
+            repo_root
+        )
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path, second_config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/npu_blocks",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_score32_local_temporal_reducer",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert [command["name"] for command in work_item.command_manifest] == [
+                "generate_attention_score32_exact_local_temporal_reducer_physical_harness_rtl_"
+                "attention_score32_exact_local_temporal_reducer_physical_harness_p53_reducer_w8",
+                "check_attention_score32_exact_local_temporal_reducer_physical_harness_guard_"
+                "attention_score32_exact_local_temporal_reducer_physical_harness_p53_reducer_w8",
+                "run_block_sweep_attention_score32_exact_local_temporal_reducer_physical_harness_p53_reducer_w8",
+                "extract_attention_score32_exact_local_temporal_reducer_physical_harness_timing_paths_"
+                "attention_score32_exact_local_temporal_reducer_physical_harness_p53_reducer_w8",
+                "generate_attention_score32_exact_local_temporal_reducer_physical_harness_rtl_"
+                "attention_score32_exact_local_temporal_reducer_physical_harness_p54_source_only_w8",
+                "check_attention_score32_exact_local_temporal_reducer_physical_harness_guard_"
+                "attention_score32_exact_local_temporal_reducer_physical_harness_p54_source_only_w8",
+                "run_block_sweep_attention_score32_exact_local_temporal_reducer_physical_harness_p54_source_only_w8",
+                "extract_attention_score32_exact_local_temporal_reducer_physical_harness_timing_paths_"
+                "attention_score32_exact_local_temporal_reducer_physical_harness_p54_source_only_w8",
+                "build_runs_index",
+                "validate",
+            ]
+            assert (
+                "gen_attention_score32_exact_local_temporal_reducer_physical_harness.py"
+                in work_item.command_manifest[0]["run"]
+            )
+            assert "attention_score32_exact_local_temporal_reducer_physical_harness_p53_reducer_w8/config.json" in (
+                work_item.command_manifest[0]["run"]
+            )
+            assert (
+                "check_attention_score32_exact_local_temporal_reducer_physical_harness_guard.py"
+                in work_item.command_manifest[1]["run"]
+            )
+            assert "attention_score32_exact_local_temporal_reducer_physical_harness_p54_source_only_w8/config.json" in (
+                work_item.command_manifest[4]["run"]
+            )
+            assert (
+                "--top attention_score32_exact_local_temporal_reducer_physical_harness_p53_reducer_w8"
+                in work_item.command_manifest[2]["run"]
+            )
+            assert (
+                "--top attention_score32_exact_local_temporal_reducer_physical_harness_p54_source_only_w8"
+                in work_item.command_manifest[6]["run"]
+            )
+            assert work_item.command_manifest[3]["run"] == (
+                "python3 npu/eval/extract_openroad_timing_summary.py "
+                "--design-dir runs/designs/npu_blocks/"
+                "attention_score32_exact_local_temporal_reducer_physical_harness_p53_reducer_w8 "
+                "--out runs/designs/npu_blocks/"
+                "attention_score32_exact_local_temporal_reducer_physical_harness_p53_reducer_w8/"
+                "timing_debug_report.md "
+                "--max-paths 8"
+            )
+            assert work_item.command_manifest[7]["run"] == (
+                "python3 npu/eval/extract_openroad_timing_summary.py "
+                "--design-dir runs/designs/npu_blocks/"
+                "attention_score32_exact_local_temporal_reducer_physical_harness_p54_source_only_w8 "
+                "--out runs/designs/npu_blocks/"
+                "attention_score32_exact_local_temporal_reducer_physical_harness_p54_source_only_w8/"
+                "timing_debug_report.md "
+                "--max-paths 8"
+            )
+            assert work_item.expected_outputs == [
+                "runs/designs/npu_blocks/"
+                "attention_score32_exact_local_temporal_reducer_physical_harness_p53_reducer_w8/metrics.csv",
+                "runs/designs/npu_blocks/"
+                "attention_score32_exact_local_temporal_reducer_physical_harness_p53_reducer_w8/"
+                "timing_debug_report.md",
+                "runs/designs/npu_blocks/"
+                "attention_score32_exact_local_temporal_reducer_physical_harness_p54_source_only_w8/metrics.csv",
+                "runs/designs/npu_blocks/"
+                "attention_score32_exact_local_temporal_reducer_physical_harness_p54_source_only_w8/"
+                "timing_debug_report.md",
             ]
 
 

--- a/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_v1/evaluation_requests.json
@@ -1,0 +1,43 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_score32_local_temporal_reducer_v1",
+  "source_commit_note": "Dispatch must use the merge commit that adds this request, sweep, and L1 task-generator support; b1a55fe4104b81e1e230cab1785190362d987089 is only the physical-harness implementation floor.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_score32_local_temporal_reducer_ppa_v1",
+      "task_type": "l1_sweep",
+      "title": "Layer 1 score32 local temporal reducer physical harness boundary sweep",
+      "objective": "Measure Nangate45 PPA for the merged score32 exact local temporal reducer physical harness at p53/p54 in reducer and source_only modes using a narrow-IO practical floorplan, accepting flow_failed and timeout outcomes as explicit boundary evidence.",
+      "status": "pending",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_score32_local_temporal_reducer",
+      "comparison_role": "functional_local_hierarchy_anchor",
+      "paired_baseline_item_id": "l1_decoder_attention_score32_exact_partial_dual_stream_producer_ppa_v1",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p53_reducer_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p53_source_only_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p54_reducer_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p54_source_only_w8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_local_temporal_reducer_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_physical_harness_boundary.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p53_reducer_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p53_reducer_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p53_source_only_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p53_source_only_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p54_reducer_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p54_reducer_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p54_source_only_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p54_source_only_w8/timing_debug_report.md"
+      ],
+      "acceptance_notes": "Run the physical-harness generator, guard, run_block_sweep, and timing-summary commands for each config. Keep the point count small because reducer synthesis is expensive. Accept status=ok rows plus non-ok rows such as flow_failed and timeout/timeouts as explicit boundary evidence.",
+      "expected_result": {
+        "direction": "measure_local_temporal_reducer_boundary",
+        "reason": "The merged local reducer and source-only harnesses establish whether the 53/54-way eight-wave stateful hierarchy is physically explorable before later L2 cadence recost work consumes it."
+      },
+      "notes": "Do not dispatch until the job-prep merge commit is on origin/master."
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_v1/proposal.json
@@ -43,24 +43,46 @@
     {
       "item_id": "l1_decoder_attention_score32_local_temporal_reducer_ppa_v1",
       "task_type": "l1_sweep",
-      "objective": "Measure the functional 53/54-way staged exact-partial local reducer with eight-wave persistent state after implementation merge.",
+      "objective": "Measure Nangate45 PPA for the merged 53/54-way staged exact-partial local reducer physical harness in reducer and source_only modes with eight-wave persistent state, accepting boundary-class flow outcomes as evidence.",
       "evaluation_mode": "frontier_followup",
       "abstraction_layer": "decoder_attention_score32_local_temporal_reducer",
       "comparison_role": "functional_local_hierarchy_anchor",
       "paired_baseline_item_id": "l1_decoder_attention_score32_exact_partial_dual_stream_producer_ppa_v1",
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p53_reducer_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p53_source_only_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p54_reducer_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p54_source_only_w8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_local_temporal_reducer_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_physical_harness_boundary.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p53_reducer_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p53_reducer_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p53_source_only_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p53_source_only_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p54_reducer_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p54_reducer_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p54_source_only_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_physical_harness_p54_source_only_w8/timing_debug_report.md"
+      ],
+      "acceptance_notes": "Run the physical-harness generator, guard, run_block_sweep, and timing-summary commands for each config. Keep the sweep small and accept flow_failed/timeouts as explicit boundary evidence.",
       "expected_result": {
-        "direction": "close_local_exact_reduction_and_temporal_state",
-        "reason": "The producer measurement alone cannot establish tile cadence without the local reducer and eight-wave persistent state."
+        "direction": "measure_local_temporal_reducer_boundary",
+        "reason": "The producer measurement alone cannot establish whether the merged local reducer and source-only harness remain physically explorable with eight-wave persistent state."
       },
-      "status": "pending_implementation_merge"
+      "status": "pending"
     }
   ],
   "source_refs": [
     "npu/eval/audit_llm_decoder_attention_score32_exact_hierarchy_cadence_r2.py",
     "npu/eval/probe_attention_score32_exact_partial_gqa8_dual_stream_producer.py",
-    "runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/config_llama_wave.json"
+    "npu/rtlgen/gen_attention_score32_exact_local_temporal_reducer_physical_harness.py",
+    "npu/eval/check_attention_score32_exact_local_temporal_reducer_physical_harness_guard.py",
+    "runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/config_llama_wave.json",
+    "runs/campaigns/npu/attention_score32_local_temporal_reducer_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_physical_harness_boundary.json"
   ],
   "knowledge_refs": [
     "npu/docs/generated/llama7b_score32_exact_hierarchy_cadence_audit_v2.md",

--- a/runs/campaigns/npu/attention_score32_local_temporal_reducer_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_physical_harness_boundary.json
+++ b/runs/campaigns/npu/attention_score32_local_temporal_reducer_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_physical_harness_boundary.json
@@ -1,0 +1,21 @@
+{
+  "tag_prefix": "attention_score32_local_temporal_reducer_physical_harness_boundary_v1",
+  "flow_params": {
+    "CLOCK_PERIOD": [
+      8.0,
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2200 2200"
+    ],
+    "CORE_AREA": [
+      "80 80 2120 2120"
+    ],
+    "PLACE_DENSITY": [
+      0.35
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- teach the L1 task generator to materialize the new local-reducer physical harness configs
- add a focused Nangate45 boundary sweep
- request the p53/p54 reducer and matched source-only controls as one four-config L1 item
- retain failed/timed-out points as explicit physical-boundary evidence

## Dispatch contract

The request remains `pending`. Dispatch must use this job-prep PR's merge commit, not the earlier harness-only commit, so the worker receives the generator, guard, configs, sweep, and task mapping together.

The sweep has two timing constraints (8 ns and 10 ns), one conservative 2.2 mm square die/core setup, one placement density, and hierarchical synthesis. This is eight total physical points across four configs, kept small because reducer synthesis is expensive.

## Validation

`PYTHONPATH=control_plane:. pytest -q control_plane/control_plane/tests/test_l1_task_generator.py -k local_temporal_reducer_physical_harness --maxfail=1`

1 focused test passed; request and sweep JSON parse successfully.
