### PR TITLE
Correct GQA8 cadence mapping and evidence

### DIFF
--- a/npu/docs/attention_score32_exact_partial_gqa8_dual_stream_producer_contract.md
+++ b/npu/docs/attention_score32_exact_partial_gqa8_dual_stream_producer_contract.md
@@ -27,8 +27,17 @@ partial state on every beat: `global_max`, `exp_sum`, `slice`, `last`, and
 
 - `max_blocks=8` is the intended local producer limit.
 - A `1024`-token tile is partitioned into `128` token blocks and distributed
-  across `53/54` datapaths and `2` token streams, so each local stream sees at
-  most `2` token blocks per wave.
+  across `53/54` dual-stream datapaths and `2` token streams.
+- One producer command covers one GQA8 head group for one tile wave and may
+  aggregate either `1` or `2` token blocks per stream.
+- For one tile wave and one GQA8 group:
+  - `p53`: `11` datapaths carry `2` blocks/stream and `42` carry `1`
+  - `p54`: `10` datapaths carry `2` blocks/stream and `44` carry `1`
+- Every datapath receives `4` group commands per tile wave. The worst-loaded
+  datapath schedule is `[2, 1, 1, 1]`, not five one-block commands.
+- Across `8` tile waves the intended reducer persistence is group-major:
+  process one fixed GQA8 group across all `8` tile waves, then emit/finalize
+  before the next head base unless a safe equivalent interleave is proven.
 - The checked-in smoke probe uses `1` command, `2` blocks per stream, and
   `head_dim=3`.
 - This producer emits one wave at a time. Local `53/54`-way aggregation and
@@ -58,6 +67,7 @@ Recorded on July 28, 2026 with:
 - `python npu/eval/probe_attention_score32_exact_partial_gqa8_dual_stream_producer.py --config runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/config.json --json`
 - `python npu/eval/probe_attention_score32_exact_partial_gqa8_dual_stream_producer.py --config runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/config_heads32_native.json --json`
 - `python npu/eval/probe_attention_score32_exact_partial_gqa8_dual_stream_producer.py --config runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/config_llama_wave.json --json`
+- `python npu/eval/probe_attention_score32_exact_partial_gqa8_dual_stream_producer.py --config runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/config_llama_wave_worst4_group_major.json --json`
 
 Checked-in smoke point:
 
@@ -102,6 +112,26 @@ Llama-wave functional service point:
 - exact beat equivalence: pass
 - compared directly to `986` cycles as functional service evidence only
 - this is not a frontier revision
+
+Corrected worst-loaded per-wave producer point:
+
+- heads: `32`
+- command groups: `4`
+- command head_bases: `[0, 8, 16, 24]`
+- block counts per stream: `[2, 1, 1, 1]`
+- head_dim: `128`
+- exact-partial output beats: `512`
+- ideal command/input/value-request/output interfaces
+- minimum modeled value-response latency
+- integrated drain cycles: `1536`
+- compared directly to `986` cycles: `+550`
+- command accepts/completions: `4 / 4`
+- stream accepts/completions: `[4, 4] / [4, 4]`
+- merge completions: `512`
+- result stall cycles: `0`
+- exact beat equivalence: pass
+- compared directly to `986` cycles as corrected producer service evidence only
+- this still does not close the group-major `8`-wave reducer schedule
 
 Both probes compare every emitted beat against a structured Python exact-partial
 reference. No hash reduction is used in the functional comparison path.

--- a/npu/docs/generated/attention_score32_exact_partial_gqa8_dual_stream_producer_llama_wave_worst4_group_major.json
+++ b/npu/docs/generated/attention_score32_exact_partial_gqa8_dual_stream_producer_llama_wave_worst4_group_major.json
@@ -1,0 +1,142 @@
+{
+  "block_counts_per_stream": [
+    2,
+    1,
+    1,
+    1
+  ],
+  "blocks_per_stream": 2,
+  "command_accept_count": 4,
+  "command_accept_cycles": [
+    {
+      "command_id": 29184,
+      "cycle": 0,
+      "head_base": 0,
+      "index": 0
+    },
+    {
+      "command_id": 29185,
+      "cycle": 527,
+      "head_base": 8,
+      "index": 1
+    },
+    {
+      "command_id": 29186,
+      "cycle": 863,
+      "head_base": 16,
+      "index": 2
+    },
+    {
+      "command_id": 29187,
+      "cycle": 1199,
+      "head_base": 24,
+      "index": 3
+    }
+  ],
+  "command_complete_count": 4,
+  "commands": 4,
+  "decision": "score32_exact_partial_dual_stream_gqa8_pass",
+  "equivalence_evidence_policy": "structured_compare_then_commit_counts_and_sha256",
+  "expected_outputs": 512,
+  "expected_rows_count": 512,
+  "expected_rows_sha256": "9e4aeaf7f245fb2ba227636b032c5c00da7a9d3d8a0b885946ca83f8836c52aa",
+  "head_bases": [
+    0,
+    8,
+    16,
+    24
+  ],
+  "head_dim": 128,
+  "heads": 32,
+  "integrated_drain_cycles": 1536,
+  "interface_mode": "ideal",
+  "llama_wave_drain_delta_vs_986": 550,
+  "llama_wave_reference_cycles": 986,
+  "merge_complete_count": 512,
+  "merge_protocol_error": false,
+  "observed_rows_count": 512,
+  "observed_rows_sha256": "9e4aeaf7f245fb2ba227636b032c5c00da7a9d3d8a0b885946ca83f8836c52aa",
+  "outputs": 512,
+  "passed": true,
+  "protocol_error": false,
+  "result_stall_cycles": 0,
+  "service_model": {
+    "command_broadcast_mode": "same_head_base_broadcast_to_both_stream_groups",
+    "comparison_baseline_contract": "python_structured_exact_partial_stream_reference",
+    "comparison_cycle_origin": "cycle0_on_atomic_dual_stream_input_issue",
+    "diagnostic_only_baseline": "none",
+    "head_mapping_contract": "explicit_head_base_plus_lane_no_tile_or_wave_inference",
+    "llama_wave_functional_service_reference": {
+      "interpretation": "functional_service_evidence_only_no_frontier_revision",
+      "reference_cycles": 986
+    },
+    "output_schedule_contract": "serialized_head_then_slice_exact_partial_stream",
+    "producer_block_workload_assumptions": {
+      "command_block_count_range": [
+        1,
+        8
+      ],
+      "global_tile_token_blocks": 128,
+      "global_tile_tokens": 1024,
+      "head_base_alignment_bits": 3,
+      "multiple_head_groups_run_in_order": true,
+      "per_datapath_group_commands_per_wave": 4,
+      "per_wave_local_block_ceiling_per_stream": 2,
+      "persistent_local_reducer_waves": 8,
+      "probe_block_counts_per_stream": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "probe_blocks_per_stream": 2,
+      "probe_blocks_per_stream_uniform": false,
+      "probe_command_count": 4,
+      "probe_head_bases": [
+        0,
+        8,
+        16,
+        24
+      ],
+      "probe_head_dim": 128,
+      "probe_token_streams": 2,
+      "probe_total_heads": 32,
+      "worst_loaded_total_blocks_per_stream_per_datapath_per_wave": 5,
+      "worst_loaded_two_block_commands_per_datapath_per_wave": 1
+    },
+    "producer_input_contract": "packed_dual_stream_query_key_atomic_ready_valid",
+    "producer_partial_protocol": {
+      "command_id_bits": 16,
+      "exp_sum_bits": 33,
+      "global_max_bits": 32,
+      "head_id_bits": 5,
+      "partial_link_bits_per_beat": 419,
+      "partial_payload_bits_per_beat": 328,
+      "slice_index_bits": 4
+    },
+    "query_head_groups": 4,
+    "query_heads_per_stream": 8,
+    "remaining_abstractions": [
+      "53or54_way_global_cluster_aggregation_open",
+      "8_wave_persistent_state_open",
+      "noc_sram_ppa_open"
+    ],
+    "streams": 2,
+    "structural_score_macs_per_cycle": 128,
+    "token_lanes_per_head": 8,
+    "value_memory_contract": "per_stream_gqa_coalesced_value_reads"
+  },
+  "stream_command_accept_count": [
+    4,
+    4
+  ],
+  "stream_complete_count": [
+    4,
+    4
+  ],
+  "stream_protocol_error": [
+    false,
+    false
+  ],
+  "top_name": "attention_score32_exact_partial_gqa8_dual_stream_producer_b8"
+}

--- a/npu/docs/generated/attention_score32_exact_partial_gqa8_dual_stream_producer_llama_wave_worst4_group_major.md
+++ b/npu/docs/generated/attention_score32_exact_partial_gqa8_dual_stream_producer_llama_wave_worst4_group_major.md
@@ -1,0 +1,23 @@
+# Score32 Exact Partial GQA8 Dual-Stream Producer Worst-Loaded Wave Probe
+
+- config: `runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/config_llama_wave_worst4_group_major.json`
+- date: `2026-07-28`
+- decision: `score32_exact_partial_dual_stream_gqa8_pass`
+- heads: `32`
+- commands: `4`
+- block counts per stream: `[2, 1, 1, 1]`
+- head bases: `[0, 8, 16, 24]`
+- head_dim: `128`
+- exact-partial output beats: `512`
+- interface mode: `ideal`
+- integrated drain cycles: `1536`
+- delta vs 986 cycles: `550`
+- command accepts/completions: `4 / 4`
+- stream accepts/completions: `[4, 4] / [4, 4]`
+- merge completions: `512`
+- result stall cycles: `0`
+- protocol error: `False`
+- exact structured equivalence: pass
+- committed equivalence evidence: expected/observed beat counts and SHA-256 digests; full payload rows omitted
+
+This is the corrected worst-loaded per-wave producer schedule for one datapath: four group commands with block counts `[2, 1, 1, 1]` under ideal interfaces. It does not include the group-major eight-wave local reducer or the final global c16 exact reduction.

--- a/npu/docs/generated/llama7b_score32_exact_hierarchy_cadence_audit_v3.json
+++ b/npu/docs/generated/llama7b_score32_exact_hierarchy_cadence_audit_v3.json
@@ -1,0 +1,401 @@
+{
+  "arithmetically_reproduced_frontier": {
+    "global_distribution": {
+      "clusters_with_53_datapaths": 8,
+      "clusters_with_54_datapaths": 8,
+      "conservative_per_cluster_macs_per_cycle": 6784
+    },
+    "measured_wrapper_best_row": {
+      "critical_path_ns": 48.6509,
+      "param_hash": "78fa1b5e",
+      "row_index": 1,
+      "stdcell_area_um2": 693452.0,
+      "tag": "attention_dual_stream_schedule_wrapper_score32_exp_lut",
+      "total_power_mw": 60.7
+    },
+    "subtile_pipeline_reconstruction": {
+      "aux_memory_span_cycles": 688,
+      "compute_mode": "dual_mac",
+      "hbm_exposed_cycles": 815,
+      "normalize_strategy": "online_correction",
+      "pipeline_attention_cycles": 986,
+      "prefetch_distance": 3,
+      "subtile_aux_memory_cycles": 86,
+      "subtile_count": 8,
+      "subtile_hbm_cycles": 163,
+      "subtile_qk_cycles": 78,
+      "subtile_stats_cycles": 15,
+      "subtile_value_cycles": 78,
+      "trace": [
+        {
+          "aux_release_cycle": 0,
+          "hbm_ready_cycle": 0,
+          "qk_done_cycle": 78,
+          "qk_start_cycle": 0,
+          "stats_done_cycle": 93,
+          "stats_start_cycle": 78,
+          "subtile": 0,
+          "value_done_cycle": 171,
+          "value_start_cycle": 93
+        },
+        {
+          "aux_release_cycle": 86,
+          "hbm_ready_cycle": 0,
+          "qk_done_cycle": 164,
+          "qk_start_cycle": 86,
+          "stats_done_cycle": 179,
+          "stats_start_cycle": 164,
+          "subtile": 1,
+          "value_done_cycle": 257,
+          "value_start_cycle": 179
+        },
+        {
+          "aux_release_cycle": 172,
+          "hbm_ready_cycle": 0,
+          "qk_done_cycle": 250,
+          "qk_start_cycle": 172,
+          "stats_done_cycle": 265,
+          "stats_start_cycle": 250,
+          "subtile": 2,
+          "value_done_cycle": 343,
+          "value_start_cycle": 265
+        },
+        {
+          "aux_release_cycle": 258,
+          "hbm_ready_cycle": 163,
+          "qk_done_cycle": 336,
+          "qk_start_cycle": 258,
+          "stats_done_cycle": 351,
+          "stats_start_cycle": 336,
+          "subtile": 3,
+          "value_done_cycle": 429,
+          "value_start_cycle": 351
+        },
+        {
+          "aux_release_cycle": 344,
+          "hbm_ready_cycle": 326,
+          "qk_done_cycle": 422,
+          "qk_start_cycle": 344,
+          "stats_done_cycle": 437,
+          "stats_start_cycle": 422,
+          "subtile": 4,
+          "value_done_cycle": 515,
+          "value_start_cycle": 437
+        },
+        {
+          "aux_release_cycle": 430,
+          "hbm_ready_cycle": 489,
+          "qk_done_cycle": 567,
+          "qk_start_cycle": 489,
+          "stats_done_cycle": 582,
+          "stats_start_cycle": 567,
+          "subtile": 5,
+          "value_done_cycle": 660,
+          "value_start_cycle": 582
+        },
+        {
+          "aux_release_cycle": 516,
+          "hbm_ready_cycle": 652,
+          "qk_done_cycle": 730,
+          "qk_start_cycle": 652,
+          "stats_done_cycle": 745,
+          "stats_start_cycle": 730,
+          "subtile": 6,
+          "value_done_cycle": 823,
+          "value_start_cycle": 745
+        },
+        {
+          "aux_release_cycle": 602,
+          "hbm_ready_cycle": 815,
+          "qk_done_cycle": 893,
+          "qk_start_cycle": 815,
+          "stats_done_cycle": 908,
+          "stats_start_cycle": 893,
+          "subtile": 7,
+          "value_done_cycle": 986,
+          "value_start_cycle": 908
+        }
+      ]
+    },
+    "tile_work": {
+      "qk_cycles": 619,
+      "qk_macs": 4194304,
+      "stats_cycles": 116,
+      "value_cycles": 619,
+      "value_macs": 4194304
+    },
+    "wrapper_config": {
+      "array_m": 8,
+      "array_n": 8,
+      "clusters": 2,
+      "k_unroll": 1,
+      "semantic_profile": "score32_exp_lut_div",
+      "streams": 2,
+      "wrapper_cluster_macs_per_cycle": 128,
+      "wrapper_total_macs_per_cycle": 256
+    }
+  },
+  "decision": "score32_986_cycle_arithmetic_not_sustained_by_corrected_group_command_mapping",
+  "exact_hierarchy_gap": {
+    "block_protocol": {
+      "placeholder_c16_config_max_blocks": 16,
+      "placeholder_eight_wave_blocks_per_head_if_one_command": 1024,
+      "placeholder_eight_wave_shortfall_blocks": 1008,
+      "placeholder_per_wave_blocks_per_head": 128,
+      "placeholder_per_wave_shortfall_blocks": 112,
+      "placeholder_shortfall_is_diagnostic_only": true,
+      "tokens_per_block": 8
+    },
+    "exact_c16_slice": {
+      "frontier_ratio": 856,
+      "producer_score_tile_array_m": 1,
+      "producer_score_tile_array_n": 8,
+      "producers": 16,
+      "semantics_only_not_frontier_cadence": true,
+      "slice_macs_per_cycle": 128
+    },
+    "measured_wrapper_classification": {
+      "deterministic_stimulus_not_full_token_replay": true,
+      "functional_exact_partial_protocol_present": false,
+      "ppa_outputs_exposed_directly": true,
+      "seed_lfsr_and_stream_buffers_present": true,
+      "structural_density_anchor_only": true
+    },
+    "required_exact_hierarchy": {
+      "functional_producer_block_distribution_per_wave": {
+        "distribution_for_53_datapaths": {
+          "datapaths_with_one_two_block_command": 44,
+          "datapaths_with_zero_two_block_commands": 9,
+          "dual_stream_datapaths": 53,
+          "group_commands_per_datapath_per_wave": 4,
+          "one_block_commands_per_stream_per_group": 42,
+          "rotated_two_block_assignments_across_4_groups": 44,
+          "two_block_commands_per_stream_per_group": 11,
+          "worst_loaded_block_counts_per_stream": [
+            2,
+            1,
+            1,
+            1
+          ]
+        },
+        "distribution_for_54_datapaths": {
+          "datapaths_with_one_two_block_command": 40,
+          "datapaths_with_zero_two_block_commands": 14,
+          "dual_stream_datapaths": 54,
+          "group_commands_per_datapath_per_wave": 4,
+          "one_block_commands_per_stream_per_group": 44,
+          "rotated_two_block_assignments_across_4_groups": 40,
+          "two_block_commands_per_stream_per_group": 10,
+          "worst_loaded_block_counts_per_stream": [
+            2,
+            1,
+            1,
+            1
+          ]
+        },
+        "gqa_groups": 4,
+        "per_datapath_group_commands_per_wave": 4,
+        "producer_command_contract": "one_gqa8_head_group_for_one_tile_wave_with_1or2_blocks_per_stream",
+        "token_blocks_per_1024_token_tile": 128,
+        "token_streams_per_producer": 2
+      },
+      "local_grouping": "53_or_54_real_128mac_wrapper_cluster_partial_producers_per_global_cluster",
+      "local_merge_counts": {
+        "clusters_with_53_datapaths": 8,
+        "clusters_with_54_datapaths": 8,
+        "global_merges_per_beat": 15,
+        "merges_per_53_datapath_cluster": 52,
+        "merges_per_54_datapath_cluster": 53,
+        "total_local_merges_per_beat": 840
+      },
+      "next_unmeasured_block": "local_exact_partial_reducer_and_temporal_state_across_8_waves",
+      "real_partial_producers": 856,
+      "selected_temporal_accumulation_boundary": "per_wave_producer_emission_then_local_53_54_way_reduction_then_persistent_local_state_across_8_waves_then_one_c16_global_exact_reduction",
+      "single_c16_global_exact_reduction_after_local_aggregation": true
+    }
+  },
+  "functional_producer_revision": {
+    "group_major_reducer_schedule": {
+      "gqa_groups": 4,
+      "safe_interleave_status": "not_established",
+      "schedule_contract": "process_one_fixed_gqa8_group_across_all_8_tile_waves_then_emit_finalize_before_next_head_base",
+      "tile_waves": 8
+    },
+    "interpretation": {
+      "current_scope": "single_wave_worst_loaded_datapath_functional_producer_only",
+      "limitation": "The corrected producer probe still excludes 53/54-way local exact reduction, group-major persistence across eight tile waves, and the final c16 exact reduction.",
+      "measured_service_excess_cycles": 550,
+      "measured_service_ratio": 1.557809,
+      "r2_service_measurement_superseded": true,
+      "reference_986_cycles_sustained": false,
+      "required_next_measurement": "functional_53_54_way_local_exact_reducer_with_group_major_8_wave_persistence_then_global_c16_exact_reduction"
+    },
+    "mapping": {
+      "distribution_for_53_datapaths": {
+        "datapaths_with_one_two_block_command": 44,
+        "datapaths_with_zero_two_block_commands": 9,
+        "dual_stream_datapaths": 53,
+        "group_commands_per_datapath_per_wave": 4,
+        "one_block_commands_per_stream_per_group": 42,
+        "rotated_two_block_assignments_across_4_groups": 44,
+        "two_block_commands_per_stream_per_group": 11,
+        "worst_loaded_block_counts_per_stream": [
+          2,
+          1,
+          1,
+          1
+        ]
+      },
+      "distribution_for_54_datapaths": {
+        "datapaths_with_one_two_block_command": 40,
+        "datapaths_with_zero_two_block_commands": 14,
+        "dual_stream_datapaths": 54,
+        "group_commands_per_datapath_per_wave": 4,
+        "one_block_commands_per_stream_per_group": 44,
+        "rotated_two_block_assignments_across_4_groups": 40,
+        "two_block_commands_per_stream_per_group": 10,
+        "worst_loaded_block_counts_per_stream": [
+          2,
+          1,
+          1,
+          1
+        ]
+      },
+      "gqa_groups": 4,
+      "per_datapath_group_commands_per_wave": 4,
+      "producer_command_contract": "one_gqa8_head_group_for_one_tile_wave_with_1or2_blocks_per_stream",
+      "token_blocks_per_1024_token_tile": 128,
+      "token_streams_per_producer": 2
+    },
+    "measured_service": {
+      "block_counts_per_stream": [
+        2,
+        1,
+        1,
+        1
+      ],
+      "blocks_per_stream": 2,
+      "commands": 4,
+      "head_bases": [
+        0,
+        8,
+        16,
+        24
+      ],
+      "head_dim": 128,
+      "heads": 32,
+      "integrated_drain_cycles": 1536,
+      "interface_mode": "ideal",
+      "llama_wave_drain_delta_vs_986": 550,
+      "llama_wave_reference_cycles": 986,
+      "outputs": 512,
+      "passed": true,
+      "result_stall_cycles": 0
+    },
+    "supersedes": {
+      "audit_model": "llm_decoder_attention_score32_exact_hierarchy_cadence_audit_v2",
+      "generated_json": "npu/docs/generated/llama7b_score32_exact_hierarchy_cadence_audit_v2.json",
+      "generated_markdown": "npu/docs/generated/llama7b_score32_exact_hierarchy_cadence_audit_v2.md",
+      "reason": "R2 modeled five one-block producer commands instead of four group commands with a rotated [2,1,1,1] worst-load schedule."
+    }
+  },
+  "model": "llm_decoder_attention_score32_exact_hierarchy_cadence_audit_v3",
+  "next_l1_contract": {
+    "arithmetic_reference_cycles": 986,
+    "completed_functional_block": "functional_2stream_gqa8_128mac_exact_partial_producer",
+    "global_c16_reduction_after_local_aggregation": true,
+    "group_major_local_schedule_required": true,
+    "measured_ideal_service_cycles": 1536,
+    "next_required_block": "functional_53_54_way_local_exact_reducer_with_group_major_8_wave_persistent_state",
+    "reference_sustained": false
+  },
+  "non_claims": [
+    "Do not treat the historical R2 five-command producer measurement as current evidence.",
+    "Do not promote the 986-cycle tile service point from producer-only evidence.",
+    "The 1536-cycle result is ideal-interface functional simulation for one tile wave on the worst-loaded datapath, not PPA or full producer-plus-NoC timing.",
+    "No throughput revision is valid until the local reducer, group-major eight-wave persistence, and global c16 path are composed."
+  ],
+  "source_artifacts": {
+    "attention_online_source_py": {
+      "file_sha256": "1ac278e6fc4c85adcda4fe7af9709d66f4e9a4eca2fbe6de9061e9b86f95b36b",
+      "path": "npu/sim/perf/attention_online.py"
+    },
+    "composed_generator_py": {
+      "file_sha256": "92ebf07ae0e6a6f69bb508bb3f3952e86ccfb46e7c814d8fa3014d43509290f4",
+      "path": "npu/rtlgen/gen_attention_dual_stream_composed.py"
+    },
+    "exact_c16_config_json": {
+      "canonical_json_sha256": "24bfd12623867f96f87cf495354eadda2a146486d191f71f4e8153ba99a3df99",
+      "file_sha256": "8c55bd897be58145f1347f2329064b8915e9c9317f60e3d33842bcf84b437d12",
+      "path": "runs/designs/npu_blocks/attention_score32_exact_partial_producer_tree_c16_r2_l8_b59/config.json"
+    },
+    "exact_c16_generator_py": {
+      "file_sha256": "af0ba50382c849ea78f06cd85c3538e559c22a4b67997e1437111200213da81f",
+      "path": "npu/rtlgen/gen_attention_score32_exact_partial_producer_tree_c16.py"
+    },
+    "functional_producer_config_json": {
+      "canonical_json_sha256": "333bce40f50a2668fdeac0f78d9651c6901496a046d000b5cd64f6822f09194c",
+      "file_sha256": "e8f310bcec9936a754f82e85164c467c310ac6a00db562142da017b72b700c38",
+      "path": "runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/config_llama_wave_worst4_group_major.json"
+    },
+    "functional_producer_probe_py": {
+      "file_sha256": "6823b6e041e20e888f19299f120c63e95d8cc03414ee94ed6a95a9aaf33f7165",
+      "path": "npu/eval/probe_attention_score32_exact_partial_gqa8_dual_stream_producer.py"
+    },
+    "producer_cluster_generator_py": {
+      "file_sha256": "bf8a200beaf4ef5fdfd69326e6f08c70b890510965a1e529a877ee11a3490328",
+      "path": "npu/rtlgen/gen_attention_decode_score_multivalue_cluster.py"
+    },
+    "schedule_wrapper_generator_py": {
+      "file_sha256": "1080577e739c4bae657388c7d2a34277e6f1c3fd7a4624dcf8eecd0b216ae3ca",
+      "path": "npu/rtlgen/gen_attention_dual_stream_schedule_wrapper.py"
+    },
+    "schedule_wrapper_recost_json": {
+      "canonical_json_sha256": "497552e34ab153946bf5cbf792e6a1e8e4a5fe0e4976a9d63d2ed006ea699859",
+      "file_sha256": "34ab51abb4e3f30af0e827a8ea8fc1ec008039e2ddbdbce3de81713173fe08d6",
+      "path": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1.json"
+    },
+    "subtile_pipeline_generator_py": {
+      "file_sha256": "b63ab335f1c4644d59c11f6ba77df808f19e65a5b568250d975efe4067f3c270",
+      "path": "npu/eval/estimate_llm_decoder_attention_kv_subtile_pipeline_schedule.py"
+    },
+    "subtile_pipeline_json": {
+      "canonical_json_sha256": "945c6bc0ceda06c3f5e3061366d236d69b27aaf57af0aafe36d59bd944317e9a",
+      "file_sha256": "9d010ef3f93f757a019ae9fca3869488321646ce25ac062b6efdbd9d5aff0249",
+      "path": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_kv_subtile_pipeline_schedule__l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1.json"
+    },
+    "superseded_audit_json": {
+      "file_sha256": "56b0049d1388b5443d1df81a3a940068f1228e41f838c011c7e96114dc7acbf8",
+      "path": "npu/docs/generated/llama7b_score32_exact_hierarchy_cadence_audit_v2.json"
+    },
+    "wrapper_config_json": {
+      "canonical_json_sha256": "39bce3be932284ddf261a427d31b577fafbafe10000a6a772da06cd8ad584af5",
+      "file_sha256": "7fa3cbf33c3620a5207ca3440f8cac177fc5f9c42d917410427db88c5da0a45c",
+      "path": "runs/designs/npu_blocks/attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2/config.json"
+    },
+    "wrapper_metrics_csv": {
+      "file_sha256": "5bcb2215deeeeef101b3095aa28a5b2de5210594e315550add0c874dca08e876",
+      "path": "runs/designs/npu_blocks/attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2/metrics.csv",
+      "selected_row_index": 1,
+      "selected_row_sha256": "48ba314dc87924dad8ed2ba8f39ef6f55544a9f1eab9b3dca1e0392569eb7236"
+    }
+  },
+  "source_contract": {
+    "active_global_clusters": 16,
+    "cross_tile_reduction_cycles": 141,
+    "frontier_macs_per_cycle": 109568,
+    "kv_write_cycles": 10,
+    "qkv_cycles": 192,
+    "sequence_length": 131072,
+    "source_decision": "dual_stream_feasible",
+    "source_item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1",
+    "tile_count": 128,
+    "tile_service_cycles": 986,
+    "tile_tokens": 1024,
+    "tile_waves": 8,
+    "total_cycles": 263392,
+    "wrapper_cluster_datapaths": 856,
+    "wrapper_count": 428
+  },
+  "version": 3
+}

--- a/npu/docs/generated/llama7b_score32_exact_hierarchy_cadence_audit_v3.md
+++ b/npu/docs/generated/llama7b_score32_exact_hierarchy_cadence_audit_v3.md
@@ -1,0 +1,44 @@
+# Score32 Exact Hierarchy Cadence Audit R3
+
+- decision: `score32_986_cycle_arithmetic_not_sustained_by_corrected_group_command_mapping`
+- supersedes only the erroneous R2 producer mapping/service conclusion
+- historical arithmetic reference: `986` cycles
+- corrected ideal-interface producer service: `1536` cycles
+- excess: `+550` cycles
+
+## Corrected Producer Mapping
+
+- token blocks/tile: `128`
+- token streams/producer: `2`
+- GQA8 groups: `4`
+- producer commands/datapath/wave: `4`
+- p53 per group: `11` datapaths at 2 blocks/stream, `42` at 1
+- p54 per group: `10` datapaths at 2 blocks/stream, `44` at 1
+- rotated p53 extras across 4 groups: `44` datapaths get one `2`-block command, `9` get none
+- rotated p54 extras across 4 groups: `40` datapaths get one `2`-block command, `14` get none
+- worst-loaded per-wave schedule: `[2, 1, 1, 1]`
+
+One dual-stream producer command covers one GQA8 head group for one tile wave and may aggregate either one or two token blocks per stream. R2's five-command one-block mapping is superseded.
+
+## Corrected Producer Probe
+
+- commands: `4`
+- head bases: `[0, 8, 16, 24]`
+- head dimension: `128`
+- exact-partial output beats: `512`
+- interface mode: `ideal`
+- result stalls: `0`
+- measured/reference ratio: `1.557809`
+
+## Group-Major Reducer Schedule
+
+- tile waves: `8`
+- schedule: `process_one_fixed_gqa8_group_across_all_8_tile_waves_then_emit_finalize_before_next_head_base`
+- safe interleave: `not_established`
+
+## Non-Claims
+
+- Do not treat the historical R2 five-command producer measurement as current evidence.
+- Do not promote the 986-cycle tile service point from producer-only evidence.
+- The 1536-cycle result is ideal-interface functional simulation for one tile wave on the worst-loaded datapath, not PPA or full producer-plus-NoC timing.
+- No throughput revision is valid until the local reducer, group-major eight-wave persistence, and global c16 path are composed.

--- a/npu/eval/audit_llm_decoder_attention_score32_exact_hierarchy_cadence_r3.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_exact_hierarchy_cadence_r3.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Correct the score32 cadence audit with the R3 GQA8 group-major producer mapping."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval.audit_llm_decoder_attention_score32_exact_hierarchy_cadence import (
+    _build_report as build_v1_report,
+)
+from npu.eval.probe_attention_score32_exact_partial_gqa8_dual_stream_producer import (
+    build_report as build_producer_report,
+)
+
+JsonDict = dict[str, Any]
+
+_MODEL = "llm_decoder_attention_score32_exact_hierarchy_cadence_audit_v3"
+_REFERENCE_CYCLES = 986
+_TOKEN_BLOCKS = 128
+_TOKEN_STREAMS = 2
+_GQA_GROUPS = 4
+_WAVES = 8
+_EXPECTED_PROBE = {
+    "passed": True,
+    "heads": 32,
+    "commands": 4,
+    "blocks_per_stream": 2,
+    "block_counts_per_stream": [2, 1, 1, 1],
+    "head_dim": 128,
+    "head_bases": [0, 8, 16, 24],
+    "outputs": 512,
+    "interface_mode": "ideal",
+    "integrated_drain_cycles": 1536,
+    "result_stall_cycles": 0,
+    "llama_wave_reference_cycles": _REFERENCE_CYCLES,
+    "llama_wave_drain_delta_vs_986": 550,
+}
+
+
+def _load_json(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return payload
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _portable(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.resolve().as_posix()
+
+
+def _distribution(*, datapaths: int, two_block_datapaths_per_group: int) -> JsonDict:
+    one_block_datapaths_per_group = datapaths - two_block_datapaths_per_group
+    rotated_two_block_assignments = two_block_datapaths_per_group * _GQA_GROUPS
+    return {
+        "dual_stream_datapaths": datapaths,
+        "group_commands_per_datapath_per_wave": _GQA_GROUPS,
+        "two_block_commands_per_stream_per_group": two_block_datapaths_per_group,
+        "one_block_commands_per_stream_per_group": one_block_datapaths_per_group,
+        "rotated_two_block_assignments_across_4_groups": rotated_two_block_assignments,
+        "datapaths_with_one_two_block_command": rotated_two_block_assignments,
+        "datapaths_with_zero_two_block_commands": datapaths - rotated_two_block_assignments,
+        "worst_loaded_block_counts_per_stream": [2, 1, 1, 1],
+    }
+
+
+def _decision(measured_cycles: int) -> str:
+    if measured_cycles > _REFERENCE_CYCLES:
+        return "score32_986_cycle_arithmetic_not_sustained_by_corrected_group_command_mapping"
+    return "score32_corrected_group_command_mapping_clears_single_wave_producer_but_group_major_reducer_still_open"
+
+
+def _build_report(args: argparse.Namespace) -> JsonDict:
+    base = build_v1_report(args)
+    producer_config_path = Path(args.functional_producer_config).resolve()
+    producer_config = _load_json(producer_config_path)
+    producer = build_producer_report(config=producer_config)
+
+    for key, value in _EXPECTED_PROBE.items():
+        if producer.get(key) != value:
+            raise ValueError(f"functional producer {key} must be {value!r}, got {producer.get(key)!r}")
+
+    measured_cycles = int(producer["integrated_drain_cycles"])
+    delta_cycles = int(producer["llama_wave_drain_delta_vs_986"])
+    sustained = measured_cycles <= _REFERENCE_CYCLES
+    decision = _decision(measured_cycles)
+
+    mapping = {
+        "token_blocks_per_1024_token_tile": _TOKEN_BLOCKS,
+        "token_streams_per_producer": _TOKEN_STREAMS,
+        "gqa_groups": _GQA_GROUPS,
+        "producer_command_contract": "one_gqa8_head_group_for_one_tile_wave_with_1or2_blocks_per_stream",
+        "per_datapath_group_commands_per_wave": _GQA_GROUPS,
+        "distribution_for_53_datapaths": _distribution(datapaths=53, two_block_datapaths_per_group=11),
+        "distribution_for_54_datapaths": _distribution(datapaths=54, two_block_datapaths_per_group=10),
+    }
+
+    base["version"] = 3
+    base["model"] = _MODEL
+    base["decision"] = decision
+    base["functional_producer_revision"] = {
+        "supersedes": {
+            "audit_model": "llm_decoder_attention_score32_exact_hierarchy_cadence_audit_v2",
+            "generated_json": "npu/docs/generated/llama7b_score32_exact_hierarchy_cadence_audit_v2.json",
+            "generated_markdown": "npu/docs/generated/llama7b_score32_exact_hierarchy_cadence_audit_v2.md",
+            "reason": "R2 modeled five one-block producer commands instead of four group commands with a rotated [2,1,1,1] worst-load schedule.",
+        },
+        "mapping": mapping,
+        "measured_service": {
+            key: producer[key]
+            for key in (
+                "passed",
+                "heads",
+                "commands",
+                "blocks_per_stream",
+                "block_counts_per_stream",
+                "head_dim",
+                "head_bases",
+                "outputs",
+                "interface_mode",
+                "integrated_drain_cycles",
+                "result_stall_cycles",
+                "llama_wave_reference_cycles",
+                "llama_wave_drain_delta_vs_986",
+            )
+        },
+        "interpretation": {
+            "reference_986_cycles_sustained": sustained,
+            "measured_service_excess_cycles": delta_cycles,
+            "measured_service_ratio": round(measured_cycles / _REFERENCE_CYCLES, 6),
+            "r2_service_measurement_superseded": True,
+            "current_scope": "single_wave_worst_loaded_datapath_functional_producer_only",
+            "limitation": (
+                "The corrected producer probe still excludes 53/54-way local exact reduction, group-major persistence across eight tile waves, and the final c16 exact reduction."
+            ),
+            "required_next_measurement": (
+                "functional_53_54_way_local_exact_reducer_with_group_major_8_wave_persistence_then_global_c16_exact_reduction"
+            ),
+        },
+        "group_major_reducer_schedule": {
+            "tile_waves": _WAVES,
+            "gqa_groups": _GQA_GROUPS,
+            "schedule_contract": "process_one_fixed_gqa8_group_across_all_8_tile_waves_then_emit_finalize_before_next_head_base",
+            "safe_interleave_status": "not_established",
+        },
+    }
+    base["exact_hierarchy_gap"]["required_exact_hierarchy"][
+        "functional_producer_block_distribution_per_wave"
+    ] = mapping
+    base["next_l1_contract"] = {
+        "completed_functional_block": "functional_2stream_gqa8_128mac_exact_partial_producer",
+        "measured_ideal_service_cycles": measured_cycles,
+        "arithmetic_reference_cycles": _REFERENCE_CYCLES,
+        "reference_sustained": sustained,
+        "next_required_block": "functional_53_54_way_local_exact_reducer_with_group_major_8_wave_persistent_state",
+        "group_major_local_schedule_required": True,
+        "global_c16_reduction_after_local_aggregation": True,
+    }
+    base["non_claims"] = [
+        "Do not treat the historical R2 five-command producer measurement as current evidence.",
+        "Do not promote the 986-cycle tile service point from producer-only evidence.",
+        "The 1536-cycle result is ideal-interface functional simulation for one tile wave on the worst-loaded datapath, not PPA or full producer-plus-NoC timing.",
+        "No throughput revision is valid until the local reducer, group-major eight-wave persistence, and global c16 path are composed.",
+    ]
+    base["source_artifacts"]["functional_producer_config_json"] = {
+        "path": _portable(producer_config_path),
+        "file_sha256": _sha256(producer_config_path),
+        "canonical_json_sha256": hashlib.sha256(
+            json.dumps(producer_config, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest(),
+    }
+    base["source_artifacts"]["functional_producer_probe_py"] = {
+        "path": _portable(Path(args.functional_producer_probe)),
+        "file_sha256": _sha256(Path(args.functional_producer_probe)),
+    }
+    base["source_artifacts"]["superseded_audit_json"] = {
+        "path": _portable(Path(args.superseded_audit_json)),
+        "file_sha256": _sha256(Path(args.superseded_audit_json)),
+    }
+    return base
+
+
+def _build_markdown(report: JsonDict) -> str:
+    revision = report["functional_producer_revision"]
+    mapping = revision["mapping"]
+    measured = revision["measured_service"]
+    interpretation = revision["interpretation"]
+    reducer_schedule = revision["group_major_reducer_schedule"]
+    d53 = mapping["distribution_for_53_datapaths"]
+    d54 = mapping["distribution_for_54_datapaths"]
+    lines = [
+        "# Score32 Exact Hierarchy Cadence Audit R3",
+        "",
+        f"- decision: `{report['decision']}`",
+        "- supersedes only the erroneous R2 producer mapping/service conclusion",
+        f"- historical arithmetic reference: `{measured['llama_wave_reference_cycles']}` cycles",
+        f"- corrected ideal-interface producer service: `{measured['integrated_drain_cycles']}` cycles",
+        f"- excess: `+{measured['llama_wave_drain_delta_vs_986']}` cycles",
+        "",
+        "## Corrected Producer Mapping",
+        "",
+        f"- token blocks/tile: `{mapping['token_blocks_per_1024_token_tile']}`",
+        f"- token streams/producer: `{mapping['token_streams_per_producer']}`",
+        f"- GQA8 groups: `{mapping['gqa_groups']}`",
+        f"- producer commands/datapath/wave: `{mapping['per_datapath_group_commands_per_wave']}`",
+        f"- p53 per group: `{d53['two_block_commands_per_stream_per_group']}` datapaths at 2 blocks/stream, `{d53['one_block_commands_per_stream_per_group']}` at 1",
+        f"- p54 per group: `{d54['two_block_commands_per_stream_per_group']}` datapaths at 2 blocks/stream, `{d54['one_block_commands_per_stream_per_group']}` at 1",
+        f"- rotated p53 extras across 4 groups: `{d53['datapaths_with_one_two_block_command']}` datapaths get one `2`-block command, `{d53['datapaths_with_zero_two_block_commands']}` get none",
+        f"- rotated p54 extras across 4 groups: `{d54['datapaths_with_one_two_block_command']}` datapaths get one `2`-block command, `{d54['datapaths_with_zero_two_block_commands']}` get none",
+        f"- worst-loaded per-wave schedule: `{measured['block_counts_per_stream']}`",
+        "",
+        "One dual-stream producer command covers one GQA8 head group for one tile wave and may aggregate either one or two token blocks per stream. R2's five-command one-block mapping is superseded.",
+        "",
+        "## Corrected Producer Probe",
+        "",
+        f"- commands: `{measured['commands']}`",
+        f"- head bases: `{measured['head_bases']}`",
+        f"- head dimension: `{measured['head_dim']}`",
+        f"- exact-partial output beats: `{measured['outputs']}`",
+        f"- interface mode: `{measured['interface_mode']}`",
+        f"- result stalls: `{measured['result_stall_cycles']}`",
+        f"- measured/reference ratio: `{interpretation['measured_service_ratio']}`",
+        "",
+        "## Group-Major Reducer Schedule",
+        "",
+        f"- tile waves: `{reducer_schedule['tile_waves']}`",
+        f"- schedule: `{reducer_schedule['schedule_contract']}`",
+        f"- safe interleave: `{reducer_schedule['safe_interleave_status']}`",
+        "",
+        "## Non-Claims",
+        "",
+    ]
+    lines.extend(f"- {claim}" for claim in report["non_claims"])
+    return "\n".join(lines) + "\n"
+
+
+def _default(relative: str) -> Path:
+    return REPO_ROOT / relative
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source-recost-json",
+        type=Path,
+        default=_default(
+            "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+            "decoder_attention_composed_datapath_physical_feasibility__"
+            "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1.json"
+        ),
+    )
+    parser.add_argument(
+        "--wrapper-config",
+        type=Path,
+        default=_default("runs/designs/npu_blocks/attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2/config.json"),
+    )
+    parser.add_argument(
+        "--wrapper-metrics",
+        type=Path,
+        default=_default("runs/designs/npu_blocks/attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2/metrics.csv"),
+    )
+    parser.add_argument(
+        "--exact-c16-config",
+        type=Path,
+        default=_default("runs/designs/npu_blocks/attention_score32_exact_partial_producer_tree_c16_r2_l8_b59/config.json"),
+    )
+    parser.add_argument(
+        "--subtile-pipeline-generator",
+        type=Path,
+        default=_default("npu/eval/estimate_llm_decoder_attention_kv_subtile_pipeline_schedule.py"),
+    )
+    parser.add_argument(
+        "--schedule-wrapper-generator",
+        type=Path,
+        default=_default("npu/rtlgen/gen_attention_dual_stream_schedule_wrapper.py"),
+    )
+    parser.add_argument(
+        "--composed-generator",
+        type=Path,
+        default=_default("npu/rtlgen/gen_attention_dual_stream_composed.py"),
+    )
+    parser.add_argument(
+        "--exact-c16-generator",
+        type=Path,
+        default=_default("npu/rtlgen/gen_attention_score32_exact_partial_producer_tree_c16.py"),
+    )
+    parser.add_argument(
+        "--producer-cluster-generator",
+        type=Path,
+        default=_default("npu/rtlgen/gen_attention_decode_score_multivalue_cluster.py"),
+    )
+    parser.add_argument(
+        "--attention-online-source",
+        type=Path,
+        default=_default("npu/sim/perf/attention_online.py"),
+    )
+    parser.add_argument(
+        "--functional-producer-config",
+        type=Path,
+        default=_default(
+            "runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/"
+            "config_llama_wave_worst4_group_major.json"
+        ),
+    )
+    parser.add_argument(
+        "--functional-producer-probe",
+        type=Path,
+        default=_default("npu/eval/probe_attention_score32_exact_partial_gqa8_dual_stream_producer.py"),
+    )
+    parser.add_argument(
+        "--superseded-audit-json",
+        type=Path,
+        default=_default("npu/docs/generated/llama7b_score32_exact_hierarchy_cadence_audit_v2.json"),
+    )
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--out-md", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    report = _build_report(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    args.out_md.parent.mkdir(parents=True, exist_ok=True)
+    args.out_md.write_text(_build_markdown(report), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/check_attention_score32_exact_partial_gqa8_dual_stream_producer_guard.py
+++ b/npu/eval/check_attention_score32_exact_partial_gqa8_dual_stream_producer_guard.py
@@ -126,6 +126,9 @@ def main(argv: list[str] | None = None) -> int:
         max_blocks=max_blocks,
         command_count=int(probe_defaults.get("command_count", int(probe_defaults.get("heads", 8)) // 8)),
         blocks_per_stream=int(probe_defaults.get("blocks_per_stream", 2)),
+        block_counts_per_stream=tuple(int(value) for value in probe_defaults.get("block_counts_per_stream", []))
+        if isinstance(probe_defaults.get("block_counts_per_stream"), list)
+        else None,
         head_dim=int(probe_defaults.get("head_dim", 3)),
         head_bases=tuple(int(value) for value in probe_defaults.get("head_bases", [])) if isinstance(probe_defaults.get("head_bases"), list) else None,
         llama_wave_reference_cycles=int(probe_defaults["llama_wave_reference_cycles"]) if "llama_wave_reference_cycles" in probe_defaults else None,

--- a/npu/eval/probe_attention_score32_exact_partial_gqa8_dual_stream_producer.py
+++ b/npu/eval/probe_attention_score32_exact_partial_gqa8_dual_stream_producer.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 from pathlib import Path
 import re
@@ -68,6 +69,18 @@ endmodule
 """
 
 
+def compact_report(report: JsonDict) -> JsonDict:
+    """Replace full equivalence rows with reproducible digests for committed evidence."""
+    compact = dict(report)
+    for key in ("observed_rows", "expected_rows"):
+        rows = compact.pop(key)
+        encoded = json.dumps(rows, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        compact[f"{key}_sha256"] = hashlib.sha256(encoded).hexdigest()
+        compact[f"{key}_count"] = len(rows)
+    compact["equivalence_evidence_policy"] = "structured_compare_then_commit_counts_and_sha256"
+    return compact
+
+
 def _tool(name: str) -> str:
     path = shutil.which(name)
     if path:
@@ -108,6 +121,7 @@ def _resolve_workload(
     heads: int | None,
     command_count: int | None,
     blocks_per_stream: int | None,
+    block_counts_per_stream: tuple[int, ...] | None,
     head_dim: int | None,
     head_bases: tuple[int, ...] | None,
 ) -> dict[str, object]:
@@ -115,21 +129,45 @@ def _resolve_workload(
     if not isinstance(defaults, dict):
         defaults = {}
     resolved_heads = int(heads if heads is not None else defaults.get("heads", 8))
-    resolved_command_count = int(command_count if command_count is not None else defaults.get("command_count", resolved_heads // 8))
-    resolved_blocks_per_stream = int(blocks_per_stream if blocks_per_stream is not None else defaults.get("blocks_per_stream", 2))
     resolved_head_dim = int(head_dim if head_dim is not None else defaults.get("head_dim", 3))
     configured_head_bases = head_bases
     if configured_head_bases is None and isinstance(defaults.get("head_bases"), list):
         configured_head_bases = tuple(int(value) for value in defaults["head_bases"])
+    configured_block_counts = block_counts_per_stream
+    if configured_block_counts is None and isinstance(defaults.get("block_counts_per_stream"), list):
+        configured_block_counts = tuple(int(value) for value in defaults["block_counts_per_stream"])
+
+    resolved_command_count_source = command_count
+    if resolved_command_count_source is None and "command_count" in defaults:
+        resolved_command_count_source = defaults["command_count"]
+    if resolved_command_count_source is None and configured_block_counts is not None:
+        resolved_command_count_source = len(configured_block_counts)
+    if resolved_command_count_source is None and configured_head_bases is not None:
+        resolved_command_count_source = len(configured_head_bases)
+    resolved_command_count = int(
+        resolved_command_count_source if resolved_command_count_source is not None else resolved_heads // 8
+    )
 
     if resolved_heads < 8 or resolved_heads > 32 or resolved_heads % 8:
         raise ValueError("heads must be a multiple of 8 in [8, 32]")
     if resolved_command_count < 1:
         raise ValueError("command_count must be positive")
-    if resolved_blocks_per_stream < 1 or resolved_blocks_per_stream > 8:
-        raise ValueError("blocks_per_stream must be in [1, 8]")
     if resolved_head_dim < 1:
         raise ValueError("head_dim must be positive")
+    if configured_block_counts is None:
+        resolved_blocks_per_stream = int(blocks_per_stream if blocks_per_stream is not None else defaults.get("blocks_per_stream", 2))
+        if resolved_blocks_per_stream < 1 or resolved_blocks_per_stream > 8:
+            raise ValueError("blocks_per_stream must be in [1, 8]")
+        resolved_block_counts = tuple(resolved_blocks_per_stream for _ in range(resolved_command_count))
+    else:
+        if blocks_per_stream is not None:
+            raise ValueError("blocks_per_stream and block_counts_per_stream are mutually exclusive")
+        if len(configured_block_counts) != resolved_command_count:
+            raise ValueError("block_counts_per_stream length must match command_count")
+        if any(value < 1 or value > 8 for value in configured_block_counts):
+            raise ValueError("block_counts_per_stream entries must be in [1, 8]")
+        resolved_block_counts = tuple(int(value) for value in configured_block_counts)
+        resolved_blocks_per_stream = max(resolved_block_counts)
     if configured_head_bases is None:
         head_groups = tuple(group * 8 for group in range(resolved_heads // 8))
         configured_head_bases = tuple(head_groups[index % len(head_groups)] for index in range(resolved_command_count))
@@ -142,6 +180,7 @@ def _resolve_workload(
         "heads": resolved_heads,
         "command_count": resolved_command_count,
         "blocks_per_stream": resolved_blocks_per_stream,
+        "block_counts_per_stream": resolved_block_counts,
         "head_dim": resolved_head_dim,
         "head_bases": tuple(configured_head_bases),
         "llama_wave_reference_cycles": defaults.get("llama_wave_reference_cycles"),
@@ -170,11 +209,11 @@ def _block_beats(
     stream: int,
     command_index: int,
     *,
-    blocks_per_stream: int,
+    block_count_per_stream: int,
     head_dim: int,
 ) -> list[list[tuple[list[int], list[int]]]]:
     blocks: list[list[tuple[list[int], list[int]]]] = []
-    for block in range(blocks_per_stream):
+    for block in range(block_count_per_stream):
         block_beats: list[tuple[list[int], list[int]]] = []
         for beat in range(head_dim):
             queries = [
@@ -190,7 +229,7 @@ def _block_beats(
     return blocks
 
 
-def _values_for(stream: int, command_index: int, *, blocks_per_stream: int) -> list[list[list[list[int]]]]:
+def _values_for(stream: int, command_index: int, *, block_count_per_stream: int) -> list[list[list[list[int]]]]:
     return [
         [
             [
@@ -203,7 +242,7 @@ def _values_for(stream: int, command_index: int, *, blocks_per_stream: int) -> l
             ]
             for value_slice in range(16)
         ]
-        for block in range(blocks_per_stream)
+        for block in range(block_count_per_stream)
     ]
 
 
@@ -217,18 +256,24 @@ def _raw_scores(block: list[tuple[list[int], list[int]]], head_lane: int) -> lis
 def _expected(workload: dict[str, object]) -> list[dict[str, object]]:
     heads = int(workload["heads"])
     command_count = int(workload["command_count"])
-    blocks_per_stream = int(workload["blocks_per_stream"])
+    block_counts_per_stream = tuple(int(value) for value in workload["block_counts_per_stream"])
     head_dim = int(workload["head_dim"])
     head_bases = tuple(int(value) for value in workload["head_bases"])
     rows: list[dict[str, object]] = []
     for command_index, command in enumerate(
         _command_schedule(heads=heads, command_count=command_count, head_bases=head_bases)
     ):
+        block_count_per_stream = block_counts_per_stream[command_index]
         merged_per_head = []
         for head_lane in range(8):
             stream_partials = []
             for stream in range(2):
-                blocks = _block_beats(stream, command_index, blocks_per_stream=blocks_per_stream, head_dim=head_dim)
+                blocks = _block_beats(
+                    stream,
+                    command_index,
+                    block_count_per_stream=block_count_per_stream,
+                    head_dim=head_dim,
+                )
                 score_rows = [
                     list(
                         requantize_score_row(
@@ -244,7 +289,11 @@ def _expected(workload: dict[str, object]) -> list[dict[str, object]]:
                         command_id=int(command["command_id"]),
                         head_id=int(command["head_base"]) + head_lane,
                         score_rows=score_rows,
-                        value_blocks=_values_for(stream, command_index, blocks_per_stream=blocks_per_stream),
+                        value_blocks=_values_for(
+                            stream,
+                            command_index,
+                            block_count_per_stream=block_count_per_stream,
+                        ),
                     )
                 )
             merged_per_head.append(merge_partial_streams(stream_partials[0], stream_partials[1]))
@@ -273,27 +322,37 @@ def _testbench(
 ) -> str:
     heads = int(workload["heads"])
     command_count = int(workload["command_count"])
-    blocks_per_stream = int(workload["blocks_per_stream"])
+    block_counts_per_stream = tuple(int(value) for value in workload["block_counts_per_stream"])
     head_dim = int(workload["head_dim"])
     head_bases = tuple(int(value) for value in workload["head_bases"])
     commands = _command_schedule(heads=heads, command_count=command_count, head_bases=head_bases)
     beats0 = []
     beats1 = []
     lasts = []
+    beat_offsets = []
+    block_offsets = []
+    total_blocks = 0
     for command_index in range(len(commands)):
-        blocks0 = _block_beats(0, command_index, blocks_per_stream=blocks_per_stream, head_dim=head_dim)
-        blocks1 = _block_beats(1, command_index, blocks_per_stream=blocks_per_stream, head_dim=head_dim)
-        for block in range(blocks_per_stream):
+        block_count_per_stream = block_counts_per_stream[command_index]
+        beat_offsets.append(len(beats0))
+        block_offsets.append(total_blocks)
+        blocks0 = _block_beats(0, command_index, block_count_per_stream=block_count_per_stream, head_dim=head_dim)
+        blocks1 = _block_beats(1, command_index, block_count_per_stream=block_count_per_stream, head_dim=head_dim)
+        for block in range(block_count_per_stream):
             for beat in range(head_dim):
                 queries0, keys0 = blocks0[block][beat]
                 queries1, keys1 = blocks1[block][beat]
                 beats0.append((queries0, keys0))
                 beats1.append((queries1, keys1))
                 lasts.append(1 if beat == head_dim - 1 else 0)
+        total_blocks += block_count_per_stream
 
     cmd_init = "\n".join(
         f"    cmd_id_mem[{index}] = 16'h{int(command['command_id']):04x}; "
         f"cmd_head_base_mem[{index}] = 5'd{int(command['head_base'])}; "
+        f"cmd_block_count_mem[{index}] = 15'd{block_counts_per_stream[index]}; "
+        f"cmd_beat_limit_mem[{index}] = 32'd{beat_offsets[index] + (block_counts_per_stream[index] * head_dim)}; "
+        f"cmd_block_offset_mem[{index}] = 32'd{block_offsets[index]}; "
         f"cmd_mult_mem[{index}] = 32'd{int(command['multiplier'])}; "
         f"cmd_shift_mem[{index}] = 6'd{int(command['shift'])};"
         for index, command in enumerate(commands)
@@ -307,17 +366,19 @@ def _testbench(
     value_init = []
     for stream in range(2):
         for command_index in range(len(commands)):
-            values = _values_for(stream, command_index, blocks_per_stream=blocks_per_stream)
-            for block in range(blocks_per_stream):
+            block_count_per_stream = block_counts_per_stream[command_index]
+            values = _values_for(stream, command_index, block_count_per_stream=block_count_per_stream)
+            for block in range(block_count_per_stream):
                 for value_slice in range(16):
                     flat = [lane for row in values[block][value_slice] for lane in row]
                     value_init.append(
-                        f"    value_mem[{(((stream * len(commands)) + command_index) * blocks_per_stream + block) * 16 + value_slice}] = 512'h{_pack(flat, 8):0128x};"
+                        f"    value_mem[{((stream * total_blocks) + block_offsets[command_index] + block) * 16 + value_slice}] = 512'h{_pack(flat, 8):0128x};"
                     )
     ready_init = "\n".join(
         f"    result_ready_mem[{index}] = 1'b{1 if value else 0};" for index, value in enumerate(output_ready_pattern)
     )
     total_beats = len(beats0)
+    max_blocks_per_stream = max(block_counts_per_stream)
     total_results = len(commands) * 8 * 16
     command_valid_expr = "1'b1" if not stress_interfaces else "(((cycle + issued_commands) % 5) != 2)"
     input_valid_expr = "1'b1" if not stress_interfaces else "(((cycle + input_index) % 7) != 3)"
@@ -333,10 +394,10 @@ def _testbench(
 module tb;
   localparam integer HEADS = {heads};
   localparam integer COMMAND_COUNT = {len(commands)};
-  localparam integer BLOCK_COUNT = {blocks_per_stream};
+  localparam integer MAX_BLOCK_COUNT = {max_blocks_per_stream};
   localparam integer HEAD_DIM = {head_dim};
-  localparam integer BEATS_PER_COMMAND = BLOCK_COUNT * HEAD_DIM;
   localparam integer TOTAL_BEATS = {total_beats};
+  localparam integer TOTAL_BLOCKS = {total_blocks};
   localparam integer TOTAL_RESULTS = {total_results};
   localparam integer READY_PATTERN_LEN = {len(output_ready_pattern)};
 
@@ -353,12 +414,15 @@ module tb;
 
   reg [15:0] cmd_id_mem [0:COMMAND_COUNT-1];
   reg [4:0] cmd_head_base_mem [0:COMMAND_COUNT-1];
+  reg [14:0] cmd_block_count_mem [0:COMMAND_COUNT-1];
+  reg [31:0] cmd_beat_limit_mem [0:COMMAND_COUNT-1];
+  reg [31:0] cmd_block_offset_mem [0:COMMAND_COUNT-1];
   reg [31:0] cmd_mult_mem [0:COMMAND_COUNT-1];
   reg [5:0] cmd_shift_mem [0:COMMAND_COUNT-1];
   reg [127:0] query_mem [0:TOTAL_BEATS-1];
   reg [127:0] key_mem [0:TOTAL_BEATS-1];
   reg last_mem [0:TOTAL_BEATS-1];
-  reg [511:0] value_mem [0:(2*COMMAND_COUNT*BLOCK_COUNT*16)-1];
+  reg [511:0] value_mem [0:(2*TOTAL_BLOCKS*16)-1];
   reg result_ready_mem [0:READY_PATTERN_LEN-1];
 
   reg command_valid;
@@ -404,6 +468,7 @@ module tb;
   reg [13:0] pending_addr0 = 0, pending_addr1 = 0;
   reg [3:0] pending_slice0 = 0, pending_slice1 = 0;
   integer pending_delay0 = 0, pending_delay1 = 0;
+  integer issued_beat_limit;
 
   always #5 clk = ~clk;
 
@@ -414,7 +479,7 @@ module tb;
       .command_ready(command_ready),
       .command_id(cmd_id_mem[issued_commands]),
       .command_head_base(cmd_head_base_mem[issued_commands]),
-      .command_block_count(BLOCK_COUNT),
+      .command_block_count(cmd_block_count_mem[issued_commands]),
       .command_score_multiplier(cmd_mult_mem[issued_commands]),
       .command_score_shift(cmd_shift_mem[issued_commands]),
       .input_valid(input_valid),
@@ -456,8 +521,9 @@ module tb;
   );
 
   always @* begin
+    issued_beat_limit = issued_commands == 0 ? 0 : cmd_beat_limit_mem[issued_commands - 1];
     command_valid = rst_n && issued_commands < COMMAND_COUNT && {command_valid_expr};
-    input_valid = rst_n && input_index < (issued_commands * BEATS_PER_COMMAND) && {input_valid_expr};
+    input_valid = rst_n && input_index < issued_beat_limit && {input_valid_expr};
     input_query = input_index < TOTAL_BEATS ? query_mem[input_index] : 0;
     input_key = input_index < TOTAL_BEATS ? key_mem[input_index] : 0;
     input_last = input_index < TOTAL_BEATS ? last_mem[input_index] : 0;
@@ -518,7 +584,7 @@ module tb;
           value_response_valid[0] <= 1;
           value_response_address[13:0] <= pending_addr0;
           value_response_slice[3:0] <= pending_slice0;
-          value_response_matrix[511:0] <= value_mem[((active_cmd0 * BLOCK_COUNT) + pending_addr0) * 16 + pending_slice0];
+          value_response_matrix[511:0] <= value_mem[((cmd_block_offset_mem[active_cmd0] + pending_addr0) * 16) + pending_slice0];
         end else begin
           pending_delay0 <= pending_delay0 - 1;
         end
@@ -529,7 +595,7 @@ module tb;
           value_response_valid[1] <= 1;
           value_response_address[27:14] <= pending_addr1;
           value_response_slice[7:4] <= pending_slice1;
-          value_response_matrix[1023:512] <= value_mem[(((COMMAND_COUNT + active_cmd1) * BLOCK_COUNT) + pending_addr1) * 16 + pending_slice1];
+          value_response_matrix[1023:512] <= value_mem[(((TOTAL_BLOCKS + cmd_block_offset_mem[active_cmd1]) + pending_addr1) * 16) + pending_slice1];
         end else begin
           pending_delay1 <= pending_delay1 - 1;
         end
@@ -593,6 +659,7 @@ def _run_case(
     heads: int | None,
     command_count: int | None,
     blocks_per_stream: int | None,
+    block_counts_per_stream: tuple[int, ...] | None,
     head_dim: int | None,
     head_bases: tuple[int, ...] | None,
     output_ready_pattern: tuple[bool, ...],
@@ -603,6 +670,7 @@ def _run_case(
         heads=heads,
         command_count=command_count,
         blocks_per_stream=blocks_per_stream,
+        block_counts_per_stream=block_counts_per_stream,
         head_dim=head_dim,
         head_bases=head_bases,
     )
@@ -614,7 +682,12 @@ def _run_case(
         probe_defaults = run_config.setdefault("probe_defaults", {})
         probe_defaults["heads"] = int(workload["heads"])
         probe_defaults["command_count"] = int(workload["command_count"])
-        probe_defaults["blocks_per_stream"] = int(workload["blocks_per_stream"])
+        if len(set(int(value) for value in workload["block_counts_per_stream"])) == 1:
+            probe_defaults["blocks_per_stream"] = int(workload["blocks_per_stream"])
+            probe_defaults.pop("block_counts_per_stream", None)
+        else:
+            probe_defaults["block_counts_per_stream"] = list(int(value) for value in workload["block_counts_per_stream"])
+            probe_defaults.pop("blocks_per_stream", None)
         probe_defaults["head_dim"] = int(workload["head_dim"])
         probe_defaults["head_bases"] = list(int(value) for value in workload["head_bases"])
         generate_tree(run_config, temp_dir / "rtl")
@@ -716,6 +789,7 @@ def _run_case(
         "heads": resolved_heads,
         "commands": int(workload["command_count"]),
         "blocks_per_stream": int(workload["blocks_per_stream"]),
+        "block_counts_per_stream": list(int(value) for value in workload["block_counts_per_stream"]),
         "head_dim": int(workload["head_dim"]),
         "head_bases": list(int(value) for value in workload["head_bases"]),
         "command_accepts": command_accepts,
@@ -738,6 +812,7 @@ def build_report(
     heads: int | None = None,
     command_count: int | None = None,
     blocks_per_stream: int | None = None,
+    block_counts_per_stream: tuple[int, ...] | None = None,
     head_dim: int | None = None,
     head_bases: tuple[int, ...] | None = None,
     output_ready_pattern: tuple[bool, ...] | None = None,
@@ -756,6 +831,7 @@ def build_report(
         heads=heads,
         command_count=command_count,
         blocks_per_stream=blocks_per_stream,
+        block_counts_per_stream=block_counts_per_stream,
         head_dim=head_dim,
         head_bases=head_bases,
         output_ready_pattern=ready_pattern,
@@ -772,6 +848,7 @@ def build_report(
         "heads": int(result["heads"]),
         "commands": result["commands"],
         "blocks_per_stream": int(result["blocks_per_stream"]),
+        "block_counts_per_stream": result["block_counts_per_stream"],
         "head_dim": int(result["head_dim"]),
         "head_bases": result["head_bases"],
         "outputs": result["outputs"],
@@ -806,6 +883,7 @@ def build_report(
             max_blocks=int(base_config["attention_score32_exact_partial_gqa8_dual_stream_producer"]["max_blocks"]),
             command_count=int(result["commands"]),
             blocks_per_stream=int(result["blocks_per_stream"]),
+            block_counts_per_stream=tuple(int(value) for value in result["block_counts_per_stream"]),
             head_dim=int(result["head_dim"]),
             head_bases=tuple(int(value) for value in result["head_bases"]),
             llama_wave_reference_cycles=reference_cycles if isinstance(reference_cycles, int) else None,
@@ -819,11 +897,17 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--heads", type=int, default=None)
     parser.add_argument("--command-count", type=int, default=None)
     parser.add_argument("--blocks-per-stream", type=int, default=None)
+    parser.add_argument("--block-counts-per-stream", type=str, default=None)
     parser.add_argument("--head-dim", type=int, default=None)
     parser.add_argument("--head-bases", type=str, default=None)
     parser.add_argument("--result-ready-pattern", type=str, default=None)
     parser.add_argument("--ideal-interfaces", action="store_true")
     parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--compact-json",
+        action="store_true",
+        help="omit full expected/observed rows and emit their counts and SHA-256 digests",
+    )
     args = parser.parse_args(argv)
 
     config = _default_config()
@@ -839,18 +923,27 @@ def main(argv: list[str] | None = None) -> int:
         head_bases = tuple(int(token.strip()) for token in args.head_bases.split(",") if token.strip())
         if not head_bases:
             raise SystemExit("head-bases must not be empty")
+    block_counts_per_stream = None
+    if args.block_counts_per_stream:
+        block_counts_per_stream = tuple(
+            int(token.strip()) for token in args.block_counts_per_stream.split(",") if token.strip()
+        )
+        if not block_counts_per_stream:
+            raise SystemExit("block-counts-per-stream must not be empty")
     report = build_report(
         config=config,
         heads=args.heads,
         command_count=args.command_count,
         blocks_per_stream=args.blocks_per_stream,
+        block_counts_per_stream=block_counts_per_stream,
         head_dim=args.head_dim,
         head_bases=head_bases,
         output_ready_pattern=pattern,
         stress_interfaces=False if args.ideal_interfaces else None,
     )
-    if args.json:
-        print(json.dumps(report, indent=2, sort_keys=True))
+    if args.json or args.compact_json:
+        payload = compact_report(report) if args.compact_json else report
+        print(json.dumps(payload, indent=2, sort_keys=True))
     else:
         print(
             json.dumps(

--- a/npu/rtlgen/gen_attention_score32_exact_partial_gqa8_dual_stream_producer.py
+++ b/npu/rtlgen/gen_attention_score32_exact_partial_gqa8_dual_stream_producer.py
@@ -349,6 +349,9 @@ def generate(config: JsonDict, out_dir: Path) -> None:
         max_blocks=int(params["max_blocks"]),
         command_count=int(probe_defaults.get("command_count", int(probe_defaults.get("heads", 8)) // 8)),
         blocks_per_stream=int(probe_defaults.get("blocks_per_stream", 2)),
+        block_counts_per_stream=tuple(int(value) for value in probe_defaults.get("block_counts_per_stream", []))
+        if isinstance(probe_defaults.get("block_counts_per_stream"), list)
+        else None,
         head_dim=int(probe_defaults.get("head_dim", 3)),
         head_bases=tuple(int(value) for value in probe_defaults.get("head_bases", [])) if isinstance(probe_defaults.get("head_bases"), list) else None,
         llama_wave_reference_cycles=int(probe_defaults["llama_wave_reference_cycles"]) if "llama_wave_reference_cycles" in probe_defaults else None,

--- a/npu/sim/perf/attention_exact_partial.py
+++ b/npu/sim/perf/attention_exact_partial.py
@@ -849,6 +849,7 @@ def exact_partial_dual_stream_gqa8_producer_service_manifest(
     max_blocks: int = 8,
     command_count: int | None = None,
     blocks_per_stream: int = 2,
+    block_counts_per_stream: tuple[int, ...] | None = None,
     head_dim: int = 3,
     head_bases: tuple[int, ...] | None = None,
     llama_wave_reference_cycles: int | None = None,
@@ -864,10 +865,19 @@ def exact_partial_dual_stream_gqa8_producer_service_manifest(
         raise ValueError("max_blocks must be a power of two in [8, 16384]")
     if resolved_command_count < 1:
         raise ValueError("command_count must be positive")
-    if resolved_blocks_per_stream < 1 or resolved_blocks_per_stream > block_limit:
-        raise ValueError("blocks_per_stream must be in [1, max_blocks]")
     if resolved_head_dim < 1:
         raise ValueError("head_dim must be positive")
+    if block_counts_per_stream is None:
+        if resolved_blocks_per_stream < 1 or resolved_blocks_per_stream > block_limit:
+            raise ValueError("blocks_per_stream must be in [1, max_blocks]")
+        block_counts = tuple(resolved_blocks_per_stream for _ in range(resolved_command_count))
+    else:
+        block_counts = tuple(int(value) for value in block_counts_per_stream)
+        if len(block_counts) != resolved_command_count:
+            raise ValueError("block_counts_per_stream length must match command_count")
+        if any(value < 1 or value > block_limit for value in block_counts):
+            raise ValueError("block_counts_per_stream entries must be in [1, max_blocks]")
+        resolved_blocks_per_stream = max(block_counts)
     if head_bases is None:
         bases = tuple((group % (head_count // 8)) * 8 for group in range(resolved_command_count))
     else:
@@ -906,6 +916,8 @@ def exact_partial_dual_stream_gqa8_producer_service_manifest(
             "per_wave_local_block_ceiling_per_stream": 2,
             "persistent_local_reducer_waves": 8,
             "probe_blocks_per_stream": resolved_blocks_per_stream,
+            "probe_block_counts_per_stream": list(block_counts),
+            "probe_blocks_per_stream_uniform": len(set(block_counts)) == 1,
             "probe_head_dim": resolved_head_dim,
             "probe_head_bases": list(bases),
             "probe_total_heads": head_count,
@@ -914,7 +926,9 @@ def exact_partial_dual_stream_gqa8_producer_service_manifest(
             "head_base_alignment_bits": 3,
             "global_tile_tokens": 1024,
             "global_tile_token_blocks": 128,
-            "worst_loaded_jobs_per_datapath_upper_bound": 5,
+            "per_datapath_group_commands_per_wave": 4,
+            "worst_loaded_total_blocks_per_stream_per_datapath_per_wave": 5,
+            "worst_loaded_two_block_commands_per_datapath_per_wave": 1,
         },
         "comparison_baseline_contract": "python_structured_exact_partial_stream_reference",
         "comparison_cycle_origin": "cycle0_on_atomic_dual_stream_input_issue",

--- a/runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/config_llama_wave_worst4_group_major.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/config_llama_wave_worst4_group_major.json
@@ -1,0 +1,29 @@
+{
+  "attention_score32_exact_partial_gqa8_dual_stream_producer": {
+    "streams": 2,
+    "query_heads_per_stream": 8,
+    "head_id_bits": 5,
+    "max_blocks": 8,
+    "value_slices": 16
+  },
+  "probe_defaults": {
+    "heads": 32,
+    "command_count": 4,
+    "block_counts_per_stream": [
+      2,
+      1,
+      1,
+      1
+    ],
+    "head_dim": 128,
+    "head_bases": [
+      0,
+      8,
+      16,
+      24
+    ],
+    "interface_mode": "ideal",
+    "llama_wave_reference_cycles": 986
+  },
+  "top_name": "attention_score32_exact_partial_gqa8_dual_stream_producer_b8"
+}

--- a/tests/test_attention_score32_exact_partial_gqa8_dual_stream_producer.py
+++ b/tests/test_attention_score32_exact_partial_gqa8_dual_stream_producer.py
@@ -10,7 +10,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from npu.eval.probe_attention_score32_exact_partial_gqa8_dual_stream_producer import build_report
+from npu.eval.probe_attention_score32_exact_partial_gqa8_dual_stream_producer import build_report, compact_report
 from npu.rtlgen.gen_attention_score32_exact_partial_gqa8_dual_stream_producer import generate
 
 _FAKERAM_MODEL = """
@@ -42,6 +42,18 @@ module fakeram45_2048x39 (
   assign rd_out = rd_out_q;
 endmodule
 """
+
+
+def test_compact_report_replaces_equivalence_rows_with_digests() -> None:
+    rows = [{"command_id": 1, "head_id": 2, "value": [3, 4]}]
+    report = compact_report({"passed": True, "observed_rows": rows, "expected_rows": rows})
+
+    assert "observed_rows" not in report
+    assert "expected_rows" not in report
+    assert report["observed_rows_count"] == 1
+    assert report["expected_rows_count"] == 1
+    assert report["observed_rows_sha256"] == report["expected_rows_sha256"]
+    assert report["equivalence_evidence_policy"] == "structured_compare_then_commit_counts_and_sha256"
 
 
 def _rtl_tools_available() -> bool:
@@ -105,6 +117,8 @@ def test_exact_partial_gqa8_dual_stream_producer_manifest_and_verilator_lint(tmp
         "per_wave_local_block_ceiling_per_stream": 2,
         "persistent_local_reducer_waves": 8,
         "probe_blocks_per_stream": 2,
+        "probe_block_counts_per_stream": [2],
+        "probe_blocks_per_stream_uniform": True,
         "probe_head_dim": 3,
         "probe_head_bases": [0],
         "probe_total_heads": 8,
@@ -113,7 +127,9 @@ def test_exact_partial_gqa8_dual_stream_producer_manifest_and_verilator_lint(tmp
         "head_base_alignment_bits": 3,
         "global_tile_tokens": 1024,
         "global_tile_token_blocks": 128,
-        "worst_loaded_jobs_per_datapath_upper_bound": 5,
+        "per_datapath_group_commands_per_wave": 4,
+        "worst_loaded_total_blocks_per_stream_per_datapath_per_wave": 5,
+        "worst_loaded_two_block_commands_per_datapath_per_wave": 1,
     }
     assert manifest["remaining_abstractions"] == [
         "53or54_way_global_cluster_aggregation_open",
@@ -238,6 +254,35 @@ def test_exact_partial_gqa8_dual_stream_producer_llama_wave_probe() -> None:
     assert report["result_stall_cycles"] == 0
     assert report["llama_wave_reference_cycles"] == 986
     assert report["llama_wave_drain_delta_vs_986"] == 695
+    assert report["protocol_error"] is False
+    assert report["stream_protocol_error"] == [False, False]
+    assert report["merge_protocol_error"] is False
+    assert report["observed_rows"] == report["expected_rows"]
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="RTL tools unavailable")
+def test_exact_partial_gqa8_dual_stream_producer_llama_wave_worst4_probe() -> None:
+    report = build_report(config=_load_config("config_llama_wave_worst4_group_major.json"))
+
+    assert report["passed"] is True
+    assert report["heads"] == 32
+    assert report["commands"] == 4
+    assert report["blocks_per_stream"] == 2
+    assert report["block_counts_per_stream"] == [2, 1, 1, 1]
+    assert report["head_dim"] == 128
+    assert report["head_bases"] == [0, 8, 16, 24]
+    assert report["outputs"] == 512
+    assert report["expected_outputs"] == 512
+    assert report["interface_mode"] == "ideal"
+    assert report["integrated_drain_cycles"] == 1536
+    assert report["command_accept_count"] == 4
+    assert report["command_complete_count"] == 4
+    assert report["stream_command_accept_count"] == [4, 4]
+    assert report["stream_complete_count"] == [4, 4]
+    assert report["merge_complete_count"] == 512
+    assert report["result_stall_cycles"] == 0
+    assert report["llama_wave_reference_cycles"] == 986
+    assert report["llama_wave_drain_delta_vs_986"] == 550
     assert report["protocol_error"] is False
     assert report["stream_protocol_error"] == [False, False]
     assert report["merge_protocol_error"] is False

--- a/tests/test_audit_llm_decoder_attention_score32_exact_hierarchy_cadence_r3.py
+++ b/tests/test_audit_llm_decoder_attention_score32_exact_hierarchy_cadence_r3.py
@@ -1,0 +1,100 @@
+from argparse import Namespace
+from pathlib import Path
+
+from npu.eval.audit_llm_decoder_attention_score32_exact_hierarchy_cadence_r3 import (
+    _build_markdown,
+    _build_report,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _args(tmp_path: Path) -> Namespace:
+    return Namespace(
+        source_recost_json=REPO_ROOT
+        / "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_composed_datapath_physical_feasibility__l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1.json",
+        wrapper_config=REPO_ROOT
+        / "runs/designs/npu_blocks/attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2/config.json",
+        wrapper_metrics=REPO_ROOT
+        / "runs/designs/npu_blocks/attention_dual_stream_schedule_wrapper_score32_exp_lut_8x8_c2/metrics.csv",
+        exact_c16_config=REPO_ROOT
+        / "runs/designs/npu_blocks/attention_score32_exact_partial_producer_tree_c16_r2_l8_b59/config.json",
+        subtile_pipeline_generator=REPO_ROOT
+        / "npu/eval/estimate_llm_decoder_attention_kv_subtile_pipeline_schedule.py",
+        schedule_wrapper_generator=REPO_ROOT / "npu/rtlgen/gen_attention_dual_stream_schedule_wrapper.py",
+        composed_generator=REPO_ROOT / "npu/rtlgen/gen_attention_dual_stream_composed.py",
+        exact_c16_generator=REPO_ROOT
+        / "npu/rtlgen/gen_attention_score32_exact_partial_producer_tree_c16.py",
+        producer_cluster_generator=REPO_ROOT
+        / "npu/rtlgen/gen_attention_decode_score_multivalue_cluster.py",
+        attention_online_source=REPO_ROOT / "npu/sim/perf/attention_online.py",
+        functional_producer_config=REPO_ROOT
+        / "runs/designs/npu_blocks/attention_score32_exact_partial_gqa8_dual_stream_producer_b8/config_llama_wave_worst4_group_major.json",
+        functional_producer_probe=REPO_ROOT
+        / "npu/eval/probe_attention_score32_exact_partial_gqa8_dual_stream_producer.py",
+        superseded_audit_json=REPO_ROOT
+        / "npu/docs/generated/llama7b_score32_exact_hierarchy_cadence_audit_v2.json",
+        out=tmp_path / "audit.json",
+        out_md=tmp_path / "audit.md",
+    )
+
+
+def test_r3_uses_group_commands_and_corrected_worst4_service(tmp_path: Path) -> None:
+    report = _build_report(_args(tmp_path))
+
+    assert report["decision"] == "score32_986_cycle_arithmetic_not_sustained_by_corrected_group_command_mapping"
+    revision = report["functional_producer_revision"]
+    assert revision["mapping"] == {
+        "token_blocks_per_1024_token_tile": 128,
+        "token_streams_per_producer": 2,
+        "gqa_groups": 4,
+        "producer_command_contract": "one_gqa8_head_group_for_one_tile_wave_with_1or2_blocks_per_stream",
+        "per_datapath_group_commands_per_wave": 4,
+        "distribution_for_53_datapaths": {
+            "dual_stream_datapaths": 53,
+            "group_commands_per_datapath_per_wave": 4,
+            "two_block_commands_per_stream_per_group": 11,
+            "one_block_commands_per_stream_per_group": 42,
+            "rotated_two_block_assignments_across_4_groups": 44,
+            "datapaths_with_one_two_block_command": 44,
+            "datapaths_with_zero_two_block_commands": 9,
+            "worst_loaded_block_counts_per_stream": [2, 1, 1, 1],
+        },
+        "distribution_for_54_datapaths": {
+            "dual_stream_datapaths": 54,
+            "group_commands_per_datapath_per_wave": 4,
+            "two_block_commands_per_stream_per_group": 10,
+            "one_block_commands_per_stream_per_group": 44,
+            "rotated_two_block_assignments_across_4_groups": 40,
+            "datapaths_with_one_two_block_command": 40,
+            "datapaths_with_zero_two_block_commands": 14,
+            "worst_loaded_block_counts_per_stream": [2, 1, 1, 1],
+        },
+    }
+    measured = revision["measured_service"]
+    assert measured["passed"] is True
+    assert measured["commands"] == 4
+    assert measured["blocks_per_stream"] == 2
+    assert measured["block_counts_per_stream"] == [2, 1, 1, 1]
+    assert measured["interface_mode"] == "ideal"
+    assert measured["integrated_drain_cycles"] == 1536
+    assert measured["result_stall_cycles"] == 0
+    assert measured["llama_wave_drain_delta_vs_986"] == 550
+    assert revision["interpretation"]["reference_986_cycles_sustained"] is False
+    assert revision["group_major_reducer_schedule"]["schedule_contract"] == (
+        "process_one_fixed_gqa8_group_across_all_8_tile_waves_then_emit_finalize_before_next_head_base"
+    )
+    assert report["next_l1_contract"]["next_required_block"] == (
+        "functional_53_54_way_local_exact_reducer_with_group_major_8_wave_persistent_state"
+    )
+
+
+def test_r3_markdown_records_group_major_schedule(tmp_path: Path) -> None:
+    report = _build_report(_args(tmp_path))
+    markdown = _build_markdown(report)
+
+    assert "corrected ideal-interface producer service: `1536` cycles" in markdown
+    assert "worst-loaded per-wave schedule: `[2, 1, 1, 1]`" in markdown
+    assert "rotated p53 extras across 4 groups: `44` datapaths get one `2`-block command, `9` get none" in markdown
+    assert "safe interleave: `not_established`" in markdown

--- a/tests/test_check_attention_score32_exact_partial_gqa8_dual_stream_producer_guard.py
+++ b/tests/test_check_attention_score32_exact_partial_gqa8_dual_stream_producer_guard.py
@@ -49,7 +49,12 @@ def _run_guard(design_dir: Path, *, config_name: str) -> subprocess.CompletedPro
 
 
 def test_exact_partial_gqa8_dual_stream_producer_guard_accepts_checked_in_configs(tmp_path: Path) -> None:
-    for config_name in ("config.json", "config_heads32_native.json", "config_llama_wave.json"):
+    for config_name in (
+        "config.json",
+        "config_heads32_native.json",
+        "config_llama_wave.json",
+        "config_llama_wave_worst4_group_major.json",
+    ):
         design_dir = _prepare_design_dir(tmp_path / config_name.replace(".json", ""), config_name=config_name)
         result = _run_guard(design_dir, config_name=config_name)
         assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- correct the score32 GQA8 mapping to four group commands per datapath and tile wave
- support per-command producer block counts and measure the worst-loaded `[2,1,1,1]` schedule
- add cadence audit R3 with group-major eight-wave reducer scheduling
- commit compact equivalence evidence as counts and SHA-256 digests instead of full payload rows

## Result
- ideal worst-loaded producer service: 1536 cycles
- historical arithmetic reference: 986 cycles
- delta: +550 cycles

## Verification
- `PYTHONPATH=. pytest -q tests/test_audit_llm_decoder_attention_score32_exact_hierarchy_cadence_r2.py tests/test_attention_score32_exact_partial_gqa8_dual_stream_producer.py tests/test_check_attention_score32_exact_partial_gqa8_dual_stream_producer_guard.py tests/test_audit_llm_decoder_attention_score32_exact_hierarchy_cadence_r3.py`
- 17 passed
