### PR TITLE
Prepare corrected GQA8 reducer PPA job

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -1602,6 +1602,67 @@ def _read_config_target(
                 },
             ],
         )
+    elif "top_name" in cfg and "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness" in cfg:
+        top_name = str(cfg["top_name"]).strip()
+        if not top_name:
+            raise Layer1TaskGenerationError(f"top_name must not be empty in {config_path}")
+        try:
+            design_dir = str(config_path.parent.resolve().relative_to(repo_root.resolve()))
+        except ValueError as exc:
+            raise Layer1TaskGenerationError(
+                "score32 exact local temporal reducer GQA8 physical harness config must live under "
+                f"repo_root/runs/designs/...: {config_path}"
+            ) from exc
+        design_name = config_path.parent.name
+        return Layer1ConfigTarget(
+            design_kind="block",
+            design_name=design_name,
+            expected_metrics_path=block_metrics_path(design_name),
+            expected_report_paths=[f"{design_dir}/timing_debug_report.md"],
+            commands=[
+                {
+                    "name": "generate_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_rtl",
+                    "run": _with_oss_cad_path(
+                        (
+                            "python3 npu/rtlgen/gen_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness.py "
+                            f"--config {config_rel} "
+                            f"--out {design_dir}/verilog"
+                        )
+                    ),
+                },
+                {
+                    "name": "check_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_guard",
+                    "run": (
+                        "python3 npu/eval/check_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_guard.py "
+                        f"--design-dir {design_dir}"
+                    ),
+                },
+                {
+                    "name": "run_block_sweep",
+                    "run": _with_oss_cad_path(
+                        (
+                            "python3 npu/synth/run_block_sweep.py "
+                            f"--design_dir {design_dir} "
+                            "--platform {platform} "
+                            f"--top {top_name} "
+                            f"--sweep {{sweep_path}} "
+                            f"--out_root {out_root} "
+                            + (f"--make_target {make_target} " if make_target else "")
+                            + "--skip_existing"
+                        )
+                    ),
+                },
+                {
+                    "name": "extract_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_timing_paths",
+                    "run": (
+                        "python3 npu/eval/extract_openroad_timing_summary.py "
+                        f"--design-dir {design_dir} "
+                        f"--out {design_dir}/timing_debug_report.md "
+                        "--max-paths 8"
+                    ),
+                },
+            ],
+        )
     elif "top_name" in cfg and "attention_hbm_replay_controller" in cfg:
         top_name = str(cfg["top_name"]).strip()
         if not top_name:

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -788,6 +788,70 @@ def _write_example_attention_score32_exact_local_temporal_reducer_physical_harne
     )
 
 
+def _write_example_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_repo(
+    repo_root: Path,
+) -> tuple[str, str]:
+    design_dir = (
+        repo_root
+        / "runs"
+        / "designs"
+        / "npu_blocks"
+        / "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8"
+    )
+    design_dir.mkdir(parents=True, exist_ok=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8",
+                "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness": {
+                    "producers": 53,
+                    "mode": "reducer",
+                    "waves": 8,
+                },
+                "report_links": {
+                    "proposal_id": "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1",
+                    "proposal_path": "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json",
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    sweep_path = (
+        repo_root
+        / "runs"
+        / "campaigns"
+        / "npu"
+        / "attention_score32_local_temporal_reducer_gqa8_v1"
+        / "sweeps"
+        / "nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary.json"
+    )
+    sweep_path.parent.mkdir(parents=True, exist_ok=True)
+    sweep_path.write_text(
+        json.dumps(
+            {
+                "tag_prefix": "attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_v1",
+                "flow_params": {
+                    "CLOCK_PERIOD": [8.0, 10.0],
+                    "DIE_AREA": ["0 0 2200 2200"],
+                    "CORE_AREA": ["80 80 2120 2120"],
+                    "PLACE_DENSITY": [0.35],
+                    "SYNTH_HIERARCHICAL": [1],
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return (
+        str(config_path.relative_to(repo_root)),
+        str(sweep_path.relative_to(repo_root)),
+    )
+
+
 def _write_example_attention_schedule_wrapper_repo(repo_root: Path) -> tuple[str, str]:
     design_dir = repo_root / "runs" / "designs" / "npu_blocks" / "attention_dual_stream_schedule_wrapper_smoke_c2"
     design_dir.mkdir(parents=True, exist_ok=True)
@@ -1737,6 +1801,38 @@ def _write_second_attention_score32_exact_local_temporal_reducer_physical_harnes
                 "report_links": {
                     "proposal_id": "prop_l1_decoder_attention_score32_local_temporal_reducer_v1",
                     "proposal_path": "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_v1/proposal.json",
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return str(config_path.relative_to(repo_root))
+
+
+def _write_second_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_repo(repo_root: Path) -> str:
+    design_dir = (
+        repo_root
+        / "runs"
+        / "designs"
+        / "npu_blocks"
+        / "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8"
+    )
+    design_dir.mkdir(parents=True, exist_ok=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8",
+                "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness": {
+                    "producers": 54,
+                    "mode": "source_only",
+                    "waves": 8,
+                },
+                "report_links": {
+                    "proposal_id": "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1",
+                    "proposal_path": "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json",
                 },
             },
             indent=2,
@@ -5249,6 +5345,108 @@ def test_generate_l1_sweep_task_supports_multi_attention_score32_exact_local_tem
                 "attention_score32_exact_local_temporal_reducer_physical_harness_p54_source_only_w8/metrics.csv",
                 "runs/designs/npu_blocks/"
                 "attention_score32_exact_local_temporal_reducer_physical_harness_p54_source_only_w8/"
+                "timing_debug_report.md",
+            ]
+
+
+def test_generate_l1_sweep_task_supports_multi_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_configs() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_repo(
+            repo_root
+        )
+        second_config_path = _write_second_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_repo(
+            repo_root
+        )
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path, second_config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/npu_blocks",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_score32_local_temporal_reducer_gqa8",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert [command["name"] for command in work_item.command_manifest] == [
+                "generate_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_rtl_"
+                "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8",
+                "check_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_guard_"
+                "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8",
+                "run_block_sweep_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8",
+                "extract_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_timing_paths_"
+                "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8",
+                "generate_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_rtl_"
+                "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8",
+                "check_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_guard_"
+                "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8",
+                "run_block_sweep_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8",
+                "extract_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_timing_paths_"
+                "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8",
+                "build_runs_index",
+                "validate",
+            ]
+            assert (
+                "gen_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness.py"
+                in work_item.command_manifest[0]["run"]
+            )
+            assert "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/config.json" in (
+                work_item.command_manifest[0]["run"]
+            )
+            assert (
+                "check_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_guard.py"
+                in work_item.command_manifest[1]["run"]
+            )
+            assert "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/config.json" in (
+                work_item.command_manifest[4]["run"]
+            )
+            assert (
+                "--top attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8"
+                in work_item.command_manifest[2]["run"]
+            )
+            assert (
+                "--top attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8"
+                in work_item.command_manifest[6]["run"]
+            )
+            assert work_item.command_manifest[3]["run"] == (
+                "python3 npu/eval/extract_openroad_timing_summary.py "
+                "--design-dir runs/designs/npu_blocks/"
+                "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8 "
+                "--out runs/designs/npu_blocks/"
+                "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/"
+                "timing_debug_report.md "
+                "--max-paths 8"
+            )
+            assert work_item.command_manifest[7]["run"] == (
+                "python3 npu/eval/extract_openroad_timing_summary.py "
+                "--design-dir runs/designs/npu_blocks/"
+                "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8 "
+                "--out runs/designs/npu_blocks/"
+                "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/"
+                "timing_debug_report.md "
+                "--max-paths 8"
+            )
+            assert work_item.expected_outputs == [
+                "runs/designs/npu_blocks/"
+                "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/metrics.csv",
+                "runs/designs/npu_blocks/"
+                "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/"
+                "timing_debug_report.md",
+                "runs/designs/npu_blocks/"
+                "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/metrics.csv",
+                "runs/designs/npu_blocks/"
+                "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/"
                 "timing_debug_report.md",
             ]
 

--- a/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/evaluation_requests.json
@@ -1,0 +1,46 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1",
+  "proposal_path": "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json",
+  "source_commit_note": "Generate the DB task only after this job-prep change is merged, and pin source_requirement.required_sha to the then-current origin/master commit containing both the harness and task-generator support.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_score32_local_temporal_reducer_gqa8_ppa_v1",
+      "task_type": "l1_sweep",
+      "title": "Layer 1 GQA8 score32 local temporal reducer physical harness boundary sweep",
+      "proposal_id": "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1",
+      "proposal_path": "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json",
+      "objective": "Measure Nangate45 PPA for the corrected merged GQA8 score32 exact local temporal reducer physical harness at p53/p54 in reducer and source_only modes using a bounded macro-style hierarchy sweep, accepting boundary-class flow outcomes as evidence.",
+      "status": "pending",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_score32_local_temporal_reducer_gqa8",
+      "comparison_role": "functional_gqa8_local_hierarchy_anchor",
+      "paired_baseline_item_id": "l1_decoder_attention_score32_exact_partial_gqa8_dual_stream_producer_ppa_v1",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_source_only_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_source_only_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_source_only_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/timing_debug_report.md"
+      ],
+      "acceptance_notes": "Run the GQA8 physical-harness generator, guard, run_block_sweep, and timing-summary commands for each config. Keep the sweep bounded, make no I/O pad assumptions, and accept ok, flow_failed, and timeout-class rows as explicit boundary evidence. Treat the structural-only reducer-vs-source_only delta as nonlinear until producer fan-in and global c16 composition are physically closed.",
+      "expected_result": {
+        "direction": "measure_gqa8_local_temporal_reducer_boundary",
+        "reason": "The corrected merged GQA8 harness establishes whether the 53/54-way eight-wave local hierarchy remains physically explorable before producer fan-in and global c16 composition consume it."
+      },
+      "notes": "Replacement remote OpenROAD request for the corrected GQA8 harness. The harness is structural-only, the reducer-vs-source_only delta is nonlinear until producer fan-in and global c16 closure exist, and the queued payload must carry exact developer_loop proposal linkage plus a queue-time source_requirement pin to the merged job-prep commit."
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json
@@ -43,10 +43,48 @@
     "Producer-to-local-reducer structural fan-in remains open.",
     "NoC and SRAM PPA remain open.",
     "The global c16 exact reducer is still uncomposed here.",
-    "The new GQA8 physical harness is structural-only, and its reducer-vs-source_only PPA delta is nonlinear until the producer fan-in and global c16 composition are closed.",
-    "No GQA8-specific sweep, evaluation request, or dispatch item is created in this change."
+    "The new GQA8 physical harness is structural-only, and its reducer-vs-source_only PPA delta is nonlinear until the producer fan-in and global c16 composition are closed."
   ],
-  "required_evaluations": [],
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_score32_local_temporal_reducer_gqa8_ppa_v1",
+      "task_type": "l1_sweep",
+      "proposal_id": "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1",
+      "proposal_path": "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json",
+      "objective": "Measure Nangate45 PPA for the corrected merged GQA8 score32 exact local temporal reducer physical harness at p53/p54 in reducer and source_only modes using a bounded macro-style hierarchy sweep, accepting boundary-class flow outcomes as evidence.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_score32_local_temporal_reducer_gqa8",
+      "comparison_role": "functional_gqa8_local_hierarchy_anchor",
+      "paired_baseline_item_id": "l1_decoder_attention_score32_exact_partial_gqa8_dual_stream_producer_ppa_v1",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_source_only_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_source_only_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_source_only_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/timing_debug_report.md"
+      ],
+      "acceptance_notes": "Run the GQA8 physical-harness generator, guard, run_block_sweep, and timing-summary commands for each config. Keep the sweep bounded, make no I/O pad assumptions, and accept ok, flow_failed, and timeout-class rows as explicit boundary evidence. Treat the structural-only reducer-vs-source_only delta as nonlinear until producer fan-in and global c16 composition are physically closed.",
+      "expected_result": {
+        "direction": "measure_gqa8_local_temporal_reducer_boundary",
+        "reason": "The corrected merged GQA8 harness establishes whether the 53/54-way eight-wave local hierarchy remains physically explorable before producer fan-in and global c16 composition consume it."
+      },
+      "status": "pending",
+      "notes": "Replacement remote OpenROAD request for the corrected GQA8 harness. Generate the work item only after this job-prep change is merged, with developer_loop proposal linkage and source_requirement.required_sha pinned at queue time to the merged origin/master commit."
+    }
+  ],
   "source_refs": [
     "npu/rtlgen/gen_attention_score32_exact_local_temporal_reducer_gqa8.py",
     "npu/rtlgen/gen_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness.py",
@@ -58,7 +96,9 @@
     "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/config.json",
     "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_source_only_w8/config.json",
     "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_w8/config.json",
-    "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/config.json"
+    "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/config.json",
+    "runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary.json",
+    "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/evaluation_requests.json"
   ],
   "knowledge_refs": [
     "npu/docs/attention_score32_exact_local_temporal_reducer_gqa8_contract.md",

--- a/runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary.json
+++ b/runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary.json
@@ -1,0 +1,21 @@
+{
+  "tag_prefix": "attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_v1",
+  "flow_params": {
+    "CLOCK_PERIOD": [
+      8.0,
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2200 2200"
+    ],
+    "CORE_AREA": [
+      "80 80 2120 2120"
+    ],
+    "PLACE_DENSITY": [
+      0.35
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- teach the L1 task generator the corrected GQA8 reducer harness config
- add a bounded macro-style p53/p54 reducer/source-only sweep
- add exact proposal/evaluation linkage for one replacement remote job
- defer the exact source SHA to queue time after this change is merged

## Sweep
- 4 configs: p53/p54 x reducer/source_only
- clock: 8ns, 10ns
- die: 2200um square
- core: 80..2120um
- density: 0.35
- hierarchical synthesis

## Verification
- focused L1 task-generator mapping tests: 2 passed
- proposal/evaluation JSON validation

No DB item was generated and no job was dispatched.
