### PR TITLE
Compose full GQA8 producers with local reducer

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_score32_local_cluster_gqa8_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_local_cluster_gqa8_v1/evaluation_requests.json
@@ -1,0 +1,6 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_score32_local_cluster_gqa8_v1",
+  "proposal_path": "docs/proposals/prop_l1_decoder_attention_score32_local_cluster_gqa8_v1/proposal.json",
+  "source_commit_note": "No DB task should be created from this file yet. Queue-time physical work stays blocked until NoC/SRAM closure and global c16 composition exist on a merged source commit.",
+  "requested_items": []
+}

--- a/docs/proposals/prop_l1_decoder_attention_score32_local_cluster_gqa8_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_local_cluster_gqa8_v1/proposal.json
@@ -1,0 +1,84 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_score32_local_cluster_gqa8_v1",
+  "created_utc": "2026-07-28T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "title": "Functional p53/p54 score32 exact local cluster wrapper with direct producer-to-reducer composition",
+  "abstraction_layer": "decoder_attention_score32_exact_local_cluster_gqa8",
+  "hypothesis": "The final functional local cluster should be the real p53 or p54 architecture: 53 or 54 exact partial GQA8 dual-stream producers, each preserving its own command block count, query/key input, and two value-memory lanes, with every producer result leaf wired index-preserving into the corrected eight-wave GQA8 local temporal reducer.",
+  "direct_comparison": {
+    "primary_question": "Can the full-width functional cluster preserve the real p53/p54 producer composition, corrected rotation schedule, and exact beat-by-beat reducer aggregate without collapsing the architecture into a proxy or hash-only check?",
+    "baselines": [
+      "prop_l1_decoder_attention_score32_exact_partial_gqa8_dual_stream_producer_v1",
+      "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1"
+    ],
+    "candidate": "l1_decoder_attention_score32_local_cluster_gqa8_v1",
+    "include": [
+      "53 or 54 direct producer instances with no reduced proxy wrapper",
+      "broadcast command_id, head_base, multiplier, and shift with packed 15-bit per-producer block counts",
+      "all-or-none atomic wave-command issue across the full producer set",
+      "independent per-producer input valid/ready/last/query/key interfaces",
+      "all 2 x producers value-memory request and response lanes exposed at the top level",
+      "index-preserving producer result leaf wiring into the GQA8 local temporal reducer",
+      "group-major execution across four head bases and eight waves",
+      "structured reference comparison using real producer semantics, staged p53/p54 merge, then eight-wave temporal merge"
+    ],
+    "exclude": [
+      "NoC closure claims",
+      "SRAM macro closure claims",
+      "global c16 exact reduction claims",
+      "dispatch or DB-side evaluation creation",
+      "OpenROAD execution in this change"
+    ],
+    "metrics": [
+      "wave_command_accept_count",
+      "producer_ready_skew_cycles",
+      "producer_protocol_error_bits",
+      "reducer_protocol_error_bits",
+      "exact_output_beats",
+      "exact_metadata_equivalence",
+      "top_pin_bits"
+    ]
+  },
+  "implementation_plan": [
+    {
+      "step": "Generate one reusable producer submodule and instantiate it 53 or 54 times in the cluster wrapper.",
+      "details": "The wrapper must retain the producer's native exact result valid/ready/metadata/value interface and native dual-stream value-memory request/response lanes."
+    },
+    {
+      "step": "Drive the reducer directly from the producer result buses.",
+      "details": "Leaf ordering must stay producer-index preserving and must not add a hash-only or reduced-proxy abstraction layer."
+    },
+    {
+      "step": "Lock the corrected p53/p54 rotation schedule into the reference and probe.",
+      "details": "P53 extras are group0 producers 0..10, group1 11..21, group2 22..32, group3 33..43. P54 extras are group0 0..9, group1 10..19, group2 20..29, group3 30..39. Extras consume two blocks per stream and all other producers consume one."
+    },
+    {
+      "step": "Keep the verification architecture-aligned.",
+      "details": "Mandatory checks are p53 and p54 generation, Verilator lint, guard coverage, corrected schedule tests, direct wiring token tests, and at least one bounded full p53 ideal probe attempt."
+    }
+  ],
+  "required_evaluations": [],
+  "remaining_abstractions": [
+    "NoC and SRAM physical closure remain open because the wrapper only exposes functional request and response lanes.",
+    "Global c16 exact reduction remains open because this wrapper terminates at the local temporal reducer aggregate."
+  ],
+  "source_refs": [
+    "npu/rtlgen/gen_attention_score32_exact_local_cluster_gqa8.py",
+    "npu/eval/probe_attention_score32_exact_local_cluster_gqa8.py",
+    "npu/eval/check_attention_score32_exact_local_cluster_gqa8_guard.py",
+    "npu/sim/perf/attention_exact_partial.py",
+    "runs/designs/npu_blocks/attention_score32_exact_local_cluster_gqa8_p53_w8/config.json",
+    "runs/designs/npu_blocks/attention_score32_exact_local_cluster_gqa8_p54_w8/config.json",
+    "docs/proposals/prop_l1_decoder_attention_score32_local_cluster_gqa8_v1/evaluation_requests.json"
+  ],
+  "knowledge_refs": [
+    "npu/docs/attention_score32_exact_local_cluster_gqa8_contract.md",
+    "npu/docs/attention_score32_exact_local_temporal_reducer_gqa8_contract.md",
+    "npu/docs/attention_score32_exact_partial_gqa8_dual_stream_producer_contract.md"
+  ],
+  "contract_refs": [
+    "npu/docs/attention_score32_exact_local_cluster_gqa8_contract.md"
+  ]
+}

--- a/npu/docs/attention_score32_exact_local_cluster_gqa8_contract.md
+++ b/npu/docs/attention_score32_exact_local_cluster_gqa8_contract.md
@@ -1,0 +1,80 @@
+# Score32 Exact Local Cluster GQA8 Contract
+
+This wrapper is the full-width functional local cluster for the exact score32
+GQA8 path. It is intentionally the real p53 or p54 architecture, not a proxy
+reduction or hash-only equivalence harness.
+
+## Scope
+
+- `53` or `54` exact partial dual-stream producers
+- direct producer leaf wiring into the corrected GQA8 local temporal reducer
+- `4` logical head groups with head bases `[0, 8, 16, 24]`
+- `8` persistent waves per logical group
+- `16` value slices per head
+- `512` final exact partial output beats per full run
+
+## Command Contract
+
+- Shared fields `command_id`, `command_head_base`, `command_score_multiplier`,
+  and `command_score_shift` are broadcast across the full producer set.
+- `command_block_count` is packed as `53 x 15` or `54 x 15` bits, one
+  independent unsigned field per producer.
+- Command issue is atomic across the cluster:
+  - the wrapper may accept a wave command only when every producer is ready;
+  - no subset command acceptance is legal.
+- Wave commands run group-major:
+  - head base `0`, waves `0..7`
+  - head base `8`, waves `0..7`
+  - head base `16`, waves `0..7`
+  - head base `24`, waves `0..7`
+
+## Corrected Rotation Schedule
+
+Each extra producer receives `2` blocks per stream for its logical group. Every
+other producer receives `1`.
+
+### P53
+
+- group `0`: producers `0..10`
+- group `1`: producers `11..21`
+- group `2`: producers `22..32`
+- group `3`: producers `33..43`
+
+### P54
+
+- group `0`: producers `0..9`
+- group `1`: producers `10..19`
+- group `2`: producers `20..29`
+- group `3`: producers `30..39`
+
+Every group still covers exactly `64` blocks per stream.
+
+## Interface Contract
+
+- The wrapper exposes independent producer input `valid`, `ready`, `last`,
+  `query`, and `key` lanes for every producer.
+- The wrapper exposes all `2 x producers` value-memory request and response
+  lanes directly at the top level.
+- The wrapper does not abstract or synthesize an SRAM or NoC fabric internally.
+- Each producer's exact result `valid`, `ready`, `command_id`, `head_id`,
+  `global_max`, `exp_sum`, `slice`, `last`, and `value` connects directly and
+  index-preserving to the matching reducer leaf input.
+
+## Reference And Probe Contract
+
+- Stimulus must use unique data keyed by producer, group, wave, head, and slice
+  so producer permutations cannot pass.
+- The structured reference path is:
+  - real producer reference per wave
+  - staged p53/p54 local merge
+  - eight-wave temporal merge
+- Comparison is exact per beat and checks both metadata and payload. Hash-only
+  equivalence is not sufficient evidence.
+
+## Remaining Abstractions
+
+- `noc_sram_ppa_open`
+- `global_c16_exact_reduction_open`
+
+No claim is made here about NoC closure, SRAM macro closure, or global c16
+composition.

--- a/npu/eval/check_attention_score32_exact_local_cluster_gqa8_guard.py
+++ b/npu/eval/check_attention_score32_exact_local_cluster_gqa8_guard.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""Strict generated RTL guard for the full-width score32 exact local cluster."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import sys
+import tempfile
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_score32_exact_local_cluster_gqa8 import generate
+from npu.sim.perf.attention_exact_partial import (
+    LOCAL_CLUSTER_GQA8_HEAD_BASES,
+    LOCAL_TEMPORAL_WAVES,
+    PARTIAL_LINK_BITS,
+    PARTIAL_PAYLOAD_BITS,
+    exact_local_cluster_gqa8_service_manifest,
+)
+
+_CONFIG_KEY = "attention_score32_exact_local_cluster_gqa8"
+_MANIFEST_NAME = "attention_score32_exact_local_cluster_gqa8_manifest.json"
+_PROPOSAL_ID = "prop_l1_decoder_attention_score32_local_cluster_gqa8_v1"
+_PROPOSAL_PATH = "docs/proposals/prop_l1_decoder_attention_score32_local_cluster_gqa8_v1/proposal.json"
+_PRODUCER_RTL_NAME = "producer.v"
+_REDUCER_RTL_NAME = "reducer.v"
+_VERILATOR_LINT_STUBS_NAME = "verilator_wrapper_blackboxes.v"
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _resolve_selected_config(*, design_dir: Path, selected: Path | None) -> Path:
+    config_path = selected or (design_dir / "config.json")
+    config_path = config_path.resolve()
+    if not config_path.exists():
+        raise SystemExit(f"missing config: {config_path}")
+    try:
+        relative_path = config_path.relative_to(design_dir)
+    except ValueError as exc:
+        raise SystemExit(f"selected config must live under design-dir: {config_path}") from exc
+    if len(relative_path.parts) != 1:
+        raise SystemExit(f"selected config must be a direct child of design-dir, got: {relative_path.as_posix()}")
+    return config_path
+
+
+def _require(mapping: dict[str, object], key: str, expected: object, label: str) -> None:
+    if mapping.get(key) != expected:
+        raise SystemExit(f"{label} {key} must be {expected}")
+
+
+def _require_token(text: str, token: str, label: str) -> None:
+    if token not in text:
+        raise SystemExit(f"{label} missing semantic token: {token}")
+
+
+def _extract_module(rtl: str, module_name: str) -> str:
+    pattern = re.compile(rf"module\s+{re.escape(module_name)}\b.*?endmodule\s*", re.DOTALL)
+    match = pattern.search(rtl)
+    if match is None:
+        raise SystemExit(f"generated RTL does not define module {module_name}")
+    return match.group(0)
+
+
+def _top_pin_bits(*, producers: int) -> int:
+    value_lanes = producers * 2
+    return (
+        2
+        + 1
+        + 1
+        + 16
+        + 5
+        + (producers * 15)
+        + 32
+        + 6
+        + producers
+        + producers
+        + producers
+        + (producers * 128)
+        + (producers * 128)
+        + value_lanes
+        + value_lanes
+        + (value_lanes * 14)
+        + (value_lanes * 4)
+        + value_lanes
+        + value_lanes
+        + (value_lanes * 14)
+        + (value_lanes * 4)
+        + (value_lanes * 512)
+        + 1
+        + 1
+        + 16
+        + 5
+        + 32
+        + 33
+        + 4
+        + 1
+        + PARTIAL_PAYLOAD_BITS
+        + 32
+        + 32
+        + 32
+        + 32
+        + 3
+        + 1
+        + 5
+        + 7
+        + 7
+        + 32
+        + 32
+        + 32
+        + 32
+        + 32
+        + 32
+        + (producers * 32)
+        + (producers * 32)
+        + (producers * 32)
+        + (producers * 64)
+        + (producers * 64)
+        + (producers * 32)
+        + (producers * 32)
+        + (producers * 2)
+        + producers
+        + producers
+        + 1
+        + 1
+        + 1
+        + 1
+        + 1
+        + 1
+    )
+
+
+def _compare_current_generation(*, config: dict[str, object], rtl_dir: Path) -> None:
+    with tempfile.TemporaryDirectory(prefix="score32_exact_local_cluster_gqa8_guard_") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        generate(config, temp_dir)
+        for relative_name in (
+            "top.v",
+            _PRODUCER_RTL_NAME,
+            _REDUCER_RTL_NAME,
+            _VERILATOR_LINT_STUBS_NAME,
+            "config.json",
+            _MANIFEST_NAME,
+        ):
+            generated_text = (temp_dir / relative_name).read_text(encoding="utf-8")
+            current_text = (rtl_dir / relative_name).read_text(encoding="utf-8")
+            if generated_text != current_text:
+                raise SystemExit(f"generated RTL artifacts do not match current generator output: {relative_name}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--design-dir", type=Path, required=True)
+    parser.add_argument("--config", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    design_dir = args.design_dir.resolve()
+    config_path = _resolve_selected_config(design_dir=design_dir, selected=args.config)
+    rtl_dir = design_dir / "verilog"
+    generated_config_path = rtl_dir / "config.json"
+    manifest_path = rtl_dir / _MANIFEST_NAME
+    top_path = rtl_dir / "top.v"
+    producer_path = rtl_dir / _PRODUCER_RTL_NAME
+    reducer_path = rtl_dir / _REDUCER_RTL_NAME
+    lint_stub_path = rtl_dir / _VERILATOR_LINT_STUBS_NAME
+    for path in (config_path, generated_config_path, manifest_path, top_path, producer_path, reducer_path, lint_stub_path):
+        if not path.is_file():
+            raise SystemExit(f"missing full-width local-cluster artifact: {path}")
+
+    config = _load_json(config_path)
+    generated_config = _load_json(generated_config_path)
+    if config != generated_config:
+        raise SystemExit("generated config does not match source config")
+
+    top_name = str(config.get("top_name") or "").strip()
+    body = config.get(_CONFIG_KEY)
+    if not top_name or not isinstance(body, dict):
+        raise SystemExit(f"config must contain top_name and {_CONFIG_KEY}")
+
+    producers = int(body.get("producers", 0))
+    max_blocks = int(body.get("max_blocks", 0))
+    value_slices = int(body.get("value_slices", 0))
+    head_id_bits = int(body.get("head_id_bits", 0))
+    persistent_waves = int(body.get("persistent_waves", 0))
+    if producers not in {53, 54}:
+        raise SystemExit("producers must remain exactly 53 or 54")
+    if max_blocks != 8:
+        raise SystemExit("max_blocks must remain fixed at 8")
+    if value_slices != 16:
+        raise SystemExit("value_slices must remain 16")
+    if head_id_bits != 5:
+        raise SystemExit("head_id_bits must remain 5")
+    if persistent_waves != LOCAL_TEMPORAL_WAVES:
+        raise SystemExit(f"persistent_waves must remain {LOCAL_TEMPORAL_WAVES}")
+
+    probe_defaults = config.get("probe_defaults")
+    if not isinstance(probe_defaults, dict):
+        raise SystemExit("config must include probe_defaults")
+    _require(probe_defaults, "head_bases", list(LOCAL_CLUSTER_GQA8_HEAD_BASES), "probe_defaults")
+    _require(probe_defaults, "head_dim", 1, "probe_defaults")
+    _require(probe_defaults, "seed", 73, "probe_defaults")
+
+    service_model = exact_local_cluster_gqa8_service_manifest(producers=producers)
+    manifest = _load_json(manifest_path)
+    expected_manifest = {
+        "generator": "npu/rtlgen/gen_attention_score32_exact_local_cluster_gqa8.py",
+        "top_name": top_name,
+        "semantic_profile": "score32_exact_local_cluster_gqa8_v1",
+        "producers": producers,
+        "producer_instance_count": producers,
+        "max_blocks": 8,
+        "value_slices": 16,
+        "head_id_bits": 5,
+        "persistent_waves": 8,
+        "query_head_groups": 4,
+        "query_heads_per_group": 8,
+        "value_memory_lanes": producers * 2,
+        "producer_input_lanes": producers,
+        "result_interface": "full_width_exact_gqa8_producer_cluster_to_128beat_aggregate_after_group_major_8wave_reduce",
+        "partial_payload_bits_per_beat": PARTIAL_PAYLOAD_BITS,
+        "partial_link_bits_per_beat": PARTIAL_LINK_BITS,
+        "equivalence_hash": False,
+        "rtl_files": [
+            "top.v",
+            _PRODUCER_RTL_NAME,
+            _REDUCER_RTL_NAME,
+            _VERILATOR_LINT_STUBS_NAME,
+        ],
+        "top_pin_bits": _top_pin_bits(producers=producers),
+        "command_schedule_contract": service_model["top_command_contract"],
+        "atomic_command_issue_contract": service_model["atomic_command_issue_contract"],
+        "producer_input_contract": service_model["producer_input_contract"],
+        "value_memory_contract": service_model["value_memory_contract"],
+        "producer_leaf_wiring_contract": service_model["producer_leaf_wiring_contract"],
+        "local_reduction_contract": service_model["local_reduction_contract"],
+        "temporal_accumulation_contract": service_model["temporal_accumulation_contract"],
+        "comparison_baseline_contract": service_model["comparison_baseline_contract"],
+        "comparison_cycle_origin": service_model["comparison_cycle_origin"],
+        "diagnostic_only_baseline": service_model["diagnostic_only_baseline"],
+        "remaining_abstractions": service_model["remaining_abstractions"],
+        "service_model": service_model,
+        "linked_proposal_id": _PROPOSAL_ID,
+        "linked_proposal_path": _PROPOSAL_PATH,
+    }
+    for key, expected in expected_manifest.items():
+        _require(manifest, key, expected, "generated manifest")
+    _require(manifest, "checked_in_probe_defaults", probe_defaults, "generated manifest")
+
+    links = config.get("report_links")
+    if not isinstance(links, dict):
+        raise SystemExit("config must include report_links for evaluator artifact linkage")
+    _require(links, "proposal_id", _PROPOSAL_ID, "report_links")
+    _require(links, "proposal_path", _PROPOSAL_PATH, "report_links")
+
+    submodule_manifests = manifest.get("submodule_manifests")
+    if not isinstance(submodule_manifests, dict):
+        raise SystemExit("generated manifest must contain submodule_manifests")
+    producer_manifest = submodule_manifests.get("producer")
+    reducer_manifest = submodule_manifests.get("gqa8_local_temporal_reducer")
+    if not isinstance(producer_manifest, dict) or not isinstance(reducer_manifest, dict):
+        raise SystemExit("generated manifest must contain producer and gqa8_local_temporal_reducer submodule manifests")
+    _require(
+        producer_manifest,
+        "generator",
+        "npu/rtlgen/gen_attention_score32_exact_partial_gqa8_dual_stream_producer.py",
+        "producer submodule manifest",
+    )
+    _require(producer_manifest, "max_blocks", 8, "producer submodule manifest")
+    _require(producer_manifest, "query_heads_per_stream", 8, "producer submodule manifest")
+    _require(producer_manifest, "head_id_bits", 5, "producer submodule manifest")
+    _require(
+        reducer_manifest,
+        "generator",
+        "npu/rtlgen/gen_attention_score32_exact_local_temporal_reducer_gqa8.py",
+        "reducer submodule manifest",
+    )
+    _require(reducer_manifest, "producers", producers, "reducer submodule manifest")
+    _require(reducer_manifest, "query_heads_per_group", 8, "reducer submodule manifest")
+
+    top_rtl = top_path.read_text(encoding="utf-8", errors="replace")
+    producer_rtl = producer_path.read_text(encoding="utf-8", errors="replace")
+    reducer_rtl = reducer_path.read_text(encoding="utf-8", errors="replace")
+    lint_stub_rtl = lint_stub_path.read_text(encoding="utf-8", errors="replace")
+    producer_top = f"{top_name}__producer"
+    reducer_top = f"{top_name}__reducer"
+    top_module = _extract_module(top_rtl, top_name)
+    _extract_module(producer_rtl, producer_top)
+    _extract_module(reducer_rtl, reducer_top)
+
+    if len(re.findall(rf"\bmodule\s+{re.escape(producer_top)}\b", producer_rtl)) != 1:
+        raise SystemExit("generated RTL must contain exactly one reusable producer module definition")
+    if len(re.findall(rf"\bmodule\s+{re.escape(reducer_top)}\b", reducer_rtl)) != 1:
+        raise SystemExit("generated RTL must contain exactly one reusable reducer module definition")
+    _require_token(lint_stub_rtl, f"(* blackbox *) module {producer_top}", "Verilator lint stubs")
+    _require_token(lint_stub_rtl, f"(* blackbox *) module {reducer_top}", "Verilator lint stubs")
+    if top_module.count(f"{producer_top} u_producer_") != producers:
+        raise SystemExit(f"generated RTL must instantiate the producer exactly {producers} times")
+    if top_module.count(f"{reducer_top} u_reducer") != 1:
+        raise SystemExit("generated RTL must instantiate the reducer exactly once")
+
+    command_hi = (producers * 15) - 1
+    command_lo = command_hi - 14
+    query_hi = (producers * 128) - 1
+    query_lo = query_hi - 127
+    lane_hi = (producers * 2) - 1
+    lane_lo = lane_hi - 1
+    addr_hi = (producers * 28) - 1
+    addr_lo = addr_hi - 27
+    matrix_hi = (producers * 1024) - 1
+    matrix_lo = matrix_hi - 1023
+    for token in (
+        "wire group_command_fire_w = command_valid && command_ready;",
+        "wire [PRODUCERS-1:0] producer_command_accept_w = {PRODUCERS{group_command_fire_w}} & producer_command_ready_w;",
+        "assign command_ready = &producer_command_ready_w;",
+        "assign protocol_error = atomic_command_protocol_error_q || (|producer_protocol_error) || reducer_protocol_error;",
+        ".command_valid(group_command_fire_w)",
+        ".leaf_valid(producer_result_valid_w)",
+        ".leaf_ready(producer_result_ready_w)",
+        ".leaf_command_id(producer_result_command_id_w)",
+        ".leaf_head_id(producer_result_head_id_w)",
+        ".leaf_global_max(producer_result_global_max_w)",
+        ".leaf_exp_sum(producer_result_exp_sum_w)",
+        ".leaf_slice(producer_result_slice_w)",
+        ".leaf_last(producer_result_last_w)",
+        ".leaf_value(producer_result_value_w)",
+        "wave_command_accept_count_q <= wave_command_accept_count_q + 1'b1;",
+        "producer_ready_skew_cycles_q <= producer_ready_skew_cycles_q + 1'b1;",
+        "if (producer_command_accept_w != {PRODUCERS{1'b1}}) begin",
+        ".command_block_count(command_block_count[14:0])",
+        f".command_block_count(command_block_count[{command_hi}:{command_lo}])",
+        ".input_query(input_query[127:0])",
+        f".input_query(input_query[{query_hi}:{query_lo}])",
+        ".value_read_req_valid(value_read_req_valid[1:0])",
+        f".value_read_req_valid(value_read_req_valid[{lane_hi}:{lane_lo}])",
+        ".value_read_req_address(value_read_req_address[27:0])",
+        f".value_read_req_address(value_read_req_address[{addr_hi}:{addr_lo}])",
+        ".value_response_matrix(value_response_matrix[1023:0])",
+        f".value_response_matrix(value_response_matrix[{matrix_hi}:{matrix_lo}])",
+    ):
+        _require_token(top_module, token, "generated RTL")
+
+    for forbidden in ("equivalence_hash", "result_hash", "reduced_proxy", "hash_only"):
+        if forbidden in top_module:
+            raise SystemExit(f"full-width local-cluster RTL must not contain {forbidden} tokens")
+
+    _compare_current_generation(config=config, rtl_dir=rtl_dir)
+
+    print(
+        json.dumps(
+            {
+                "design": top_name,
+                "guard": "attention_score32_exact_local_cluster_gqa8_v1",
+                "producers": producers,
+                "top_pin_bits": _top_pin_bits(producers=producers),
+                "status": "ok",
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/probe_attention_score32_exact_local_cluster_gqa8.py
+++ b/npu/eval/probe_attention_score32_exact_local_cluster_gqa8.py
@@ -1,0 +1,1199 @@
+#!/usr/bin/env python3
+"""Probe the full-width score32 exact local cluster against a structured reference."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_score32_exact_local_cluster_gqa8 import generate
+from npu.sim.perf.attention_exact_partial import (
+    LOCAL_CLUSTER_GQA8_HEAD_BASES,
+    LOCAL_TEMPORAL_WAVES,
+    exact_local_cluster_gqa8_command_block_counts,
+    exact_local_cluster_gqa8_extra_producers,
+    exact_local_cluster_gqa8_service_manifest,
+    merge_partial_streams,
+    partial_stream_from_blocks,
+    reduce_local_temporal_partial_waves,
+    unpack_numerators,
+)
+from npu.sim.perf.attention_online import requantize_score_row
+
+JsonDict = dict[str, Any]
+
+_CONFIG_KEY = "attention_score32_exact_local_cluster_gqa8"
+_COMMAND_RE = re.compile(
+    r"COMMAND_ACCEPT idx=(\d+) cmd=(\d+) head_base=(\d+) group=(\d+) wave=(\d+) cycle=(\d+)"
+)
+_RESULT_RE = re.compile(
+    r"RESULT idx=(\d+) cmd=(\d+) head=(\d+) slice=(\d+) last=(\d+) max=(-?\d+) sum=(\d+) value=([0-9a-fA-F]+) cycle=(\d+)"
+)
+_PRODUCER_RE = re.compile(
+    r"PRODUCER idx=(\d+) accept=(\d+) complete=(\d+) merge=(\d+) stall=(\d+) "
+    r"stream0_accept=(\d+) stream1_accept=(\d+) stream0_complete=(\d+) stream1_complete=(\d+) "
+    r"stream_error=(\d+) merge_error=(\d+) protocol=(\d+)"
+)
+_SUMMARY_RE = re.compile(
+    r"SUMMARY outputs=(\d+) drain=(\d+) protocol_error=(\d+) atomic_error=(\d+) group_error=(\d+) "
+    r"local_tree_error=(\d+) temporal_error=(\d+) reducer_error=(\d+) wave_accept=(\d+) "
+    r"group_complete=(\d+) local_root_completed=(\d+) temporal_completed=(\d+) emitted=(\d+) "
+    r"issue_wait=(\d+) ready_skew=(\d+)"
+)
+_TB_TIMEOUT_RE = re.compile(r"TIMEOUT cycle=(\d+)")
+
+_FAKERAM_MODEL = """
+module fakeram45_2048x39 (
+    output wire [38:0] rd_out, input wire [10:0] addr_in,
+    input wire we_in, input wire [38:0] wd_in, input wire [38:0] w_mask_in,
+    input wire clk, input wire ce_in
+);
+  reg [38:0] mem [0:2047];
+  reg [10:0] addr_q;
+  reg [38:0] rd_out_q;
+  integer idx;
+  initial begin
+    addr_q = 0;
+    rd_out_q = 0;
+    for (idx = 0; idx < 2048; idx = idx + 1) mem[idx] = 0;
+  end
+  always @(posedge clk) begin
+    rd_out_q <= mem[addr_q];
+    if (ce_in) begin
+      if (we_in) begin
+        for (idx = 0; idx < 39; idx = idx + 1) begin
+          if (w_mask_in[idx]) mem[addr_in][idx] <= wd_in[idx];
+        end
+      end
+      addr_q <= addr_in;
+    end
+  end
+  assign rd_out = rd_out_q;
+endmodule
+"""
+
+
+def _tool(name: str) -> str:
+    path = shutil.which(name)
+    if path:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    if fallback.exists():
+        return str(fallback)
+    raise RuntimeError(f"required tool unavailable: {name}")
+
+
+def _pack(values: list[int], bits: int) -> int:
+    mask = (1 << bits) - 1
+    return sum((int(value) & mask) << (index * bits) for index, value in enumerate(values))
+
+
+def _default_config(producers: int = 53) -> JsonDict:
+    return {
+        "top_name": f"attention_score32_exact_local_cluster_gqa8_p{producers}_w8",
+        _CONFIG_KEY: {
+            "producers": producers,
+            "max_blocks": 8,
+            "value_slices": 16,
+            "head_id_bits": 5,
+            "persistent_waves": 8,
+        },
+        "probe_defaults": {
+            "head_bases": [0, 8, 16, 24],
+            "head_dim": 1,
+            "seed": 73,
+            "timeout_s": 300,
+        },
+        "report_links": {
+            "proposal_id": "prop_l1_decoder_attention_score32_local_cluster_gqa8_v1",
+            "proposal_path": "docs/proposals/prop_l1_decoder_attention_score32_local_cluster_gqa8_v1/proposal.json",
+        },
+    }
+
+
+def _resolve_workload(
+    config: JsonDict,
+    *,
+    head_dim: int | None,
+    seed: int | None,
+    head_bases: tuple[int, ...] | None = None,
+    timeout_s: int | None = None,
+) -> dict[str, object]:
+    defaults = config.get("probe_defaults", {})
+    if not isinstance(defaults, dict):
+        defaults = {}
+    resolved_head_dim = int(head_dim if head_dim is not None else defaults.get("head_dim", 1))
+    resolved_seed = int(seed if seed is not None else defaults.get("seed", 73))
+    configured_head_bases = head_bases
+    if configured_head_bases is None and isinstance(defaults.get("head_bases"), list):
+        configured_head_bases = tuple(int(value) for value in defaults["head_bases"])
+    if configured_head_bases is None:
+        configured_head_bases = LOCAL_CLUSTER_GQA8_HEAD_BASES
+    resolved_timeout_s = int(timeout_s if timeout_s is not None else defaults.get("timeout_s", 300))
+
+    if configured_head_bases != LOCAL_CLUSTER_GQA8_HEAD_BASES:
+        raise ValueError(f"head_bases must remain fixed at {LOCAL_CLUSTER_GQA8_HEAD_BASES}")
+    if resolved_head_dim < 1:
+        raise ValueError("head_dim must be positive")
+    if resolved_timeout_s < 1:
+        raise ValueError("timeout_s must be positive")
+
+    return {
+        "head_bases": configured_head_bases,
+        "head_dim": resolved_head_dim,
+        "seed": resolved_seed,
+        "timeout_s": resolved_timeout_s,
+        "groups": len(configured_head_bases),
+        "waves": LOCAL_TEMPORAL_WAVES,
+        "wave_commands": len(configured_head_bases) * LOCAL_TEMPORAL_WAVES,
+    }
+
+
+def _logical_commands(head_bases: tuple[int, ...]) -> tuple[dict[str, int], ...]:
+    schedule = []
+    for group_index, head_base in enumerate(head_bases):
+        if group_index == 0:
+            multiplier, shift = (1 << 20), 0
+        elif group_index == 1:
+            multiplier, shift = 13, 1
+        elif group_index == 2:
+            multiplier, shift = 29, 2
+        else:
+            multiplier, shift = 37, 1
+        schedule.append(
+            {
+                "group_index": group_index,
+                "command_id": 0x7D00 + group_index,
+                "head_base": int(head_base),
+                "multiplier": multiplier,
+                "shift": shift,
+            }
+        )
+    return tuple(schedule)
+
+
+def _wave_commands(producers: int, workload: dict[str, object]) -> tuple[dict[str, object], ...]:
+    commands = []
+    for logical_command in _logical_commands(tuple(int(value) for value in workload["head_bases"])):
+        group_index = int(logical_command["group_index"])
+        block_counts = exact_local_cluster_gqa8_command_block_counts(producers=producers, group_index=group_index)
+        for wave_index in range(LOCAL_TEMPORAL_WAVES):
+            commands.append(
+                {
+                    **logical_command,
+                    "wave_index": wave_index,
+                    "block_counts": block_counts,
+                }
+            )
+    return tuple(commands)
+
+
+def _stream_block_beats(
+    *,
+    producer: int,
+    group_index: int,
+    wave_index: int,
+    stream: int,
+    block_count: int,
+    head_dim: int,
+    seed: int,
+) -> tuple[tuple[tuple[tuple[int, ...], tuple[int, ...]], ...], ...]:
+    blocks = []
+    for block_index in range(block_count):
+        beats = []
+        for beat_index in range(head_dim):
+            queries = tuple(
+                (
+                    (
+                        seed * 17
+                        + producer * 19
+                        + group_index * 23
+                        + wave_index * 29
+                        + stream * 31
+                        + block_index * 37
+                        + beat_index * 41
+                        + head_lane * 43
+                    )
+                    % 127
+                )
+                - 63
+                for head_lane in range(8)
+            )
+            keys = tuple(
+                (
+                    (
+                        seed * 47
+                        + producer * 53
+                        + group_index * 59
+                        + wave_index * 61
+                        + stream * 67
+                        + block_index * 71
+                        + beat_index * 73
+                        + token_lane * 79
+                    )
+                    % 127
+                )
+                - 63
+                for token_lane in range(8)
+            )
+            beats.append((queries, keys))
+        blocks.append(tuple(beats))
+    return tuple(blocks)
+
+
+def _value_blocks(
+    *,
+    producer: int,
+    group_index: int,
+    wave_index: int,
+    stream: int,
+    block_count: int,
+    seed: int,
+) -> tuple[tuple[tuple[tuple[int, ...], ...], ...], ...]:
+    return tuple(
+        tuple(
+            tuple(
+                tuple(
+                    (
+                        (
+                            seed * 83
+                            + producer * 89
+                            + group_index * 97
+                            + wave_index * 101
+                            + stream * 103
+                            + block_index * 107
+                            + value_slice * 109
+                            + row * 113
+                            + lane * 127
+                        )
+                        % 255
+                    )
+                    - 127
+                    for lane in range(8)
+                )
+                for row in range(8)
+            )
+            for value_slice in range(16)
+        )
+        for block_index in range(block_count)
+    )
+
+
+def _raw_scores(block: tuple[tuple[int, ...], tuple[int, ...]], head_lane: int) -> list[int]:
+    return [
+        sum(queries[head_lane] * keys[token_lane] for queries, keys in block)
+        for token_lane in range(8)
+    ]
+
+
+def _producer_wave_stream(
+    *,
+    producer: int,
+    logical_command: dict[str, int],
+    wave_index: int,
+    block_count: int,
+    head_dim: int,
+    seed: int,
+) -> tuple[object, ...]:
+    merged_per_head = []
+    for head_lane in range(8):
+        stream_partials = []
+        for stream in range(2):
+            blocks = _stream_block_beats(
+                producer=producer,
+                group_index=int(logical_command["group_index"]),
+                wave_index=wave_index,
+                stream=stream,
+                block_count=block_count,
+                head_dim=head_dim,
+                seed=seed,
+            )
+            score_rows = [
+                list(
+                    requantize_score_row(
+                        _raw_scores(block, head_lane),
+                        multiplier=int(logical_command["multiplier"]),
+                        shift=int(logical_command["shift"]),
+                    )
+                )
+                for block in blocks
+            ]
+            stream_partials.append(
+                partial_stream_from_blocks(
+                    command_id=int(logical_command["command_id"]),
+                    head_id=int(logical_command["head_base"]) + head_lane,
+                    score_rows=score_rows,
+                    value_blocks=_value_blocks(
+                        producer=producer,
+                        group_index=int(logical_command["group_index"]),
+                        wave_index=wave_index,
+                        stream=stream,
+                        block_count=block_count,
+                        seed=seed,
+                    ),
+                )
+            )
+        merged_per_head.append(merge_partial_streams(stream_partials[0], stream_partials[1]))
+    return tuple(beat for head_stream in merged_per_head for beat in head_stream)
+
+
+def _expected_rows(producers: int, workload: dict[str, object]) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for logical_command in _logical_commands(tuple(int(value) for value in workload["head_bases"])):
+        waves = []
+        for wave_index in range(LOCAL_TEMPORAL_WAVES):
+            producer_streams = []
+            block_counts = exact_local_cluster_gqa8_command_block_counts(
+                producers=producers,
+                group_index=int(logical_command["group_index"]),
+            )
+            for producer in range(producers):
+                producer_streams.append(
+                    _producer_wave_stream(
+                        producer=producer,
+                        logical_command=logical_command,
+                        wave_index=wave_index,
+                        block_count=int(block_counts[producer]),
+                        head_dim=int(workload["head_dim"]),
+                        seed=int(workload["seed"]),
+                    )
+                )
+            waves.append(tuple(producer_streams))
+        for beat in reduce_local_temporal_partial_waves(tuple(waves)):
+            rows.append(
+                {
+                    "command_id": beat.command_id,
+                    "head_id": beat.head_id,
+                    "slice": beat.slice_index,
+                    "last": beat.last,
+                    "global_max": beat.max_score,
+                    "exp_sum": beat.exp_sum,
+                    "value": list(beat.numerators),
+                }
+            )
+    return rows
+
+
+def _producer_command_data(
+    *,
+    producers: int,
+    workload: dict[str, object],
+) -> dict[str, object]:
+    wave_commands = _wave_commands(producers, workload)
+    head_dim = int(workload["head_dim"])
+    seed = int(workload["seed"])
+    max_beats_per_producer = 0
+    max_blocks_per_producer = 0
+    query_mem: list[list[int]] = []
+    key_mem: list[list[int]] = []
+    last_mem: list[int] = []
+    value_mem: list[list[int]] = []
+    beat_limits = [[0 for _ in range(producers)] for _ in range(len(wave_commands))]
+    block_offsets = [[0 for _ in range(producers)] for _ in range(len(wave_commands))]
+
+    for producer in range(producers):
+        producer_queries: list[int] = []
+        producer_keys: list[int] = []
+        producer_lasts: list[int] = []
+        producer_blocks_flat: list[list[list[int]]] = [[], []]
+        cumulative_beats = 0
+        cumulative_blocks = 0
+        for command_index, wave_command in enumerate(wave_commands):
+            block_count = int(tuple(int(value) for value in wave_command["block_counts"])[producer])
+            block_offsets[command_index][producer] = cumulative_blocks
+            blocks0 = _stream_block_beats(
+                producer=producer,
+                group_index=int(wave_command["group_index"]),
+                wave_index=int(wave_command["wave_index"]),
+                stream=0,
+                block_count=block_count,
+                head_dim=head_dim,
+                seed=seed,
+            )
+            blocks1 = _stream_block_beats(
+                producer=producer,
+                group_index=int(wave_command["group_index"]),
+                wave_index=int(wave_command["wave_index"]),
+                stream=1,
+                block_count=block_count,
+                head_dim=head_dim,
+                seed=seed,
+            )
+            values0 = _value_blocks(
+                producer=producer,
+                group_index=int(wave_command["group_index"]),
+                wave_index=int(wave_command["wave_index"]),
+                stream=0,
+                block_count=block_count,
+                seed=seed,
+            )
+            values1 = _value_blocks(
+                producer=producer,
+                group_index=int(wave_command["group_index"]),
+                wave_index=int(wave_command["wave_index"]),
+                stream=1,
+                block_count=block_count,
+                seed=seed,
+            )
+            for block_index in range(block_count):
+                producer_blocks_flat[0].append(
+                    [[lane for row in values0[block_index][value_slice] for lane in row] for value_slice in range(16)]
+                )
+                producer_blocks_flat[1].append(
+                    [[lane for row in values1[block_index][value_slice] for lane in row] for value_slice in range(16)]
+                )
+                for beat_index in range(head_dim):
+                    queries0, keys0 = blocks0[block_index][beat_index]
+                    queries1, keys1 = blocks1[block_index][beat_index]
+                    producer_queries.append(_pack(list(queries0), 8) | (_pack(list(queries1), 8) << 64))
+                    producer_keys.append(_pack(list(keys0), 8) | (_pack(list(keys1), 8) << 64))
+                    producer_lasts.append(1 if beat_index == head_dim - 1 else 0)
+            cumulative_beats += block_count * head_dim
+            cumulative_blocks += block_count
+            beat_limits[command_index][producer] = cumulative_beats
+        max_beats_per_producer = max(max_beats_per_producer, cumulative_beats)
+        max_blocks_per_producer = max(max_blocks_per_producer, cumulative_blocks)
+        query_mem.append(producer_queries)
+        key_mem.append(producer_keys)
+        last_mem.append(producer_lasts)
+        stream_values: list[list[int]] = [[], []]
+        for stream in range(2):
+            for block_slices in producer_blocks_flat[stream]:
+                for flat_slice in block_slices:
+                    stream_values[stream].append(_pack(flat_slice, 8))
+        value_mem.append(stream_values[0])
+        value_mem.append(stream_values[1])
+
+    return {
+        "wave_commands": wave_commands,
+        "query_mem": query_mem,
+        "key_mem": key_mem,
+        "last_mem": last_mem,
+        "value_mem": value_mem,
+        "beat_limits": beat_limits,
+        "block_offsets": block_offsets,
+        "max_beats_per_producer": max_beats_per_producer,
+        "max_blocks_per_producer": max_blocks_per_producer,
+    }
+
+
+def _testbench(
+    *,
+    top_name: str,
+    producers: int,
+    workload: dict[str, object],
+    output_ready_pattern: tuple[bool, ...],
+) -> str:
+    command_data = _producer_command_data(producers=producers, workload=workload)
+    wave_commands = tuple(command_data["wave_commands"])
+    query_mem = command_data["query_mem"]
+    key_mem = command_data["key_mem"]
+    last_mem = command_data["last_mem"]
+    value_mem = command_data["value_mem"]
+    beat_limits = command_data["beat_limits"]
+    block_offsets = command_data["block_offsets"]
+    max_beats_per_producer = int(command_data["max_beats_per_producer"])
+    max_blocks_per_producer = int(command_data["max_blocks_per_producer"])
+    total_results = len(LOCAL_CLUSTER_GQA8_HEAD_BASES) * 8 * 16
+
+    cmd_init = []
+    for command_index, wave_command in enumerate(wave_commands):
+        cmd_init.append(
+            f"    cmd_id_mem[{command_index}] = 16'h{int(wave_command['command_id']):04x}; "
+            f"cmd_head_base_mem[{command_index}] = 5'd{int(wave_command['head_base'])}; "
+            f"cmd_multiplier_mem[{command_index}] = 32'd{int(wave_command['multiplier'])}; "
+            f"cmd_shift_mem[{command_index}] = 6'd{int(wave_command['shift'])}; "
+            f"cmd_block_count_mem[{command_index}] = {producers * 15}'h{_pack(list(int(v) for v in wave_command['block_counts']), 15):x};"
+        )
+    beat_limit_init = []
+    for command_index in range(len(wave_commands)):
+        for producer in range(producers):
+            beat_limit_init.append(
+                f"    cmd_beat_limit_mem[{command_index}][{producer}] = 32'd{int(beat_limits[command_index][producer])}; "
+                f"cmd_block_offset_mem[{command_index}][{producer}] = 32'd{int(block_offsets[command_index][producer])};"
+            )
+    beat_init = []
+    for producer in range(producers):
+        for beat_index, packed_query in enumerate(query_mem[producer]):
+            flat_index = (producer * max_beats_per_producer) + beat_index
+            beat_init.append(
+                f"    query_mem[{flat_index}] = 128'h{packed_query:032x}; "
+                f"key_mem[{flat_index}] = 128'h{int(key_mem[producer][beat_index]):032x}; "
+                f"last_mem[{flat_index}] = 1'b{int(last_mem[producer][beat_index])};"
+            )
+    value_init = []
+    for producer_stream in range(producers * 2):
+        for slice_index, packed_matrix in enumerate(value_mem[producer_stream]):
+            flat_index = (producer_stream * max_blocks_per_producer * 16) + slice_index
+            value_init.append(f"    value_mem[{flat_index}] = 512'h{int(packed_matrix):0128x};")
+    ready_init = "\n".join(
+        f"    result_ready_mem[{index}] = 1'b{1 if value else 0};" for index, value in enumerate(output_ready_pattern)
+    )
+    return f"""`timescale 1ns/1ps
+module tb;
+  localparam integer PRODUCERS = {producers};
+  localparam integer VALUE_LANES = PRODUCERS * 2;
+  localparam integer COMMAND_COUNT = {len(wave_commands)};
+  localparam integer MAX_BEATS_PER_PRODUCER = {max_beats_per_producer};
+  localparam integer MAX_BLOCKS_PER_PRODUCER = {max_blocks_per_producer};
+  localparam integer TOTAL_RESULTS = {total_results};
+  localparam integer READY_PATTERN_LEN = {len(output_ready_pattern)};
+
+  reg clk = 0;
+  reg rst_n = 0;
+  integer cycle = 0;
+  integer issued_commands = 0;
+  integer active_command_index = -1;
+  integer result_seen = 0;
+  reg pending_summary = 0;
+
+  reg [15:0] cmd_id_mem [0:COMMAND_COUNT-1];
+  reg [4:0] cmd_head_base_mem [0:COMMAND_COUNT-1];
+  reg [31:0] cmd_multiplier_mem [0:COMMAND_COUNT-1];
+  reg [5:0] cmd_shift_mem [0:COMMAND_COUNT-1];
+  reg [(PRODUCERS*15)-1:0] cmd_block_count_mem [0:COMMAND_COUNT-1];
+  reg [31:0] cmd_beat_limit_mem [0:COMMAND_COUNT-1][0:PRODUCERS-1];
+  reg [31:0] cmd_block_offset_mem [0:COMMAND_COUNT-1][0:PRODUCERS-1];
+
+  reg [127:0] query_mem [0:(PRODUCERS*MAX_BEATS_PER_PRODUCER)-1];
+  reg [127:0] key_mem [0:(PRODUCERS*MAX_BEATS_PER_PRODUCER)-1];
+  reg last_mem [0:(PRODUCERS*MAX_BEATS_PER_PRODUCER)-1];
+  reg [511:0] value_mem [0:(VALUE_LANES*MAX_BLOCKS_PER_PRODUCER*16)-1];
+  reg result_ready_mem [0:READY_PATTERN_LEN-1];
+
+  reg command_valid;
+  wire command_ready;
+  reg [15:0] command_id;
+  reg [4:0] command_head_base;
+  reg [(PRODUCERS*15)-1:0] command_block_count;
+  reg [31:0] command_score_multiplier;
+  reg [5:0] command_score_shift;
+  reg [PRODUCERS-1:0] input_valid;
+  wire [PRODUCERS-1:0] input_ready;
+  reg [PRODUCERS-1:0] input_last;
+  reg signed [(PRODUCERS*128)-1:0] input_query;
+  reg signed [(PRODUCERS*128)-1:0] input_key;
+  wire [VALUE_LANES-1:0] value_read_req_valid;
+  reg  [VALUE_LANES-1:0] value_read_req_ready;
+  wire [(VALUE_LANES*14)-1:0] value_read_req_address;
+  wire [(VALUE_LANES*4)-1:0] value_read_req_slice;
+  reg  [VALUE_LANES-1:0] value_response_valid;
+  wire [VALUE_LANES-1:0] value_response_ready;
+  reg  [(VALUE_LANES*14)-1:0] value_response_address;
+  reg  [(VALUE_LANES*4)-1:0] value_response_slice;
+  reg  [(VALUE_LANES*512)-1:0] value_response_matrix;
+  wire out_valid;
+  reg out_ready;
+  wire [15:0] out_command_id;
+  wire [4:0] out_head_id;
+  wire signed [31:0] out_global_max;
+  wire [32:0] out_exp_sum;
+  wire [3:0] out_slice;
+  wire out_last;
+  wire [327:0] out_value;
+  wire [31:0] cluster_cycle_count;
+  wire [31:0] wave_command_accept_count;
+  wire [31:0] wave_command_issue_wait_cycles;
+  wire [31:0] producer_ready_skew_cycles;
+  wire [2:0] reducer_active_wave_index;
+  wire reducer_emitting;
+  wire [4:0] reducer_active_head_base;
+  wire [6:0] reducer_collect_beat_index;
+  wire [6:0] reducer_emit_beat_index;
+  wire [31:0] reducer_cycle_count;
+  wire [31:0] reducer_local_root_completed_count;
+  wire [31:0] reducer_temporal_merge_completed_count;
+  wire [31:0] reducer_emitted_beat_count;
+  wire [31:0] reducer_completed_command_count;
+  wire [31:0] reducer_local_stall_cycles;
+  wire [31:0] reducer_output_stall_cycles;
+  wire [(PRODUCERS*32)-1:0] producer_cycle_count;
+  wire [(PRODUCERS*32)-1:0] producer_command_accept_count;
+  wire [(PRODUCERS*32)-1:0] producer_command_completed_count;
+  wire [(PRODUCERS*64)-1:0] producer_stream_command_accept_count;
+  wire [(PRODUCERS*64)-1:0] producer_stream_completed_count;
+  wire [(PRODUCERS*32)-1:0] producer_merge_completed_count;
+  wire [(PRODUCERS*32)-1:0] producer_result_stall_cycles;
+  wire [(PRODUCERS*2)-1:0] producer_stream_protocol_error;
+  wire [PRODUCERS-1:0] producer_merge_protocol_error;
+  wire [PRODUCERS-1:0] producer_protocol_error;
+  wire group_contract_error;
+  wire local_tree_protocol_error;
+  wire temporal_merge_protocol_error;
+  wire reducer_protocol_error;
+  wire atomic_command_protocol_error;
+  wire protocol_error;
+
+  integer beat_issue [0:PRODUCERS-1];
+  reg pending_valid [0:VALUE_LANES-1];
+  reg [13:0] pending_addr [0:VALUE_LANES-1];
+  reg [3:0] pending_slice [0:VALUE_LANES-1];
+  integer pending_delay [0:VALUE_LANES-1];
+  integer producer_index;
+  integer lane_index;
+  integer stream_index;
+  integer flat_index;
+  integer response_index;
+  integer init_index;
+
+  always #5 clk = ~clk;
+
+  {top_name} dut (
+      .clk(clk),
+      .rst_n(rst_n),
+      .command_valid(command_valid),
+      .command_ready(command_ready),
+      .command_id(command_id),
+      .command_head_base(command_head_base),
+      .command_block_count(command_block_count),
+      .command_score_multiplier(command_score_multiplier),
+      .command_score_shift(command_score_shift),
+      .input_valid(input_valid),
+      .input_ready(input_ready),
+      .input_last(input_last),
+      .input_query(input_query),
+      .input_key(input_key),
+      .value_read_req_valid(value_read_req_valid),
+      .value_read_req_ready(value_read_req_ready),
+      .value_read_req_address(value_read_req_address),
+      .value_read_req_slice(value_read_req_slice),
+      .value_response_valid(value_response_valid),
+      .value_response_ready(value_response_ready),
+      .value_response_address(value_response_address),
+      .value_response_slice(value_response_slice),
+      .value_response_matrix(value_response_matrix),
+      .out_valid(out_valid),
+      .out_ready(out_ready),
+      .out_command_id(out_command_id),
+      .out_head_id(out_head_id),
+      .out_global_max(out_global_max),
+      .out_exp_sum(out_exp_sum),
+      .out_slice(out_slice),
+      .out_last(out_last),
+      .out_value(out_value),
+      .cluster_cycle_count(cluster_cycle_count),
+      .wave_command_accept_count(wave_command_accept_count),
+      .wave_command_issue_wait_cycles(wave_command_issue_wait_cycles),
+      .producer_ready_skew_cycles(producer_ready_skew_cycles),
+      .reducer_active_wave_index(reducer_active_wave_index),
+      .reducer_emitting(reducer_emitting),
+      .reducer_active_head_base(reducer_active_head_base),
+      .reducer_collect_beat_index(reducer_collect_beat_index),
+      .reducer_emit_beat_index(reducer_emit_beat_index),
+      .reducer_cycle_count(reducer_cycle_count),
+      .reducer_local_root_completed_count(reducer_local_root_completed_count),
+      .reducer_temporal_merge_completed_count(reducer_temporal_merge_completed_count),
+      .reducer_emitted_beat_count(reducer_emitted_beat_count),
+      .reducer_completed_command_count(reducer_completed_command_count),
+      .reducer_local_stall_cycles(reducer_local_stall_cycles),
+      .reducer_output_stall_cycles(reducer_output_stall_cycles),
+      .producer_cycle_count(producer_cycle_count),
+      .producer_command_accept_count(producer_command_accept_count),
+      .producer_command_completed_count(producer_command_completed_count),
+      .producer_stream_command_accept_count(producer_stream_command_accept_count),
+      .producer_stream_completed_count(producer_stream_completed_count),
+      .producer_merge_completed_count(producer_merge_completed_count),
+      .producer_result_stall_cycles(producer_result_stall_cycles),
+      .producer_stream_protocol_error(producer_stream_protocol_error),
+      .producer_merge_protocol_error(producer_merge_protocol_error),
+      .producer_protocol_error(producer_protocol_error),
+      .group_contract_error(group_contract_error),
+      .local_tree_protocol_error(local_tree_protocol_error),
+      .temporal_merge_protocol_error(temporal_merge_protocol_error),
+      .reducer_protocol_error(reducer_protocol_error),
+      .atomic_command_protocol_error(atomic_command_protocol_error),
+      .protocol_error(protocol_error)
+  );
+
+  always @* begin
+    command_valid = rst_n && (issued_commands < COMMAND_COUNT);
+    command_id = command_valid ? cmd_id_mem[issued_commands] : 16'd0;
+    command_head_base = command_valid ? cmd_head_base_mem[issued_commands] : 5'd0;
+    command_block_count = command_valid ? cmd_block_count_mem[issued_commands] : {{(PRODUCERS*15){{1'b0}}}};
+    command_score_multiplier = command_valid ? cmd_multiplier_mem[issued_commands] : 32'd0;
+    command_score_shift = command_valid ? cmd_shift_mem[issued_commands] : 6'd0;
+    input_valid = {{PRODUCERS{{1'b0}}}};
+    input_last = {{PRODUCERS{{1'b0}}}};
+    input_query = {{(PRODUCERS*128){{1'b0}}}};
+    input_key = {{(PRODUCERS*128){{1'b0}}}};
+    value_read_req_ready = {{VALUE_LANES{{1'b1}}}};
+    out_ready = result_ready_mem[cycle % READY_PATTERN_LEN];
+    for (producer_index = 0; producer_index < PRODUCERS; producer_index = producer_index + 1) begin
+      if (rst_n && (active_command_index >= 0) && (beat_issue[producer_index] < cmd_beat_limit_mem[active_command_index][producer_index])) begin
+        flat_index = (producer_index * MAX_BEATS_PER_PRODUCER) + beat_issue[producer_index];
+        input_valid[producer_index] = 1'b1;
+        input_last[producer_index] = last_mem[flat_index];
+        input_query[(producer_index * 128) +: 128] = query_mem[flat_index];
+        input_key[(producer_index * 128) +: 128] = key_mem[flat_index];
+      end
+    end
+  end
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      cycle <= 0;
+      issued_commands <= 0;
+      active_command_index <= -1;
+      result_seen <= 0;
+      pending_summary <= 1'b0;
+      value_response_valid <= {{VALUE_LANES{{1'b0}}}};
+      value_response_address <= {{(VALUE_LANES*14){{1'b0}}}};
+      value_response_slice <= {{(VALUE_LANES*4){{1'b0}}}};
+      value_response_matrix <= {{(VALUE_LANES*512){{1'b0}}}};
+      for (producer_index = 0; producer_index < PRODUCERS; producer_index = producer_index + 1) begin
+        beat_issue[producer_index] <= 0;
+      end
+      for (lane_index = 0; lane_index < VALUE_LANES; lane_index = lane_index + 1) begin
+        pending_valid[lane_index] <= 1'b0;
+        pending_addr[lane_index] <= 14'd0;
+        pending_slice[lane_index] <= 4'd0;
+        pending_delay[lane_index] <= 0;
+      end
+    end else begin
+      cycle <= cycle + 1;
+      if (command_valid && command_ready) begin
+        active_command_index <= issued_commands;
+        $display(
+          "COMMAND_ACCEPT idx=%0d cmd=%0d head_base=%0d group=%0d wave=%0d cycle=%0d",
+          issued_commands,
+          cmd_id_mem[issued_commands],
+          cmd_head_base_mem[issued_commands],
+          issued_commands / {LOCAL_TEMPORAL_WAVES},
+          issued_commands % {LOCAL_TEMPORAL_WAVES},
+          cluster_cycle_count
+        );
+        issued_commands <= issued_commands + 1;
+      end
+
+      for (producer_index = 0; producer_index < PRODUCERS; producer_index = producer_index + 1) begin
+        if (input_valid[producer_index] && input_ready[producer_index]) begin
+          beat_issue[producer_index] <= beat_issue[producer_index] + 1;
+        end
+      end
+
+      for (lane_index = 0; lane_index < VALUE_LANES; lane_index = lane_index + 1) begin
+        if (value_response_valid[lane_index] && value_response_ready[lane_index]) begin
+          value_response_valid[lane_index] <= 1'b0;
+        end
+        if (value_read_req_valid[lane_index] && value_read_req_ready[lane_index]) begin
+          if (pending_valid[lane_index]) $fatal(1, "value lane %0d multiple outstanding request", lane_index);
+          pending_valid[lane_index] <= 1'b1;
+          pending_addr[lane_index] <= value_read_req_address[(lane_index * 14) +: 14];
+          pending_slice[lane_index] <= value_read_req_slice[(lane_index * 4) +: 4];
+          pending_delay[lane_index] <= 0;
+        end
+        if (pending_valid[lane_index]) begin
+          if (pending_delay[lane_index] == 0) begin
+            if (!value_response_valid[lane_index]) begin
+              producer_index = lane_index / 2;
+              stream_index = lane_index % 2;
+              response_index =
+                  ((((producer_index * 2) + stream_index) * MAX_BLOCKS_PER_PRODUCER)
+                   + cmd_block_offset_mem[active_command_index][producer_index]
+                   + pending_addr[lane_index]) * 16
+                  + pending_slice[lane_index];
+              pending_valid[lane_index] <= 1'b0;
+              value_response_valid[lane_index] <= 1'b1;
+              value_response_address[(lane_index * 14) +: 14] <= pending_addr[lane_index];
+              value_response_slice[(lane_index * 4) +: 4] <= pending_slice[lane_index];
+              value_response_matrix[(lane_index * 512) +: 512] <= value_mem[response_index];
+            end
+          end else begin
+            pending_delay[lane_index] <= pending_delay[lane_index] - 1;
+          end
+        end
+      end
+
+      if (out_valid && out_ready) begin
+        $display(
+          "RESULT idx=%0d cmd=%0d head=%0d slice=%0d last=%0d max=%0d sum=%0d value=%082x cycle=%0d",
+          result_seen,
+          out_command_id,
+          out_head_id,
+          out_slice,
+          out_last,
+          $signed(out_global_max),
+          out_exp_sum,
+          out_value,
+          reducer_cycle_count
+        );
+        result_seen <= result_seen + 1;
+        if (result_seen + 1 == TOTAL_RESULTS) begin
+          pending_summary <= 1'b1;
+        end
+      end
+
+      if (pending_summary) begin
+        for (producer_index = 0; producer_index < PRODUCERS; producer_index = producer_index + 1) begin
+          $display(
+            "PRODUCER idx=%0d accept=%0d complete=%0d merge=%0d stall=%0d stream0_accept=%0d stream1_accept=%0d stream0_complete=%0d stream1_complete=%0d stream_error=%0d merge_error=%0d protocol=%0d",
+            producer_index,
+            producer_command_accept_count[(producer_index * 32) +: 32],
+            producer_command_completed_count[(producer_index * 32) +: 32],
+            producer_merge_completed_count[(producer_index * 32) +: 32],
+            producer_result_stall_cycles[(producer_index * 32) +: 32],
+            producer_stream_command_accept_count[(producer_index * 64) +: 32],
+            producer_stream_command_accept_count[(producer_index * 64) + 32 +: 32],
+            producer_stream_completed_count[(producer_index * 64) +: 32],
+            producer_stream_completed_count[(producer_index * 64) + 32 +: 32],
+            producer_stream_protocol_error[(producer_index * 2) +: 2],
+            producer_merge_protocol_error[producer_index],
+            producer_protocol_error[producer_index]
+          );
+        end
+        $display(
+          "SUMMARY outputs=%0d drain=%0d protocol_error=%0d atomic_error=%0d group_error=%0d local_tree_error=%0d temporal_error=%0d reducer_error=%0d wave_accept=%0d group_complete=%0d local_root_completed=%0d temporal_completed=%0d emitted=%0d issue_wait=%0d ready_skew=%0d",
+          result_seen,
+          cluster_cycle_count,
+          protocol_error,
+          atomic_command_protocol_error,
+          group_contract_error,
+          local_tree_protocol_error,
+          temporal_merge_protocol_error,
+          reducer_protocol_error,
+          wave_command_accept_count,
+          reducer_completed_command_count,
+          reducer_local_root_completed_count,
+          reducer_temporal_merge_completed_count,
+          reducer_emitted_beat_count,
+          wave_command_issue_wait_cycles,
+          producer_ready_skew_cycles
+        );
+        #1 $finish;
+      end
+
+      if (cycle > 500000) begin
+        $display("TIMEOUT cycle=%0d", cycle);
+        $finish;
+      end
+    end
+  end
+
+  initial begin
+{chr(10).join(cmd_init)}
+{chr(10).join(beat_limit_init)}
+{chr(10).join(beat_init)}
+{chr(10).join(value_init)}
+{ready_init}
+    clk = 0;
+    rst_n = 0;
+    repeat (3) @(posedge clk);
+    @(negedge clk);
+    rst_n = 1'b1;
+  end
+endmodule
+"""
+
+
+def build_report(
+    config: JsonDict | None = None,
+    *,
+    head_dim: int | None = None,
+    seed: int | None = None,
+    head_bases: tuple[int, ...] | None = None,
+    timeout_s: int | None = None,
+    output_ready_pattern: tuple[bool, ...] | None = None,
+) -> JsonDict:
+    payload = json.loads(json.dumps(config or _default_config()))
+    body = payload.get(_CONFIG_KEY)
+    if not isinstance(body, dict):
+        raise ValueError(f"config must contain {_CONFIG_KEY}")
+    producers = int(body.get("producers", 53))
+    workload = _resolve_workload(
+        payload,
+        head_dim=head_dim,
+        seed=seed,
+        head_bases=head_bases,
+        timeout_s=timeout_s,
+    )
+    ready_pattern = tuple(bool(value) for value in output_ready_pattern) if output_ready_pattern is not None else (True,)
+    expected_rows = _expected_rows(producers, workload)
+    wave_commands = _wave_commands(producers, workload)
+    expected_command_schedule = [
+        {
+            "index": index,
+            "command_id": int(command["command_id"]),
+            "head_base": int(command["head_base"]),
+            "group_index": int(command["group_index"]),
+            "wave_index": int(command["wave_index"]),
+        }
+        for index, command in enumerate(wave_commands)
+    ]
+
+    base_report: JsonDict = {
+        "model": "attention_score32_exact_local_cluster_gqa8_probe_v1",
+        "producers": producers,
+        "groups": int(workload["groups"]),
+        "waves": int(workload["waves"]),
+        "wave_commands": int(workload["wave_commands"]),
+        "head_bases": list(int(value) for value in workload["head_bases"]),
+        "head_dim": int(workload["head_dim"]),
+        "expected_outputs": len(expected_rows),
+        "rotation_schedule": {
+            f"group_{group_index}": {
+                "extra_producers": list(
+                    exact_local_cluster_gqa8_extra_producers(producers=producers, group_index=group_index)
+                ),
+                "block_counts": list(
+                    exact_local_cluster_gqa8_command_block_counts(producers=producers, group_index=group_index)
+                ),
+            }
+            for group_index in range(len(LOCAL_CLUSTER_GQA8_HEAD_BASES))
+        },
+        "command_schedule": expected_command_schedule,
+        "service_model": exact_local_cluster_gqa8_service_manifest(producers=producers),
+        "source_links": payload.get("report_links", {}),
+        "timed_out": False,
+        "full_probe_attempted": True,
+    }
+
+    with tempfile.TemporaryDirectory(prefix="score32_exact_local_cluster_gqa8_probe_") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        rtl_dir = temp_dir / "rtl"
+        tb_path = temp_dir / "tb.sv"
+        fakeram_path = temp_dir / "fakeram45_2048x39.sv"
+        generate(payload, rtl_dir)
+        tb_path.write_text(
+            _testbench(
+                top_name=str(payload["top_name"]),
+                producers=producers,
+                workload=workload,
+                output_ready_pattern=ready_pattern,
+            ),
+            encoding="utf-8",
+        )
+        fakeram_path.write_text(_FAKERAM_MODEL, encoding="utf-8")
+        simv = temp_dir / "simv"
+        try:
+            subprocess.run(
+                [
+                    _tool("iverilog"),
+                    "-g2012",
+                    "-s",
+                    "tb",
+                    "-o",
+                    str(simv),
+                    str(rtl_dir / "producer.v"),
+                    str(rtl_dir / "reducer.v"),
+                    str(rtl_dir / "top.v"),
+                    str(fakeram_path),
+                    str(tb_path),
+                ],
+                cwd=REPO_ROOT,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=int(workload["timeout_s"]),
+            )
+            run = subprocess.run(
+                [_tool("vvp"), str(simv)],
+                cwd=REPO_ROOT,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=int(workload["timeout_s"]),
+            )
+        except subprocess.TimeoutExpired as exc:
+            base_report.update(
+                {
+                    "timed_out": True,
+                    "timeout_s": int(workload["timeout_s"]),
+                    "timeout_phase": "iverilog" if exc.cmd and "iverilog" in str(exc.cmd[0]) else "vvp",
+                    "passed": False,
+                }
+            )
+            return base_report
+        except subprocess.CalledProcessError as exc:
+            phase = Path(str(exc.cmd[0])).name if exc.cmd else "subprocess"
+            raise RuntimeError(
+                f"{phase} failed while probing the full-width local cluster\n"
+                f"stdout:\n{exc.stdout}\n"
+                f"stderr:\n{exc.stderr}"
+            ) from exc
+
+    observed_rows: list[dict[str, object]] = []
+    producer_rows: list[dict[str, object]] = []
+    command_rows: list[dict[str, int]] = []
+    summary: JsonDict | None = None
+    timeout_cycle: int | None = None
+    for line in run.stdout.splitlines():
+        stripped = line.strip()
+        if match := _COMMAND_RE.fullmatch(stripped):
+            command_rows.append(
+                {
+                    "index": int(match.group(1)),
+                    "command_id": int(match.group(2)),
+                    "head_base": int(match.group(3)),
+                    "group_index": int(match.group(4)),
+                    "wave_index": int(match.group(5)),
+                    "cycle": int(match.group(6)),
+                }
+            )
+            continue
+        if match := _RESULT_RE.fullmatch(stripped):
+            observed_rows.append(
+                {
+                    "command_id": int(match.group(2)),
+                    "head_id": int(match.group(3)),
+                    "slice": int(match.group(4)),
+                    "last": bool(int(match.group(5))),
+                    "global_max": int(match.group(6)),
+                    "exp_sum": int(match.group(7)),
+                    "value": list(unpack_numerators(int(match.group(8), 16))),
+                    "cycle": int(match.group(9)),
+                }
+            )
+            continue
+        if match := _PRODUCER_RE.fullmatch(stripped):
+            producer_rows.append(
+                {
+                    "index": int(match.group(1)),
+                    "accept_count": int(match.group(2)),
+                    "complete_count": int(match.group(3)),
+                    "merge_completed_count": int(match.group(4)),
+                    "stall_cycles": int(match.group(5)),
+                    "stream_accept_count": [int(match.group(6)), int(match.group(7))],
+                    "stream_complete_count": [int(match.group(8)), int(match.group(9))],
+                    "stream_protocol_error": int(match.group(10)),
+                    "merge_protocol_error": bool(int(match.group(11))),
+                    "protocol_error": bool(int(match.group(12))),
+                }
+            )
+            continue
+        if match := _SUMMARY_RE.fullmatch(stripped):
+            summary = {
+                "outputs": int(match.group(1)),
+                "drain_cycles": int(match.group(2)),
+                "protocol_error": bool(int(match.group(3))),
+                "atomic_command_protocol_error": bool(int(match.group(4))),
+                "group_contract_error": bool(int(match.group(5))),
+                "local_tree_protocol_error": bool(int(match.group(6))),
+                "temporal_merge_protocol_error": bool(int(match.group(7))),
+                "reducer_protocol_error": bool(int(match.group(8))),
+                "wave_command_accept_count": int(match.group(9)),
+                "reducer_completed_command_count": int(match.group(10)),
+                "reducer_local_root_completed_count": int(match.group(11)),
+                "reducer_temporal_merge_completed_count": int(match.group(12)),
+                "reducer_emitted_beat_count": int(match.group(13)),
+                "wave_command_issue_wait_cycles": int(match.group(14)),
+                "producer_ready_skew_cycles": int(match.group(15)),
+            }
+            continue
+        if match := _TB_TIMEOUT_RE.fullmatch(stripped):
+            timeout_cycle = int(match.group(1))
+
+    if summary is None:
+        if timeout_cycle is not None:
+            base_report.update(
+                {
+                    "timed_out": True,
+                    "timeout_s": int(workload["timeout_s"]),
+                    "timeout_phase": "tb",
+                    "timeout_cycle": timeout_cycle,
+                    "outputs": len(observed_rows),
+                    "command_rows": command_rows,
+                    "producer_rows": producer_rows,
+                    "passed": False,
+                }
+            )
+            return base_report
+        raise RuntimeError(f"missing summary in simulator output:\n{run.stdout}")
+
+    normalized_observed_rows = [
+        {key: row[key] for key in ("command_id", "head_id", "slice", "last", "global_max", "exp_sum", "value")}
+        for row in observed_rows
+    ]
+    expected_producer_accepts = int(workload["wave_commands"])
+    expected_producer_merges = int(workload["wave_commands"]) * 8 * 16
+    command_schedule_matches = [
+        {key: row[key] for key in ("index", "command_id", "head_base", "group_index", "wave_index")}
+        for row in command_rows
+    ] == expected_command_schedule
+    producer_counts_match = len(producer_rows) == producers and all(
+        row["accept_count"] == expected_producer_accepts
+        and row["complete_count"] == expected_producer_accepts
+        and row["merge_completed_count"] == expected_producer_merges
+        and row["stall_cycles"] == 0
+        and row["stream_accept_count"] == [expected_producer_accepts, expected_producer_accepts]
+        and row["stream_complete_count"] == [expected_producer_accepts, expected_producer_accepts]
+        and row["stream_protocol_error"] == 0
+        and not row["merge_protocol_error"]
+        and not row["protocol_error"]
+        for row in producer_rows
+    )
+
+    passed = (
+        command_schedule_matches
+        and producer_counts_match
+        and normalized_observed_rows == expected_rows
+        and summary["outputs"] == len(expected_rows)
+        and summary["wave_command_accept_count"] == int(workload["wave_commands"])
+        and summary["reducer_completed_command_count"] == len(LOCAL_CLUSTER_GQA8_HEAD_BASES)
+        and summary["reducer_local_root_completed_count"] == len(LOCAL_CLUSTER_GQA8_HEAD_BASES) * LOCAL_TEMPORAL_WAVES * 8 * 16
+        and summary["reducer_temporal_merge_completed_count"]
+        == len(LOCAL_CLUSTER_GQA8_HEAD_BASES) * (LOCAL_TEMPORAL_WAVES - 1) * 8 * 16
+        and summary["reducer_emitted_beat_count"] == len(expected_rows)
+        and not summary["protocol_error"]
+        and not summary["atomic_command_protocol_error"]
+        and not summary["group_contract_error"]
+        and not summary["local_tree_protocol_error"]
+        and not summary["temporal_merge_protocol_error"]
+        and not summary["reducer_protocol_error"]
+    )
+
+    base_report.update(summary)
+    base_report.update(
+        {
+            "outputs": len(observed_rows),
+            "observed_rows": normalized_observed_rows,
+            "expected_rows": expected_rows,
+            "command_rows": command_rows,
+            "producer_rows": producer_rows,
+            "command_schedule_matches": command_schedule_matches,
+            "producer_counts_match": producer_counts_match,
+            "passed": passed,
+        }
+    )
+    return base_report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=None)
+    parser.add_argument("--head-dim", type=int, default=None)
+    parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument("--timeout-s", type=int, default=None)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args()
+
+    payload = _default_config()
+    if args.config is not None:
+        payload = json.loads(args.config.read_text(encoding="utf-8"))
+    report = build_report(
+        payload,
+        head_dim=args.head_dim,
+        seed=args.seed,
+        timeout_s=args.timeout_s,
+    )
+    encoded = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.out is not None:
+        args.out.write_text(encoded, encoding="utf-8")
+    if args.json or args.out is None:
+        print(encoded, end="")
+    return 0 if report.get("passed") or report.get("timed_out") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/rtlgen/gen_attention_score32_exact_local_cluster_gqa8.py
+++ b/npu/rtlgen/gen_attention_score32_exact_local_cluster_gqa8.py
@@ -1,0 +1,607 @@
+#!/usr/bin/env python3
+"""Generate a full-width GQA8 score32 exact local cluster from real producers and reducer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_score32_exact_local_temporal_reducer_gqa8 import generate as generate_reducer
+from npu.rtlgen.gen_attention_score32_exact_partial_gqa8_dual_stream_producer import generate as generate_producer
+from npu.sim.perf.attention_exact_partial import (
+    LOCAL_TEMPORAL_WAVES,
+    PARTIAL_LINK_BITS,
+    PARTIAL_PAYLOAD_BITS,
+    exact_local_cluster_gqa8_service_manifest,
+)
+
+JsonDict = dict[str, Any]
+
+_CONFIG_KEY = "attention_score32_exact_local_cluster_gqa8"
+_MANIFEST_NAME = "attention_score32_exact_local_cluster_gqa8_manifest.json"
+_PRODUCER_RTL_NAME = "producer.v"
+_REDUCER_RTL_NAME = "reducer.v"
+_VERILATOR_LINT_STUBS_NAME = "verilator_wrapper_blackboxes.v"
+
+
+def _load(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit(f"config must decode to a JSON object: {path}")
+    return payload
+
+
+def _validate(config: JsonDict) -> JsonDict:
+    top_name = str(config.get("top_name") or "").strip()
+    body = config.get(_CONFIG_KEY)
+    if not top_name or not isinstance(body, dict):
+        raise SystemExit(f"config requires top_name and {_CONFIG_KEY}")
+
+    producers = int(body.get("producers", 53))
+    max_blocks = int(body.get("max_blocks", 8))
+    value_slices = int(body.get("value_slices", 16))
+    head_id_bits = int(body.get("head_id_bits", 5))
+    persistent_waves = int(body.get("persistent_waves", LOCAL_TEMPORAL_WAVES))
+
+    if producers not in {53, 54}:
+        raise SystemExit("producers must be exactly 53 or 54")
+    if max_blocks != 8:
+        raise SystemExit("max_blocks must remain fixed at 8 for the corrected p53/p54 cluster schedule")
+    if value_slices != 16:
+        raise SystemExit("value_slices must remain fixed at 16")
+    if head_id_bits != 5:
+        raise SystemExit("head_id_bits must remain fixed at 5")
+    if persistent_waves != LOCAL_TEMPORAL_WAVES:
+        raise SystemExit(f"persistent_waves must remain fixed at {LOCAL_TEMPORAL_WAVES}")
+
+    return {
+        "top_name": top_name,
+        "producers": producers,
+        "max_blocks": max_blocks,
+        "value_slices": value_slices,
+        "head_id_bits": head_id_bits,
+        "persistent_waves": persistent_waves,
+    }
+
+
+def _slice(name: str, index: int, width: int) -> str:
+    lo = index * width
+    return f"{name}[{lo + width - 1}:{lo}]"
+
+
+def _top_pin_bits(*, producers: int, head_id_bits: int) -> int:
+    value_lanes = producers * 2
+    return (
+        2
+        + 1
+        + 1
+        + 16
+        + head_id_bits
+        + (producers * 15)
+        + 32
+        + 6
+        + producers
+        + producers
+        + producers
+        + (producers * 128)
+        + (producers * 128)
+        + value_lanes
+        + value_lanes
+        + (value_lanes * 14)
+        + (value_lanes * 4)
+        + value_lanes
+        + value_lanes
+        + (value_lanes * 14)
+        + (value_lanes * 4)
+        + (value_lanes * 512)
+        + 1
+        + 1
+        + 16
+        + head_id_bits
+        + 32
+        + 33
+        + 4
+        + 1
+        + PARTIAL_PAYLOAD_BITS
+        + 32
+        + 32
+        + 32
+        + 32
+        + 3
+        + 1
+        + 5
+        + 7
+        + 7
+        + 32
+        + 32
+        + 32
+        + 32
+        + 32
+        + 32
+        + (producers * 32)
+        + (producers * 32)
+        + (producers * 32)
+        + (producers * 64)
+        + (producers * 64)
+        + (producers * 32)
+        + (producers * 32)
+        + (producers * 2)
+        + producers
+        + producers
+        + 1
+        + 1
+        + 1
+        + 1
+        + 1
+        + 1
+    )
+
+
+def _producer_instances(*, producer_top: str, producers: int) -> str:
+    blocks: list[str] = []
+    for producer in range(producers):
+        blocks.append(
+            f"""  {producer_top} u_producer_{producer} (
+      .clk(clk),
+      .rst_n(rst_n),
+      .command_valid(group_command_fire_w),
+      .command_ready(producer_command_ready_w[{producer}]),
+      .command_id(command_id),
+      .command_head_base(command_head_base),
+      .command_block_count({_slice("command_block_count", producer, 15)}),
+      .command_score_multiplier(command_score_multiplier),
+      .command_score_shift(command_score_shift),
+      .input_valid(input_valid[{producer}]),
+      .input_ready(input_ready[{producer}]),
+      .input_last(input_last[{producer}]),
+      .input_query({_slice("input_query", producer, 128)}),
+      .input_key({_slice("input_key", producer, 128)}),
+      .value_read_req_valid({_slice("value_read_req_valid", producer, 2)}),
+      .value_read_req_ready({_slice("value_read_req_ready", producer, 2)}),
+      .value_read_req_address({_slice("value_read_req_address", producer, 28)}),
+      .value_read_req_slice({_slice("value_read_req_slice", producer, 8)}),
+      .value_response_valid({_slice("value_response_valid", producer, 2)}),
+      .value_response_ready({_slice("value_response_ready", producer, 2)}),
+      .value_response_address({_slice("value_response_address", producer, 28)}),
+      .value_response_slice({_slice("value_response_slice", producer, 8)}),
+      .value_response_matrix({_slice("value_response_matrix", producer, 1024)}),
+      .result_valid(producer_result_valid_w[{producer}]),
+      .result_ready(producer_result_ready_w[{producer}]),
+      .result_command_id({_slice("producer_result_command_id_w", producer, 16)}),
+      .result_head_id({_slice("producer_result_head_id_w", producer, 5)}),
+      .result_global_max({_slice("producer_result_global_max_w", producer, 32)}),
+      .result_exp_sum({_slice("producer_result_exp_sum_w", producer, 33)}),
+      .result_slice({_slice("producer_result_slice_w", producer, 4)}),
+      .result_last(producer_result_last_w[{producer}]),
+      .result_value({_slice("producer_result_value_w", producer, PARTIAL_PAYLOAD_BITS)}),
+      .cycle_count({_slice("producer_cycle_count", producer, 32)}),
+      .command_accept_count({_slice("producer_command_accept_count", producer, 32)}),
+      .command_completed_count({_slice("producer_command_completed_count", producer, 32)}),
+      .stream_command_accept_count({_slice("producer_stream_command_accept_count", producer, 64)}),
+      .stream_completed_count({_slice("producer_stream_completed_count", producer, 64)}),
+      .stream_partial_valid(),
+      .stream_partial_ready(),
+      .stream_partial_last(),
+      .merge_completed_count({_slice("producer_merge_completed_count", producer, 32)}),
+      .result_stall_cycles({_slice("producer_result_stall_cycles", producer, 32)}),
+      .stream_protocol_error({_slice("producer_stream_protocol_error", producer, 2)}),
+      .merge_protocol_error(producer_merge_protocol_error[{producer}]),
+      .protocol_error(producer_protocol_error[{producer}])
+  );"""
+        )
+    return "\n\n".join(blocks)
+
+
+def _verilator_lint_stubs(*, producer_top: str, reducer_top: str, producers: int, head_id_bits: int) -> str:
+    slice_bits = 4
+    return f"""// Auto-generated Verilator wrapper-lint blackboxes for score32 exact local cluster GQA8
+(* blackbox *) module {producer_top} (
+    input  wire         clk,
+    input  wire         rst_n,
+    input  wire         command_valid,
+    output wire         command_ready,
+    input  wire [15:0]  command_id,
+    input  wire [{head_id_bits - 1}:0] command_head_base,
+    input  wire [14:0]  command_block_count,
+    input  wire [31:0]  command_score_multiplier,
+    input  wire [5:0]   command_score_shift,
+    input  wire         input_valid,
+    output wire         input_ready,
+    input  wire         input_last,
+    input  wire signed [127:0] input_query,
+    input  wire signed [127:0] input_key,
+    output wire [1:0]   value_read_req_valid,
+    input  wire [1:0]   value_read_req_ready,
+    output wire [27:0]  value_read_req_address,
+    output wire [7:0]   value_read_req_slice,
+    input  wire [1:0]   value_response_valid,
+    output wire [1:0]   value_response_ready,
+    input  wire [27:0]  value_response_address,
+    input  wire [7:0]   value_response_slice,
+    input  wire [1023:0] value_response_matrix,
+    output wire         result_valid,
+    input  wire         result_ready,
+    output wire [15:0]  result_command_id,
+    output wire [{head_id_bits - 1}:0] result_head_id,
+    output wire signed [31:0] result_global_max,
+    output wire [32:0]  result_exp_sum,
+    output wire [3:0]   result_slice,
+    output wire         result_last,
+    output wire [327:0] result_value,
+    output wire [31:0]  cycle_count,
+    output wire [31:0]  command_accept_count,
+    output wire [31:0]  command_completed_count,
+    output wire [63:0]  stream_command_accept_count,
+    output wire [63:0]  stream_completed_count,
+    output wire [1:0]   stream_partial_valid,
+    output wire [1:0]   stream_partial_ready,
+    output wire [1:0]   stream_partial_last,
+    output wire [31:0]  merge_completed_count,
+    output wire [31:0]  result_stall_cycles,
+    output wire [1:0]   stream_protocol_error,
+    output wire         merge_protocol_error,
+    output wire         protocol_error
+);
+endmodule
+
+(* blackbox *) module {reducer_top} (
+    input  wire         clk,
+    input  wire         rst_n,
+    input  wire [{producers - 1}:0] leaf_valid,
+    output wire [{producers - 1}:0] leaf_ready,
+    input  wire [{producers * 16 - 1}:0] leaf_command_id,
+    input  wire [{producers * head_id_bits - 1}:0] leaf_head_id,
+    input  wire [{producers * 32 - 1}:0] leaf_global_max,
+    input  wire [{producers * 33 - 1}:0] leaf_exp_sum,
+    input  wire [{producers * slice_bits - 1}:0] leaf_slice,
+    input  wire [{producers - 1}:0] leaf_last,
+    input  wire [{producers * PARTIAL_PAYLOAD_BITS - 1}:0] leaf_value,
+    output wire         out_valid,
+    input  wire         out_ready,
+    output wire [15:0]  out_command_id,
+    output wire [{head_id_bits - 1}:0] out_head_id,
+    output wire signed [31:0] out_global_max,
+    output wire [32:0]  out_exp_sum,
+    output wire [{slice_bits - 1}:0] out_slice,
+    output wire         out_last,
+    output wire [327:0] out_value,
+    output wire [2:0]   active_wave_index,
+    output wire         emitting,
+    output wire [4:0]   active_head_base,
+    output wire [6:0]   collect_beat_index,
+    output wire [6:0]   emit_beat_index,
+    output wire [31:0]  cycle_count,
+    output wire [31:0]  local_root_completed_count,
+    output wire [31:0]  temporal_merge_completed_count,
+    output wire [31:0]  emitted_beat_count,
+    output wire [31:0]  completed_command_count,
+    output wire [31:0]  local_stall_cycles,
+    output wire [31:0]  output_stall_cycles,
+    output wire         group_contract_error,
+    output wire         local_tree_protocol_error,
+    output wire         temporal_merge_protocol_error,
+    output wire         protocol_error
+);
+endmodule
+"""
+
+
+def _top(*, top_name: str, producer_top: str, reducer_top: str, producers: int, head_id_bits: int) -> str:
+    return f"""// Auto-generated by npu/rtlgen/gen_attention_score32_exact_local_cluster_gqa8.py
+module {top_name} (
+    input  wire         clk,
+    input  wire         rst_n,
+    input  wire         command_valid,
+    output wire         command_ready,
+    input  wire [15:0]  command_id,
+    input  wire [{head_id_bits - 1}:0] command_head_base,
+    input  wire [{(producers * 15) - 1}:0] command_block_count,
+    input  wire [31:0]  command_score_multiplier,
+    input  wire [5:0]   command_score_shift,
+    input  wire [{producers - 1}:0] input_valid,
+    output wire [{producers - 1}:0] input_ready,
+    input  wire [{producers - 1}:0] input_last,
+    input  wire signed [{(producers * 128) - 1}:0] input_query,
+    input  wire signed [{(producers * 128) - 1}:0] input_key,
+    output wire [{(producers * 2) - 1}:0] value_read_req_valid,
+    input  wire [{(producers * 2) - 1}:0] value_read_req_ready,
+    output wire [{(producers * 28) - 1}:0] value_read_req_address,
+    output wire [{(producers * 8) - 1}:0] value_read_req_slice,
+    input  wire [{(producers * 2) - 1}:0] value_response_valid,
+    output wire [{(producers * 2) - 1}:0] value_response_ready,
+    input  wire [{(producers * 28) - 1}:0] value_response_address,
+    input  wire [{(producers * 8) - 1}:0] value_response_slice,
+    input  wire [{(producers * 1024) - 1}:0] value_response_matrix,
+    output wire         out_valid,
+    input  wire         out_ready,
+    output wire [15:0]  out_command_id,
+    output wire [{head_id_bits - 1}:0] out_head_id,
+    output wire signed [31:0] out_global_max,
+    output wire [32:0]  out_exp_sum,
+    output wire [3:0]   out_slice,
+    output wire         out_last,
+    output wire [327:0] out_value,
+    output wire [31:0]  cluster_cycle_count,
+    output wire [31:0]  wave_command_accept_count,
+    output wire [31:0]  wave_command_issue_wait_cycles,
+    output wire [31:0]  producer_ready_skew_cycles,
+    output wire [2:0]   reducer_active_wave_index,
+    output wire         reducer_emitting,
+    output wire [4:0]   reducer_active_head_base,
+    output wire [6:0]   reducer_collect_beat_index,
+    output wire [6:0]   reducer_emit_beat_index,
+    output wire [31:0]  reducer_cycle_count,
+    output wire [31:0]  reducer_local_root_completed_count,
+    output wire [31:0]  reducer_temporal_merge_completed_count,
+    output wire [31:0]  reducer_emitted_beat_count,
+    output wire [31:0]  reducer_completed_command_count,
+    output wire [31:0]  reducer_local_stall_cycles,
+    output wire [31:0]  reducer_output_stall_cycles,
+    output wire [{(producers * 32) - 1}:0] producer_cycle_count,
+    output wire [{(producers * 32) - 1}:0] producer_command_accept_count,
+    output wire [{(producers * 32) - 1}:0] producer_command_completed_count,
+    output wire [{(producers * 64) - 1}:0] producer_stream_command_accept_count,
+    output wire [{(producers * 64) - 1}:0] producer_stream_completed_count,
+    output wire [{(producers * 32) - 1}:0] producer_merge_completed_count,
+    output wire [{(producers * 32) - 1}:0] producer_result_stall_cycles,
+    output wire [{(producers * 2) - 1}:0] producer_stream_protocol_error,
+    output wire [{producers - 1}:0] producer_merge_protocol_error,
+    output wire [{producers - 1}:0] producer_protocol_error,
+    output wire         group_contract_error,
+    output wire         local_tree_protocol_error,
+    output wire         temporal_merge_protocol_error,
+    output wire         reducer_protocol_error,
+    output wire         atomic_command_protocol_error,
+    output wire         protocol_error
+);
+  localparam integer PRODUCERS = {producers};
+  localparam integer HEAD_ID_BITS = {head_id_bits};
+  localparam integer PARTIAL_PAYLOAD_BITS = {PARTIAL_PAYLOAD_BITS};
+
+  wire [PRODUCERS-1:0] producer_command_ready_w;
+  wire [PRODUCERS-1:0] producer_result_valid_w;
+  wire [PRODUCERS-1:0] producer_result_ready_w;
+  wire [(PRODUCERS * 16) - 1:0] producer_result_command_id_w;
+  wire [(PRODUCERS * HEAD_ID_BITS) - 1:0] producer_result_head_id_w;
+  wire [(PRODUCERS * 32) - 1:0] producer_result_global_max_w;
+  wire [(PRODUCERS * 33) - 1:0] producer_result_exp_sum_w;
+  wire [(PRODUCERS * 4) - 1:0] producer_result_slice_w;
+  wire [PRODUCERS-1:0] producer_result_last_w;
+  wire [(PRODUCERS * PARTIAL_PAYLOAD_BITS) - 1:0] producer_result_value_w;
+
+  wire group_command_fire_w = command_valid && command_ready;
+  wire [PRODUCERS-1:0] producer_command_accept_w = {{PRODUCERS{{group_command_fire_w}}}} & producer_command_ready_w;
+
+  reg [31:0] cluster_cycle_count_q;
+  reg [31:0] wave_command_accept_count_q;
+  reg [31:0] wave_command_issue_wait_cycles_q;
+  reg [31:0] producer_ready_skew_cycles_q;
+  reg atomic_command_protocol_error_q;
+
+  assign command_ready = &producer_command_ready_w;
+  assign cluster_cycle_count = cluster_cycle_count_q;
+  assign wave_command_accept_count = wave_command_accept_count_q;
+  assign wave_command_issue_wait_cycles = wave_command_issue_wait_cycles_q;
+  assign producer_ready_skew_cycles = producer_ready_skew_cycles_q;
+  assign atomic_command_protocol_error = atomic_command_protocol_error_q;
+  assign protocol_error = atomic_command_protocol_error_q || (|producer_protocol_error) || reducer_protocol_error;
+
+{_producer_instances(producer_top=producer_top, producers=producers)}
+
+  {reducer_top} u_reducer (
+      .clk(clk),
+      .rst_n(rst_n),
+      .leaf_valid(producer_result_valid_w),
+      .leaf_ready(producer_result_ready_w),
+      .leaf_command_id(producer_result_command_id_w),
+      .leaf_head_id(producer_result_head_id_w),
+      .leaf_global_max(producer_result_global_max_w),
+      .leaf_exp_sum(producer_result_exp_sum_w),
+      .leaf_slice(producer_result_slice_w),
+      .leaf_last(producer_result_last_w),
+      .leaf_value(producer_result_value_w),
+      .out_valid(out_valid),
+      .out_ready(out_ready),
+      .out_command_id(out_command_id),
+      .out_head_id(out_head_id),
+      .out_global_max(out_global_max),
+      .out_exp_sum(out_exp_sum),
+      .out_slice(out_slice),
+      .out_last(out_last),
+      .out_value(out_value),
+      .active_wave_index(reducer_active_wave_index),
+      .emitting(reducer_emitting),
+      .active_head_base(reducer_active_head_base),
+      .collect_beat_index(reducer_collect_beat_index),
+      .emit_beat_index(reducer_emit_beat_index),
+      .cycle_count(reducer_cycle_count),
+      .local_root_completed_count(reducer_local_root_completed_count),
+      .temporal_merge_completed_count(reducer_temporal_merge_completed_count),
+      .emitted_beat_count(reducer_emitted_beat_count),
+      .completed_command_count(reducer_completed_command_count),
+      .local_stall_cycles(reducer_local_stall_cycles),
+      .output_stall_cycles(reducer_output_stall_cycles),
+      .group_contract_error(group_contract_error),
+      .local_tree_protocol_error(local_tree_protocol_error),
+      .temporal_merge_protocol_error(temporal_merge_protocol_error),
+      .protocol_error(reducer_protocol_error)
+  );
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      cluster_cycle_count_q <= 32'd0;
+      wave_command_accept_count_q <= 32'd0;
+      wave_command_issue_wait_cycles_q <= 32'd0;
+      producer_ready_skew_cycles_q <= 32'd0;
+      atomic_command_protocol_error_q <= 1'b0;
+    end else begin
+      cluster_cycle_count_q <= cluster_cycle_count_q + 1'b1;
+      if (command_valid && !command_ready) begin
+        wave_command_issue_wait_cycles_q <= wave_command_issue_wait_cycles_q + 1'b1;
+      end
+      if (command_valid && (|producer_command_ready_w) && !(&producer_command_ready_w)) begin
+        producer_ready_skew_cycles_q <= producer_ready_skew_cycles_q + 1'b1;
+      end
+      if (group_command_fire_w) begin
+        wave_command_accept_count_q <= wave_command_accept_count_q + 1'b1;
+        if (producer_command_accept_w != {{PRODUCERS{{1'b1}}}}) begin
+          atomic_command_protocol_error_q <= 1'b1;
+        end
+      end
+    end
+  end
+endmodule
+"""
+
+
+def generate(config: JsonDict, out_dir: Path) -> None:
+    params = _validate(json.loads(json.dumps(config)))
+    top_name = str(params["top_name"])
+    producer_top = f"{top_name}__producer"
+    reducer_top = f"{top_name}__reducer"
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="score32_exact_local_cluster_gqa8_") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        producer_dir = temp_dir / "producer"
+        reducer_dir = temp_dir / "reducer"
+        generate_producer(
+            {
+                "top_name": producer_top,
+                "attention_score32_exact_partial_gqa8_dual_stream_producer": {
+                    "streams": 2,
+                    "query_heads_per_stream": 8,
+                    "max_blocks": int(params["max_blocks"]),
+                    "value_slices": int(params["value_slices"]),
+                    "head_id_bits": int(params["head_id_bits"]),
+                },
+            },
+            producer_dir,
+        )
+        generate_reducer(
+            {
+                "top_name": reducer_top,
+                "attention_score32_exact_local_temporal_reducer_gqa8": {
+                    "producers": int(params["producers"]),
+                    "value_slices": int(params["value_slices"]),
+                    "head_id_bits": int(params["head_id_bits"]),
+                    "persistent_waves": int(params["persistent_waves"]),
+                },
+            },
+            reducer_dir,
+        )
+        producer_rtl = (producer_dir / "top.v").read_text(encoding="utf-8")
+        reducer_rtl = (reducer_dir / "top.v").read_text(encoding="utf-8")
+        producer_manifest = json.loads(
+            (producer_dir / "attention_score32_exact_partial_gqa8_dual_stream_producer_manifest.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        reducer_manifest = json.loads(
+            (reducer_dir / "attention_score32_exact_local_temporal_reducer_gqa8_manifest.json").read_text(
+                encoding="utf-8"
+            )
+        )
+
+    top_text = _top(
+        top_name=top_name,
+        producer_top=producer_top,
+        reducer_top=reducer_top,
+        producers=int(params["producers"]),
+        head_id_bits=int(params["head_id_bits"]),
+    )
+    (out_dir / _PRODUCER_RTL_NAME).write_text(producer_rtl + "\n", encoding="utf-8")
+    (out_dir / _REDUCER_RTL_NAME).write_text(reducer_rtl + "\n", encoding="utf-8")
+    (out_dir / "top.v").write_text(top_text + "\n", encoding="utf-8")
+    (out_dir / _VERILATOR_LINT_STUBS_NAME).write_text(
+        _verilator_lint_stubs(
+            producer_top=producer_top,
+            reducer_top=reducer_top,
+            producers=int(params["producers"]),
+            head_id_bits=int(params["head_id_bits"]),
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (out_dir / "config.json").write_text(json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    service_model = exact_local_cluster_gqa8_service_manifest(
+        producers=int(params["producers"]),
+        waves=int(params["persistent_waves"]),
+    )
+    manifest: JsonDict = {
+        "version": 1,
+        "generator": "npu/rtlgen/gen_attention_score32_exact_local_cluster_gqa8.py",
+        "top_name": top_name,
+        "semantic_profile": "score32_exact_local_cluster_gqa8_v1",
+        "producers": int(params["producers"]),
+        "producer_instance_count": int(params["producers"]),
+        "max_blocks": int(params["max_blocks"]),
+        "value_slices": int(params["value_slices"]),
+        "head_id_bits": int(params["head_id_bits"]),
+        "persistent_waves": int(params["persistent_waves"]),
+        "query_head_groups": 4,
+        "query_heads_per_group": 8,
+        "value_memory_lanes": int(params["producers"]) * 2,
+        "producer_input_lanes": int(params["producers"]),
+        "result_interface": "full_width_exact_gqa8_producer_cluster_to_128beat_aggregate_after_group_major_8wave_reduce",
+        "partial_payload_bits_per_beat": PARTIAL_PAYLOAD_BITS,
+        "partial_link_bits_per_beat": PARTIAL_LINK_BITS,
+        "equivalence_hash": False,
+        "rtl_files": [
+            "top.v",
+            _PRODUCER_RTL_NAME,
+            _REDUCER_RTL_NAME,
+            _VERILATOR_LINT_STUBS_NAME,
+        ],
+        "top_pin_bits": _top_pin_bits(
+            producers=int(params["producers"]),
+            head_id_bits=int(params["head_id_bits"]),
+        ),
+        "command_schedule_contract": service_model["top_command_contract"],
+        "atomic_command_issue_contract": service_model["atomic_command_issue_contract"],
+        "producer_input_contract": service_model["producer_input_contract"],
+        "value_memory_contract": service_model["value_memory_contract"],
+        "producer_leaf_wiring_contract": service_model["producer_leaf_wiring_contract"],
+        "local_reduction_contract": service_model["local_reduction_contract"],
+        "temporal_accumulation_contract": service_model["temporal_accumulation_contract"],
+        "comparison_baseline_contract": service_model["comparison_baseline_contract"],
+        "comparison_cycle_origin": service_model["comparison_cycle_origin"],
+        "diagnostic_only_baseline": service_model["diagnostic_only_baseline"],
+        "remaining_abstractions": service_model["remaining_abstractions"],
+        "service_model": service_model,
+        "submodule_manifests": {
+            "producer": producer_manifest,
+            "gqa8_local_temporal_reducer": reducer_manifest,
+        },
+    }
+    if isinstance(config.get("probe_defaults"), dict):
+        manifest["checked_in_probe_defaults"] = config["probe_defaults"]
+    report_links = config.get("report_links")
+    if isinstance(report_links, dict):
+        if "proposal_id" in report_links:
+            manifest["linked_proposal_id"] = str(report_links["proposal_id"])
+        if "proposal_path" in report_links:
+            manifest["linked_proposal_path"] = str(report_links["proposal_path"])
+    (out_dir / _MANIFEST_NAME).write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    generate(_load(args.config), args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/sim/perf/attention_exact_partial.py
+++ b/npu/sim/perf/attention_exact_partial.py
@@ -29,6 +29,7 @@ HEAD_ID_BITS = 5
 SLICE_LANES = 8
 VALUE_SLICES = 16
 LOCAL_TEMPORAL_WAVES = 8
+LOCAL_CLUSTER_GQA8_HEAD_BASES = (0, 8, 16, 24)
 SLICE_INDEX_BITS = (VALUE_SLICES - 1).bit_length()
 PARTIAL_PAYLOAD_BITS = SLICE_LANES * WEIGHTED_NUMERATOR_BITS
 PARTIAL_LINK_BITS = PARTIAL_PAYLOAD_BITS + 16 + HEAD_ID_BITS + SCORE_BITS + EXP_SUM_BITS + SLICE_INDEX_BITS + 1
@@ -1053,6 +1054,98 @@ def exact_local_temporal_reducer_gqa8_service_manifest(
     }
 
 
+def exact_local_cluster_gqa8_extra_producers(*, producers: int, group_index: int) -> tuple[int, ...]:
+    producer_count = int(producers)
+    resolved_group_index = int(group_index)
+    if producer_count == 53:
+        group_windows = ((0, 11), (11, 22), (22, 33), (33, 44))
+    elif producer_count == 54:
+        group_windows = ((0, 10), (10, 20), (20, 30), (30, 40))
+    else:
+        raise ValueError("producers must be exactly 53 or 54")
+    if resolved_group_index < 0 or resolved_group_index >= len(group_windows):
+        raise ValueError("group_index must be in [0, 3]")
+    start, stop = group_windows[resolved_group_index]
+    return tuple(range(start, stop))
+
+
+def exact_local_cluster_gqa8_command_block_counts(*, producers: int, group_index: int) -> tuple[int, ...]:
+    producer_count = int(producers)
+    extras = set(exact_local_cluster_gqa8_extra_producers(producers=producer_count, group_index=group_index))
+    return tuple(2 if producer_index in extras else 1 for producer_index in range(producer_count))
+
+
+def exact_local_cluster_gqa8_service_manifest(
+    *,
+    producers: int,
+    waves: int = LOCAL_TEMPORAL_WAVES,
+    head_bases: Iterable[int] = LOCAL_CLUSTER_GQA8_HEAD_BASES,
+) -> dict[str, object]:
+    producer_count = int(producers)
+    wave_count = int(waves)
+    resolved_head_bases = tuple(int(value) for value in head_bases)
+    if producer_count not in {53, 54}:
+        raise ValueError("producers must be exactly 53 or 54")
+    if wave_count != LOCAL_TEMPORAL_WAVES:
+        raise ValueError(f"waves must be exactly {LOCAL_TEMPORAL_WAVES}")
+    if resolved_head_bases != LOCAL_CLUSTER_GQA8_HEAD_BASES:
+        raise ValueError(f"head_bases must be exactly {LOCAL_CLUSTER_GQA8_HEAD_BASES}")
+
+    reducer_manifest = exact_local_temporal_reducer_gqa8_service_manifest(
+        producers=producer_count,
+        waves=wave_count,
+        head_groups=len(resolved_head_bases),
+    )
+    per_group_extra_producers = [
+        list(exact_local_cluster_gqa8_extra_producers(producers=producer_count, group_index=group_index))
+        for group_index in range(len(resolved_head_bases))
+    ]
+    per_group_block_counts = [
+        list(exact_local_cluster_gqa8_command_block_counts(producers=producer_count, group_index=group_index))
+        for group_index in range(len(resolved_head_bases))
+    ]
+    per_group_total_blocks_per_stream = [sum(group_counts) for group_counts in per_group_block_counts]
+    if any(total != 64 for total in per_group_total_blocks_per_stream):
+        raise AssertionError("every corrected GQA8 local-cluster group must cover exactly 64 blocks per stream")
+
+    return {
+        "producers": producer_count,
+        "persistent_waves": wave_count,
+        "query_head_groups": len(resolved_head_bases),
+        "query_heads_per_group": 8,
+        "head_bases": list(resolved_head_bases),
+        "group_major_wave_commands_per_group": wave_count,
+        "full_run_wave_command_count": len(resolved_head_bases) * wave_count,
+        "max_blocks": 8,
+        "per_producer_command_block_count_bits": 15,
+        "per_group_extra_producers": per_group_extra_producers,
+        "per_group_command_block_counts": per_group_block_counts,
+        "per_group_total_blocks_per_stream": per_group_total_blocks_per_stream,
+        "value_slices": VALUE_SLICES,
+        "aggregate_output_beats_per_group": 8 * VALUE_SLICES,
+        "aggregate_output_beats_per_full_run": len(resolved_head_bases) * 8 * VALUE_SLICES,
+        "partial_payload_bits_per_beat": PARTIAL_PAYLOAD_BITS,
+        "partial_link_bits_per_beat": PARTIAL_LINK_BITS,
+        "top_command_contract": "broadcast_command_id_head_base_multiplier_shift_with_packed_per_producer_block_counts",
+        "atomic_command_issue_contract": "all_producers_accept_same_wave_command_same_cycle_or_none",
+        "producer_input_contract": "independent_per_producer_dual_stream_query_key_last_ready_valid",
+        "value_memory_contract": "independent_per_producer_dual_stream_value_request_response_lanes",
+        "producer_leaf_wiring_contract": "index_preserving_direct_producer_result_leaf_connection_into_local_temporal_reducer",
+        "local_reduction_contract": reducer_manifest["local_reduction_contract"],
+        "temporal_accumulation_contract": "group_major_same_logical_command_across_8_waves_then_emit_before_next_head_base",
+        "comparison_baseline_contract": (
+            "python_structured_producer_reference_then_staged_p53p54_merge_then_group_major_8_wave_temporal_merge"
+        ),
+        "comparison_cycle_origin": "cycle0_on_first_atomic_wave_command_issue_for_head_base0_wave0",
+        "diagnostic_only_baseline": "none",
+        "remaining_abstractions": [
+            "noc_sram_ppa_open",
+            "global_c16_exact_reduction_open",
+        ],
+        "reducer_service_model": reducer_manifest,
+    }
+
+
 __all__ = [
     "EXACT_STATE_BYTES_PER_CLUSTER_32_HEADS",
     "ExactFinalizedBeat",
@@ -1061,6 +1154,7 @@ __all__ = [
     "FINAL_LINK_BITS",
     "HEAD_ID_BITS",
     "LOCAL_TEMPORAL_WAVES",
+    "LOCAL_CLUSTER_GQA8_HEAD_BASES",
     "LEAF_STREAM_BYTES_PER_CLUSTER_32_HEADS",
     "PARTIAL_PAYLOAD_BITS",
     "PARTIAL_LINK_BITS",
@@ -1073,6 +1167,9 @@ __all__ = [
     "exact_banked_finalized_tree_service_manifest",
     "exact_local_temporal_reducer_service_manifest",
     "exact_local_temporal_reducer_gqa8_service_manifest",
+    "exact_local_cluster_gqa8_extra_producers",
+    "exact_local_cluster_gqa8_command_block_counts",
+    "exact_local_cluster_gqa8_service_manifest",
     "exact_partial_producer_tree_service_manifest",
     "exact_partial_dual_stream_gqa8_producer_service_manifest",
     "exact_banked_finalized_tree_full_wave_saturated_service",

--- a/runs/designs/npu_blocks/attention_score32_exact_local_cluster_gqa8_p53_w8/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_local_cluster_gqa8_p53_w8/config.json
@@ -1,0 +1,20 @@
+{
+  "top_name": "attention_score32_exact_local_cluster_gqa8_p53_w8",
+  "attention_score32_exact_local_cluster_gqa8": {
+    "producers": 53,
+    "max_blocks": 8,
+    "value_slices": 16,
+    "head_id_bits": 5,
+    "persistent_waves": 8
+  },
+  "probe_defaults": {
+    "head_bases": [0, 8, 16, 24],
+    "head_dim": 1,
+    "seed": 73,
+    "timeout_s": 300
+  },
+  "report_links": {
+    "proposal_id": "prop_l1_decoder_attention_score32_local_cluster_gqa8_v1",
+    "proposal_path": "docs/proposals/prop_l1_decoder_attention_score32_local_cluster_gqa8_v1/proposal.json"
+  }
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_local_cluster_gqa8_p54_w8/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_local_cluster_gqa8_p54_w8/config.json
@@ -1,0 +1,20 @@
+{
+  "top_name": "attention_score32_exact_local_cluster_gqa8_p54_w8",
+  "attention_score32_exact_local_cluster_gqa8": {
+    "producers": 54,
+    "max_blocks": 8,
+    "value_slices": 16,
+    "head_id_bits": 5,
+    "persistent_waves": 8
+  },
+  "probe_defaults": {
+    "head_bases": [0, 8, 16, 24],
+    "head_dim": 1,
+    "seed": 73,
+    "timeout_s": 300
+  },
+  "report_links": {
+    "proposal_id": "prop_l1_decoder_attention_score32_local_cluster_gqa8_v1",
+    "proposal_path": "docs/proposals/prop_l1_decoder_attention_score32_local_cluster_gqa8_v1/proposal.json"
+  }
+}

--- a/tests/test_attention_score32_exact_local_cluster_gqa8.py
+++ b/tests/test_attention_score32_exact_local_cluster_gqa8.py
@@ -1,0 +1,277 @@
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval.probe_attention_score32_exact_local_cluster_gqa8 import build_report
+from npu.rtlgen.gen_attention_score32_exact_local_cluster_gqa8 import generate
+from npu.sim.perf.attention_exact_partial import (
+    LOCAL_CLUSTER_GQA8_HEAD_BASES,
+    exact_local_cluster_gqa8_command_block_counts,
+    exact_local_cluster_gqa8_service_manifest,
+)
+
+_FAKERAM_MODEL = """
+module fakeram45_2048x39 (
+    output wire [38:0] rd_out, input wire [10:0] addr_in,
+    input wire we_in, input wire [38:0] wd_in, input wire [38:0] w_mask_in,
+    input wire clk, input wire ce_in
+);
+  reg [38:0] mem [0:2047];
+  reg [10:0] addr_q;
+  reg [38:0] rd_out_q;
+  integer idx;
+  initial begin
+    addr_q = 0;
+    rd_out_q = 0;
+    for (idx = 0; idx < 2048; idx = idx + 1) mem[idx] = 0;
+  end
+  always @(posedge clk) begin
+    rd_out_q <= mem[addr_q];
+    if (ce_in) begin
+      if (we_in) begin
+        for (idx = 0; idx < 39; idx = idx + 1) begin
+          if (w_mask_in[idx]) mem[addr_in][idx] <= wd_in[idx];
+        end
+      end
+      addr_q <= addr_in;
+    end
+  end
+  assign rd_out = rd_out_q;
+endmodule
+"""
+
+
+def _tool_available(name: str) -> bool:
+    return bool(shutil.which(name) or (Path("/oss-cad-suite/bin") / name).exists())
+
+
+def _rtl_tools_available() -> bool:
+    return all(_tool_available(name) for name in ("iverilog", "vvp", "verilator"))
+
+
+def _tool(name: str) -> str:
+    path = shutil.which(name)
+    if path:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    if fallback.exists():
+        return str(fallback)
+    raise RuntimeError(f"required tool unavailable: {name}")
+
+
+def _config_path(producers: int) -> Path:
+    return (
+        REPO_ROOT
+        / "runs"
+        / "designs"
+        / "npu_blocks"
+        / f"attention_score32_exact_local_cluster_gqa8_p{producers}_w8"
+        / "config.json"
+    )
+
+
+def _load_config(producers: int) -> dict[str, object]:
+    return json.loads(_config_path(producers).read_text(encoding="utf-8"))
+
+
+def test_local_cluster_gqa8_schedule_rotation_and_counts() -> None:
+    schedule53 = [
+        list(exact_local_cluster_gqa8_command_block_counts(producers=53, group_index=group_index))
+        for group_index in range(4)
+    ]
+    schedule54 = [
+        list(exact_local_cluster_gqa8_command_block_counts(producers=54, group_index=group_index))
+        for group_index in range(4)
+    ]
+
+    assert schedule53[0][:11] == [2] * 11
+    assert schedule53[0][11:] == [1] * 42
+    assert schedule53[1][11:22] == [2] * 11
+    assert schedule53[2][22:33] == [2] * 11
+    assert schedule53[3][33:44] == [2] * 11
+    assert all(sum(group) == 64 for group in schedule53)
+
+    assert schedule54[0][:10] == [2] * 10
+    assert schedule54[0][10:] == [1] * 44
+    assert schedule54[1][10:20] == [2] * 10
+    assert schedule54[2][20:30] == [2] * 10
+    assert schedule54[3][30:40] == [2] * 10
+    assert all(sum(group) == 64 for group in schedule54)
+
+    manifest53 = exact_local_cluster_gqa8_service_manifest(producers=53)
+    manifest54 = exact_local_cluster_gqa8_service_manifest(producers=54)
+    assert manifest53["head_bases"] == list(LOCAL_CLUSTER_GQA8_HEAD_BASES)
+    assert manifest54["head_bases"] == list(LOCAL_CLUSTER_GQA8_HEAD_BASES)
+    assert manifest53["aggregate_output_beats_per_full_run"] == 512
+    assert manifest54["aggregate_output_beats_per_full_run"] == 512
+
+
+def test_local_cluster_gqa8_rejects_wrong_max_blocks(tmp_path: Path) -> None:
+    config = _load_config(53)
+    config["attention_score32_exact_local_cluster_gqa8"]["max_blocks"] = 16
+    with pytest.raises(SystemExit, match="max_blocks must remain fixed at 8"):
+        generate(config, tmp_path / "rtl")
+
+
+def test_local_cluster_gqa8_generated_top_contains_full_width_wiring_tokens(tmp_path: Path) -> None:
+    config = _load_config(54)
+    generate(config, tmp_path / "rtl")
+
+    top_text = (tmp_path / "rtl" / "top.v").read_text(encoding="utf-8")
+    top_name = str(config["top_name"])
+    top_start = top_text.index(f"module {top_name} ")
+    top_end = top_text.index("endmodule", top_start)
+    top_module = top_text[top_start:top_end]
+
+    assert top_module.count(f"{top_name}__producer u_producer_") == 54
+    assert f"{top_name}__reducer u_reducer" in top_module
+    assert "wire group_command_fire_w = command_valid && command_ready;" in top_module
+    assert "wire [PRODUCERS-1:0] producer_command_accept_w = {PRODUCERS{group_command_fire_w}} & producer_command_ready_w;" in top_module
+    assert "assign command_ready = &producer_command_ready_w;" in top_module
+    assert ".leaf_valid(producer_result_valid_w)" in top_module
+    assert ".leaf_ready(producer_result_ready_w)" in top_module
+    assert ".leaf_command_id(producer_result_command_id_w)" in top_module
+    assert ".leaf_value(producer_result_value_w)" in top_module
+    assert ".command_block_count(command_block_count[14:0])" in top_module
+    assert ".command_block_count(command_block_count[809:795])" in top_module
+    assert ".value_read_req_valid(value_read_req_valid[1:0])" in top_module
+    assert ".value_read_req_valid(value_read_req_valid[107:106])" in top_module
+    assert ".value_response_matrix(value_response_matrix[1023:0])" in top_module
+    assert ".value_response_matrix(value_response_matrix[55295:54272])" in top_module
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="RTL tools unavailable")
+@pytest.mark.parametrize("producers", (53, 54))
+def test_local_cluster_gqa8_manifest_and_verilator_lint(tmp_path: Path, producers: int) -> None:
+    config = _load_config(producers)
+    generate(config, tmp_path / "rtl")
+    fakeram_path = tmp_path / "fakeram45_2048x39.sv"
+    fakeram_path.write_text(_FAKERAM_MODEL, encoding="utf-8")
+
+    manifest = json.loads(
+        (tmp_path / "rtl" / "attention_score32_exact_local_cluster_gqa8_manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert manifest["producers"] == producers
+    assert manifest["max_blocks"] == 8
+    assert manifest["persistent_waves"] == 8
+    assert manifest["query_head_groups"] == 4
+    assert manifest["query_heads_per_group"] == 8
+    assert manifest["value_memory_lanes"] == producers * 2
+    assert manifest["producer_input_lanes"] == producers
+    assert manifest["remaining_abstractions"] == [
+        "noc_sram_ppa_open",
+        "global_c16_exact_reduction_open",
+    ]
+    assert manifest["checked_in_probe_defaults"] == {
+        "head_bases": [0, 8, 16, 24],
+        "head_dim": 1,
+        "seed": 73,
+        "timeout_s": 300,
+    }
+    assert manifest["rtl_files"] == [
+        "top.v",
+        "producer.v",
+        "reducer.v",
+        "verilator_wrapper_blackboxes.v",
+    ]
+    assert manifest["service_model"]["per_group_total_blocks_per_stream"] == [64, 64, 64, 64]
+    assert manifest["service_model"]["full_run_wave_command_count"] == 32
+    assert manifest["submodule_manifests"]["producer"]["max_blocks"] == 8
+    assert manifest["submodule_manifests"]["gqa8_local_temporal_reducer"]["producers"] == producers
+
+    producer_lint = subprocess.run(
+        [
+            _tool("verilator"),
+            "--lint-only",
+            "-Wno-WIDTHEXPAND",
+            "-Wno-WIDTHTRUNC",
+            "--top-module",
+            f"{config['top_name']}__producer",
+            str(tmp_path / "rtl" / "producer.v"),
+            str(fakeram_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert producer_lint.returncode == 0, producer_lint.stderr
+
+    reducer_lint = subprocess.run(
+        [
+            _tool("verilator"),
+            "--lint-only",
+            "-Wno-WIDTHEXPAND",
+            "-Wno-WIDTHTRUNC",
+            "--top-module",
+            f"{config['top_name']}__reducer",
+            str(tmp_path / "rtl" / "reducer.v"),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert reducer_lint.returncode == 0, reducer_lint.stderr
+
+    wrapper_lint = subprocess.run(
+        [
+            _tool("verilator"),
+            "--lint-only",
+            "-Wno-WIDTHEXPAND",
+            "-Wno-WIDTHTRUNC",
+            "--top-module",
+            str(config["top_name"]),
+            str(tmp_path / "rtl" / "top.v"),
+            str(tmp_path / "rtl" / "verilator_wrapper_blackboxes.v"),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert wrapper_lint.returncode == 0, wrapper_lint.stderr
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="RTL tools unavailable")
+def test_local_cluster_gqa8_full_p53_probe_attempt_is_bounded_and_honest() -> None:
+    report = build_report(config=_load_config(53))
+
+    assert report["full_probe_attempted"] is True
+    assert report["producers"] == 53
+    assert report["groups"] == 4
+    assert report["waves"] == 8
+    assert report["wave_commands"] == 32
+    assert report["head_bases"] == [0, 8, 16, 24]
+    assert report["head_dim"] == 1
+    assert report["expected_outputs"] == 512
+    assert report["service_model"]["per_group_total_blocks_per_stream"] == [64, 64, 64, 64]
+
+    if report["timed_out"]:
+        assert report["timeout_s"] == 300
+        assert report["passed"] is False
+        return
+
+    assert report["passed"] is True
+    assert report["outputs"] == 512
+    assert report["command_schedule_matches"] is True
+    assert report["producer_counts_match"] is True
+    assert report["wave_command_accept_count"] == 32
+    assert report["reducer_completed_command_count"] == 4
+    assert report["reducer_local_root_completed_count"] == 4096
+    assert report["reducer_temporal_merge_completed_count"] == 3584
+    assert report["reducer_emitted_beat_count"] == 512
+    assert report["protocol_error"] is False
+    assert report["atomic_command_protocol_error"] is False
+    assert report["group_contract_error"] is False
+    assert report["local_tree_protocol_error"] is False
+    assert report["temporal_merge_protocol_error"] is False
+    assert report["reducer_protocol_error"] is False
+    assert report["observed_rows"] == report["expected_rows"]

--- a/tests/test_check_attention_score32_exact_local_cluster_gqa8_guard.py
+++ b/tests/test_check_attention_score32_exact_local_cluster_gqa8_guard.py
@@ -1,0 +1,97 @@
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_score32_exact_local_cluster_gqa8 import generate
+
+
+def _config_path(producers: int) -> Path:
+    return (
+        REPO_ROOT
+        / "runs"
+        / "designs"
+        / "npu_blocks"
+        / f"attention_score32_exact_local_cluster_gqa8_p{producers}_w8"
+        / "config.json"
+    )
+
+
+def _prepare_design_dir(tmp_path: Path, *, producers: int) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    design_dir = tmp_path / f"design_p{producers}"
+    design_dir.mkdir()
+    config = json.loads(_config_path(producers).read_text(encoding="utf-8"))
+    (design_dir / "config.json").write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    generate(config, design_dir / "verilog")
+    return design_dir
+
+
+def _run_guard(design_dir: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/check_attention_score32_exact_local_cluster_gqa8_guard.py",
+            "--design-dir",
+            str(design_dir),
+            "--config",
+            str(design_dir / "config.json"),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_local_cluster_gqa8_guard_accepts_checked_in_configs(tmp_path: Path) -> None:
+    for producers in (53, 54):
+        design_dir = _prepare_design_dir(tmp_path / f"p{producers}", producers=producers)
+        result = _run_guard(design_dir)
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["producers"] == producers
+        assert payload["status"] == "ok"
+
+
+def test_local_cluster_gqa8_guard_rejects_stale_top(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, producers=53)
+    top_path = design_dir / "verilog" / "top.v"
+    top_path.write_text(top_path.read_text(encoding="utf-8") + "\n// stale drift\n", encoding="utf-8")
+
+    result = _run_guard(design_dir)
+    assert result.returncode != 0
+    assert "generated RTL artifacts do not match current generator output: top.v" in result.stderr
+
+
+def test_local_cluster_gqa8_guard_rejects_missing_proposal_linkage(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, producers=54)
+    for config_path in (design_dir / "config.json", design_dir / "verilog" / "config.json"):
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        config["report_links"]["proposal_id"] = "wrong_proposal"
+        config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+
+    result = _run_guard(design_dir)
+    assert result.returncode != 0
+    assert "report_links proposal_id must be prop_l1_decoder_attention_score32_local_cluster_gqa8_v1" in result.stderr
+
+
+def test_local_cluster_gqa8_guard_rejects_missing_atomic_issue_token(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, producers=53)
+    top_path = design_dir / "verilog" / "top.v"
+    text = top_path.read_text(encoding="utf-8")
+    top_path.write_text(
+        text.replace(
+            "wire group_command_fire_w = command_valid && command_ready;",
+            "wire group_command_fire_w = command_valid;",
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run_guard(design_dir)
+    assert result.returncode != 0
+    assert "generated RTL missing semantic token: wire group_command_fire_w = command_valid && command_ready;" in result.stderr


### PR DESCRIPTION
## Summary
- instantiate the real p53/p54 dual-stream GQA8 producer arrays
- connect exact producer result streams directly and index-preserving into the corrected local temporal reducer
- expose all producer input and 2xP value-memory lanes without SRAM/NoC substitution
- add explicit per-producer block-count rotation and structured reference/probe evidence

## Architecture
- p53 top pins: 89,343 bits
- p54 top pins: 91,013 bits
- four GQA groups, eight tile waves per group
- deterministic extra-block rotation matching the corrected 64 blocks/stream distribution

## Verification
- generator/guard/Verilator suite: 10 passed in 528.90s
- full p53 ideal RTL probe attempted with actual 53 producers; `vvp` reached the explicit 300s bound
- no reduced producer-count proxy replaces the final RTL

No PPA job or DB item is created by this PR.
