### PR TITLE
Add proposal-backed full GQA8 SRAM equivalence job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -10254,6 +10254,8 @@ def _decoder_producer_ranker_ready_valid_equivalence_evidence(*, item_id: str) -
 def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_evidence(
     *,
     item_id: str,
+    proposal_id: str | None = None,
+    proposal_path: str | None = None,
 ) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     config = (
@@ -10269,6 +10271,12 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equiv
         f"{base}/decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence__"
         f"{item_id}.md"
     )
+    proposal_args: list[str] = []
+    if str(proposal_id or "").strip():
+        proposal_args.extend(["--proposal-id", str(proposal_id).strip()])
+    if str(proposal_path or "").strip():
+        proposal_args.extend(["--proposal-path", str(proposal_path).strip()])
+    proposal_arg_text = " ".join(shlex.quote(arg) for arg in proposal_args)
     command = (
         "systemd-run --user --scope "
         "-p MemoryHigh=6G -p MemoryMax=8G -p CPUQuota=300% -p TasksMax=512 "
@@ -10277,8 +10285,9 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equiv
         "--timeout-sec 900 "
         "--root-ready-pattern 1,1,0,1 "
         f"--out {out} "
-        f"--out-md {report}"
-    )
+        f"--out-md {report} "
+        f"{proposal_arg_text}"
+    ).strip()
     return {
         "inputs": {
             "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_config": config,
@@ -11754,7 +11763,9 @@ def _build_payload(
         elif abstraction_layer_name == "decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence":
             decoder_evidence = (
                 _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_evidence(
-                    item_id=item_id
+                    item_id=item_id,
+                    proposal_id=proposal_id,
+                    proposal_path=proposal_path,
                 )
             )
         elif abstraction_layer_name == "decoder_attention_separated_cluster_equivalence":

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -10251,6 +10251,77 @@ def _decoder_producer_ranker_ready_valid_equivalence_evidence(*, item_id: str) -
     }
 
 
+def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_evidence(
+    *,
+    item_id: str,
+) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    config = (
+        "runs/designs/npu_blocks/"
+        "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_p54x8_p53x8_c16_r2_l8_b59/"
+        "config.json"
+    )
+    out = (
+        f"{base}/decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence__"
+        f"{item_id}.json"
+    )
+    report = (
+        f"{base}/decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence__"
+        f"{item_id}.md"
+    )
+    command = (
+        "systemd-run --user --scope "
+        "-p MemoryHigh=6G -p MemoryMax=8G -p CPUQuota=300% -p TasksMax=512 "
+        "python3 npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py "
+        f"--config {config} "
+        "--timeout-sec 900 "
+        "--root-ready-pattern 1,1,0,1 "
+        f"--out {out} "
+        f"--out-md {report}"
+    )
+    return {
+        "inputs": {
+            "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_config": config,
+            "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_out": out,
+            "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_report": report,
+            "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_scope": (
+                "Run the single composed GQA8 cluster-SRAM RTL equivalence probe under bounded "
+                "remote resources. Accept only a passed bounded report with exact producer/fill/"
+                "SRAM/root counts, zero protocol or sticky cluster errors, and a full structured "
+                "row audit pass across all 16 clusters plus the root stream."
+            ),
+        },
+        "commands": [
+            {
+                "name": "probe_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence",
+                "run": command,
+            },
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+        "acceptance": [
+            "Write exactly the bounded JSON and Markdown probe reports declared in expected_outputs",
+            "Require report passed=true, classification=passed, and counts_passed=true",
+            (
+                "Require exact totals in report.summary: producer_handshake_count=8192, "
+                "fill_target_accept_count=128, fill_row_accept_count=262144, "
+                "sram_request_accept_count=262144, sram_response_accept_count=262144, "
+                "cluster_row_count=2048, root_row_count=128, command_accept_count=8, "
+                "cadence_command_accept_count=8, protocol_error=0"
+            ),
+            (
+                "Require 16 cluster_summaries with errors=0 and exact per-cluster counts: "
+                "wave_command_accept_count=8, completed_command_count=1, emitted_beat_count=128, "
+                "fill_target_accept_count=8, fill_row_accept_count=16384, request_accept_count=16384, "
+                "response_accept_count=16384, command_accept_count=8, command_release_count=8"
+            ),
+            "Require full_row_audit.passed=true for every cluster stream and the root stream",
+            "Keep evidence artifact paths repo-portable",
+            "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing",
+        ],
+    }
+
+
 def _decoder_producer_ranker_physical_wrapper_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
     out = f"{base}/decoder_producer_ranker_physical_wrapper__{item_id}.json"
@@ -11245,6 +11316,7 @@ def _build_payload(
     }
     abstraction_layer_name = str(abstraction_layer or "").strip()
     evidence_only = False
+    evidence_acceptance: list[str] | None = None
     if abstraction_layer_name in {
         "decoder_probability_path",
         "decoder_probability_sweep",
@@ -11368,6 +11440,7 @@ def _build_payload(
         "decoder_attention_score32_exact_reduction_recost",
         "decoder_attention_score32_compute_activity_energy",
         "decoder_attention_score32_separated_compute_recost",
+        "decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence",
         "decoder_attention_separated_cluster_equivalence",
         "decoder_attention_hierarchical_softmax_architecture",
         "decoder_attention_two_pass_global_max_equivalence",
@@ -11678,6 +11751,12 @@ def _build_payload(
                 item_id=item_id,
                 depends_on_item_ids=depends_on_item_ids,
             )
+        elif abstraction_layer_name == "decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence":
+            decoder_evidence = (
+                _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_evidence(
+                    item_id=item_id
+                )
+            )
         elif abstraction_layer_name == "decoder_attention_separated_cluster_equivalence":
             decoder_evidence = _decoder_attention_separated_cluster_equivalence_evidence(item_id=item_id)
         elif abstraction_layer_name == "decoder_attention_hierarchical_softmax_architecture":
@@ -11897,6 +11976,9 @@ def _build_payload(
         else:
             decoder_evidence = _decoder_probability_path_evidence(item_id=item_id)
         evidence_only = bool(decoder_evidence.get("evidence_only"))
+        candidate_acceptance = decoder_evidence.get("acceptance")
+        if isinstance(candidate_acceptance, list) and candidate_acceptance:
+            evidence_acceptance = [str(value) for value in candidate_acceptance]
         if evidence_only:
             commands = [
                 *decoder_evidence["commands"],
@@ -11924,6 +12006,8 @@ def _build_payload(
             "Keep evidence artifact paths repo-portable",
             "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing",
         ]
+    if evidence_acceptance is not None:
+        acceptance = evidence_acceptance
 
     payload = {
         "version": 0.1,

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -13724,3 +13724,98 @@ def test_generate_l2_campaign_task_adds_attention_pwl_recip_lut_boundary_evidenc
             assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
                 "layer": "decoder_attention_pwl_recip_lut_boundary",
             }
+
+
+def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_equivalence_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=(
+                        "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_"
+                        "equivalence_llama7b_v1"
+                    ),
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer=(
+                        "decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
+            acceptance = work_item.task_request.request_payload["task"]["acceptance"]
+            run = commands[0]["run"]
+
+            assert command_names == [
+                "probe_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence",
+                "validate_runs",
+            ]
+            assert (
+                "systemd-run --user --scope -p MemoryHigh=6G -p MemoryMax=8G "
+                "-p CPUQuota=300% -p TasksMax=512"
+            ) in run
+            assert (
+                "python3 npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py"
+                in run
+            )
+            assert (
+                "runs/designs/npu_blocks/"
+                "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_p54x8_p53x8_c16_r2_l8_b59/"
+                "config.json"
+            ) in run
+            assert "--timeout-sec 900" in run
+            assert "--root-ready-pattern 1,1,0,1" in run
+            assert "--out " in run
+            assert "--out-md " in run
+            assert decoder_inputs[
+                "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_config"
+            ].endswith(
+                "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_p54x8_p53x8_c16_r2_l8_b59/config.json"
+            )
+            assert decoder_inputs[
+                "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_out"
+            ].endswith(
+                "decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence__"
+                "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_"
+                "equivalence_llama7b_v1.json"
+            )
+            assert decoder_inputs[
+                "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_report"
+            ].endswith(
+                "decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence__"
+                "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_"
+                "equivalence_llama7b_v1.md"
+            )
+            assert expected_outputs == [
+                decoder_inputs[
+                    "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_out"
+                ],
+                decoder_inputs[
+                    "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_report"
+                ],
+            ]
+            assert work_item.expected_outputs == expected_outputs
+            assert acceptance == work_item.acceptance_rules
+            assert any("passed=true" in rule and "classification=passed" in rule for rule in acceptance)
+            assert any("producer_handshake_count=8192" in rule for rule in acceptance)
+            assert any("cluster_summaries" in rule and "errors=0" in rule for rule in acceptance)
+            assert any("full_row_audit.passed=true" in rule for rule in acceptance)
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert work_item.task_request.request_payload["source_requirement"]["required_sha"] == source_commit

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -13747,6 +13747,15 @@ def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_equivalence_evidence()
                     ),
                     requested_by="@tester",
                     source_commit=source_commit,
+                    proposal_id=(
+                        "prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_"
+                        "equivalence_llama7b_v1"
+                    ),
+                    proposal_path=(
+                        "docs/proposals/"
+                        "prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_"
+                        "equivalence_llama7b_v1/proposal.json"
+                    ),
                     abstraction_layer=(
                         "decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence"
                     ),
@@ -13784,6 +13793,16 @@ def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_equivalence_evidence()
             assert "--root-ready-pattern 1,1,0,1" in run
             assert "--out " in run
             assert "--out-md " in run
+            assert (
+                "--proposal-id "
+                "prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_"
+                "equivalence_llama7b_v1"
+            ) in run
+            assert (
+                "--proposal-path docs/proposals/"
+                "prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_"
+                "equivalence_llama7b_v1/proposal.json"
+            ) in run
             assert decoder_inputs[
                 "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_config"
             ].endswith(

--- a/docs/architecture/llama7b_attention_abstraction_closure_plan.md
+++ b/docs/architecture/llama7b_attention_abstraction_closure_plan.md
@@ -401,6 +401,23 @@ run the already queued exp-LUT branch:
     It should scale from this wrapper evidence and keep external SRAM, NoC,
     HBM/DRAM service, and full-array physical signoff as explicit remaining
     abstractions.
+13. Run
+    `l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1`
+    against the full 856-producer, sixteen-cluster SRAM, local-reducer, and
+    finalized-tree composition. Require exact aggregate and per-cluster
+    traffic counts, zero sticky errors, and structured equality for every
+    cluster and root row. Timeout or OOM is inconclusive; an arithmetic,
+    ordering, metadata, or protocol mismatch is conclusive.
+14. After the equivalence artifact merges, recost the Llama7B score32 point
+    with the measured command-to-root service interval and measured SRAM
+    request/fill traffic. Do not treat deterministic fill arrival as measured
+    HBM service, and do not charge inferred SRAM as a characterized macro.
+15. Close the remaining communication and physical abstractions with a
+    logically valid mesh topology/scheduler pair, SRAM macro PPA substitution,
+    and utilization-matched cluster-array physical slices. Rerank token
+    throughput, energy, area, and precision only after each substituted term
+    names its measured source and leaves no incompatible category mixed into
+    the same rank.
 
 All new evaluation jobs should run on the remote evaluator
 `eval-daemon-b7c2d9c80c1c`, not the devcontainer.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/README.md
@@ -1,0 +1,12 @@
+# Full score32 GQA8 cluster-SRAM equivalence
+
+This proposal gates the first complete RTL path from 856 score32 producers
+through sixteen concrete cluster SRAM services and local reducers into the
+ordered finalized tree.
+
+The job is an equivalence and service-observability gate, not a physical PPA
+claim. A pass permits the measured cycle and traffic behavior to enter the
+Llama7B architecture model. It does not close HBM timing, SRAM macro PPA, mesh
+NoC behavior, or full-array physical feasibility.
+
+See `evaluation_gate.md` for the exact remote resource and acceptance contract.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/evaluation_gate.md
@@ -1,0 +1,47 @@
+# Full GQA8 cluster-SRAM equivalence gate
+
+## Dispatch
+
+- Required machine: `eval-daemon-b7c2d9c80c1c`
+- Required source: the merge SHA containing this proposal and task mapping
+- Physical flow: disabled
+- Subprocess timeout: 900 seconds
+- Outer job timeout: 1200 seconds
+- Stall timeout: 300 seconds
+- Memory: `MemoryHigh=6G`, `MemoryMax=8G`
+- CPU: `CPUQuota=300%`
+- Tasks: `TasksMax=512`
+
+Do not run this probe in the devcontainer.
+
+## Pass criteria
+
+The JSON report must contain:
+
+- `passed: true`
+- `classification: passed`
+- 8,192 producer handshakes
+- 128 accepted fill targets
+- 262,144 accepted fill rows
+- 262,144 SRAM requests and responses
+- 2,048 cluster rows
+- 128 root rows
+- 16 passing per-cluster summaries
+- zero protocol or sticky errors
+- passing structured comparisons for every cluster row and root row
+
+Hashes are diagnostics only. They cannot substitute for structured comparison.
+
+## Failure classification
+
+Timeout, OOM, or resource termination is inconclusive and must not reject the
+architecture. Count, protocol, metadata, ordering, or row mismatches are
+conclusive implementation failures and must be fixed before PPA or Llama7B
+recosting.
+
+## Follow-on
+
+After a passing artifact is merged, use measured cycle and traffic evidence to
+replace the current idealized cluster-SRAM service interval in the Llama7B
+model. Keep HBM arrival timing, SRAM macro PPA, mesh NoC behavior, broader head
+groups, and full-array physical closure explicit until separately measured.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,39 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1",
+  "proposal_path": "docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/proposal.json",
+  "source_commit_note": "Generate and dispatch only after this proposal and its task-generator mapping are merged. Pin the work item source_commit to that merge SHA.",
+  "requests": [
+    {
+      "item_id": "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1",
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence",
+      "comparison_role": "equivalence_check",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_direction": "prove_full_composed_equivalence_or_diagnose",
+      "expected_reason": "Promote the complete score32 GQA8 producer-to-SRAM-to-finalized-tree path only after exact structured-row, traffic-count, and protocol equivalence passes.",
+      "dispatch_machine_key": "eval-daemon-b7c2d9c80c1c"
+    }
+  ],
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the bounded remote RTL/perf equivalence gate for the complete score32 GQA8 producer, cluster-SRAM, local-reducer, and finalized-tree path.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence",
+      "comparison_role": "equivalence_check",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "prove_full_composed_equivalence_or_diagnose",
+        "reason": "Only a complete structured-row and protocol pass can promote this composed path into the measured Llama7B architecture model."
+      },
+      "status": "pending",
+      "notes": "Dispatch only to eval-daemon-b7c2d9c80c1c with the bounded resource contract in evaluation_gate.md."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/proposal.json
@@ -1,0 +1,104 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1",
+  "created_utc": "2026-07-29T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Full score32 GQA8 producer, cluster-SRAM, and finalized-tree equivalence",
+  "abstraction_layer": "decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence",
+  "hypothesis": "The 856 real score32 producers, sixteen exact local temporal reducers, sixteen double-buffered cluster SRAM services, and the c16/r2/l8/b59 finalized tree preserve the perf-reference result under the exact eight-wave GQA8 schedule, bounded SRAM prefetch, release, and root backpressure contracts.",
+  "direct_comparison": {
+    "primary_question": "Does the fully composed producer-to-SRAM-to-local/global RTL path produce every expected cluster and root row while satisfying exact traffic counts and all ready-valid, residency, cadence, and release invariants?",
+    "baselines": [
+      "prop_l1_decoder_attention_score32_exact_local16_global_tree_gqa8_v1",
+      "prop_l1_decoder_attention_score32_local_cluster_gqa8_v1"
+    ],
+    "candidate": "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1",
+    "include": [
+      "856 real dual-stream score32 producer instances",
+      "eight p54 and eight p53 local temporal clusters",
+      "sixteen explicit double-buffered cluster SRAM services",
+      "eight persistent wave commands for one GQA8 head group",
+      "current and next-wave fill prefetch",
+      "SRAM command release after producer completion and response drain",
+      "all 2048 structured cluster rows",
+      "all 128 structured finalized root rows",
+      "root ready pattern 1,1,0,1",
+      "exact aggregate and per-cluster traffic counters"
+    ],
+    "exclude": [
+      "OpenROAD or SRAM macro physical characterization",
+      "real HBM controller arrival timing and row policy",
+      "mesh NoC routing and arbitration",
+      "multiple simultaneous head groups",
+      "quality or precision comparison beyond exact score32 arithmetic",
+      "full Llama7B token-level reranking in this equivalence job"
+    ],
+    "metrics": [
+      "producer_handshake_count",
+      "fill_target_accept_count",
+      "fill_row_accept_count",
+      "sram_request_accept_count",
+      "sram_response_accept_count",
+      "cluster_row_count",
+      "root_row_count",
+      "full_structured_cluster_row_audit",
+      "full_structured_root_row_audit",
+      "protocol_and_sticky_error_bits",
+      "first_and_last_root_cycle"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the bounded remote RTL/perf equivalence gate for the complete score32 GQA8 producer, cluster-SRAM, local-reducer, and finalized-tree path.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence",
+      "comparison_role": "equivalence_check",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "prove_full_composed_equivalence_or_diagnose",
+        "reason": "Only a complete structured-row and protocol pass can promote this composed path into the measured Llama7B architecture model."
+      }
+    }
+  ],
+  "acceptance_contract": {
+    "classification": "passed",
+    "passed": true,
+    "aggregate_counts": {
+      "producer_handshake_count": 8192,
+      "fill_target_accept_count": 128,
+      "fill_row_accept_count": 262144,
+      "sram_request_accept_count": 262144,
+      "sram_response_accept_count": 262144,
+      "cluster_row_count": 2048,
+      "root_row_count": 128
+    },
+    "cluster_summaries": 16,
+    "protocol_errors": 0,
+    "structured_row_audit": true
+  },
+  "remaining_abstractions": [
+    "The external fill driver is deterministic and does not yet embody measured HBM command, row-hit, or contention behavior.",
+    "The inferred SRAM service is functionally concrete but not characterized as a foundry SRAM macro.",
+    "Inter-cluster and producer traffic does not yet traverse a physically measured mesh NoC.",
+    "The equivalence workload covers one GQA8 head group and one deterministic seed.",
+    "Full-array timing, power, area, and congestion remain unmeasured."
+  ],
+  "source_refs": [
+    "npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py",
+    "npu/rtlgen/gen_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py",
+    "npu/rtlgen/gen_attention_score32_exact_cluster_sram_composed_gqa8.py",
+    "npu/sim/perf/attention_score32_exact_cluster_sram_service_gqa8.py",
+    "npu/sim/perf/attention_exact_partial.py",
+    "runs/designs/npu_blocks/attention_score32_exact_local16_global_tree_cluster_sram_gqa8_p54x8_p53x8_c16_r2_l8_b59/config.json"
+  ],
+  "knowledge_refs": [
+    "npu/docs/attention_score32_exact_local16_global_tree_cluster_sram_gqa8_contract.md",
+    "npu/docs/attention_score32_exact_cluster_sram_service_gqa8_contract.md",
+    "docs/architecture/llama7b_attention_abstraction_closure_plan.md"
+  ]
+}

--- a/npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
+++ b/npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
@@ -1062,6 +1062,15 @@ def _render_text(report: JsonDict) -> str:
     )
 
 
+def _render_json(report: JsonDict) -> str:
+    return json.dumps(report, indent=2, sort_keys=True)
+
+
+def _write_output(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body + ("" if body.endswith("\n") else "\n"), encoding="utf-8")
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--config", type=Path)
@@ -1069,6 +1078,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--timeout-sec", type=int, default=DEFAULT_SUBPROCESS_TIMEOUT_SEC)
     parser.add_argument("--proposal-id", type=str)
     parser.add_argument("--proposal-path", type=str)
+    parser.add_argument("--out", type=Path)
+    parser.add_argument("--out-md", type=Path)
     parser.add_argument("--json", action="store_true")
     args = parser.parse_args(argv)
     config = build_default_config() if args.config is None else json.loads(args.config.read_text(encoding="utf-8"))
@@ -1080,7 +1091,13 @@ def main(argv: list[str] | None = None) -> int:
         proposal_id=str(args.proposal_id or "").strip() or None,
         proposal_path=str(args.proposal_path or "").strip() or None,
     )
-    print(json.dumps(report, indent=2, sort_keys=True) if args.json else _render_text(report))
+    rendered_json = _render_json(report)
+    rendered_text = _render_text(report)
+    if args.out is not None:
+        _write_output(args.out, rendered_json)
+    if args.out_md is not None:
+        _write_output(args.out_md, rendered_text)
+    print(rendered_json if args.json else rendered_text)
     return 0 if report["passed"] else 1
 
 

--- a/tests/test_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
+++ b/tests/test_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
@@ -22,6 +22,7 @@ from npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa
     compare_full_rows,
     expected_counts,
     expected_schedule_prefix,
+    main,
 )
 from npu.rtlgen.gen_attention_score32_exact_local16_global_tree_cluster_sram_gqa8 import _validate
 
@@ -359,3 +360,56 @@ def test_checked_in_top_removes_external_value_lanes_and_enforces_fill_window() 
     assert "fill_target_head_base[(gfill * 5) +: 5] == next_expected_head_base_w" in rtl
     assert ".fill_target_valid(fill_target_valid[0] && fill_target_schedule_allowed_w[0])" in rtl
     assert "fill_target_valid[0] && (!fill_target_metadata_valid_w[0] || !fill_target_schedule_allowed_w[0])" in rtl
+
+
+def test_main_writes_bounded_json_and_markdown_reports(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    fake_report = {
+        "passed": True,
+        "classification": "passed",
+        "simulation_status": "ok",
+        "summary": dict(EXPECTED_TOTALS),
+        "cluster_summaries": [{"cluster": cluster, **EXPECTED_PER_CLUSTER, "errors": 0} for cluster in range(16)],
+        "counts_passed": True,
+        "full_row_audit": {"passed": True, "clusters": [], "root": {"passed": True}},
+        "observed_cluster_hashes": ["abc"] * 16,
+        "expected_cluster_hashes": ["abc"] * 16,
+        "observed_root_hash": "root",
+        "expected_root_hash": "root",
+    }
+    fake_config = {
+        "top_name": "fake_top",
+        "attention_score32_exact_local16_global_tree_cluster_sram_gqa8": {
+            "cluster_producers": [54] * 8 + [53] * 8
+        },
+    }
+
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.build_default_config",
+        lambda: fake_config,
+    )
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.build_report",
+        lambda **_: fake_report,
+    )
+
+    out = tmp_path / "nested" / "probe.json"
+    out_md = tmp_path / "nested" / "probe.md"
+    exit_code = main(["--json", "--out", str(out), "--out-md", str(out_md)])
+
+    assert exit_code == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["passed"] is True
+    assert payload["classification"] == "passed"
+    assert "observed_cluster_rows" not in payload
+    assert "expected_cluster_rows" not in payload
+    assert "observed_root_rows" not in payload
+    assert "expected_root_rows" not in payload
+    markdown = out_md.read_text(encoding="utf-8")
+    assert "# attention_score32_exact_local16_global_tree_cluster_sram_gqa8_probe" in markdown
+    assert "- producer_handshakes: `8192`" in markdown
+    stdout = capsys.readouterr().out
+    assert json.loads(stdout) == payload


### PR DESCRIPTION
## Summary

- add one-run JSON and Markdown artifact output to the full composed GQA8 SRAM probe
- map the composed equivalence abstraction into the L2 task generator as evidence-only work
- enforce remote `systemd-run` memory, CPU, and task bounds in the generated command
- carry proposal ID/path into the probe report to preserve developer-loop artifact linkage
- define exact aggregate, per-cluster, protocol, and structured-row acceptance rules
- add the proposal, evaluation gate, remote dispatch requirement, and follow-on Llama7B closure steps

## Validation

- 11 focused composed-probe tests passed
- focused L2 task-generator test passed
- Python compile checks
- proposal JSON syntax checks
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`

No RTL simulator, CMake build, or physical flow was run locally.