### PR TITLE
Make full GQA8 equivalence worker-exclusive

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -10280,6 +10280,7 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equiv
     command = (
         "systemd-run --user --scope "
         "-p MemoryHigh=6G -p MemoryMax=8G -p CPUQuota=300% -p TasksMax=512 "
+        "-p RuntimeMaxSec=1200 "
         "python3 npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py "
         f"--config {config} "
         "--timeout-sec 900 "
@@ -10308,6 +10309,15 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equiv
         ],
         "expected_outputs": [out, report],
         "evidence_only": True,
+        "worker_resources": {
+            "exclusive_worker": True,
+            "memory_high": "6G",
+            "memory_max": "8G",
+            "cpu_quota": "300%",
+            "tasks_max": 512,
+            "outer_timeout_seconds": 1200,
+            "stall_timeout_seconds": 300,
+        },
         "acceptance": [
             "Write exactly the bounded JSON and Markdown probe reports declared in expected_outputs",
             "Require report passed=true, classification=passed, and counts_passed=true",
@@ -12004,6 +12014,9 @@ def _build_payload(
             commands = [*decoder_evidence["commands"], *commands]
             expected_outputs = _uniq([*expected_outputs, *decoder_evidence["expected_outputs"]])
             task_inputs["decoder_contract"] = decoder_evidence["inputs"]
+        worker_resources = decoder_evidence.get("worker_resources")
+        if isinstance(worker_resources, dict) and worker_resources:
+            task_inputs["worker_resources"] = dict(worker_resources)
 
     acceptance = [
         "Populate metrics.csv for all referenced design dirs",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -13771,6 +13771,15 @@ def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_equivalence_evidence()
             expected_outputs = work_item.task_request.request_payload["task"]["expected_outputs"]
             acceptance = work_item.task_request.request_payload["task"]["acceptance"]
             run = commands[0]["run"]
+            expected_worker_resources = {
+                "exclusive_worker": True,
+                "memory_high": "6G",
+                "memory_max": "8G",
+                "cpu_quota": "300%",
+                "tasks_max": 512,
+                "outer_timeout_seconds": 1200,
+                "stall_timeout_seconds": 300,
+            }
 
             assert command_names == [
                 "probe_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence",
@@ -13778,7 +13787,7 @@ def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_equivalence_evidence()
             ]
             assert (
                 "systemd-run --user --scope -p MemoryHigh=6G -p MemoryMax=8G "
-                "-p CPUQuota=300% -p TasksMax=512"
+                "-p CPUQuota=300% -p TasksMax=512 -p RuntimeMaxSec=1200"
             ) in run
             assert (
                 "python3 npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py"
@@ -13837,4 +13846,9 @@ def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_equivalence_evidence()
             assert any("cluster_summaries" in rule and "errors=0" in rule for rule in acceptance)
             assert any("full_row_audit.passed=true" in rule for rule in acceptance)
             assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert work_item.input_manifest["worker_resources"] == expected_worker_resources
+            assert (
+                work_item.task_request.request_payload["task"]["inputs"]["worker_resources"]
+                == expected_worker_resources
+            )
             assert work_item.task_request.request_payload["source_requirement"]["required_sha"] == source_commit


### PR DESCRIPTION
## Summary

- mark the composed GQA8 SRAM equivalence work item as scheduler-exclusive
- propagate explicit worker resource metadata only for evidence definitions that provide it
- record 6/8 GiB memory bounds, 300% CPU, 512 tasks, 1,200-second outer runtime, and 300-second stall timeout
- add `RuntimeMaxSec=1200` to the generated systemd scope
- verify the exact command and input manifest in the focused task-generator test

## Validation

- focused L2 task-generator test passed
- Python compile checks
- `git diff --check`

No simulation or physical flow was run.