### PR TITLE
Add portable bounded evaluator launcher

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -10,7 +10,7 @@ import re
 import shlex
 import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, Sequence
 
 from sqlalchemy.orm import Session
 
@@ -136,6 +136,31 @@ def _repo_rel(path_text: str, repo_root: Path) -> str:
 
 def _load_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _bounded_launcher_command(
+    *,
+    memory_high: str | None,
+    memory_max: str | None,
+    cpu_quota: str | None,
+    tasks_max: int | None,
+    runtime_max_sec: int | None,
+    child_command: Sequence[str],
+) -> str:
+    command = ["python3", "control_plane/scripts/run_bounded_command.py"]
+    if memory_high is not None:
+        command.extend(["--memory-high", memory_high])
+    if memory_max is not None:
+        command.extend(["--memory-max", memory_max])
+    if cpu_quota is not None:
+        command.extend(["--cpu-quota", cpu_quota])
+    if tasks_max is not None:
+        command.extend(["--tasks-max", str(tasks_max)])
+    if runtime_max_sec is not None:
+        command.extend(["--runtime-max-sec", str(runtime_max_sec)])
+    command.append("--")
+    command.extend(child_command)
+    return " ".join(shlex.quote(arg) for arg in command)
 
 
 def _retry_base(item_id: str) -> str:
@@ -10276,19 +10301,29 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equiv
         proposal_args.extend(["--proposal-id", str(proposal_id).strip()])
     if str(proposal_path or "").strip():
         proposal_args.extend(["--proposal-path", str(proposal_path).strip()])
-    proposal_arg_text = " ".join(shlex.quote(arg) for arg in proposal_args)
-    command = (
-        "systemd-run --user --scope "
-        "-p MemoryHigh=6G -p MemoryMax=8G -p CPUQuota=300% -p TasksMax=512 "
-        "-p RuntimeMaxSec=1200 "
-        "python3 npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py "
-        f"--config {config} "
-        "--timeout-sec 900 "
-        "--root-ready-pattern 1,1,0,1 "
-        f"--out {out} "
-        f"--out-md {report} "
-        f"{proposal_arg_text}"
-    ).strip()
+    child_command = [
+        "python3",
+        "npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py",
+        "--config",
+        config,
+        "--timeout-sec",
+        "900",
+        "--root-ready-pattern",
+        "1,1,0,1",
+        "--out",
+        out,
+        "--out-md",
+        report,
+        *proposal_args,
+    ]
+    command = _bounded_launcher_command(
+        memory_high="6G",
+        memory_max="8G",
+        cpu_quota="300%",
+        tasks_max=512,
+        runtime_max_sec=1200,
+        child_command=child_command,
+    )
     return {
         "inputs": {
             "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_config": config,
@@ -10366,20 +10401,31 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotat
         proposal_args.extend(["--proposal-id", str(proposal_id).strip()])
     if str(proposal_path or "").strip():
         proposal_args.extend(["--proposal-path", str(proposal_path).strip()])
-    proposal_arg_text = " ".join(shlex.quote(arg) for arg in proposal_args)
-    command = (
-        "systemd-run --user --scope "
-        "-p MemoryHigh=6G -p MemoryMax=8G -p CPUQuota=300% -p TasksMax=512 "
-        "-p RuntimeMaxSec=4500 "
-        "python3 npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py "
-        f"--config {config} "
-        "--logical-head-groups 4 "
-        "--timeout-sec 3600 "
-        "--root-ready-pattern 1,1,0,1 "
-        f"--out {out} "
-        f"--out-md {report} "
-        f"{proposal_arg_text}"
-    ).strip()
+    child_command = [
+        "python3",
+        "npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py",
+        "--config",
+        config,
+        "--logical-head-groups",
+        "4",
+        "--timeout-sec",
+        "3600",
+        "--root-ready-pattern",
+        "1,1,0,1",
+        "--out",
+        out,
+        "--out-md",
+        report,
+        *proposal_args,
+    ]
+    command = _bounded_launcher_command(
+        memory_high="6G",
+        memory_max="8G",
+        cpu_quota="300%",
+        tasks_max=512,
+        runtime_max_sec=4500,
+        child_command=child_command,
+    )
     return {
         "inputs": {
             "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_config": config,

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -13786,8 +13786,9 @@ def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_equivalence_evidence()
                 "validate_runs",
             ]
             assert (
-                "systemd-run --user --scope -p MemoryHigh=6G -p MemoryMax=8G "
-                "-p CPUQuota=300% -p TasksMax=512 -p RuntimeMaxSec=1200"
+                "python3 control_plane/scripts/run_bounded_command.py "
+                "--memory-high 6G --memory-max 8G --cpu-quota 300% "
+                "--tasks-max 512 --runtime-max-sec 1200 --"
             ) in run
             assert (
                 "python3 npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py"
@@ -13915,8 +13916,9 @@ def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_rotation_equivalence_e
                 "validate_runs",
             ]
             assert (
-                "systemd-run --user --scope -p MemoryHigh=6G -p MemoryMax=8G "
-                "-p CPUQuota=300% -p TasksMax=512 -p RuntimeMaxSec=4500"
+                "python3 control_plane/scripts/run_bounded_command.py "
+                "--memory-high 6G --memory-max 8G --cpu-quota 300% "
+                "--tasks-max 512 --runtime-max-sec 4500 --"
             ) in run
             assert "--logical-head-groups 4" in run
             assert "--timeout-sec 3600" in run

--- a/control_plane/control_plane/tests/test_run_bounded_command.py
+++ b/control_plane/control_plane/tests/test_run_bounded_command.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import time
+
+import pytest
+
+
+def _load_launcher_module():
+    script_path = (
+        Path(__file__).resolve().parents[2] / "scripts" / "run_bounded_command.py"
+    )
+    spec = importlib.util.spec_from_file_location("run_bounded_command_test_module", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_cli_requires_separator_and_payload() -> None:
+    module = _load_launcher_module()
+
+    with pytest.raises(SystemExit, match="missing `--` separator"):
+        module.parse_cli(["--memory-max", "8G"])
+
+    with pytest.raises(SystemExit, match="missing child command"):
+        module.parse_cli(["--memory-max", "8G", "--"])
+
+
+def test_parse_helpers_validate_sizes_quotas_and_runtime() -> None:
+    module = _load_launcher_module()
+
+    assert module._parse_size("8G") == 8 * 1024**3
+    assert module._parse_size("512m") == 512 * 1024**2
+    assert module._parse_cpu_quota_percent("300%") == 300.0
+    assert module._parse_runtime_max_sec("4500") == 4500
+
+    with pytest.raises(argparse.ArgumentTypeError):
+        module._parse_size("7Q")
+    with pytest.raises(argparse.ArgumentTypeError):
+        module._parse_cpu_quota_percent("300")
+    with pytest.raises(argparse.ArgumentTypeError):
+        module._parse_tasks_max("0")
+    with pytest.raises(argparse.ArgumentTypeError):
+        module._parse_runtime_max_sec("-1")
+
+
+def test_select_affinity_caps_by_cpu_quota() -> None:
+    module = _load_launcher_module()
+
+    assert module._select_affinity((3, 7, 9, 11), "300%") == (3, 7, 9)
+    assert module._select_affinity((3, 7, 9, 11), "250%") == (3, 7, 9)
+    assert module._select_affinity((3, 7), None) == (3, 7)
+
+
+def test_apply_fallback_limits_sets_rlimits_and_affinity() -> None:
+    module = _load_launcher_module()
+    rlimit_calls: list[tuple[int, tuple[int, int]]] = []
+    affinity_calls: list[tuple[int, tuple[int, ...]]] = []
+    spec = module.LimitSpec(
+        memory_high="6G",
+        memory_max="8G",
+        cpu_quota="300%",
+        tasks_max=512,
+        runtime_max_sec=1200,
+    )
+
+    selected = module._apply_fallback_limits(
+        spec,
+        allowed_cpus=(2, 4, 6, 8),
+        setrlimit=lambda limit, value: rlimit_calls.append((limit, value)),
+        sched_setaffinity=lambda pid, cpus: affinity_calls.append((pid, tuple(cpus))),
+    )
+
+    assert selected == (2, 4, 6)
+    assert rlimit_calls == [
+        (module.resource.RLIMIT_AS, (8 * 1024**3, 8 * 1024**3)),
+        (module.resource.RLIMIT_NPROC, (512, 512)),
+    ]
+    assert affinity_calls == [(0, (2, 4, 6))]
+
+
+def test_detect_systemd_user_manager_and_build_command(tmp_path: Path) -> None:
+    module = _load_launcher_module()
+    env = {
+        "DBUS_SESSION_BUS_ADDRESS": "unix:path=/tmp/fake-bus",
+        "XDG_RUNTIME_DIR": str(tmp_path),
+    }
+    recorded_commands: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        recorded_commands.append(list(command))
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    probe = module._detect_systemd_user_manager(
+        env=env,
+        which=lambda name: f"/usr/bin/{name}",
+        run=fake_run,
+    )
+    spec = module.LimitSpec(
+        memory_high="6G",
+        memory_max="8G",
+        cpu_quota="300%",
+        tasks_max=512,
+        runtime_max_sec=1200,
+    )
+    command = module._build_systemd_command(spec, ["python3", "child.py", "--flag"])
+
+    assert probe.usable is True
+    assert probe.reason == "systemd_run_scope_ok"
+    assert recorded_commands == [["/usr/bin/systemd-run", "--user", "--scope", "--quiet", "/usr/bin/true"]]
+    assert command == [
+        "systemd-run",
+        "--user",
+        "--scope",
+        "-p",
+        "MemoryHigh=6G",
+        "-p",
+        "MemoryMax=8G",
+        "-p",
+        "CPUQuota=300%",
+        "-p",
+        "TasksMax=512",
+        "-p",
+        "RuntimeMaxSec=1200",
+        "python3",
+        "child.py",
+        "--flag",
+    ]
+
+
+def test_main_uses_portable_fallback_when_systemd_binary_exists_without_user_bus(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_launcher_module()
+    fallback_calls: list[list[str]] = []
+
+    monkeypatch.setattr(module.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    monkeypatch.setattr(module.os, "sched_getaffinity", lambda pid: {0, 1, 2, 3})
+    monkeypatch.setattr(
+        module,
+        "_run_portable_fallback",
+        lambda spec, child_command, term_grace_sec=module._TERM_GRACE_SEC: (
+            fallback_calls.append(list(child_command)) or 0
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "_run_systemd_command",
+        lambda spec, child_command: pytest.fail("systemd backend should not be selected"),
+    )
+
+    result = module.main(["--memory-max", "8G", "--runtime-max-sec", "1200", "--", "python3", "-c", "print(1)"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert fallback_calls == [["python3", "-c", "print(1)"]]
+    assert '"backend": "portable_fallback"' in captured.err
+    assert '"reason": "missing_env:DBUS_SESSION_BUS_ADDRESS,XDG_RUNTIME_DIR"' in captured.err
+
+
+def test_run_portable_fallback_preserves_exit_code() -> None:
+    module = _load_launcher_module()
+    spec = module.LimitSpec(
+        memory_high=None,
+        memory_max=None,
+        cpu_quota=None,
+        tasks_max=None,
+        runtime_max_sec=10,
+    )
+
+    result = module._run_portable_fallback(
+        spec,
+        [sys.executable, "-c", "import sys; sys.exit(7)"],
+        term_grace_sec=0.1,
+    )
+
+    assert result == 7
+
+
+def test_run_portable_fallback_normalizes_signal_exit() -> None:
+    module = _load_launcher_module()
+    spec = module.LimitSpec(
+        memory_high=None,
+        memory_max=None,
+        cpu_quota=None,
+        tasks_max=None,
+        runtime_max_sec=10,
+    )
+
+    result = module._run_portable_fallback(
+        spec,
+        [sys.executable, "-c", "import os, signal; os.kill(os.getpid(), signal.SIGKILL)"],
+        term_grace_sec=0.1,
+    )
+
+    assert result == 137
+
+
+def test_run_portable_fallback_times_out_and_kills_process_group(tmp_path: Path) -> None:
+    module = _load_launcher_module()
+    pid_path = tmp_path / "grandchild.pid"
+    spec = module.LimitSpec(
+        memory_high=None,
+        memory_max=None,
+        cpu_quota=None,
+        tasks_max=None,
+        runtime_max_sec=1,
+    )
+    grandchild_code = (
+        "import os, signal, sys, time\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "Path = __import__('pathlib').Path\n"
+        "Path(sys.argv[1]).write_text(str(os.getpid()), encoding='utf-8')\n"
+        "time.sleep(60)\n"
+    )
+    parent_code = (
+        "import signal, subprocess, sys, time\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "subprocess.Popen([sys.executable, '-c', sys.argv[2], sys.argv[1]])\n"
+        "time.sleep(60)\n"
+    )
+
+    result = module._run_portable_fallback(
+        spec,
+        [sys.executable, "-c", parent_code, str(pid_path), grandchild_code],
+        term_grace_sec=0.2,
+    )
+
+    assert result == module.TIMEOUT_EXIT_CODE
+    grandchild_pid = int(pid_path.read_text(encoding="utf-8").strip())
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        try:
+            os.kill(grandchild_pid, 0)
+        except ProcessLookupError:
+            break
+        time.sleep(0.05)
+    else:
+        pytest.fail(f"grandchild process {grandchild_pid} survived process-group timeout")

--- a/control_plane/scripts/run_bounded_command.py
+++ b/control_plane/scripts/run_bounded_command.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Run a command under bounded resources with a systemd or portable backend."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import errno
+import json
+import math
+import os
+from pathlib import Path
+import resource
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from typing import Any, Sequence
+
+TIMEOUT_EXIT_CODE = 124
+_SYSTEMD_CHECK_TIMEOUT_SEC = 5.0
+_TERM_GRACE_SEC = 5.0
+_SIZE_SUFFIXES = {
+    "": 1,
+    "K": 1024,
+    "M": 1024**2,
+    "G": 1024**3,
+    "T": 1024**4,
+}
+
+
+@dataclass(frozen=True)
+class LimitSpec:
+    memory_high: str | None
+    memory_max: str | None
+    cpu_quota: str | None
+    tasks_max: int | None
+    runtime_max_sec: int | None
+
+
+@dataclass(frozen=True)
+class SystemdProbeResult:
+    usable: bool
+    reason: str
+
+
+def _parse_size(text: str) -> int:
+    value = str(text).strip()
+    if not value:
+        raise argparse.ArgumentTypeError("size must not be empty")
+    upper = value.upper()
+    if upper.endswith("IB"):
+        upper = upper[:-2]
+    elif upper.endswith("B") and len(upper) > 1:
+        upper = upper[:-1]
+    suffix = upper[-1] if upper and upper[-1].isalpha() else ""
+    digits = upper[:-1] if suffix else upper
+    if suffix not in _SIZE_SUFFIXES or not digits.isdigit():
+        raise argparse.ArgumentTypeError(f"invalid size value: {text}")
+    number = int(digits)
+    if number <= 0:
+        raise argparse.ArgumentTypeError(f"size must be positive: {text}")
+    return number * _SIZE_SUFFIXES[suffix]
+
+
+def _parse_positive_size_arg(text: str) -> str:
+    _parse_size(text)
+    return text
+
+
+def _parse_cpu_quota_percent(text: str) -> float:
+    value = str(text).strip()
+    if not value.endswith("%"):
+        raise argparse.ArgumentTypeError(f"cpu quota must end with %: {text}")
+    try:
+        percent = float(value[:-1])
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid cpu quota: {text}") from exc
+    if percent <= 0:
+        raise argparse.ArgumentTypeError(f"cpu quota must be positive: {text}")
+    return percent
+
+
+def _parse_cpu_quota_arg(text: str) -> str:
+    _parse_cpu_quota_percent(text)
+    return text
+
+
+def _parse_tasks_max(text: str) -> int:
+    try:
+        value = int(str(text).strip())
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid tasks-max: {text}") from exc
+    if value <= 0:
+        raise argparse.ArgumentTypeError(f"tasks-max must be positive: {text}")
+    return value
+
+
+def _parse_runtime_max_sec(text: str) -> int:
+    try:
+        value = int(str(text).strip())
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid runtime-max-sec: {text}") from exc
+    if value <= 0:
+        raise argparse.ArgumentTypeError(f"runtime-max-sec must be positive: {text}")
+    return value
+
+
+def parse_cli(argv: Sequence[str]) -> tuple[LimitSpec, list[str]]:
+    raw_args = list(argv)
+    if "--" not in raw_args:
+        raise SystemExit("missing `--` separator before child command")
+    split_index = raw_args.index("--")
+    child_command = raw_args[split_index + 1 :]
+    if not child_command:
+        raise SystemExit("missing child command after `--`")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--memory-high", type=_parse_positive_size_arg, default=None)
+    parser.add_argument("--memory-max", type=_parse_positive_size_arg, default=None)
+    parser.add_argument("--cpu-quota", type=_parse_cpu_quota_arg, default=None)
+    parser.add_argument("--tasks-max", type=_parse_tasks_max, default=None)
+    parser.add_argument("--runtime-max-sec", type=_parse_runtime_max_sec, default=None)
+    namespace = parser.parse_args(raw_args[:split_index])
+    spec = LimitSpec(
+        memory_high=namespace.memory_high,
+        memory_max=namespace.memory_max,
+        cpu_quota=namespace.cpu_quota,
+        tasks_max=namespace.tasks_max,
+        runtime_max_sec=namespace.runtime_max_sec,
+    )
+    return spec, child_command
+
+
+def _normalize_exit_code(returncode: int) -> int:
+    if returncode < 0:
+        return 128 + abs(returncode)
+    return returncode
+
+
+def _selected_cpu_count(cpu_quota: str | None) -> int | None:
+    if cpu_quota is None:
+        return None
+    percent = _parse_cpu_quota_percent(cpu_quota)
+    return max(1, math.ceil(percent / 100.0))
+
+
+def _select_affinity(allowed_cpus: Sequence[int], cpu_quota: str | None) -> tuple[int, ...]:
+    normalized = tuple(sorted(int(cpu) for cpu in allowed_cpus))
+    if not normalized:
+        return ()
+    selected_count = _selected_cpu_count(cpu_quota)
+    if selected_count is None:
+        return normalized
+    return normalized[: min(len(normalized), selected_count)]
+
+
+def _detect_systemd_user_manager(
+    *,
+    env: dict[str, str] | None = None,
+    which: Any = shutil.which,
+    run: Any = subprocess.run,
+) -> SystemdProbeResult:
+    effective_env = dict(os.environ if env is None else env)
+    systemd_run_path = which("systemd-run")
+    if systemd_run_path is None:
+        return SystemdProbeResult(usable=False, reason="systemd_tools_missing")
+    missing = [name for name in ("DBUS_SESSION_BUS_ADDRESS", "XDG_RUNTIME_DIR") if not effective_env.get(name)]
+    if missing:
+        return SystemdProbeResult(usable=False, reason=f"missing_env:{','.join(missing)}")
+    runtime_dir = effective_env["XDG_RUNTIME_DIR"]
+    if not Path(runtime_dir).is_dir():
+        return SystemdProbeResult(usable=False, reason="xdg_runtime_dir_missing")
+    true_path = which("true") or "/bin/true"
+    try:
+        result = run(
+            [systemd_run_path, "--user", "--scope", "--quiet", true_path],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_SYSTEMD_CHECK_TIMEOUT_SEC,
+            env=effective_env,
+        )
+    except OSError as exc:
+        return SystemdProbeResult(usable=False, reason=f"systemd_run_exec_error:{exc.errno or 'unknown'}")
+    except subprocess.TimeoutExpired:
+        return SystemdProbeResult(usable=False, reason="systemd_run_scope_timeout")
+    if result.returncode != 0:
+        return SystemdProbeResult(usable=False, reason=f"systemd_run_scope_exit:{result.returncode}")
+    return SystemdProbeResult(usable=True, reason="systemd_run_scope_ok")
+
+
+def _build_systemd_command(spec: LimitSpec, child_command: Sequence[str]) -> list[str]:
+    command = ["systemd-run", "--user", "--scope"]
+    if spec.memory_high is not None:
+        command.extend(["-p", f"MemoryHigh={spec.memory_high}"])
+    if spec.memory_max is not None:
+        command.extend(["-p", f"MemoryMax={spec.memory_max}"])
+    if spec.cpu_quota is not None:
+        command.extend(["-p", f"CPUQuota={spec.cpu_quota}"])
+    if spec.tasks_max is not None:
+        command.extend(["-p", f"TasksMax={spec.tasks_max}"])
+    if spec.runtime_max_sec is not None:
+        command.extend(["-p", f"RuntimeMaxSec={spec.runtime_max_sec}"])
+    command.extend(child_command)
+    return command
+
+
+def _apply_fallback_limits(
+    spec: LimitSpec,
+    *,
+    allowed_cpus: Sequence[int],
+    setrlimit: Any = resource.setrlimit,
+    sched_setaffinity: Any | None = getattr(os, "sched_setaffinity", None),
+) -> tuple[int, ...]:
+    selected_cpus = _select_affinity(allowed_cpus, spec.cpu_quota)
+    if spec.memory_max is not None:
+        memory_limit = _parse_size(spec.memory_max)
+        setrlimit(resource.RLIMIT_AS, (memory_limit, memory_limit))
+    if spec.tasks_max is not None:
+        setrlimit(resource.RLIMIT_NPROC, (spec.tasks_max, spec.tasks_max))
+    if sched_setaffinity is not None and selected_cpus:
+        sched_setaffinity(0, selected_cpus)
+    return selected_cpus
+
+
+def _portable_backend_diagnostic(
+    spec: LimitSpec,
+    *,
+    probe: SystemdProbeResult,
+    allowed_cpus: Sequence[int],
+) -> dict[str, Any]:
+    selected_cpus = list(_select_affinity(allowed_cpus, spec.cpu_quota))
+    return {
+        "event": "run_bounded_command",
+        "backend": "portable_fallback",
+        "systemd_probe": {"usable": probe.usable, "reason": probe.reason},
+        "limits": {
+            "memory_high": spec.memory_high,
+            "memory_max": spec.memory_max,
+            "cpu_quota": spec.cpu_quota,
+            "tasks_max": spec.tasks_max,
+            "runtime_max_sec": spec.runtime_max_sec,
+        },
+        "enforcement": {
+            "memory_high": "advisory_unavailable",
+            "memory_max": "rlimit_as" if spec.memory_max is not None else None,
+            "cpu_quota": "sched_affinity_ceiling" if spec.cpu_quota is not None else None,
+            "tasks_max": "rlimit_nproc" if spec.tasks_max is not None else None,
+            "runtime_max_sec": "process_group_timeout" if spec.runtime_max_sec is not None else None,
+        },
+        "allowed_cpus": list(sorted(int(cpu) for cpu in allowed_cpus)),
+        "selected_cpus": selected_cpus,
+    }
+
+
+def _systemd_backend_diagnostic(spec: LimitSpec, *, probe: SystemdProbeResult) -> dict[str, Any]:
+    return {
+        "event": "run_bounded_command",
+        "backend": "systemd_user_scope",
+        "systemd_probe": {"usable": probe.usable, "reason": probe.reason},
+        "limits": {
+            "memory_high": spec.memory_high,
+            "memory_max": spec.memory_max,
+            "cpu_quota": spec.cpu_quota,
+            "tasks_max": spec.tasks_max,
+            "runtime_max_sec": spec.runtime_max_sec,
+        },
+        "enforcement": {
+            "memory_high": "cgroup_memoryhigh" if spec.memory_high is not None else None,
+            "memory_max": "cgroup_memorymax" if spec.memory_max is not None else None,
+            "cpu_quota": "cgroup_cpuquota" if spec.cpu_quota is not None else None,
+            "tasks_max": "cgroup_tasksmax" if spec.tasks_max is not None else None,
+            "runtime_max_sec": "systemd_runtimemaxsec" if spec.runtime_max_sec is not None else None,
+        },
+    }
+
+
+def _emit_diagnostic(payload: dict[str, Any], *, stream: Any = sys.stderr) -> None:
+    stream.write(json.dumps(payload, sort_keys=True))
+    stream.write("\n")
+    stream.flush()
+
+
+def _shell_error_code(exc: OSError) -> int:
+    if exc.errno == errno.ENOENT:
+        return 127
+    return 126
+
+
+def _terminate_process_group(process: subprocess.Popen[Any], *, term_grace_sec: float) -> None:
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    deadline = time.monotonic() + term_grace_sec
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            return
+        time.sleep(0.05)
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+
+
+def _run_systemd_command(spec: LimitSpec, child_command: Sequence[str]) -> int:
+    try:
+        result = subprocess.run(_build_systemd_command(spec, child_command), check=False)
+    except OSError as exc:
+        return _shell_error_code(exc)
+    return _normalize_exit_code(result.returncode)
+
+
+def _run_portable_fallback(
+    spec: LimitSpec,
+    child_command: Sequence[str],
+    *,
+    term_grace_sec: float = _TERM_GRACE_SEC,
+) -> int:
+    if hasattr(os, "sched_getaffinity"):
+        allowed_cpus = tuple(sorted(int(cpu) for cpu in os.sched_getaffinity(0)))
+    else:
+        cpu_total = os.cpu_count() or 1
+        allowed_cpus = tuple(range(cpu_total))
+
+    def preexec() -> None:
+        os.setsid()
+        _apply_fallback_limits(spec, allowed_cpus=allowed_cpus)
+
+    try:
+        process = subprocess.Popen(child_command, preexec_fn=preexec)
+    except OSError as exc:
+        return _shell_error_code(exc)
+    try:
+        returncode = process.wait(timeout=spec.runtime_max_sec)
+    except subprocess.TimeoutExpired:
+        _emit_diagnostic(
+            {
+                "event": "run_bounded_command_timeout",
+                "backend": "portable_fallback",
+                "runtime_max_sec": spec.runtime_max_sec,
+                "term_grace_sec": term_grace_sec,
+            }
+        )
+        _terminate_process_group(process, term_grace_sec=term_grace_sec)
+        process.wait()
+        return TIMEOUT_EXIT_CODE
+    return _normalize_exit_code(returncode)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    spec, child_command = parse_cli(list(sys.argv[1:] if argv is None else argv))
+    probe = _detect_systemd_user_manager()
+    if probe.usable:
+        _emit_diagnostic(_systemd_backend_diagnostic(spec, probe=probe))
+        return _run_systemd_command(spec, child_command)
+    if hasattr(os, "sched_getaffinity"):
+        allowed_cpus = tuple(sorted(int(cpu) for cpu in os.sched_getaffinity(0)))
+    else:
+        cpu_total = os.cpu_count() or 1
+        allowed_cpus = tuple(range(cpu_total))
+    _emit_diagnostic(_portable_backend_diagnostic(spec, probe=probe, allowed_cpus=allowed_cpus))
+    return _run_portable_fallback(spec, child_command)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/README.md
@@ -9,4 +9,12 @@ claim. A pass permits the measured cycle and traffic behavior to enter the
 Llama7B architecture model. It does not close HBM timing, SRAM macro PPA, mesh
 NoC behavior, or full-array physical feasibility.
 
+Dispatch uses `control_plane/scripts/run_bounded_command.py`. When the evaluator
+has a usable user `systemd` manager the launcher applies the existing cgroup
+limits through `systemd-run --user --scope`; when the evaluator is inside a
+container without a user bus it falls back to process-group timeout, `RLIMIT_AS`
+/ `RLIMIT_NPROC`, and a CPU-affinity ceiling derived from the current allowed
+CPUs and the requested quota rounded to whole CPUs. In both modes, timeout,
+OOM, or other resource termination remains inconclusive.
+
 See `evaluation_gate.md` for the exact remote resource and acceptance contract.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/evaluation_gate.md
@@ -11,6 +11,16 @@
 - Memory: `MemoryHigh=6G`, `MemoryMax=8G`
 - CPU: `CPUQuota=300%`
 - Tasks: `TasksMax=512`
+- Launcher: `control_plane/scripts/run_bounded_command.py`
+
+If a usable user `systemd` manager exists, the launcher applies the contract
+with `systemd-run --user --scope`. In evaluator containers without a user bus,
+the launcher falls back to process-group timeout, `RLIMIT_AS` for
+`MemoryMax=8G`, `RLIMIT_NPROC` for `TasksMax=512`, and a CPU-affinity ceiling
+derived from the current allowed CPUs and the requested quota rounded to whole
+CPUs (`CPUQuota=300%` becomes at most three allowed CPUs). `MemoryHigh=6G` is
+advisory and reported as unavailable in fallback mode rather than claimed as
+exact cgroup enforcement.
 
 Do not run this probe in the devcontainer.
 

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/evaluation_requests.json
@@ -33,7 +33,7 @@
         "reason": "Only a complete structured-row and protocol pass can promote this composed path into the measured Llama7B architecture model."
       },
       "status": "pending",
-      "notes": "Dispatch only to eval-daemon-b7c2d9c80c1c with the bounded resource contract in evaluation_gate.md."
+      "notes": "Dispatch only to eval-daemon-b7c2d9c80c1c with the bounded resource contract in evaluation_gate.md. The launcher may use user-systemd cgroups or the documented portable fallback; timeout, OOM, or resource kill remains inconclusive."
     }
   ]
 }

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/README.md
@@ -6,3 +6,10 @@ rotation. The purpose is to prove that distinct command IDs, rotated p54/p53
 extra-block ownership, bounded fill traffic, and finalized root rows remain
 exact before the measured Llama7B model consumes this hierarchy as a full
 attention score service.
+
+Dispatch uses `control_plane/scripts/run_bounded_command.py`. When a usable user
+`systemd` manager exists, the launcher applies the contract through
+`systemd-run --user --scope`; otherwise it falls back to process-group timeout,
+`RLIMIT_AS` / `RLIMIT_NPROC`, and a CPU-affinity ceiling derived from the
+current allowed CPUs and the requested quota rounded to whole CPUs. Timeout,
+OOM, or other resource termination remains inconclusive in either backend.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/evaluation_gate.md
@@ -11,6 +11,16 @@
   - outer runtime `4500 s`
   - stall timeout `600 s`
   - probe timeout `3600 s`
+  - launcher `control_plane/scripts/run_bounded_command.py`
+
+If a usable user `systemd` manager exists, the launcher applies the contract
+with `systemd-run --user --scope`. In evaluator containers without a user bus,
+the launcher falls back to process-group timeout, `RLIMIT_AS` for
+`MemoryMax=8G`, `RLIMIT_NPROC` for `TasksMax=512`, and a CPU-affinity ceiling
+derived from the current allowed CPUs and the requested quota rounded to whole
+CPUs (`CPUQuota=300%` becomes at most three allowed CPUs). `MemoryHigh=6G`
+stays advisory in fallback mode and is reported that way instead of claimed as
+exact cgroup enforcement.
 
 Acceptance:
 

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/evaluation_requests.json
@@ -33,7 +33,7 @@
         "reason": "The full Llama7B score32 hierarchy should not be recosted from a single-head-group proof alone."
       },
       "status": "pending",
-      "notes": "Dispatch only to eval-daemon-b7c2d9c80c1c with the exclusive larger bounded resource contract in evaluation_gate.md."
+      "notes": "Dispatch only to eval-daemon-b7c2d9c80c1c with the exclusive larger bounded resource contract in evaluation_gate.md. The launcher may use user-systemd cgroups or the documented portable fallback; timeout, OOM, or resource kill remains inconclusive."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- replace hard-coded `systemd-run --user --scope` in both composed GQA8 equivalence jobs with a portable bounded-command launcher
- probe an actual user-systemd scope and fall back to process-group timeout, `RLIMIT_AS`/`RLIMIT_NPROC`, and a CPU-affinity ceiling when the evaluator has no user bus
- preserve shell-style signal exit codes and document that timeout/OOM/resource termination remains inconclusive

## Root cause
The one-group remote run failed before RTL compile/simulation because the evaluator container has the `systemd-run` binary but no `DBUS_SESSION_BUS_ADDRESS`, `XDG_RUNTIME_DIR`, or usable user systemd manager.

## Verification
- `PYTHONPATH=control_plane ... pytest test_run_bounded_command.py test_l2_task_generator.py -k 'run_bounded_command or cluster_sram_gqa8_equivalence or cluster_sram_gqa8_rotation_equivalence'` -> 11 passed
- direct missing-bus smoke invocation selected `portable_fallback`, restricted affinity to one CPU, and completed the payload
- `python3 scripts/validate_runs.py --skip_eval_queue` -> passed
- `git diff --check` -> clean

Closes #1478.