### PR TITLE
Classify composed GQA8 resource kills as inconclusive

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/evaluation_gate.md
@@ -45,9 +45,10 @@ Hashes are diagnostics only. They cannot substitute for structured comparison.
 ## Failure classification
 
 Timeout, OOM, or resource termination is inconclusive and must not reject the
-architecture. Count, protocol, metadata, ordering, or row mismatches are
-conclusive implementation failures and must be fixed before PPA or Llama7B
-recosting.
+architecture. That includes compile or simulation termination by SIGKILL, shell
+exit `137`, or a bare `Killed` diagnostic from the bounded launcher/runtime.
+Count, protocol, metadata, ordering, or row mismatches are conclusive
+implementation failures and must be fixed before PPA or Llama7B recosting.
 
 ## Follow-on
 

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/evaluation_gate.md
@@ -52,5 +52,5 @@ Acceptance:
 
 Classification policy:
 
-- timeout, OOM, kill, or bounded resource failure: inconclusive
+- timeout, OOM, kill, or bounded resource failure, including compile or simulation termination by SIGKILL, shell exit `137`, or a bare `Killed` diagnostic: inconclusive
 - structured row mismatch, metadata mismatch, count mismatch, or protocol error: conclusive

--- a/npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
+++ b/npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
@@ -54,6 +54,7 @@ WAVES = LOCAL_TEMPORAL_WAVES
 TB_TIMEOUT_CYCLES = 50_000
 DEFAULT_SUBPROCESS_TIMEOUT_SEC = 900
 DEFAULT_ROOT_READY_PATTERN = (True, True, False, True)
+DIAGNOSTIC_TAIL_LIMIT = 4096
 ROWS_PER_STREAM = ROWS_PER_BUFFER // STREAMS
 
 EXPECTED_TOTALS = {
@@ -956,15 +957,59 @@ def _failure_classification(
     if passed:
         return "passed"
     inconclusive_codes = {124, 125, 137, -9}
-    oom = "out of memory" in stderr.lower() or "cannot allocate memory" in stderr.lower()
+    normalized_returncode = _normalize_returncode(returncode)
+    oom = _looks_like_oom(stderr)
+    killed = _looks_like_killed(stderr)
     if (
         simulation_status in {"subprocess_timeout", "resource_failure", "testbench_timeout"}
         or tb_timeout_cycle is not None
         or returncode in inconclusive_codes
+        or normalized_returncode == 137
         or oom
+        or killed
     ):
         return "failed_inconclusive"
     return "failed_conclusive"
+
+
+def _normalize_returncode(returncode: int | None) -> int | None:
+    if returncode is None:
+        return None
+    if returncode < 0:
+        return 128 + abs(returncode)
+    return returncode
+
+
+def _looks_like_oom(text: str) -> bool:
+    lowered = text.lower()
+    return "out of memory" in lowered or "cannot allocate memory" in lowered
+
+
+def _looks_like_killed(text: str) -> bool:
+    return any(line.strip().lower() == "killed" for line in text.splitlines())
+
+
+def _resource_diagnostic_text(*, stdout: str, stderr: str) -> str:
+    if stderr.strip():
+        return stderr
+    stdout_lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+    for line in reversed(stdout_lines):
+        if _looks_like_killed(line) or _looks_like_oom(line):
+            return line
+    return ""
+
+
+def _is_resource_termination(*, returncode: int | None, stdout: str, stderr: str) -> bool:
+    diagnostic_text = "\n".join(part for part in (stderr, stdout) if part)
+    normalized_returncode = _normalize_returncode(returncode)
+    return normalized_returncode == 137 or _looks_like_oom(diagnostic_text) or _looks_like_killed(diagnostic_text)
+
+
+def _bounded_tail(text: str, *, limit: int = DIAGNOSTIC_TAIL_LIMIT) -> str:
+    if len(text) <= limit:
+        return text
+    omitted = len(text) - limit
+    return f"[truncated {omitted} chars]\n{text[-limit:]}"
 
 
 def _evaluate_observations(
@@ -1023,6 +1068,8 @@ def _evaluate_observations(
         "classification": classification,
         "simulation_status": simulation_status,
         "returncode": returncode,
+        "normalized_returncode": _normalize_returncode(returncode),
+        "stderr_tail": _bounded_tail(stderr),
         "tb_timeout_cycle": tb_timeout_cycle,
         "summary": summary,
         "cluster_summaries": cluster_summaries,
@@ -1097,9 +1144,21 @@ def build_report(
                 timeout=int(timeout_sec),
             )
             if compile_result.returncode:
-                simulation_status = "compile_failed"
+                stdout = compile_result.stdout or ""
                 returncode = compile_result.returncode
-                stderr = compile_result.stderr
+                stderr = _resource_diagnostic_text(
+                    stdout=stdout,
+                    stderr=compile_result.stderr or "",
+                )
+                simulation_status = (
+                    "resource_failure"
+                    if _is_resource_termination(
+                        returncode=compile_result.returncode,
+                        stdout=compile_result.stdout or "",
+                        stderr=compile_result.stderr or "",
+                    )
+                    else "compile_failed"
+                )
             else:
                 run_result = subprocess.run(
                     [_tool("vvp"), str(sim_path)],
@@ -1109,15 +1168,26 @@ def build_report(
                     timeout=int(timeout_sec),
                 )
                 stdout = run_result.stdout
-                stderr = run_result.stderr
+                stderr = _resource_diagnostic_text(
+                    stdout=run_result.stdout or "",
+                    stderr=run_result.stderr or "",
+                )
                 returncode = run_result.returncode
                 if run_result.returncode:
-                    simulation_status = "run_failed"
+                    simulation_status = (
+                        "resource_failure"
+                        if _is_resource_termination(
+                            returncode=run_result.returncode,
+                            stdout=run_result.stdout or "",
+                            stderr=run_result.stderr or "",
+                        )
+                        else "run_failed"
+                    )
         except subprocess.TimeoutExpired as exc:
             simulation_status = "subprocess_timeout"
             returncode = 124
             stdout = exc.stdout or ""
-            stderr = exc.stderr or ""
+            stderr = _resource_diagnostic_text(stdout=stdout, stderr=exc.stderr or "")
         except (MemoryError, OSError, RuntimeError) as exc:
             simulation_status = "resource_failure"
             returncode = 137 if isinstance(exc, MemoryError) else 125

--- a/tests/test_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
+++ b/tests/test_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
@@ -9,12 +9,14 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8 import (
+    DIAGNOSTIC_TAIL_LIMIT,
     DEFAULT_ROOT_READY_PATTERN,
     DEFAULT_SUBPROCESS_TIMEOUT_SEC,
     EXPECTED_PER_CLUSTER,
     EXPECTED_TOTALS,
     ROWS_PER_BUFFER,
     TB_TIMEOUT_CYCLES,
+    build_report,
     _evaluate_observations,
     _failure_classification,
     _fill_rows_for_wave,
@@ -297,6 +299,15 @@ def _audit_fixture() -> tuple[
     return reference, summary, cluster_summaries, cluster_rows, root_rows
 
 
+def _minimal_probe_config() -> dict[str, object]:
+    return {
+        "top_name": "fake_top",
+        "attention_score32_exact_local16_global_tree_cluster_sram_gqa8": {
+            "cluster_producers": [54] * 8 + [53] * 8
+        },
+    }
+
+
 def test_observation_evaluator_validates_every_exact_total_and_row() -> None:
     reference, summary, cluster_summaries, cluster_rows, root_rows = _audit_fixture()
     result = _evaluate_observations(
@@ -406,10 +417,105 @@ def test_failure_classification_marks_timeouts_oom_and_kills_inconclusive() -> N
         assert _failure_classification(
             simulation_status=simulation_status,
             returncode=1,
-            stderr="ordinary simulator failure",
+            stderr="top.v:10: syntax error",
             tb_timeout_cycle=None,
             passed=False,
         ) == "failed_conclusive"
+
+
+def test_build_report_classifies_compile_sigkill_resource_failures_inconclusive(
+    monkeypatch: Any,
+) -> None:
+    reference, summary, cluster_summaries, cluster_rows, root_rows = _audit_fixture()
+
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.generate",
+        lambda _config, rtl_dir: (rtl_dir.mkdir(parents=True, exist_ok=True), (rtl_dir / "top.v").write_text("module top; endmodule\n", encoding="ascii")),
+    )
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8._write_memh_sidecars",
+        lambda *_args, **_kwargs: {},
+    )
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8._reference",
+        lambda **_kwargs: reference,
+    )
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8._parse_stdout",
+        lambda _stdout: (summary, cluster_summaries, cluster_rows, root_rows, None),
+    )
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8._tool",
+        lambda _name: "/bin/true",
+    )
+
+    for returncode, stdout, stderr in (
+        (137, "", "Killed\n"),
+        (-9, "Killed\n", ""),
+    ):
+        monkeypatch.setattr(
+            "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.subprocess.run",
+            lambda *_args, **_kwargs: __import__("subprocess").CompletedProcess(
+                args=["iverilog"],
+                returncode=returncode,
+                stdout=stdout,
+                stderr=stderr,
+            ),
+        )
+        report = build_report(config=_minimal_probe_config(), timeout_sec=1)
+        assert report["passed"] is False
+        assert report["simulation_status"] == "resource_failure"
+        assert report["classification"] == "failed_inconclusive"
+        assert report["returncode"] == returncode
+        assert report["normalized_returncode"] == 137
+        assert "Killed" in report["stderr_tail"]
+
+
+def test_build_report_keeps_compile_syntax_errors_conclusive_and_bounded(
+    monkeypatch: Any,
+) -> None:
+    reference, summary, cluster_summaries, cluster_rows, root_rows = _audit_fixture()
+    long_stderr = ("noise\n" * 2000) + "top.v:10: syntax error\n"
+
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.generate",
+        lambda _config, rtl_dir: (rtl_dir.mkdir(parents=True, exist_ok=True), (rtl_dir / "top.v").write_text("module top; endmodule\n", encoding="ascii")),
+    )
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8._write_memh_sidecars",
+        lambda *_args, **_kwargs: {},
+    )
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8._reference",
+        lambda **_kwargs: reference,
+    )
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8._parse_stdout",
+        lambda _stdout: (summary, cluster_summaries, cluster_rows, root_rows, None),
+    )
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8._tool",
+        lambda _name: "/bin/true",
+    )
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.subprocess.run",
+        lambda *_args, **_kwargs: __import__("subprocess").CompletedProcess(
+            args=["iverilog"],
+            returncode=2,
+            stdout="",
+            stderr=long_stderr,
+        ),
+    )
+
+    report = build_report(config=_minimal_probe_config(), timeout_sec=1)
+
+    assert report["passed"] is False
+    assert report["simulation_status"] == "compile_failed"
+    assert report["classification"] == "failed_conclusive"
+    assert report["returncode"] == 2
+    assert report["normalized_returncode"] == 2
+    assert len(report["stderr_tail"]) <= DIAGNOSTIC_TAIL_LIMIT + 64
+    assert "top.v:10: syntax error" in report["stderr_tail"]
 
 
 def test_checked_in_config_rejects_partition_drift() -> None:


### PR DESCRIPTION
## Summary
- classify compiler/simulator SIGKILL, exit 137, bare `Killed`, and OOM diagnostics as `resource_failure` / `failed_inconclusive`
- preserve bounded `returncode`, normalized return code, and stderr tail in the JSON report
- keep ordinary compile syntax errors conclusive
- document the rule in both composed GQA8 evaluation gates

## Evidence
The bounded one-group retry reached `iverilog` but produced zero simulation activity. Isolated compilation returned `137` with `Killed`; the evaluator cgroup recorded `oom_kill=1` and about 27.2 GB peak memory. This is an elaboration resource failure, not an RTL/perf mismatch.

## Verification
- `python3 -m pytest tests/test_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py` -> 16 passed
- `python3 scripts/validate_runs.py --skip_eval_queue` -> passed
- `git diff --check` -> clean

Related: #1481