### PR TITLE
Add hierarchical Verilator backend for composed GQA8

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -10306,6 +10306,10 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equiv
         "npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py",
         "--config",
         config,
+        "--sim-backend",
+        "verilator_hierarchical",
+        "--compile-timeout-sec",
+        "1200",
         "--timeout-sec",
         "900",
         "--root-ready-pattern",
@@ -10321,7 +10325,7 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equiv
         memory_max="8G",
         cpu_quota="300%",
         tasks_max=512,
-        runtime_max_sec=1200,
+        runtime_max_sec=2400,
         child_command=child_command,
     )
     return {
@@ -10350,8 +10354,8 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equiv
             "memory_max": "8G",
             "cpu_quota": "300%",
             "tasks_max": 512,
-            "outer_timeout_seconds": 1200,
-            "stall_timeout_seconds": 300,
+            "outer_timeout_seconds": 2400,
+            "stall_timeout_seconds": 1500,
         },
         "acceptance": [
             "Write exactly the bounded JSON and Markdown probe reports declared in expected_outputs",
@@ -10406,6 +10410,10 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotat
         "npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py",
         "--config",
         config,
+        "--sim-backend",
+        "verilator_hierarchical",
+        "--compile-timeout-sec",
+        "1200",
         "--logical-head-groups",
         "4",
         "--timeout-sec",
@@ -10423,7 +10431,7 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotat
         memory_max="8G",
         cpu_quota="300%",
         tasks_max=512,
-        runtime_max_sec=4500,
+        runtime_max_sec=5100,
         child_command=child_command,
     )
     return {
@@ -10453,8 +10461,8 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotat
             "memory_max": "8G",
             "cpu_quota": "300%",
             "tasks_max": 512,
-            "outer_timeout_seconds": 4500,
-            "stall_timeout_seconds": 600,
+            "outer_timeout_seconds": 5100,
+            "stall_timeout_seconds": 1500,
         },
         "acceptance": [
             "Write exactly the bounded JSON and Markdown probe reports declared in expected_outputs",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -13777,8 +13777,8 @@ def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_equivalence_evidence()
                 "memory_max": "8G",
                 "cpu_quota": "300%",
                 "tasks_max": 512,
-                "outer_timeout_seconds": 1200,
-                "stall_timeout_seconds": 300,
+                "outer_timeout_seconds": 2400,
+                "stall_timeout_seconds": 1500,
             }
 
             assert command_names == [
@@ -13788,12 +13788,14 @@ def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_equivalence_evidence()
             assert (
                 "python3 control_plane/scripts/run_bounded_command.py "
                 "--memory-high 6G --memory-max 8G --cpu-quota 300% "
-                "--tasks-max 512 --runtime-max-sec 1200 --"
+                "--tasks-max 512 --runtime-max-sec 2400 --"
             ) in run
             assert (
                 "python3 npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py"
                 in run
             )
+            assert "--sim-backend verilator_hierarchical" in run
+            assert "--compile-timeout-sec 1200" in run
             assert (
                 "runs/designs/npu_blocks/"
                 "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_p54x8_p53x8_c16_r2_l8_b59/"
@@ -13907,8 +13909,8 @@ def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_rotation_equivalence_e
                 "memory_max": "8G",
                 "cpu_quota": "300%",
                 "tasks_max": 512,
-                "outer_timeout_seconds": 4500,
-                "stall_timeout_seconds": 600,
+                "outer_timeout_seconds": 5100,
+                "stall_timeout_seconds": 1500,
             }
 
             assert command_names == [
@@ -13918,8 +13920,10 @@ def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_rotation_equivalence_e
             assert (
                 "python3 control_plane/scripts/run_bounded_command.py "
                 "--memory-high 6G --memory-max 8G --cpu-quota 300% "
-                "--tasks-max 512 --runtime-max-sec 4500 --"
+                "--tasks-max 512 --runtime-max-sec 5100 --"
             ) in run
+            assert "--sim-backend verilator_hierarchical" in run
+            assert "--compile-timeout-sec 1200" in run
             assert "--logical-head-groups 4" in run
             assert "--timeout-sec 3600" in run
             assert (

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/README.md
@@ -17,4 +17,15 @@ container without a user bus it falls back to process-group timeout, `RLIMIT_AS`
 CPUs and the requested quota rounded to whole CPUs. In both modes, timeout,
 OOM, or other resource termination remains inconclusive.
 
+The remote job now requests `--sim-backend verilator_hierarchical` so Verilator
+can use `--binary --timing --hierarchical` with exact control-file markings for
+the generated p54 cluster, p53 cluster, and global-tree modules. This keeps the
+generated top RTL, testbench, memh sidecars, stdout contract, and structured
+row oracle unchanged while avoiding Icarus monolithic elaboration blow-up.
+The probe also carries a distinct `--compile-timeout-sec 1200` while the
+simulation timeout remains `--timeout-sec 900`. The bounded launcher contract
+is widened to a 2400-second outer timeout and a 1500-second stall timeout so a
+quiet hierarchical compile is not misclassified as a failed simulation. Timeout,
+OOM, or other resource termination remains inconclusive.
+
 See `evaluation_gate.md` for the exact remote resource and acceptance contract.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/evaluation_gate.md
@@ -5,13 +5,15 @@
 - Required machine: `eval-daemon-b7c2d9c80c1c`
 - Required source: the merge SHA containing this proposal and task mapping
 - Physical flow: disabled
-- Subprocess timeout: 900 seconds
-- Outer job timeout: 1200 seconds
-- Stall timeout: 300 seconds
+- Compile timeout: 1200 seconds
+- Simulation timeout: 900 seconds
+- Outer job timeout: 2400 seconds
+- Stall timeout: 1500 seconds
 - Memory: `MemoryHigh=6G`, `MemoryMax=8G`
 - CPU: `CPUQuota=300%`
 - Tasks: `TasksMax=512`
 - Launcher: `control_plane/scripts/run_bounded_command.py`
+- Simulation backend: `verilator_hierarchical`
 
 If a usable user `systemd` manager exists, the launcher applies the contract
 with `systemd-run --user --scope`. In evaluator containers without a user bus,
@@ -21,6 +23,13 @@ derived from the current allowed CPUs and the requested quota rounded to whole
 CPUs (`CPUQuota=300%` becomes at most three allowed CPUs). `MemoryHigh=6G` is
 advisory and reported as unavailable in fallback mode rather than claimed as
 exact cgroup enforcement.
+
+The probe backend should be `python3 npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py --sim-backend verilator_hierarchical --compile-timeout-sec 1200 --timeout-sec 900`.
+This backend uses Verilator `--binary --timing --hierarchical` with a generated
+control file that marks exactly the generated p54 cluster, p53 cluster, and
+global-tree modules as hierarchy blocks, adds `-Wno-fatal` so warnings do not
+become false compile failures, and records separate compile/simulation timeout
+metadata in the bounded JSON report.
 
 Do not run this probe in the devcontainer.
 

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/README.md
@@ -13,3 +13,14 @@ Dispatch uses `control_plane/scripts/run_bounded_command.py`. When a usable user
 `RLIMIT_AS` / `RLIMIT_NPROC`, and a CPU-affinity ceiling derived from the
 current allowed CPUs and the requested quota rounded to whole CPUs. Timeout,
 OOM, or other resource termination remains inconclusive in either backend.
+
+The remote job now requests `--sim-backend verilator_hierarchical` so Verilator
+can use `--binary --timing --hierarchical` with exact control-file markings for
+the generated p54 cluster, p53 cluster, and global-tree modules. This preserves
+the generated top RTL, testbench, memh sidecars, stdout contract, and
+structured row oracle while avoiding Icarus monolithic elaboration blow-up on
+the four-group rotation proof.
+The probe also carries a distinct `--compile-timeout-sec 1200` while the
+simulation timeout remains `--timeout-sec 3600`. The bounded launcher contract
+is widened to a 5100-second outer timeout and a 1500-second stall timeout so a
+quiet hierarchical compile is not misclassified as a failed simulation.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/evaluation_gate.md
@@ -8,10 +8,12 @@
   - `MemoryMax=8G`
   - `CPUQuota=300%`
   - `TasksMax=512`
-  - outer runtime `4500 s`
-  - stall timeout `600 s`
+  - outer runtime `5100 s`
+  - stall timeout `1500 s`
+  - compile timeout `1200 s`
   - probe timeout `3600 s`
   - launcher `control_plane/scripts/run_bounded_command.py`
+  - simulation backend `verilator_hierarchical`
 
 If a usable user `systemd` manager exists, the launcher applies the contract
 with `systemd-run --user --scope`. In evaluator containers without a user bus,
@@ -21,6 +23,13 @@ derived from the current allowed CPUs and the requested quota rounded to whole
 CPUs (`CPUQuota=300%` becomes at most three allowed CPUs). `MemoryHigh=6G`
 stays advisory in fallback mode and is reported that way instead of claimed as
 exact cgroup enforcement.
+
+The probe backend should be `python3 npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py --sim-backend verilator_hierarchical --compile-timeout-sec 1200 --timeout-sec 3600`.
+This backend uses Verilator `--binary --timing --hierarchical` with a generated
+control file that marks exactly the generated p54 cluster, p53 cluster, and
+global-tree modules as hierarchy blocks, adds `-Wno-fatal` so warnings do not
+become false compile failures, and records separate compile/simulation timeout
+metadata in the bounded JSON report.
 
 Acceptance:
 

--- a/npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
+++ b/npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
@@ -55,6 +55,13 @@ TB_TIMEOUT_CYCLES = 50_000
 DEFAULT_SUBPROCESS_TIMEOUT_SEC = 900
 DEFAULT_ROOT_READY_PATTERN = (True, True, False, True)
 DIAGNOSTIC_TAIL_LIMIT = 4096
+DEFAULT_SIM_BACKEND = "icarus"
+VERILATOR_HIERARCHICAL_BACKEND = "verilator_hierarchical"
+SIM_BACKEND_CHOICES = (DEFAULT_SIM_BACKEND, VERILATOR_HIERARCHICAL_BACKEND)
+VERILATOR_BUILD_JOBS = 3
+VERILATOR_CONTROL_FILE_NAME = "verilator_hier.vlt"
+VERILATOR_BINARY_NAME = "simv"
+DEFAULT_VERILATOR_COMPILE_TIMEOUT_SEC = 1200
 ROWS_PER_STREAM = ROWS_PER_BUFFER // STREAMS
 
 EXPECTED_TOTALS = {
@@ -447,6 +454,112 @@ def _write_memh_sidecars(
         "logical_head_groups": int(logical_head_groups),
         "total_wave_commands": int(logical_head_groups) * WAVES,
     }
+
+
+def _hierarchical_module_names(top_name: str) -> dict[str, str]:
+    resolved_top = str(top_name).strip()
+    if not resolved_top:
+        raise ValueError("top_name must not be empty")
+    return {
+        "p54_cluster": f"{resolved_top}__cluster_p54",
+        "p53_cluster": f"{resolved_top}__cluster_p53",
+        "global_tree": f"{resolved_top}__global_tree",
+    }
+
+
+def _verilator_control_file_text(top_name: str) -> str:
+    module_names = _hierarchical_module_names(top_name)
+    return "\n".join(
+        [
+            "`verilator_config",
+            f'hier_block -module "{module_names["p54_cluster"]}"',
+            f'hier_block -module "{module_names["p53_cluster"]}"',
+            f'hier_block -module "{module_names["global_tree"]}"',
+            "",
+        ]
+    )
+
+
+def _write_verilator_control_file(directory: Path, *, top_name: str) -> Path:
+    control_path = directory / VERILATOR_CONTROL_FILE_NAME
+    control_path.write_text(_verilator_control_file_text(top_name), encoding="ascii")
+    return control_path
+
+
+def _icarus_compile_command(*, rtl_dir: Path, fakeram_path: Path, tb_path: Path, sim_path: Path) -> list[str]:
+    return [
+        _tool("iverilog"),
+        "-g2012",
+        "-s",
+        "tb",
+        "-o",
+        str(sim_path),
+        str(rtl_dir / "top.v"),
+        str(fakeram_path),
+        str(tb_path),
+    ]
+
+
+def _verilator_hierarchical_compile_command(
+    *,
+    rtl_dir: Path,
+    fakeram_path: Path,
+    tb_path: Path,
+    control_path: Path,
+    obj_dir: Path,
+) -> list[str]:
+    return [
+        _tool("verilator"),
+        "--binary",
+        "--timing",
+        "--hierarchical",
+        "-Wno-fatal",
+        "-j",
+        str(VERILATOR_BUILD_JOBS),
+        "--Mdir",
+        str(obj_dir),
+        "--top-module",
+        "tb",
+        "-o",
+        VERILATOR_BINARY_NAME,
+        str(control_path),
+        str(rtl_dir / "top.v"),
+        str(fakeram_path),
+        str(tb_path),
+    ]
+
+
+def _sim_backend_metadata(
+    *,
+    sim_backend: str,
+    top_name: str,
+    compile_timeout_sec: int,
+    simulation_timeout_sec: int,
+) -> JsonDict:
+    metadata: JsonDict = {
+        "compile_tool": "iverilog" if sim_backend == DEFAULT_SIM_BACKEND else "verilator",
+        "run_tool": "vvp" if sim_backend == DEFAULT_SIM_BACKEND else "verilated_binary",
+        "compile_timeout_sec": int(compile_timeout_sec),
+        "simulation_timeout_sec": int(simulation_timeout_sec),
+    }
+    if sim_backend == VERILATOR_HIERARCHICAL_BACKEND:
+        metadata.update(
+            {
+                "top_module": "tb",
+                "build_jobs": VERILATOR_BUILD_JOBS,
+                "control_file": VERILATOR_CONTROL_FILE_NAME,
+                "hierarchical_modules": _hierarchical_module_names(top_name),
+            }
+        )
+    return metadata
+
+
+def _resolve_compile_timeout_sec(*, sim_backend: str, timeout_sec: int, compile_timeout_sec: int | None) -> int:
+    if compile_timeout_sec is not None:
+        return int(compile_timeout_sec)
+    if sim_backend == VERILATOR_HIERARCHICAL_BACKEND:
+        return DEFAULT_VERILATOR_COMPILE_TIMEOUT_SEC
+    return int(timeout_sec)
 
 
 def _sum_slices(signal: str, width: int = 32) -> str:
@@ -1088,6 +1201,8 @@ def build_report(
     output_ready_pattern: tuple[bool, ...] = DEFAULT_ROOT_READY_PATTERN,
     logical_head_groups: int = DEFAULT_LOGICAL_HEAD_GROUPS,
     timeout_sec: int = DEFAULT_SUBPROCESS_TIMEOUT_SEC,
+    compile_timeout_sec: int | None = None,
+    sim_backend: str = DEFAULT_SIM_BACKEND,
     proposal_id: str | None = None,
     proposal_path: str | None = None,
 ) -> JsonDict:
@@ -1098,6 +1213,14 @@ def build_report(
     cluster_producers = tuple(int(value) for value in body.get("cluster_producers", ()))
     if cluster_producers != CLUSTER_PRODUCERS:
         raise ValueError("probe requires exactly eight p54 clusters followed by eight p53 clusters")
+    resolved_backend = str(sim_backend).strip()
+    if resolved_backend not in SIM_BACKEND_CHOICES:
+        raise ValueError(f"sim_backend must be one of {SIM_BACKEND_CHOICES}")
+    resolved_compile_timeout_sec = _resolve_compile_timeout_sec(
+        sim_backend=resolved_backend,
+        timeout_sec=int(timeout_sec),
+        compile_timeout_sec=compile_timeout_sec,
+    )
     resolved_groups = int(logical_head_groups)
     if resolved_groups < 1 or resolved_groups > MAX_LOGICAL_HEAD_GROUPS:
         raise ValueError(f"logical_head_groups must be in [1, {MAX_LOGICAL_HEAD_GROUPS}]")
@@ -1125,23 +1248,34 @@ def build_report(
         fakeram_path = temp_dir / "fakeram45_2048x39.v"
         fakeram_path.write_text(full_probe._FAKERAM_MODEL, encoding="ascii")
         sim_path = temp_dir / "sim.out"
+        control_path = temp_dir / VERILATOR_CONTROL_FILE_NAME
+        obj_dir = temp_dir / "obj_dir"
         try:
+            if resolved_backend == VERILATOR_HIERARCHICAL_BACKEND:
+                control_path = _write_verilator_control_file(
+                    temp_dir,
+                    top_name=str(resolved_config["top_name"]),
+                )
+                compile_command = _verilator_hierarchical_compile_command(
+                    rtl_dir=rtl_dir,
+                    fakeram_path=fakeram_path,
+                    tb_path=tb_path,
+                    control_path=control_path,
+                    obj_dir=obj_dir,
+                )
+            else:
+                compile_command = _icarus_compile_command(
+                    rtl_dir=rtl_dir,
+                    fakeram_path=fakeram_path,
+                    tb_path=tb_path,
+                    sim_path=sim_path,
+                )
             compile_result = subprocess.run(
-                [
-                    _tool("iverilog"),
-                    "-g2012",
-                    "-s",
-                    "tb",
-                    "-o",
-                    str(sim_path),
-                    str(rtl_dir / "top.v"),
-                    str(fakeram_path),
-                    str(tb_path),
-                ],
+                compile_command,
                 cwd=temp_dir,
                 capture_output=True,
                 text=True,
-                timeout=int(timeout_sec),
+                timeout=resolved_compile_timeout_sec,
             )
             if compile_result.returncode:
                 stdout = compile_result.stdout or ""
@@ -1160,8 +1294,13 @@ def build_report(
                     else "compile_failed"
                 )
             else:
+                run_command = (
+                    [str(obj_dir / VERILATOR_BINARY_NAME)]
+                    if resolved_backend == VERILATOR_HIERARCHICAL_BACKEND
+                    else [_tool("vvp"), str(sim_path)]
+                )
                 run_result = subprocess.run(
-                    [_tool("vvp"), str(sim_path)],
+                    run_command,
                     cwd=temp_dir,
                     capture_output=True,
                     text=True,
@@ -1227,7 +1366,16 @@ def build_report(
             "total_wave_commands": resolved_groups * WAVES,
             "root_ready_pattern": [int(value) for value in output_ready_pattern],
             "tb_timeout_cycles": resolved_groups * TB_TIMEOUT_CYCLES,
+            "compile_timeout_sec": resolved_compile_timeout_sec,
+            "simulation_timeout_sec": int(timeout_sec),
             "subprocess_timeout_sec": int(timeout_sec),
+            "sim_backend": resolved_backend,
+            "sim_backend_metadata": _sim_backend_metadata(
+                sim_backend=resolved_backend,
+                top_name=str(resolved_config["top_name"]),
+                compile_timeout_sec=resolved_compile_timeout_sec,
+                simulation_timeout_sec=int(timeout_sec),
+            ),
             "expected_counts": expected_counts(logical_head_groups=resolved_groups),
             "memh_sidecars": sidecars,
             "service_model": exact_local16_global_tree_cluster_sram_gqa8_service_manifest(
@@ -1254,6 +1402,9 @@ def _render_text(report: JsonDict) -> str:
             f"- passed: `{report['passed']}`",
             f"- classification: `{report['classification']}`",
             f"- simulation_status: `{report['simulation_status']}`",
+            f"- sim_backend: `{report['sim_backend']}`",
+            f"- compile_timeout_sec: `{report['compile_timeout_sec']}`",
+            f"- simulation_timeout_sec: `{report['simulation_timeout_sec']}`",
             f"- producer_handshakes: `{summary.get('producer_handshake_count', 0)}`",
             f"- fill_targets: `{summary.get('fill_target_accept_count', 0)}`",
             f"- fill_rows: `{summary.get('fill_row_accept_count', 0)}`",
@@ -1282,6 +1433,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--root-ready-pattern", type=str, default="1,1,0,1")
     parser.add_argument("--logical-head-groups", type=int, default=DEFAULT_LOGICAL_HEAD_GROUPS)
     parser.add_argument("--timeout-sec", type=int, default=DEFAULT_SUBPROCESS_TIMEOUT_SEC)
+    parser.add_argument("--compile-timeout-sec", type=int)
+    parser.add_argument("--sim-backend", choices=SIM_BACKEND_CHOICES, default=DEFAULT_SIM_BACKEND)
     parser.add_argument("--proposal-id", type=str)
     parser.add_argument("--proposal-path", type=str)
     parser.add_argument("--out", type=Path)
@@ -1295,6 +1448,8 @@ def main(argv: list[str] | None = None) -> int:
         output_ready_pattern=ready_pattern or DEFAULT_ROOT_READY_PATTERN,
         logical_head_groups=int(args.logical_head_groups),
         timeout_sec=args.timeout_sec,
+        compile_timeout_sec=args.compile_timeout_sec,
+        sim_backend=str(args.sim_backend),
         proposal_id=str(args.proposal_id or "").strip() or None,
         proposal_path=str(args.proposal_path or "").strip() or None,
     )
@@ -1310,10 +1465,13 @@ def main(argv: list[str] | None = None) -> int:
 
 __all__ = [
     "DEFAULT_ROOT_READY_PATTERN",
+    "DEFAULT_SIM_BACKEND",
     "DEFAULT_SUBPROCESS_TIMEOUT_SEC",
     "EXPECTED_PER_CLUSTER",
     "EXPECTED_TOTALS",
+    "SIM_BACKEND_CHOICES",
     "TB_TIMEOUT_CYCLES",
+    "VERILATOR_HIERARCHICAL_BACKEND",
     "build_report",
     "compare_compositional_rows",
     "compare_full_rows",

--- a/tests/test_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
+++ b/tests/test_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
@@ -11,16 +11,25 @@ if str(REPO_ROOT) not in sys.path:
 from npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8 import (
     DIAGNOSTIC_TAIL_LIMIT,
     DEFAULT_ROOT_READY_PATTERN,
+    DEFAULT_SIM_BACKEND,
     DEFAULT_SUBPROCESS_TIMEOUT_SEC,
+    DEFAULT_VERILATOR_COMPILE_TIMEOUT_SEC,
     EXPECTED_PER_CLUSTER,
     EXPECTED_TOTALS,
     ROWS_PER_BUFFER,
+    SIM_BACKEND_CHOICES,
     TB_TIMEOUT_CYCLES,
+    VERILATOR_BUILD_JOBS,
+    VERILATOR_HIERARCHICAL_BACKEND,
     build_report,
     _evaluate_observations,
     _failure_classification,
     _fill_rows_for_wave,
+    _hierarchical_module_names,
+    _icarus_compile_command,
     _testbench,
+    _verilator_control_file_text,
+    _verilator_hierarchical_compile_command,
     _write_memh_sidecars,
     compare_compositional_rows,
     compare_full_rows,
@@ -308,6 +317,83 @@ def _minimal_probe_config() -> dict[str, object]:
     }
 
 
+def test_verilator_control_file_marks_exact_hierarchical_modules() -> None:
+    assert _hierarchical_module_names("score32_top") == {
+        "p54_cluster": "score32_top__cluster_p54",
+        "p53_cluster": "score32_top__cluster_p53",
+        "global_tree": "score32_top__global_tree",
+    }
+    assert _verilator_control_file_text("score32_top") == "\n".join(
+        [
+            "`verilator_config",
+            'hier_block -module "score32_top__cluster_p54"',
+            'hier_block -module "score32_top__cluster_p53"',
+            'hier_block -module "score32_top__global_tree"',
+            "",
+        ]
+    )
+
+
+def test_verilator_hierarchical_command_uses_bounded_parallelism_and_control_file(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8._tool",
+        lambda name: f"/tools/{name}",
+    )
+
+    command = _verilator_hierarchical_compile_command(
+        rtl_dir=tmp_path / "rtl",
+        fakeram_path=tmp_path / "fakeram45_2048x39.v",
+        tb_path=tmp_path / "tb.v",
+        control_path=tmp_path / "verilator_hier.vlt",
+        obj_dir=tmp_path / "obj_dir",
+    )
+
+    assert command[:7] == [
+        "/tools/verilator",
+        "--binary",
+        "--timing",
+        "--hierarchical",
+        "-Wno-fatal",
+        "-j",
+        str(VERILATOR_BUILD_JOBS),
+    ]
+    assert "--Mdir" in command
+    assert "--top-module" in command
+    assert "tb" in command
+    assert str(tmp_path / "verilator_hier.vlt") in command
+    assert str(tmp_path / "rtl" / "top.v") in command
+    assert str(tmp_path / "tb.v") in command
+
+
+def test_icarus_command_remains_the_default_compilation_path(monkeypatch: Any, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8._tool",
+        lambda name: f"/tools/{name}",
+    )
+
+    command = _icarus_compile_command(
+        rtl_dir=tmp_path / "rtl",
+        fakeram_path=tmp_path / "fakeram45_2048x39.v",
+        tb_path=tmp_path / "tb.v",
+        sim_path=tmp_path / "sim.out",
+    )
+
+    assert command == [
+        "/tools/iverilog",
+        "-g2012",
+        "-s",
+        "tb",
+        "-o",
+        str(tmp_path / "sim.out"),
+        str(tmp_path / "rtl" / "top.v"),
+        str(tmp_path / "fakeram45_2048x39.v"),
+        str(tmp_path / "tb.v"),
+    ]
+
+
 def test_observation_evaluator_validates_every_exact_total_and_row() -> None:
     reference, summary, cluster_summaries, cluster_rows, root_rows = _audit_fixture()
     result = _evaluate_observations(
@@ -518,6 +604,130 @@ def test_build_report_keeps_compile_syntax_errors_conclusive_and_bounded(
     assert "top.v:10: syntax error" in report["stderr_tail"]
 
 
+def test_build_report_records_verilator_backend_metadata_and_command(
+    monkeypatch: Any,
+) -> None:
+    reference, summary, cluster_summaries, cluster_rows, root_rows = _audit_fixture()
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.generate",
+        lambda _config, rtl_dir: (
+            rtl_dir.mkdir(parents=True, exist_ok=True),
+            (rtl_dir / "top.v").write_text("module top; endmodule\n", encoding="ascii"),
+        ),
+    )
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8._write_memh_sidecars",
+        lambda *_args, **_kwargs: {},
+    )
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8._reference",
+        lambda **_kwargs: reference,
+    )
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8._parse_stdout",
+        lambda _stdout: (summary, cluster_summaries, cluster_rows, root_rows, None),
+    )
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8._tool",
+        lambda name: f"/tools/{name}",
+    )
+
+    def fake_run(command: list[str], **_kwargs: object) -> Any:
+        calls.append(list(command))
+        if len(calls) == 1:
+            return __import__("subprocess").CompletedProcess(args=command, returncode=0, stdout="", stderr="")
+        return __import__("subprocess").CompletedProcess(args=command, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.subprocess.run",
+        fake_run,
+    )
+
+    report = build_report(
+        config=_minimal_probe_config(),
+        timeout_sec=1,
+        sim_backend=VERILATOR_HIERARCHICAL_BACKEND,
+    )
+
+    assert report["passed"] is True
+    assert report["sim_backend"] == VERILATOR_HIERARCHICAL_BACKEND
+    assert report["compile_timeout_sec"] == DEFAULT_VERILATOR_COMPILE_TIMEOUT_SEC
+    assert report["simulation_timeout_sec"] == 1
+    assert report["sim_backend_metadata"] == {
+        "compile_tool": "verilator",
+        "run_tool": "verilated_binary",
+        "compile_timeout_sec": DEFAULT_VERILATOR_COMPILE_TIMEOUT_SEC,
+        "simulation_timeout_sec": 1,
+        "top_module": "tb",
+        "build_jobs": VERILATOR_BUILD_JOBS,
+        "control_file": "verilator_hier.vlt",
+        "hierarchical_modules": {
+            "p54_cluster": "fake_top__cluster_p54",
+            "p53_cluster": "fake_top__cluster_p53",
+            "global_tree": "fake_top__global_tree",
+        },
+    }
+    assert len(calls) == 2
+    assert calls[0][:4] == ["/tools/verilator", "--binary", "--timing", "--hierarchical"]
+    assert "verilator_hier.vlt" in " ".join(calls[0])
+    assert calls[1] == [str(Path(calls[0][calls[0].index("--Mdir") + 1]) / "simv")]
+
+
+def test_build_report_defaults_to_icarus_backend(
+    monkeypatch: Any,
+) -> None:
+    reference, summary, cluster_summaries, cluster_rows, root_rows = _audit_fixture()
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.generate",
+        lambda _config, rtl_dir: (
+            rtl_dir.mkdir(parents=True, exist_ok=True),
+            (rtl_dir / "top.v").write_text("module top; endmodule\n", encoding="ascii"),
+        ),
+    )
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8._write_memh_sidecars",
+        lambda *_args, **_kwargs: {},
+    )
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8._reference",
+        lambda **_kwargs: reference,
+    )
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8._parse_stdout",
+        lambda _stdout: (summary, cluster_summaries, cluster_rows, root_rows, None),
+    )
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8._tool",
+        lambda name: f"/tools/{name}",
+    )
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.subprocess.run",
+        lambda command, **_kwargs: (
+            calls.append(list(command))
+            or __import__("subprocess").CompletedProcess(args=command, returncode=0, stdout="", stderr="")
+        ),
+    )
+
+    report = build_report(config=_minimal_probe_config(), timeout_sec=1)
+
+    assert DEFAULT_SIM_BACKEND in SIM_BACKEND_CHOICES
+    assert report["sim_backend"] == DEFAULT_SIM_BACKEND
+    assert report["compile_timeout_sec"] == 1
+    assert report["simulation_timeout_sec"] == 1
+    assert report["sim_backend_metadata"] == {
+        "compile_tool": "iverilog",
+        "run_tool": "vvp",
+        "compile_timeout_sec": 1,
+        "simulation_timeout_sec": 1,
+    }
+    assert calls[0][0] == "/tools/iverilog"
+    assert calls[1] == ["/tools/vvp", calls[0][5]]
+
+
 def test_checked_in_config_rejects_partition_drift() -> None:
     config = json.loads((_design_dir() / "config.json").read_text(encoding="utf-8"))
     _validate(config)
@@ -564,6 +774,15 @@ def test_main_writes_bounded_json_and_markdown_reports(
         "passed": True,
         "classification": "passed",
         "simulation_status": "ok",
+        "sim_backend": DEFAULT_SIM_BACKEND,
+        "compile_timeout_sec": DEFAULT_SUBPROCESS_TIMEOUT_SEC,
+        "simulation_timeout_sec": DEFAULT_SUBPROCESS_TIMEOUT_SEC,
+        "sim_backend_metadata": {
+            "compile_tool": "iverilog",
+            "run_tool": "vvp",
+            "compile_timeout_sec": DEFAULT_SUBPROCESS_TIMEOUT_SEC,
+            "simulation_timeout_sec": DEFAULT_SUBPROCESS_TIMEOUT_SEC,
+        },
         "summary": dict(EXPECTED_TOTALS),
         "cluster_summaries": [{"cluster": cluster, **EXPECTED_PER_CLUSTER, "errors": 0} for cluster in range(16)],
         "counts_passed": True,
@@ -603,6 +822,8 @@ def test_main_writes_bounded_json_and_markdown_reports(
 
     assert exit_code == 0
     assert captured["logical_head_groups"] == 4
+    assert captured["compile_timeout_sec"] is None
+    assert captured["sim_backend"] == DEFAULT_SIM_BACKEND
     payload = json.loads(out.read_text(encoding="utf-8"))
     assert payload["passed"] is True
     assert payload["classification"] == "passed"


### PR DESCRIPTION
## Summary
- add an exact `verilator_hierarchical` backend for the composed score32 GQA8 probe
- mark the generated p54 cluster, p53 cluster, and global tree as reusable Verilator hierarchy blocks
- preserve the same generated DUT, testbench, memh inputs, cycle behavior, count/protocol gates, and structured row oracle
- use bounded `-j 3` build parallelism with separate compile and simulation timeouts
- make both one-group and four-group remote jobs select this backend

## Motivation
Monolithic Icarus elaboration of 16 clusters / 856 producers reached about 27.2 GB and was OOM-killed. Verilator hierarchical compilation builds marked modules as libraries instead of uniquifying every instance, avoiding that elaboration strategy without replacing any RTL datapath component.

## Bounded contracts
- one group: compile 1200s, simulate 900s, stall 1500s, outer 2400s
- four groups: compile 1200s, simulate 3600s, stall 1500s, outer 5100s
- 8 GiB address space, three CPUs, 512 tasks remain unchanged

## Verification
- composed probe tests: 21 passed
- focused L2 generator tests: 2 passed
- `validate_runs.py --skip_eval_queue`: passed
- py_compile and diff check: passed

No heavy RTL simulation was run locally.

Related: #1481