### PR TITLE
Fix oversized GQA8 Verilator testbench literals

### DIFF
--- a/npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
+++ b/npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
@@ -55,6 +55,7 @@ TB_TIMEOUT_CYCLES = 50_000
 DEFAULT_SUBPROCESS_TIMEOUT_SEC = 900
 DEFAULT_ROOT_READY_PATTERN = (True, True, False, True)
 DIAGNOSTIC_TAIL_LIMIT = 4096
+MARKDOWN_DIAGNOSTIC_TAIL_LIMIT = 1024
 DEFAULT_SIM_BACKEND = "icarus"
 VERILATOR_HIERARCHICAL_BACKEND = "verilator_hierarchical"
 SIM_BACKEND_CHOICES = (DEFAULT_SIM_BACKEND, VERILATOR_HIERARCHICAL_BACKEND)
@@ -885,8 +886,8 @@ module tb;
 
     input_valid = 856'd0;
     input_last = 856'd0;
-    input_query = 109568'd0;
-    input_key = 109568'd0;
+    input_query = '0;
+    input_key = '0;
     for (producer_index = 0; producer_index < TOTAL_PRODUCERS; producer_index = producer_index + 1) begin
       if (rst_n && (active_command_index >= 0) &&
           (beat_issue[producer_index] < cmd_beat_limit_mem[active_command_index][producer_index])) begin
@@ -1395,27 +1396,42 @@ def build_report(
 
 def _render_text(report: JsonDict) -> str:
     summary = dict(report.get("summary") or {})
-    return "\n".join(
-        [
-            "# attention_score32_exact_local16_global_tree_cluster_sram_gqa8_probe",
-            "",
-            f"- passed: `{report['passed']}`",
-            f"- classification: `{report['classification']}`",
-            f"- simulation_status: `{report['simulation_status']}`",
-            f"- sim_backend: `{report['sim_backend']}`",
-            f"- compile_timeout_sec: `{report['compile_timeout_sec']}`",
-            f"- simulation_timeout_sec: `{report['simulation_timeout_sec']}`",
-            f"- producer_handshakes: `{summary.get('producer_handshake_count', 0)}`",
-            f"- fill_targets: `{summary.get('fill_target_accept_count', 0)}`",
-            f"- fill_rows: `{summary.get('fill_row_accept_count', 0)}`",
-            f"- sram_requests: `{summary.get('sram_request_accept_count', 0)}`",
-            f"- sram_responses: `{summary.get('sram_response_accept_count', 0)}`",
-            f"- cluster_rows: `{summary.get('cluster_row_count', 0)}`",
-            f"- root_rows: `{summary.get('root_row_count', 0)}`",
-            f"- observed_root_hash: `{report['observed_root_hash']}`",
-            f"- expected_root_hash: `{report['expected_root_hash']}`",
-        ]
-    )
+    lines = [
+        "# attention_score32_exact_local16_global_tree_cluster_sram_gqa8_probe",
+        "",
+        f"- passed: `{report['passed']}`",
+        f"- classification: `{report['classification']}`",
+        f"- simulation_status: `{report['simulation_status']}`",
+        f"- sim_backend: `{report['sim_backend']}`",
+        f"- compile_timeout_sec: `{report['compile_timeout_sec']}`",
+        f"- simulation_timeout_sec: `{report['simulation_timeout_sec']}`",
+        f"- producer_handshakes: `{summary.get('producer_handshake_count', 0)}`",
+        f"- fill_targets: `{summary.get('fill_target_accept_count', 0)}`",
+        f"- fill_rows: `{summary.get('fill_row_accept_count', 0)}`",
+        f"- sram_requests: `{summary.get('sram_request_accept_count', 0)}`",
+        f"- sram_responses: `{summary.get('sram_response_accept_count', 0)}`",
+        f"- cluster_rows: `{summary.get('cluster_row_count', 0)}`",
+        f"- root_rows: `{summary.get('root_row_count', 0)}`",
+        f"- observed_root_hash: `{report['observed_root_hash']}`",
+        f"- expected_root_hash: `{report['expected_root_hash']}`",
+    ]
+    if not bool(report["passed"]):
+        stderr_tail = _bounded_tail(
+            str(report.get("stderr_tail") or ""),
+            limit=MARKDOWN_DIAGNOSTIC_TAIL_LIMIT,
+        ).strip()
+        lines.extend(
+            [
+                f"- returncode: `{report.get('returncode')}`",
+                f"- normalized_returncode: `{report.get('normalized_returncode')}`",
+                "- stderr_tail:",
+                "",
+                "```text",
+                stderr_tail.replace("```", "`` `") or "(empty)",
+                "```",
+            ]
+        )
+    return "\n".join(lines)
 
 
 def _render_json(report: JsonDict) -> str:

--- a/tests/test_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
+++ b/tests/test_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
@@ -10,6 +10,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8 import (
     DIAGNOSTIC_TAIL_LIMIT,
+    MARKDOWN_DIAGNOSTIC_TAIL_LIMIT,
     DEFAULT_ROOT_READY_PATTERN,
     DEFAULT_SIM_BACKEND,
     DEFAULT_SUBPROCESS_TIMEOUT_SEC,
@@ -27,6 +28,7 @@ from npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa
     _fill_rows_for_wave,
     _hierarchical_module_names,
     _icarus_compile_command,
+    _render_text,
     _testbench,
     _verilator_control_file_text,
     _verilator_hierarchical_compile_command,
@@ -164,6 +166,9 @@ def test_generated_testbench_is_real_memh_backed_composed_traffic() -> None:
     assert '$readmemh("key.memh", key_mem);' in tb
     assert '$readmemh("fill.memh", fill_mem);' in tb
     assert "input_valid[producer_index] = 1'b1;" in tb
+    assert "input_query = '0;" in tb
+    assert "input_key = '0;" in tb
+    assert "109568'd0" not in tb
     assert "input_query[(producer_index * 128) +: 128] = query_mem[flat_index];" in tb
     assert "input_key[(producer_index * 128) +: 128] = key_mem[flat_index];" in tb
     assert "input_valid[producer_index] && input_ready[producer_index]" in tb
@@ -602,6 +607,56 @@ def test_build_report_keeps_compile_syntax_errors_conclusive_and_bounded(
     assert report["normalized_returncode"] == 2
     assert len(report["stderr_tail"]) <= DIAGNOSTIC_TAIL_LIMIT + 64
     assert "top.v:10: syntax error" in report["stderr_tail"]
+
+
+def test_markdown_failure_report_keeps_bounded_subprocess_diagnostics() -> None:
+    stderr_tail = ("warning\n" * 400) + "Killed\n"
+    report = {
+        "passed": False,
+        "classification": "failed_inconclusive",
+        "simulation_status": "resource_failure",
+        "sim_backend": VERILATOR_HIERARCHICAL_BACKEND,
+        "compile_timeout_sec": 1200,
+        "simulation_timeout_sec": 900,
+        "returncode": -9,
+        "normalized_returncode": 137,
+        "stderr_tail": stderr_tail,
+        "summary": {},
+        "observed_root_hash": "",
+        "expected_root_hash": "",
+    }
+
+    rendered = _render_text(report)
+
+    assert "- returncode: `-9`" in rendered
+    assert "- normalized_returncode: `137`" in rendered
+    assert "- stderr_tail:" in rendered
+    assert "Killed" in rendered
+    assert stderr_tail not in rendered
+    diagnostic = rendered.split("```text\n", 1)[1].rsplit("\n```", 1)[0]
+    assert len(diagnostic) <= MARKDOWN_DIAGNOSTIC_TAIL_LIMIT + 64
+
+
+def test_markdown_pass_report_omits_failure_diagnostics() -> None:
+    report = {
+        "passed": True,
+        "classification": "passed",
+        "simulation_status": "ok",
+        "sim_backend": DEFAULT_SIM_BACKEND,
+        "compile_timeout_sec": 900,
+        "simulation_timeout_sec": 900,
+        "returncode": 0,
+        "normalized_returncode": 0,
+        "stderr_tail": "",
+        "summary": {},
+        "observed_root_hash": "expected",
+        "expected_root_hash": "expected",
+    }
+
+    rendered = _render_text(report)
+
+    assert "returncode" not in rendered
+    assert "stderr_tail" not in rendered
 
 
 def test_build_report_records_verilator_backend_metadata_and_command(


### PR DESCRIPTION
## Summary
- replace Verilator-incompatible `109568'd0` testbench initializers with semantically identical width-independent SystemVerilog `'0`
- preserve bounded return code and compiler stderr diagnostics in failure Markdown, not only transient JSON
- add focused regressions for emitted literals and diagnostic rendering

## Root cause
The first hierarchical-Verilator remote run failed before simulation with:
```text
Unsupported: Width of number exceeds implementation limit: 109568'd0
```
for `input_query` and `input_key`. No RTL logic or equivalence result was reached.

## Verification
- composed GQA8 probe tests: 23 passed
- `validate_runs.py --skip_eval_queue`: passed
- py_compile and diff check: passed

Related: #1484