### PR TITLE
Replace broken GQA8 hierarchy build with compositional RTL proof

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -10307,7 +10307,7 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equiv
         "--config",
         config,
         "--sim-backend",
-        "verilator_hierarchical",
+        "compositional_icarus",
         "--compile-timeout-sec",
         "1200",
         "--timeout-sec",
@@ -10334,10 +10334,10 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equiv
             "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_out": out,
             "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_report": report,
             "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_scope": (
-                "Run the single composed GQA8 cluster-SRAM RTL equivalence probe under bounded "
-                "remote resources. Accept only a passed bounded report with exact producer/fill/"
-                "SRAM/root counts, zero protocol or sticky cluster errors, and a full structured "
-                "row audit pass across all 16 clusters plus the root stream."
+                "Run the concrete compositional GQA8 cluster-SRAM RTL equivalence probe under bounded "
+                "remote resources. Require the strict generated-top guard, concrete p54/p53 cluster "
+                "replays, and concrete global-tree simulation. Accept only exact producer/fill/SRAM/"
+                "root counts, zero protocol or sticky errors, and a full structured row audit."
             ),
         },
         "commands": [
@@ -10360,6 +10360,7 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equiv
         "acceptance": [
             "Write exactly the bounded JSON and Markdown probe reports declared in expected_outputs",
             "Require report passed=true, classification=passed, and counts_passed=true",
+            "Require compositional_components.strict_generated_top_guard=passed",
             (
                 "Require exact totals in report.summary: producer_handshake_count=8192, "
                 "fill_target_accept_count=128, fill_row_accept_count=262144, "
@@ -10411,7 +10412,7 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotat
         "--config",
         config,
         "--sim-backend",
-        "verilator_hierarchical",
+        "compositional_icarus",
         "--compile-timeout-sec",
         "1200",
         "--logical-head-groups",
@@ -10440,11 +10441,10 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotat
             "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_out": out,
             "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_report": report,
             "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_scope": (
-                "Run the bounded remote four-head-group rotation RTL equivalence probe under exclusive "
-                "resources. Accept only a passed bounded report with exact producer/fill/SRAM/root "
-                "counts, distinct command-id and head-base metadata for 0/8/16/24, rotated p54/p53 "
-                "ownership through group_index=head_base>>3, zero protocol or sticky cluster errors, "
-                "and a full structured row audit pass across all 16 clusters plus the root stream."
+                "Run the bounded concrete compositional four-head-group RTL equivalence probe under "
+                "exclusive resources. Require the strict generated-top guard, concrete p54/p53 "
+                "cluster replays, and concrete global-tree simulation with exact producer/fill/SRAM/"
+                "root counts, rotated 0/8/16/24 ownership, zero protocol errors, and full row audits."
             ),
         },
         "commands": [
@@ -10467,6 +10467,7 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotat
         "acceptance": [
             "Write exactly the bounded JSON and Markdown probe reports declared in expected_outputs",
             "Require report passed=true, classification=passed, and counts_passed=true",
+            "Require compositional_components.strict_generated_top_guard=passed",
             (
                 "Require exact totals in report.summary: producer_handshake_count=32768, "
                 "fill_target_accept_count=512, fill_row_accept_count=1048576, "

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -13794,7 +13794,7 @@ def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_equivalence_evidence()
                 "python3 npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py"
                 in run
             )
-            assert "--sim-backend verilator_hierarchical" in run
+            assert "--sim-backend compositional_icarus" in run
             assert "--compile-timeout-sec 1200" in run
             assert (
                 "runs/designs/npu_blocks/"
@@ -13805,6 +13805,7 @@ def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_equivalence_evidence()
             assert "--root-ready-pattern 1,1,0,1" in run
             assert "--out " in run
             assert "--out-md " in run
+            assert any("strict_generated_top_guard=passed" in rule for rule in acceptance)
             assert (
                 "--proposal-id "
                 "prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_"
@@ -13922,7 +13923,7 @@ def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_rotation_equivalence_e
                 "--memory-high 6G --memory-max 8G --cpu-quota 300% "
                 "--tasks-max 512 --runtime-max-sec 5100 --"
             ) in run
-            assert "--sim-backend verilator_hierarchical" in run
+            assert "--sim-backend compositional_icarus" in run
             assert "--compile-timeout-sec 1200" in run
             assert "--logical-head-groups 4" in run
             assert "--timeout-sec 3600" in run
@@ -13943,6 +13944,7 @@ def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_rotation_equivalence_e
             ]
             assert any("producer_handshake_count=32768" in rule for rule in acceptance)
             assert any("completed_command_count=4" in rule for rule in acceptance)
+            assert any("strict_generated_top_guard=passed" in rule for rule in acceptance)
             assert any("report.command_ids=[33280, 33281, 33282, 33283]" in rule for rule in acceptance)
             assert work_item.input_manifest["worker_resources"] == expected_worker_resources
             assert (

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/README.md
@@ -17,15 +17,19 @@ container without a user bus it falls back to process-group timeout, `RLIMIT_AS`
 CPUs and the requested quota rounded to whole CPUs. In both modes, timeout,
 OOM, or other resource termination remains inconclusive.
 
-The remote job now requests `--sim-backend verilator_hierarchical` so Verilator
-can use `--binary --timing --hierarchical` with exact control-file markings for
-the generated p54 cluster, p53 cluster, and global-tree modules. This keeps the
-generated top RTL, testbench, memh sidecars, stdout contract, and structured
-row oracle unchanged while avoiding Icarus monolithic elaboration blow-up.
+The remote job requests `--sim-backend compositional_icarus`. The probe first
+runs the existing strict generated-top regeneration, wiring, ordering, and
+semantic guard. It then compiles one concrete p54 cluster and one concrete p53
+cluster, including their real producers, reducers, temporal merge, and SRAM
+endpoint, and replays those binaries with each cluster's exact sidecars. A
+separate concrete global-tree simulation consumes the 16 observed cluster row
+streams. The existing strict structured-row, count, and protocol oracle judges
+the combined result. This avoids elaborating all 856 producers at once and
+does not substitute abstract arithmetic for RTL.
 The probe also carries a distinct `--compile-timeout-sec 1200` while the
 simulation timeout remains `--timeout-sec 900`. The bounded launcher contract
 is widened to a 2400-second outer timeout and a 1500-second stall timeout so a
-quiet hierarchical compile is not misclassified as a failed simulation. Timeout,
+quiet component compile is not misclassified as a failed simulation. Timeout,
 OOM, or other resource termination remains inconclusive.
 
 See `evaluation_gate.md` for the exact remote resource and acceptance contract.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/evaluation_gate.md
@@ -13,7 +13,7 @@
 - CPU: `CPUQuota=300%`
 - Tasks: `TasksMax=512`
 - Launcher: `control_plane/scripts/run_bounded_command.py`
-- Simulation backend: `verilator_hierarchical`
+- Simulation backend: `compositional_icarus`
 
 If a usable user `systemd` manager exists, the launcher applies the contract
 with `systemd-run --user --scope`. In evaluator containers without a user bus,
@@ -24,12 +24,11 @@ CPUs (`CPUQuota=300%` becomes at most three allowed CPUs). `MemoryHigh=6G` is
 advisory and reported as unavailable in fallback mode rather than claimed as
 exact cgroup enforcement.
 
-The probe backend should be `python3 npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py --sim-backend verilator_hierarchical --compile-timeout-sec 1200 --timeout-sec 900`.
-This backend uses Verilator `--binary --timing --hierarchical` with a generated
-control file that marks exactly the generated p54 cluster, p53 cluster, and
-global-tree modules as hierarchy blocks, adds `-Wno-fatal` so warnings do not
-become false compile failures, and records separate compile/simulation timeout
-metadata in the bounded JSON report.
+The probe backend should be `python3 npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py --sim-backend compositional_icarus --compile-timeout-sec 1200 --timeout-sec 900`.
+It must pass the existing strict generated-top guard, simulate the concrete p54
+and p53 cluster wrappers with all cluster-specific sidecars, and simulate the
+concrete global tree from the observed cluster streams. The JSON report must
+record the component phases and separate compile/simulation timeouts.
 
 Do not run this probe in the devcontainer.
 
@@ -48,6 +47,7 @@ The JSON report must contain:
 - 16 passing per-cluster summaries
 - zero protocol or sticky errors
 - passing structured comparisons for every cluster row and root row
+- `compositional_components.strict_generated_top_guard: passed`
 
 Hashes are diagnostics only. They cannot substitute for structured comparison.
 

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/README.md
@@ -14,13 +14,15 @@ Dispatch uses `control_plane/scripts/run_bounded_command.py`. When a usable user
 current allowed CPUs and the requested quota rounded to whole CPUs. Timeout,
 OOM, or other resource termination remains inconclusive in either backend.
 
-The remote job now requests `--sim-backend verilator_hierarchical` so Verilator
-can use `--binary --timing --hierarchical` with exact control-file markings for
-the generated p54 cluster, p53 cluster, and global-tree modules. This preserves
-the generated top RTL, testbench, memh sidecars, stdout contract, and
-structured row oracle while avoiding Icarus monolithic elaboration blow-up on
-the four-group rotation proof.
+The remote job requests `--sim-backend compositional_icarus`. The existing
+strict generated-top guard first proves regeneration, module multiplicity,
+wiring, ordering, and semantic contracts. The probe then replays concrete p54
+and p53 cluster wrappers with all 16 cluster-specific sidecar sets and drives
+their observed rows through the concrete global tree. Producer, reducer,
+temporal-merge, SRAM endpoint, ordering, and finalizer behavior remain RTL;
+only the simulation boundary is decomposed to avoid the 856-producer
+monolithic elaboration.
 The probe also carries a distinct `--compile-timeout-sec 1200` while the
 simulation timeout remains `--timeout-sec 3600`. The bounded launcher contract
 is widened to a 5100-second outer timeout and a 1500-second stall timeout so a
-quiet hierarchical compile is not misclassified as a failed simulation.
+quiet component compile is not misclassified as a failed simulation.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/evaluation_gate.md
@@ -13,7 +13,7 @@
   - compile timeout `1200 s`
   - probe timeout `3600 s`
   - launcher `control_plane/scripts/run_bounded_command.py`
-  - simulation backend `verilator_hierarchical`
+  - simulation backend `compositional_icarus`
 
 If a usable user `systemd` manager exists, the launcher applies the contract
 with `systemd-run --user --scope`. In evaluator containers without a user bus,
@@ -24,12 +24,12 @@ CPUs (`CPUQuota=300%` becomes at most three allowed CPUs). `MemoryHigh=6G`
 stays advisory in fallback mode and is reported that way instead of claimed as
 exact cgroup enforcement.
 
-The probe backend should be `python3 npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py --sim-backend verilator_hierarchical --compile-timeout-sec 1200 --timeout-sec 3600`.
-This backend uses Verilator `--binary --timing --hierarchical` with a generated
-control file that marks exactly the generated p54 cluster, p53 cluster, and
-global-tree modules as hierarchy blocks, adds `-Wno-fatal` so warnings do not
-become false compile failures, and records separate compile/simulation timeout
-metadata in the bounded JSON report.
+The probe backend should be `python3 npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py --sim-backend compositional_icarus --compile-timeout-sec 1200 --timeout-sec 3600`.
+It must pass the existing strict generated-top guard, simulate the concrete p54
+and p53 cluster wrappers for every cluster-specific rotation sidecar set, and
+simulate the concrete global tree from the observed cluster streams. The
+bounded JSON report records each component phase and separate
+compile/simulation timeout metadata.
 
 Acceptance:
 
@@ -58,6 +58,7 @@ Acceptance:
    - `command_accept_count=32`
    - `command_release_count=32`
 6. `full_row_audit.passed=true` for all 16 clusters and the root stream
+7. `compositional_components.strict_generated_top_guard=passed`
 
 Classification policy:
 

--- a/npu/eval/gqa8_compositional_exact.py
+++ b/npu/eval/gqa8_compositional_exact.py
@@ -1,0 +1,750 @@
+#!/usr/bin/env python3
+"""Bounded concrete-RTL component simulations for the composed GQA8 probe."""
+
+from __future__ import annotations
+
+import contextlib
+from concurrent.futures import ThreadPoolExecutor
+import io
+from pathlib import Path
+import re
+import shutil
+import subprocess
+from typing import Any
+
+from npu.eval.check_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_guard import (
+    main as strict_guard_main,
+)
+
+JsonDict = dict[str, Any]
+
+BACKEND = "compositional_icarus"
+CLUSTER_RUN_JOBS = 3
+GLOBAL_ROW_BITS = 419
+_GLOBAL_SUMMARY_RE = re.compile(
+    r"GLOBAL_SUMMARY root_rows=(\d+) root_completed=(\d+) finalizer_accepted=(\d+) "
+    r"tree_completed=(\d+) protocol_error=(\d+) first_root=(-?\d+) last_root=(-?\d+) drain=(\d+)"
+)
+_MODULE_RE = re.compile(r"(?ms)^module\s+([A-Za-z_][A-Za-z0-9_$]*)\b.*?^endmodule\s*$")
+
+
+def extract_module_family(rtl: str, *, prefix: str) -> str:
+    modules = [match.group(0) for match in _MODULE_RE.finditer(rtl) if match.group(1).startswith(prefix)]
+    if not modules or not any(re.match(rf"module\s+{re.escape(prefix)}\b", module) for module in modules):
+        raise ValueError(f"generated RTL has no complete module family for {prefix}")
+    return "\n\n".join(modules) + "\n"
+
+
+def _cluster_driver_data(*, cluster: int, logical_head_groups: int) -> JsonDict:
+    from npu.eval import probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8 as probe
+
+    producers = probe.CLUSTER_PRODUCERS[cluster]
+    wave_commands = probe._wave_commands(logical_head_groups=logical_head_groups)
+    query_streams: list[list[int]] = [[] for _ in range(producers)]
+    key_streams: list[list[int]] = [[] for _ in range(producers)]
+    beat_limits = [[0 for _ in range(producers)] for _ in wave_commands]
+    max_beats = 0
+    for producer in range(producers):
+        cursor = 0
+        for command_index, command in enumerate(wave_commands):
+            block_count = probe.exact_local_cluster_gqa8_command_block_counts(
+                producers=producers,
+                group_index=int(command["group_index"]),
+            )[producer]
+            blocks = [
+                probe.full_probe._stream_block_beats(
+                    cluster=cluster,
+                    producer=producer,
+                    group_index=int(command["group_index"]),
+                    wave_index=int(command["wave_index"]),
+                    stream=stream,
+                    block_count=block_count,
+                    seed=probe.SEED,
+                )
+                for stream in range(probe.STREAMS)
+            ]
+            for block in range(block_count):
+                queries0, keys0 = blocks[0][block][0]
+                queries1, keys1 = blocks[1][block][0]
+                query_streams[producer].append(
+                    probe.full_probe._pack(list(queries0), 8)
+                    | (probe.full_probe._pack(list(queries1), 8) << 64)
+                )
+                key_streams[producer].append(
+                    probe.full_probe._pack(list(keys0), 8)
+                    | (probe.full_probe._pack(list(keys1), 8) << 64)
+                )
+                cursor += 1
+            beat_limits[command_index][producer] = cursor
+        max_beats = max(max_beats, cursor)
+    query_words = [0] * (producers * max_beats)
+    key_words = [0] * (producers * max_beats)
+    for producer in range(producers):
+        for beat_index, query in enumerate(query_streams[producer]):
+            flat = producer * max_beats + beat_index
+            query_words[flat] = query
+            key_words[flat] = key_streams[producer][beat_index]
+    return {
+        "wave_commands": wave_commands,
+        "query_words": query_words,
+        "key_words": key_words,
+        "beat_limits": beat_limits,
+        "max_beats_per_producer": max_beats,
+    }
+
+
+def _write_cluster_sidecars(directory: Path, *, cluster: int, logical_head_groups: int) -> JsonDict:
+    from npu.eval import probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8 as probe
+
+    data = _cluster_driver_data(cluster=cluster, logical_head_groups=logical_head_groups)
+    probe._write_memh(directory / "query.memh", data["query_words"], width_bits=128)
+    probe._write_memh(directory / "key.memh", data["key_words"], width_bits=128)
+    fill_words = [
+        value
+        for command in data["wave_commands"]
+        for value in probe._fill_rows_for_wave(
+            cluster=cluster,
+            head_base=int(command["head_base"]),
+            wave=int(command["wave_index"]),
+        )
+    ]
+    probe._write_memh(directory / "fill.memh", fill_words, width_bits=512)
+    return {
+        "query_words": len(data["query_words"]),
+        "key_words": len(data["key_words"]),
+        "fill_words": len(fill_words),
+        "max_beats_per_producer": int(data["max_beats_per_producer"]),
+    }
+
+
+def _command_initializers(*, logical_head_groups: int) -> tuple[str, str]:
+    from npu.eval import probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8 as probe
+
+    commands = probe._wave_commands(logical_head_groups=logical_head_groups)
+    command_lines = []
+    for index, command in enumerate(commands):
+        command_lines.append(
+            f"    command_id_mem[{index}] = 16'h{int(command['command_id']):04x}; "
+            f"head_base_mem[{index}] = 5'd{int(command['head_base'])}; "
+            f"multiplier_mem[{index}] = 32'd{int(command['multiplier'])}; "
+            f"shift_mem[{index}] = 6'd{int(command['shift'])}; "
+            f"wave_index_mem[{index}] = 3'd{int(command['wave_index'])};"
+        )
+    return "\n".join(command_lines), str(len(commands))
+
+
+def cluster_testbench(
+    *,
+    top_name: str,
+    producers: int,
+    logical_head_groups: int,
+    output_ready_pattern: tuple[bool, ...] = (True, True, False, True),
+) -> str:
+    from npu.eval import probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8 as probe
+
+    if producers not in (53, 54):
+        raise ValueError("component cluster must have 53 or 54 producers")
+    command_init, command_count = _command_initializers(logical_head_groups=logical_head_groups)
+    representative = 0 if producers == 54 else 8
+    data = _cluster_driver_data(cluster=representative, logical_head_groups=logical_head_groups)
+    beat_limit_init = "\n".join(
+        f"    beat_limit_mem[{command}][{producer}] = 32'd{int(data['beat_limits'][command][producer])};"
+        for command in range(int(command_count))
+        for producer in range(producers)
+    )
+    expected_rows = logical_head_groups * probe.EXPECTED_PER_CLUSTER["emitted_beat_count"]
+    timeout_cycles = logical_head_groups * probe.TB_TIMEOUT_CYCLES
+    if not output_ready_pattern:
+        raise ValueError("cluster output ready pattern must not be empty")
+    ready_init = "\n".join(
+        f"    out_ready_mem[{index}] = 1'b{int(value)};"
+        for index, value in enumerate(output_ready_pattern)
+    )
+    return f"""`timescale 1ns/1ps
+module tb;
+  localparam integer PRODUCERS = {producers};
+  localparam integer COMMANDS = {command_count};
+  localparam integer MAX_BEATS = {int(data["max_beats_per_producer"])};
+  localparam integer ROWS_PER_TARGET = {probe.ROWS_PER_BUFFER};
+  localparam integer ROWS_PER_STREAM = {probe.ROWS_PER_STREAM};
+  localparam integer EXPECTED_ROWS = {expected_rows};
+  localparam integer TB_TIMEOUT_CYCLES = {timeout_cycles};
+  localparam integer OUT_READY_LEN = {len(output_ready_pattern)};
+  reg clk = 0, rst_n = 0;
+  integer cluster_id = 0, cycle = 0, issued = 0, active = -1;
+  integer fill_command = 0, fill_row = -1, rows_seen = 0, producer_handshakes = 0;
+  integer producer, flat_index, command_drive_index, fill_drive_index;
+  integer beat_issue [0:PRODUCERS-1];
+  reg pending_summary = 0;
+  reg [15:0] command_id_mem [0:COMMANDS-1];
+  reg [4:0] head_base_mem [0:COMMANDS-1];
+  reg [31:0] multiplier_mem [0:COMMANDS-1];
+  reg [5:0] shift_mem [0:COMMANDS-1];
+  reg [2:0] wave_index_mem [0:COMMANDS-1];
+  reg [31:0] beat_limit_mem [0:COMMANDS-1][0:PRODUCERS-1];
+  reg [127:0] query_mem [0:(PRODUCERS*MAX_BEATS)-1];
+  reg [127:0] key_mem [0:(PRODUCERS*MAX_BEATS)-1];
+  reg [511:0] fill_mem [0:(COMMANDS*ROWS_PER_TARGET)-1];
+  reg out_ready_mem [0:OUT_READY_LEN-1];
+  wire preload_complete = fill_command >= ((COMMANDS < 2) ? COMMANDS : 2);
+  wire command_valid = rst_n && preload_complete && (issued < COMMANDS);
+  wire command_ready, fill_target_ready, fill_ready, out_valid;
+  wire [PRODUCERS-1:0] input_ready;
+  reg [PRODUCERS-1:0] input_valid, input_last;
+  reg signed [(PRODUCERS*128)-1:0] input_query, input_key;
+  wire [15:0] out_command_id;
+  wire [4:0] out_head_id;
+  wire signed [31:0] out_global_max;
+  wire [32:0] out_exp_sum;
+  wire [3:0] out_slice;
+  wire out_last;
+  wire [327:0] out_value;
+  wire [31:0] wave_accept, completed, emitted, fill_targets, fill_rows;
+  wire [31:0] requests, responses, command_accepts, command_releases;
+  wire group_error, local_error, temporal_error, reducer_error, atomic_error;
+  wire invalid_metadata_error, invalid_address_error, residency_error, overwrite_error;
+  wire command_error, buffer_map_error, release_guard_error, sram_error, protocol_error;
+  wire fill_target_valid = rst_n && (fill_command < COMMANDS) && (fill_row < 0)
+      && (fill_command <= issued + 1);
+  wire fill_valid = rst_n && (fill_command < COMMANDS) && (fill_row >= 0);
+  wire [511:0] fill_data = (fill_row >= 0)
+      ? fill_mem[fill_drive_index * ROWS_PER_TARGET + fill_row] : '0;
+  wire out_ready = out_ready_mem[cycle % OUT_READY_LEN];
+
+  {top_name} dut (
+    .clk(clk), .rst_n(rst_n),
+    .fill_target_valid(fill_target_valid), .fill_target_ready(fill_target_ready),
+    .fill_target_buffer_sel(wave_index_mem[fill_drive_index][0]),
+    .fill_target_command_id(command_id_mem[fill_drive_index]),
+    .fill_target_head_base(head_base_mem[fill_drive_index]),
+    .fill_target_wave_index(wave_index_mem[fill_drive_index]),
+    .fill_valid(fill_valid), .fill_ready(fill_ready),
+    .fill_buffer_sel(wave_index_mem[fill_drive_index][0]),
+    .fill_stream(fill_row >= ROWS_PER_STREAM),
+    .fill_block_slot((fill_row >> 4) & 6'h3f), .fill_slice(fill_row & 4'hf), .fill_data(fill_data),
+    .command_valid(command_valid), .command_ready(command_ready),
+    .command_id(command_id_mem[command_drive_index]), .command_head_base(head_base_mem[command_drive_index]),
+    .command_wave_index(wave_index_mem[command_drive_index]),
+    .command_score_multiplier(multiplier_mem[command_drive_index]),
+    .command_score_shift(shift_mem[command_drive_index]),
+    .input_valid(input_valid), .input_ready(input_ready), .input_last(input_last),
+    .input_query(input_query), .input_key(input_key),
+    .out_valid(out_valid), .out_ready(out_ready), .out_command_id(out_command_id),
+    .out_head_id(out_head_id), .out_global_max(out_global_max), .out_exp_sum(out_exp_sum),
+    .out_slice(out_slice), .out_last(out_last), .out_value(out_value),
+    .wave_command_accept_count(wave_accept), .reducer_completed_command_count(completed),
+    .reducer_emitted_beat_count(emitted),
+    .group_contract_error(group_error), .local_tree_protocol_error(local_error),
+    .temporal_merge_protocol_error(temporal_error), .reducer_protocol_error(reducer_error),
+    .atomic_command_protocol_error(atomic_error),
+    .sram_fill_target_accept_count(fill_targets), .sram_fill_row_accept_count(fill_rows),
+    .sram_request_accept_count(requests), .sram_response_accept_count(responses),
+    .sram_command_accept_count(command_accepts), .sram_command_release_count(command_releases),
+    .sram_invalid_metadata_error(invalid_metadata_error),
+    .sram_invalid_address_error(invalid_address_error), .sram_residency_error(residency_error),
+    .sram_overwrite_error(overwrite_error), .sram_command_error(command_error),
+    .sram_buffer_map_error(buffer_map_error), .sram_release_guard_error(release_guard_error),
+    .sram_protocol_error(sram_error), .protocol_error(protocol_error)
+  );
+  always #5 clk = ~clk;
+  always @* begin
+    command_drive_index = (issued < COMMANDS) ? issued : COMMANDS-1;
+    fill_drive_index = (fill_command < COMMANDS) ? fill_command : COMMANDS-1;
+    input_valid = '0; input_last = '0; input_query = '0; input_key = '0;
+    for (producer = 0; producer < PRODUCERS; producer = producer + 1) begin
+      if (rst_n && active >= 0 && beat_issue[producer] < beat_limit_mem[active][producer]) begin
+        flat_index = producer * MAX_BEATS + beat_issue[producer];
+        input_valid[producer] = 1'b1; input_last[producer] = 1'b1;
+        input_query[producer*128 +: 128] = query_mem[flat_index];
+        input_key[producer*128 +: 128] = key_mem[flat_index];
+      end
+    end
+  end
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      cycle <= 0; issued <= 0; active <= -1; fill_command <= 0; fill_row <= -1;
+      rows_seen <= 0; producer_handshakes <= 0; pending_summary <= 0;
+      for (producer = 0; producer < PRODUCERS; producer = producer + 1) beat_issue[producer] <= 0;
+    end else begin
+      cycle <= cycle + 1;
+      if (fill_target_valid && fill_target_ready) fill_row <= 0;
+      if (fill_valid && fill_ready) begin
+        if (fill_row == ROWS_PER_TARGET-1) begin fill_command <= fill_command + 1; fill_row <= -1; end
+        else fill_row <= fill_row + 1;
+      end
+      if (command_valid && command_ready) begin active <= issued; issued <= issued + 1; end
+      for (producer = 0; producer < PRODUCERS; producer = producer + 1)
+        if (input_valid[producer] && input_ready[producer]) beat_issue[producer] <= beat_issue[producer] + 1;
+      producer_handshakes <= producer_handshakes + $countones(input_valid & input_ready);
+      if (out_valid && out_ready) begin
+        $display("CLUSTER_RESULT cluster=%0d cmd=%0d head=%0d slice=%0d last=%0d max=%0d sum=%0d value=%082x cycle=%0d",
+                 cluster_id, out_command_id, out_head_id, out_slice, out_last,
+                 out_global_max, out_exp_sum, out_value, cycle);
+        rows_seen <= rows_seen + 1;
+        if (rows_seen + 1 == EXPECTED_ROWS) pending_summary <= 1;
+      end
+      if (pending_summary) begin
+        $display("CLUSTER_SUMMARY cluster=%0d wave_accept=%0d completed=%0d emitted=%0d fill_targets=%0d fill_rows=%0d requests=%0d responses=%0d command_accepts=%0d command_releases=%0d errors=%0d",
+                 cluster_id, wave_accept, completed, emitted, fill_targets, fill_rows, requests, responses,
+                 command_accepts, command_releases,
+                 group_error | local_error | temporal_error | reducer_error | atomic_error |
+                 invalid_metadata_error | invalid_address_error | residency_error | overwrite_error |
+                 command_error | buffer_map_error | release_guard_error | sram_error | protocol_error);
+        $display("CLUSTER_COUNTS cluster=%0d producer_handshakes=%0d", cluster_id, producer_handshakes);
+        #1 $finish;
+      end
+      if (cycle >= TB_TIMEOUT_CYCLES) begin $display("TB_TIMEOUT cycle=%0d", cycle); #1 $finish; end
+    end
+  end
+  initial begin
+    if (!$value$plusargs("CLUSTER=%d", cluster_id)) cluster_id = 0;
+    $readmemh("query.memh", query_mem); $readmemh("key.memh", key_mem); $readmemh("fill.memh", fill_mem);
+{command_init}
+{beat_limit_init}
+{ready_init}
+    repeat (3) @(posedge clk); @(negedge clk); rst_n = 1;
+  end
+endmodule
+"""
+
+
+def _pack_global_row(row: JsonDict) -> int:
+    value = 0
+    value |= int(row["command_id"])
+    value |= int(row["head_id"]) << 16
+    value |= (int(row["global_max"]) & 0xFFFF_FFFF) << 21
+    value |= int(row["exp_sum"]) << 53
+    value |= int(row["slice"]) << 86
+    value |= int(bool(row["last"])) << 90
+    numerators = row["value"]
+    packed_value = sum((int(lane) & 0xFFFF_FFFF) << (32 * index) for index, lane in enumerate(numerators))
+    value |= packed_value << 91
+    return value
+
+
+def _write_global_sidecar(directory: Path, cluster_rows: list[list[JsonDict]]) -> JsonDict:
+    from npu.eval import probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8 as probe
+
+    if len(cluster_rows) != probe.CLUSTERS or len({len(rows) for rows in cluster_rows}) != 1:
+        raise ValueError("global composition requires 16 equal-length cluster streams")
+    words = [_pack_global_row(row) for rows in cluster_rows for row in rows]
+    probe._write_memh(directory / "global_rows.memh", words, width_bits=GLOBAL_ROW_BITS)
+    return {"global_row_words": len(words), "rows_per_cluster": len(cluster_rows[0])}
+
+
+def global_testbench(
+    *,
+    top_name: str,
+    rows_per_cluster: int,
+    output_ready_pattern: tuple[bool, ...],
+    timeout_cycles: int,
+) -> str:
+    ready_init = "\n".join(
+        f"    ready_mem[{index}] = 1'b{int(value)};" for index, value in enumerate(output_ready_pattern)
+    )
+    return f"""`timescale 1ns/1ps
+module tb;
+  localparam integer CLUSTERS=16, ROWS={rows_per_cluster}, READY_LEN={len(output_ready_pattern)};
+  localparam integer EXPECTED_ROOT_ROWS={rows_per_cluster}, TB_TIMEOUT_CYCLES={timeout_cycles};
+  reg clk=0, rst_n=0; integer cycle=0, root_rows=0, first_root=-1, last_root=-1, leaf;
+  integer row_index [0:CLUSTERS-1]; reg pending_summary=0;
+  reg [{GLOBAL_ROW_BITS - 1}:0] row_mem [0:(CLUSTERS*ROWS)-1]; reg ready_mem [0:READY_LEN-1];
+  reg [15:0] leaf_valid; wire [15:0] leaf_ready; reg [255:0] leaf_command_id;
+  reg [79:0] leaf_head_id; reg [511:0] leaf_global_max; reg [527:0] leaf_exp_sum;
+  reg [63:0] leaf_slice; reg [15:0] leaf_last; reg [5247:0] leaf_value;
+  wire root_valid; wire [15:0] root_command_id; wire [4:0] root_head_id;
+  wire [3:0] root_slice; wire root_last; wire [319:0] root_value;
+  wire [31:0] root_completed, finalizer_accepted, tree_completed;
+  wire tree_error, order_error, finalizer_error, protocol_error;
+  wire root_ready = ready_mem[cycle % READY_LEN];
+  {top_name} dut (
+    .clk(clk), .rst_n(rst_n), .leaf_valid(leaf_valid), .leaf_ready(leaf_ready),
+    .leaf_command_id(leaf_command_id), .leaf_head_id(leaf_head_id),
+    .leaf_global_max(leaf_global_max), .leaf_exp_sum(leaf_exp_sum),
+    .leaf_slice(leaf_slice), .leaf_last(leaf_last), .leaf_value(leaf_value),
+    .root_valid(root_valid), .root_ready(root_ready), .root_command_id(root_command_id),
+    .root_head_id(root_head_id), .root_slice(root_slice), .root_last(root_last), .root_value(root_value),
+    .root_completed_count(root_completed), .finalizer_accepted_count(finalizer_accepted),
+    .tree_root_completed_count(tree_completed), .tree_protocol_error(tree_error),
+    .order_protocol_error(order_error), .finalizer_protocol_error(finalizer_error),
+    .protocol_error(protocol_error)
+  );
+  always #5 clk=~clk;
+  always @* begin
+    leaf_valid='0; leaf_command_id='0; leaf_head_id='0; leaf_global_max='0;
+    leaf_exp_sum='0; leaf_slice='0; leaf_last='0; leaf_value='0;
+    for (leaf=0; leaf<CLUSTERS; leaf=leaf+1) if (row_index[leaf] < ROWS) begin
+      leaf_valid[leaf]=1;
+      leaf_command_id[leaf*16 +: 16]=row_mem[leaf*ROWS+row_index[leaf]][0 +: 16];
+      leaf_head_id[leaf*5 +: 5]=row_mem[leaf*ROWS+row_index[leaf]][16 +: 5];
+      leaf_global_max[leaf*32 +: 32]=row_mem[leaf*ROWS+row_index[leaf]][21 +: 32];
+      leaf_exp_sum[leaf*33 +: 33]=row_mem[leaf*ROWS+row_index[leaf]][53 +: 33];
+      leaf_slice[leaf*4 +: 4]=row_mem[leaf*ROWS+row_index[leaf]][86 +: 4];
+      leaf_last[leaf]=row_mem[leaf*ROWS+row_index[leaf]][90];
+      leaf_value[leaf*328 +: 328]=row_mem[leaf*ROWS+row_index[leaf]][91 +: 328];
+    end
+  end
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      cycle<=0; root_rows<=0; first_root<=-1; last_root<=-1; pending_summary<=0;
+      for (leaf=0; leaf<CLUSTERS; leaf=leaf+1) row_index[leaf]<=0;
+    end else begin
+      cycle<=cycle+1;
+      for (leaf=0; leaf<CLUSTERS; leaf=leaf+1)
+        if (leaf_valid[leaf] && leaf_ready[leaf]) row_index[leaf]<=row_index[leaf]+1;
+      if (root_valid && root_ready) begin
+        $display("ROOT_RESULT cmd=%0d head=%0d slice=%0d last=%0d value=%080x cycle=%0d",
+                 root_command_id, root_head_id, root_slice, root_last, root_value, cycle);
+        if (first_root<0) first_root<=cycle; last_root<=cycle; root_rows<=root_rows+1;
+        if (root_rows+1==EXPECTED_ROOT_ROWS) pending_summary<=1;
+      end
+      if (pending_summary) begin
+        $display("GLOBAL_SUMMARY root_rows=%0d root_completed=%0d finalizer_accepted=%0d tree_completed=%0d protocol_error=%0d first_root=%0d last_root=%0d drain=%0d",
+                 root_rows, root_completed, finalizer_accepted, tree_completed,
+                 tree_error | order_error | finalizer_error | protocol_error,
+                 first_root, last_root, cycle);
+        #1 $finish;
+      end
+      if (cycle>=TB_TIMEOUT_CYCLES) begin $display("TB_TIMEOUT cycle=%0d",cycle); #1 $finish; end
+    end
+  end
+  initial begin
+    $readmemh("global_rows.memh",row_mem);
+{ready_init}
+    repeat(3) @(posedge clk); @(negedge clk); rst_n=1;
+  end
+endmodule
+"""
+
+
+def _run_process(
+    command: list[str],
+    *,
+    cwd: Path,
+    timeout_sec: int,
+    phase: str,
+) -> tuple[subprocess.CompletedProcess[str] | None, JsonDict | None]:
+    try:
+        result = subprocess.run(command, cwd=cwd, capture_output=True, text=True, timeout=timeout_sec)
+    except subprocess.TimeoutExpired as exc:
+        return None, {
+            "phase": phase,
+            "status": "subprocess_timeout",
+            "returncode": 124,
+            "stdout": exc.stdout or "",
+            "stderr": exc.stderr or "",
+        }
+    except (MemoryError, OSError, RuntimeError) as exc:
+        return None, {
+            "phase": phase,
+            "status": "resource_failure",
+            "returncode": 137 if isinstance(exc, MemoryError) else 125,
+            "stdout": "",
+            "stderr": str(exc),
+        }
+    if result.returncode:
+        from npu.eval import probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8 as probe
+
+        resource_failure = probe._is_resource_termination(
+            returncode=result.returncode,
+            stdout=result.stdout or "",
+            stderr=result.stderr or "",
+        )
+        return result, {
+            "phase": phase,
+            "status": (
+                "resource_failure"
+                if resource_failure
+                else ("compile_failed" if phase.startswith("compile_") else "run_failed")
+            ),
+            "returncode": result.returncode,
+            "stdout": result.stdout or "",
+            "stderr": result.stderr or "",
+        }
+    if "TB_TIMEOUT" in (result.stdout or ""):
+        return result, {
+            "phase": phase,
+            "status": "testbench_timeout",
+            "returncode": 124,
+            "stdout": result.stdout or "",
+            "stderr": result.stderr or "",
+        }
+    return result, None
+
+
+def _diagnostic(failure: JsonDict) -> str:
+    text = str(failure.get("stderr") or failure.get("stdout") or "")
+    return f"phase={failure['phase']} returncode={failure['returncode']}\n{text}".strip()
+
+
+def run_compositional_exact(
+    *,
+    config: JsonDict,
+    work_dir: Path,
+    rtl_dir: Path,
+    fakeram_path: Path,
+    logical_head_groups: int,
+    output_ready_pattern: tuple[bool, ...],
+    compile_timeout_sec: int,
+    simulation_timeout_sec: int,
+) -> JsonDict:
+    from npu.eval import probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8 as probe
+
+    top_name = str(config["top_name"])
+    modules = probe._hierarchical_module_names(top_name)
+    try:
+        with contextlib.redirect_stdout(io.StringIO()):
+            strict_guard_main(["--design-dir", str(work_dir), "--config", str(rtl_dir / "config.json")])
+    except SystemExit as exc:
+        return {
+            "simulation_status": "guard_failed",
+            "returncode": 1,
+            "stderr": f"phase=strict_generated_top_guard\n{exc}",
+            "stdout": "",
+            "phase_records": [{"phase": "strict_generated_top_guard", "returncode": 1}],
+        }
+
+    compile_dir = work_dir / "component_build"
+    compile_dir.mkdir()
+    generated_rtl = (rtl_dir / "top.v").read_text(encoding="utf-8")
+    component_rtl_dirs: dict[str, Path] = {}
+    for kind in ("p54_cluster", "p53_cluster", "global_tree"):
+        component_rtl_dir = compile_dir / f"{kind}_rtl"
+        component_rtl_dir.mkdir()
+        family = extract_module_family(generated_rtl, prefix=modules[kind])
+        (component_rtl_dir / "top.v").write_text(family, encoding="utf-8")
+        component_rtl_dirs[kind] = component_rtl_dir
+    binaries: dict[str, Path] = {}
+    phase_records: list[JsonDict] = [{"phase": "strict_generated_top_guard", "returncode": 0}]
+    for kind, producers in (("p54_cluster", 54), ("p53_cluster", 53)):
+        tb_path = compile_dir / f"{kind}_tb.v"
+        sim_path = compile_dir / f"{kind}.out"
+        tb_path.write_text(
+            cluster_testbench(
+                top_name=modules[kind],
+                producers=producers,
+                logical_head_groups=logical_head_groups,
+                output_ready_pattern=output_ready_pattern,
+            ),
+            encoding="ascii",
+        )
+        command = probe._icarus_compile_command(
+            rtl_dir=component_rtl_dirs[kind],
+            fakeram_path=fakeram_path,
+            tb_path=tb_path,
+            sim_path=sim_path,
+        )
+        result, failure = _run_process(
+            command,
+            cwd=compile_dir,
+            timeout_sec=compile_timeout_sec,
+            phase=f"compile_{kind}",
+        )
+        phase_records.append(
+            {"phase": f"compile_{kind}", "returncode": failure["returncode"] if failure else 0}
+        )
+        if failure:
+            return {
+                "simulation_status": failure["status"],
+                "returncode": failure["returncode"],
+                "stderr": _diagnostic(failure),
+                "stdout": str(failure.get("stdout") or ""),
+                "phase_records": phase_records,
+            }
+        binaries[kind] = sim_path
+
+    cluster_stdout: list[str] = []
+    cluster_sidecars: list[JsonDict] = []
+    observed_cluster_rows: list[list[JsonDict]] = [[] for _ in range(probe.CLUSTERS)]
+    cluster_summaries: list[JsonDict] = []
+    producer_handshakes = 0
+
+    def run_cluster(
+        cluster: int,
+    ) -> tuple[int, JsonDict, subprocess.CompletedProcess[str] | None, JsonDict | None]:
+        producers = probe.CLUSTER_PRODUCERS[cluster]
+        run_dir = work_dir / f"cluster_{cluster:02d}"
+        run_dir.mkdir()
+        try:
+            sidecar = _write_cluster_sidecars(
+                run_dir,
+                cluster=cluster,
+                logical_head_groups=logical_head_groups,
+            )
+            kind = "p54_cluster" if producers == 54 else "p53_cluster"
+            result, failure = _run_process(
+                [probe._tool("vvp"), str(binaries[kind]), f"+CLUSTER={cluster}"],
+                cwd=run_dir,
+                timeout_sec=simulation_timeout_sec,
+                phase=f"run_cluster_{cluster}",
+            )
+            return cluster, sidecar, result, failure
+        finally:
+            shutil.rmtree(run_dir, ignore_errors=True)
+
+    try:
+        with ThreadPoolExecutor(max_workers=CLUSTER_RUN_JOBS) as executor:
+            cluster_results = list(executor.map(run_cluster, range(probe.CLUSTERS)))
+    except (MemoryError, OSError, RuntimeError, ValueError) as exc:
+        resource_failure = isinstance(exc, (MemoryError, OSError))
+        return {
+            "simulation_status": "resource_failure" if resource_failure else "run_failed",
+            "returncode": 137 if isinstance(exc, MemoryError) else (125 if resource_failure else 1),
+            "stderr": f"phase=prepare_or_run_clusters\n{exc}",
+            "stdout": "",
+            "phase_records": phase_records,
+        }
+    for cluster, sidecar, result, failure in cluster_results:
+        cluster_sidecars.append(sidecar)
+        phase_records.append(
+            {"phase": f"run_cluster_{cluster}", "returncode": failure["returncode"] if failure else 0}
+        )
+        if failure:
+            return {
+                "simulation_status": failure["status"],
+                "returncode": failure["returncode"],
+                "stderr": _diagnostic(failure),
+                "stdout": str(failure.get("stdout") or ""),
+                "phase_records": phase_records,
+            }
+        stdout = result.stdout or ""
+        cluster_stdout.append(stdout)
+        _, parsed_summaries, parsed_rows, _, timeout_cycle = probe._parse_stdout(stdout)
+        if timeout_cycle is not None or len(parsed_summaries) != 1:
+            return {
+                "simulation_status": "testbench_timeout" if timeout_cycle is not None else "run_failed",
+                "returncode": 124 if timeout_cycle is not None else 1,
+                "stderr": f"phase=run_cluster_{cluster}: missing unique cluster summary",
+                "stdout": stdout,
+                "phase_records": phase_records,
+            }
+        observed_cluster_rows[cluster] = parsed_rows[cluster]
+        cluster_summaries.extend(parsed_summaries)
+        match = re.search(r"CLUSTER_COUNTS cluster=\d+ producer_handshakes=(\d+)", stdout)
+        if not match:
+            return {
+                "simulation_status": "run_failed",
+                "returncode": 1,
+                "stderr": f"phase=run_cluster_{cluster}: missing producer handshake count",
+                "stdout": stdout,
+                "phase_records": phase_records,
+            }
+        producer_handshakes += int(match.group(1))
+
+    global_dir = work_dir / "global"
+    global_dir.mkdir()
+    global_sidecar = _write_global_sidecar(global_dir, observed_cluster_rows)
+    global_tb = compile_dir / "global_tb.v"
+    global_sim = compile_dir / "global.out"
+    global_tb.write_text(
+        global_testbench(
+            top_name=modules["global_tree"],
+            rows_per_cluster=int(global_sidecar["rows_per_cluster"]),
+            output_ready_pattern=output_ready_pattern,
+            timeout_cycles=logical_head_groups * probe.TB_TIMEOUT_CYCLES,
+        ),
+        encoding="ascii",
+    )
+    result, failure = _run_process(
+        probe._icarus_compile_command(
+            rtl_dir=component_rtl_dirs["global_tree"],
+            fakeram_path=fakeram_path,
+            tb_path=global_tb,
+            sim_path=global_sim,
+        ),
+        cwd=compile_dir,
+        timeout_sec=compile_timeout_sec,
+        phase="compile_global_tree",
+    )
+    phase_records.append(
+        {"phase": "compile_global_tree", "returncode": failure["returncode"] if failure else 0}
+    )
+    if failure:
+        return {
+            "simulation_status": failure["status"],
+            "returncode": failure["returncode"],
+            "stderr": _diagnostic(failure),
+            "stdout": str(failure.get("stdout") or ""),
+            "phase_records": phase_records,
+        }
+    result, failure = _run_process(
+        [probe._tool("vvp"), str(global_sim)],
+        cwd=global_dir,
+        timeout_sec=simulation_timeout_sec,
+        phase="run_global_tree",
+    )
+    phase_records.append(
+        {"phase": "run_global_tree", "returncode": failure["returncode"] if failure else 0}
+    )
+    if failure:
+        return {
+            "simulation_status": failure["status"],
+            "returncode": failure["returncode"],
+            "stderr": _diagnostic(failure),
+            "stdout": str(failure.get("stdout") or ""),
+            "phase_records": phase_records,
+        }
+    global_stdout = result.stdout or ""
+    global_match = _GLOBAL_SUMMARY_RE.search(global_stdout)
+    if not global_match:
+        return {
+            "simulation_status": "run_failed",
+            "returncode": 1,
+            "stderr": "phase=run_global_tree: missing global summary",
+            "stdout": global_stdout,
+            "phase_records": phase_records,
+        }
+    root_rows, root_completed, finalizer_accepted, tree_completed, global_error, first_root, last_root, drain = (
+        int(value) for value in global_match.groups()
+    )
+    totals = {
+        key: sum(int(summary[key]) for summary in cluster_summaries)
+        for key in (
+            "fill_target_accept_count",
+            "fill_row_accept_count",
+            "request_accept_count",
+            "response_accept_count",
+            "emitted_beat_count",
+        )
+    }
+    global_count_error = int(
+        root_completed != root_rows
+        or finalizer_accepted != root_rows
+        or tree_completed != root_rows
+    )
+    protocol_error = (
+        global_error
+        | global_count_error
+        | int(any(int(summary["errors"]) for summary in cluster_summaries))
+    )
+    wave_commands = logical_head_groups * probe.WAVES
+    synthetic_summary = (
+        f"SUMMARY producer_handshakes={producer_handshakes} fill_targets={totals['fill_target_accept_count']} "
+        f"fill_rows={totals['fill_row_accept_count']} sram_requests={totals['request_accept_count']} "
+        f"sram_responses={totals['response_accept_count']} cluster_rows={totals['emitted_beat_count']} "
+        f"root_rows={root_rows} command_accepts={wave_commands} cadence_accepts={wave_commands} "
+        f"protocol_error={protocol_error} first_root={first_root} last_root={last_root} drain={drain}"
+    )
+    return {
+        "simulation_status": "ok",
+        "returncode": 0,
+        "stderr": "",
+        "stdout": "\n".join(cluster_stdout + [global_stdout, synthetic_summary]),
+        "phase_records": phase_records,
+        "component_metadata": {
+            "proof": "concrete_rtl_composition",
+            "strict_generated_top_guard": "passed",
+            "compiled_cluster_variants": {"p54": 1, "p53": 1},
+            "cluster_replays": 16,
+            "cluster_run_jobs": CLUSTER_RUN_JOBS,
+            "global_tree_simulations": 1,
+            "cluster_sidecars": cluster_sidecars,
+            "global_sidecar": global_sidecar,
+            "global_counts": {
+                "root_completed_count": root_completed,
+                "finalizer_accepted_count": finalizer_accepted,
+                "tree_root_completed_count": tree_completed,
+                "counts_passed": not bool(global_count_error),
+            },
+        },
+    }

--- a/npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
+++ b/npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
@@ -58,7 +58,12 @@ DIAGNOSTIC_TAIL_LIMIT = 4096
 MARKDOWN_DIAGNOSTIC_TAIL_LIMIT = 1024
 DEFAULT_SIM_BACKEND = "icarus"
 VERILATOR_HIERARCHICAL_BACKEND = "verilator_hierarchical"
-SIM_BACKEND_CHOICES = (DEFAULT_SIM_BACKEND, VERILATOR_HIERARCHICAL_BACKEND)
+COMPOSITIONAL_ICARUS_BACKEND = "compositional_icarus"
+SIM_BACKEND_CHOICES = (
+    DEFAULT_SIM_BACKEND,
+    VERILATOR_HIERARCHICAL_BACKEND,
+    COMPOSITIONAL_ICARUS_BACKEND,
+)
 VERILATOR_BUILD_JOBS = 3
 VERILATOR_CONTROL_FILE_NAME = "verilator_hier.vlt"
 VERILATOR_BINARY_NAME = "simv"
@@ -538,8 +543,8 @@ def _sim_backend_metadata(
     simulation_timeout_sec: int,
 ) -> JsonDict:
     metadata: JsonDict = {
-        "compile_tool": "iverilog" if sim_backend == DEFAULT_SIM_BACKEND else "verilator",
-        "run_tool": "vvp" if sim_backend == DEFAULT_SIM_BACKEND else "verilated_binary",
+        "compile_tool": "verilator" if sim_backend == VERILATOR_HIERARCHICAL_BACKEND else "iverilog",
+        "run_tool": "verilated_binary" if sim_backend == VERILATOR_HIERARCHICAL_BACKEND else "vvp",
         "compile_timeout_sec": int(compile_timeout_sec),
         "simulation_timeout_sec": int(simulation_timeout_sec),
     }
@@ -552,13 +557,22 @@ def _sim_backend_metadata(
                 "hierarchical_modules": _hierarchical_module_names(top_name),
             }
         )
+    elif sim_backend == COMPOSITIONAL_ICARUS_BACKEND:
+        metadata.update(
+            {
+                "proof": "concrete_rtl_composition",
+                "strict_generated_top_guard": True,
+                "components": ["p54_cluster", "p53_cluster", "global_tree"],
+                "cluster_replays": CLUSTERS,
+            }
+        )
     return metadata
 
 
 def _resolve_compile_timeout_sec(*, sim_backend: str, timeout_sec: int, compile_timeout_sec: int | None) -> int:
     if compile_timeout_sec is not None:
         return int(compile_timeout_sec)
-    if sim_backend == VERILATOR_HIERARCHICAL_BACKEND:
+    if sim_backend in (VERILATOR_HIERARCHICAL_BACKEND, COMPOSITIONAL_ICARUS_BACKEND):
         return DEFAULT_VERILATOR_COMPILE_TIMEOUT_SEC
     return int(timeout_sec)
 
@@ -1126,6 +1140,16 @@ def _bounded_tail(text: str, *, limit: int = DIAGNOSTIC_TAIL_LIMIT) -> str:
     return f"[truncated {omitted} chars]\n{text[-limit:]}"
 
 
+def _bounded_first_and_tail(text: str, *, limit: int = DIAGNOSTIC_TAIL_LIMIT) -> str:
+    if len(text) <= limit:
+        return text
+    marker = "\n...[middle omitted]...\n"
+    available = max(2, limit - len(marker))
+    head = available // 2
+    tail = available - head
+    return text[:head] + marker + text[-tail:]
+
+
 def _evaluate_observations(
     *,
     reference: dict[str, object],
@@ -1183,7 +1207,7 @@ def _evaluate_observations(
         "simulation_status": simulation_status,
         "returncode": returncode,
         "normalized_returncode": _normalize_returncode(returncode),
-        "stderr_tail": _bounded_tail(stderr),
+        "stderr_tail": _bounded_first_and_tail(stderr),
         "tb_timeout_cycle": tb_timeout_cycle,
         "summary": summary,
         "cluster_summaries": cluster_summaries,
@@ -1231,28 +1255,55 @@ def build_report(
     stdout = ""
     stderr = ""
     sidecars: dict[str, object] = {}
+    component_metadata: dict[str, object] = {}
+    phase_records: list[dict[str, object]] = []
 
     with tempfile.TemporaryDirectory(prefix="score32_exact_full_cluster_sram_probe_") as temp_name:
         temp_dir = Path(temp_name)
-        rtl_dir = temp_dir / "rtl"
+        rtl_dir = temp_dir / "verilog"
         generate(resolved_config, rtl_dir)
-        sidecars = _write_memh_sidecars(temp_dir, logical_head_groups=resolved_groups)
         tb_path = temp_dir / "tb.v"
-        tb_path.write_text(
-            _testbench(
-                top_name=str(resolved_config["top_name"]),
-                output_ready_pattern=tuple(bool(value) for value in output_ready_pattern),
-                logical_head_groups=resolved_groups,
-            ),
-            encoding="ascii",
-        )
+        if resolved_backend != COMPOSITIONAL_ICARUS_BACKEND:
+            sidecars = _write_memh_sidecars(temp_dir, logical_head_groups=resolved_groups)
+            tb_path.write_text(
+                _testbench(
+                    top_name=str(resolved_config["top_name"]),
+                    output_ready_pattern=tuple(bool(value) for value in output_ready_pattern),
+                    logical_head_groups=resolved_groups,
+                ),
+                encoding="ascii",
+            )
         fakeram_path = temp_dir / "fakeram45_2048x39.v"
         fakeram_path.write_text(full_probe._FAKERAM_MODEL, encoding="ascii")
         sim_path = temp_dir / "sim.out"
         control_path = temp_dir / VERILATOR_CONTROL_FILE_NAME
         obj_dir = temp_dir / "obj_dir"
         try:
-            if resolved_backend == VERILATOR_HIERARCHICAL_BACKEND:
+            if resolved_backend == COMPOSITIONAL_ICARUS_BACKEND:
+                from npu.eval.gqa8_compositional_exact import run_compositional_exact
+
+                compositional = run_compositional_exact(
+                    config=resolved_config,
+                    work_dir=temp_dir,
+                    rtl_dir=rtl_dir,
+                    fakeram_path=fakeram_path,
+                    logical_head_groups=resolved_groups,
+                    output_ready_pattern=tuple(bool(value) for value in output_ready_pattern),
+                    compile_timeout_sec=resolved_compile_timeout_sec,
+                    simulation_timeout_sec=int(timeout_sec),
+                )
+                simulation_status = str(compositional["simulation_status"])
+                returncode = int(compositional["returncode"])
+                stdout = str(compositional.get("stdout") or "")
+                stderr = str(compositional.get("stderr") or "")
+                component_metadata = dict(compositional.get("component_metadata") or {})
+                phase_records = list(compositional.get("phase_records") or [])
+                sidecars = {
+                    "storage": "temporary_component_local_memh",
+                    "persisted": False,
+                    "logical_head_groups": resolved_groups,
+                }
+            elif resolved_backend == VERILATOR_HIERARCHICAL_BACKEND:
                 control_path = _write_verilator_control_file(
                     temp_dir,
                     top_name=str(resolved_config["top_name"]),
@@ -1271,58 +1322,59 @@ def build_report(
                     tb_path=tb_path,
                     sim_path=sim_path,
                 )
-            compile_result = subprocess.run(
-                compile_command,
-                cwd=temp_dir,
-                capture_output=True,
-                text=True,
-                timeout=resolved_compile_timeout_sec,
-            )
-            if compile_result.returncode:
-                stdout = compile_result.stdout or ""
-                returncode = compile_result.returncode
-                stderr = _resource_diagnostic_text(
-                    stdout=stdout,
-                    stderr=compile_result.stderr or "",
-                )
-                simulation_status = (
-                    "resource_failure"
-                    if _is_resource_termination(
-                        returncode=compile_result.returncode,
-                        stdout=compile_result.stdout or "",
-                        stderr=compile_result.stderr or "",
-                    )
-                    else "compile_failed"
-                )
-            else:
-                run_command = (
-                    [str(obj_dir / VERILATOR_BINARY_NAME)]
-                    if resolved_backend == VERILATOR_HIERARCHICAL_BACKEND
-                    else [_tool("vvp"), str(sim_path)]
-                )
-                run_result = subprocess.run(
-                    run_command,
+            if resolved_backend != COMPOSITIONAL_ICARUS_BACKEND:
+                compile_result = subprocess.run(
+                    compile_command,
                     cwd=temp_dir,
                     capture_output=True,
                     text=True,
-                    timeout=int(timeout_sec),
+                    timeout=resolved_compile_timeout_sec,
                 )
-                stdout = run_result.stdout
-                stderr = _resource_diagnostic_text(
-                    stdout=run_result.stdout or "",
-                    stderr=run_result.stderr or "",
-                )
-                returncode = run_result.returncode
-                if run_result.returncode:
+                if compile_result.returncode:
+                    stdout = compile_result.stdout or ""
+                    returncode = compile_result.returncode
+                    stderr = _resource_diagnostic_text(
+                        stdout=stdout,
+                        stderr=compile_result.stderr or "",
+                    )
                     simulation_status = (
                         "resource_failure"
                         if _is_resource_termination(
-                            returncode=run_result.returncode,
-                            stdout=run_result.stdout or "",
-                            stderr=run_result.stderr or "",
+                            returncode=compile_result.returncode,
+                            stdout=compile_result.stdout or "",
+                            stderr=compile_result.stderr or "",
                         )
-                        else "run_failed"
+                        else "compile_failed"
                     )
+                else:
+                    run_command = (
+                        [str(obj_dir / VERILATOR_BINARY_NAME)]
+                        if resolved_backend == VERILATOR_HIERARCHICAL_BACKEND
+                        else [_tool("vvp"), str(sim_path)]
+                    )
+                    run_result = subprocess.run(
+                        run_command,
+                        cwd=temp_dir,
+                        capture_output=True,
+                        text=True,
+                        timeout=int(timeout_sec),
+                    )
+                    stdout = run_result.stdout
+                    stderr = _resource_diagnostic_text(
+                        stdout=run_result.stdout or "",
+                        stderr=run_result.stderr or "",
+                    )
+                    returncode = run_result.returncode
+                    if run_result.returncode:
+                        simulation_status = (
+                            "resource_failure"
+                            if _is_resource_termination(
+                                returncode=run_result.returncode,
+                                stdout=run_result.stdout or "",
+                                stderr=run_result.stderr or "",
+                            )
+                            else "run_failed"
+                        )
         except subprocess.TimeoutExpired as exc:
             simulation_status = "subprocess_timeout"
             returncode = 124
@@ -1377,6 +1429,8 @@ def build_report(
                 compile_timeout_sec=resolved_compile_timeout_sec,
                 simulation_timeout_sec=int(timeout_sec),
             ),
+            "compositional_components": component_metadata,
+            "component_phase_records": phase_records,
             "expected_counts": expected_counts(logical_head_groups=resolved_groups),
             "memh_sidecars": sidecars,
             "service_model": exact_local16_global_tree_cluster_sram_gqa8_service_manifest(
@@ -1416,7 +1470,7 @@ def _render_text(report: JsonDict) -> str:
         f"- expected_root_hash: `{report['expected_root_hash']}`",
     ]
     if not bool(report["passed"]):
-        stderr_tail = _bounded_tail(
+        stderr_tail = _bounded_first_and_tail(
             str(report.get("stderr_tail") or ""),
             limit=MARKDOWN_DIAGNOSTIC_TAIL_LIMIT,
         ).strip()

--- a/tests/test_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
+++ b/tests/test_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
@@ -11,6 +11,7 @@ if str(REPO_ROOT) not in sys.path:
 from npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8 import (
     DIAGNOSTIC_TAIL_LIMIT,
     MARKDOWN_DIAGNOSTIC_TAIL_LIMIT,
+    COMPOSITIONAL_ICARUS_BACKEND,
     DEFAULT_ROOT_READY_PATTERN,
     DEFAULT_SIM_BACKEND,
     DEFAULT_SUBPROCESS_TIMEOUT_SEC,
@@ -38,6 +39,14 @@ from npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa
     expected_counts,
     expected_schedule_prefix,
     main,
+)
+from npu.eval.gqa8_compositional_exact import (
+    BACKEND as COMPOSITIONAL_RUNNER_BACKEND,
+    _pack_global_row,
+    _run_process,
+    cluster_testbench,
+    extract_module_family,
+    global_testbench,
 )
 from npu.rtlgen.gen_attention_score32_exact_local16_global_tree_cluster_sram_gqa8 import _validate
 
@@ -399,6 +408,144 @@ def test_icarus_command_remains_the_default_compilation_path(monkeypatch: Any, t
     ]
 
 
+def test_compositional_cluster_testbenches_use_concrete_rtl_and_local_sidecars() -> None:
+    p54 = cluster_testbench(top_name="score32_top__cluster_p54", producers=54, logical_head_groups=1)
+    p53 = cluster_testbench(top_name="score32_top__cluster_p53", producers=53, logical_head_groups=4)
+
+    assert COMPOSITIONAL_RUNNER_BACKEND == COMPOSITIONAL_ICARUS_BACKEND
+    assert "score32_top__cluster_p54 dut (" in p54
+    assert "localparam integer PRODUCERS = 54;" in p54
+    assert ".sram_fill_row_accept_count(fill_rows)" in p54
+    assert ".sram_release_guard_error(release_guard_error)" in p54
+    assert ".out_valid(out_valid), .out_ready(out_ready)" in p54
+    assert "if (out_valid && out_ready)" in p54
+    assert "$readmemh(\"query.memh\", query_mem)" in p54
+    assert "$readmemh(\"fill.memh\", fill_mem)" in p54
+    assert "input_query = '0" in p54
+    assert "score32_top__cluster_p53 dut (" in p53
+    assert "localparam integer PRODUCERS = 53;" in p53
+    assert "localparam integer COMMANDS = 32;" in p53
+
+
+def test_compositional_source_split_keeps_only_exact_generated_module_family() -> None:
+    rtl = "\n".join(
+        [
+            "module score__p54__leaf;\nendmodule",
+            "module score__p54;\n  score__p54__leaf u();\nendmodule",
+            "module score__p53;\nendmodule",
+        ]
+    )
+
+    family = extract_module_family(rtl, prefix="score__p54")
+
+    assert "module score__p54__leaf" in family
+    assert "module score__p54;" in family
+    assert "score__p53" not in family
+
+
+def test_compositional_source_split_selects_checked_concrete_rtl_families() -> None:
+    config = json.loads((_design_dir() / "config.json").read_text(encoding="utf-8"))
+    top_name = str(config["top_name"])
+    rtl = (_rtl_dir() / "top.v").read_text(encoding="utf-8")
+
+    p54 = extract_module_family(rtl, prefix=f"{top_name}__cluster_p54")
+    p53 = extract_module_family(rtl, prefix=f"{top_name}__cluster_p53")
+    global_tree = extract_module_family(rtl, prefix=f"{top_name}__global_tree")
+
+    assert f"module {top_name}__cluster_p54 (" in p54
+    assert f"module {top_name}__cluster_p53 (" not in p54
+    assert f"module {top_name}__cluster_p53 (" in p53
+    assert f"module {top_name}__cluster_p54 (" not in p53
+    assert f"module {top_name}__global_tree (" in global_tree
+    assert f"module {top_name}__global_tree__root_finalizer (" in global_tree
+
+
+def test_compositional_global_testbench_drives_exact_structured_cluster_rows() -> None:
+    tb = global_testbench(
+        top_name="score32_top__global_tree",
+        rows_per_cluster=128,
+        output_ready_pattern=(True, False),
+        timeout_cycles=50_000,
+    )
+
+    assert "score32_top__global_tree dut (" in tb
+    assert "reg [418:0] row_mem" in tb
+    assert ".leaf_global_max(leaf_global_max)" in tb
+    assert ".tree_protocol_error(tree_error)" in tb
+    assert "$readmemh(\"global_rows.memh\",row_mem)" in tb
+    assert "ROOT_RESULT" in tb
+    assert "GLOBAL_SUMMARY" in tb
+
+    row = {
+        "command_id": 0x8200,
+        "head_id": 7,
+        "global_max": -3,
+        "exp_sum": 123,
+        "slice": 9,
+        "last": True,
+        "value": [index - 4 for index in range(8)],
+    }
+    packed = _pack_global_row(row)
+    assert packed & 0xFFFF == 0x8200
+    assert (packed >> 16) & 0x1F == 7
+    assert (packed >> 21) & 0xFFFF_FFFF == 0xFFFF_FFFD
+    assert (packed >> 53) & ((1 << 33) - 1) == 123
+    assert (packed >> 86) & 0xF == 9
+    assert (packed >> 90) & 1 == 1
+
+
+def test_compositional_subprocess_resource_kill_stays_inconclusive(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        "npu.eval.gqa8_compositional_exact.subprocess.run",
+        lambda *_args, **_kwargs: __import__("subprocess").CompletedProcess(
+            args=["iverilog"],
+            returncode=137,
+            stdout="",
+            stderr="Killed\n",
+        ),
+    )
+
+    _, failure = _run_process(
+        ["iverilog"],
+        cwd=tmp_path,
+        timeout_sec=1,
+        phase="compile_p54_cluster",
+    )
+
+    assert failure is not None
+    assert failure["status"] == "resource_failure"
+    assert failure["returncode"] == 137
+
+
+def test_compositional_subprocess_syntax_error_stays_conclusive(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        "npu.eval.gqa8_compositional_exact.subprocess.run",
+        lambda *_args, **_kwargs: __import__("subprocess").CompletedProcess(
+            args=["iverilog"],
+            returncode=2,
+            stdout="",
+            stderr="tb.v:12: syntax error\n",
+        ),
+    )
+
+    _, failure = _run_process(
+        ["iverilog"],
+        cwd=tmp_path,
+        timeout_sec=1,
+        phase="compile_global_tree",
+    )
+
+    assert failure is not None
+    assert failure["status"] == "compile_failed"
+    assert failure["returncode"] == 2
+
+
 def test_observation_evaluator_validates_every_exact_total_and_row() -> None:
     reference, summary, cluster_summaries, cluster_rows, root_rows = _audit_fixture()
     result = _evaluate_observations(
@@ -610,7 +757,7 @@ def test_build_report_keeps_compile_syntax_errors_conclusive_and_bounded(
 
 
 def test_markdown_failure_report_keeps_bounded_subprocess_diagnostics() -> None:
-    stderr_tail = ("warning\n" * 400) + "Killed\n"
+    stderr_tail = "first meaningful error\n" + ("warning\n" * 400) + "Killed\n"
     report = {
         "passed": False,
         "classification": "failed_inconclusive",
@@ -631,6 +778,8 @@ def test_markdown_failure_report_keeps_bounded_subprocess_diagnostics() -> None:
     assert "- returncode: `-9`" in rendered
     assert "- normalized_returncode: `137`" in rendered
     assert "- stderr_tail:" in rendered
+    assert "first meaningful error" in rendered
+    assert "...[middle omitted]..." in rendered
     assert "Killed" in rendered
     assert stderr_tail not in rendered
     diagnostic = rendered.split("```text\n", 1)[1].rsplit("\n```", 1)[0]
@@ -781,6 +930,63 @@ def test_build_report_defaults_to_icarus_backend(
     }
     assert calls[0][0] == "/tools/iverilog"
     assert calls[1] == ["/tools/vvp", calls[0][5]]
+
+
+def test_build_report_selects_concrete_compositional_backend(monkeypatch: Any) -> None:
+    reference, summary, cluster_summaries, cluster_rows, root_rows = _audit_fixture()
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.generate",
+        lambda config, rtl_dir: (
+            rtl_dir.mkdir(parents=True, exist_ok=True),
+            (rtl_dir / "config.json").write_text(json.dumps(config), encoding="utf-8"),
+        ),
+    )
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8._reference",
+        lambda **_kwargs: reference,
+    )
+    monkeypatch.setattr(
+        "npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8._parse_stdout",
+        lambda _stdout: (summary, cluster_summaries, cluster_rows, root_rows, None),
+    )
+
+    def fake_compositional(**kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return {
+            "simulation_status": "ok",
+            "returncode": 0,
+            "stdout": "component observations",
+            "stderr": "",
+            "phase_records": [{"phase": "strict_generated_top_guard", "returncode": 0}],
+            "component_metadata": {
+                "proof": "concrete_rtl_composition",
+                "strict_generated_top_guard": "passed",
+            },
+        }
+
+    monkeypatch.setattr(
+        "npu.eval.gqa8_compositional_exact.run_compositional_exact",
+        fake_compositional,
+    )
+
+    report = build_report(
+        config=_minimal_probe_config(),
+        timeout_sec=9,
+        compile_timeout_sec=17,
+        sim_backend=COMPOSITIONAL_ICARUS_BACKEND,
+    )
+
+    assert report["passed"] is True
+    assert report["sim_backend"] == COMPOSITIONAL_ICARUS_BACKEND
+    assert report["compile_timeout_sec"] == 17
+    assert report["simulation_timeout_sec"] == 9
+    assert report["sim_backend_metadata"]["proof"] == "concrete_rtl_composition"
+    assert report["compositional_components"]["strict_generated_top_guard"] == "passed"
+    assert captured["compile_timeout_sec"] == 17
+    assert captured["simulation_timeout_sec"] == 9
+    assert captured["logical_head_groups"] == 1
 
 
 def test_checked_in_config_rejects_partition_drift() -> None:


### PR DESCRIPTION
## Summary
- replace the evaluator-incompatible Verilator hierarchical backend with bounded concrete compositional Icarus simulation
- regenerate and strictly guard the full top-level wiring/order contract
- compile concrete p54 and p53 producer/reducer/SRAM cluster module families once, replay all 16 cluster-specific streams, then drive the concrete global tree from observed cluster RTL rows
- retain exact structured row, count, metadata, cadence, protocol, and resource-inconclusive gates
- preserve meaningful first compiler errors plus the diagnostic tail

## Root cause
The evaluator OSS CAD Suite Verilator 5.039-devel hierarchy build first resolves its child executable to missing `/oss-cad-suite/libexec/verilator`. `--build-dep-bin` exposes further child-option/linking defects. No RTL simulation is reached, so the prior `r3` result is tool-inconclusive for equivalence.

## Verification
- probe and strict guard tests: 32 passed
- focused L2 generator tests: 2 passed, 239 deselected
- `python3 scripts/validate_runs.py --skip_eval_queue`: passed
- py_compile and diff check: passed

The real p54 compile exceeded a deliberately short 90-second local diagnostic without an error. Heavy simulation remains remote-only under the existing 6/8 GiB, 3-CPU, exclusive-worker bounds.

Related: #1487