### PR TITLE
Kill escaped descendant sessions on evaluator cancellation

### DIFF
--- a/control_plane/control_plane/tests/test_command_runner.py
+++ b/control_plane/control_plane/tests/test_command_runner.py
@@ -2,10 +2,65 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 import tempfile
+import time
 
 from control_plane.workers.command_runner import run_command_manifest
+
+
+def _write_escaped_session_scripts(tmp_path: Path) -> tuple[Path, Path, Path, Path, Path]:
+    probe_pid_path = tmp_path / "probe.pid"
+    grandchild_pid_path = tmp_path / "grandchild.pid"
+    grandchild_script = tmp_path / "grandchild.py"
+    probe_script = tmp_path / "probe.py"
+    root_script = tmp_path / "root.py"
+    grandchild_script.write_text(
+        "import os, signal, sys, time\n"
+        "from pathlib import Path\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "Path(sys.argv[1]).write_text(str(os.getpid()), encoding='utf-8')\n"
+        "time.sleep(60)\n",
+        encoding="utf-8",
+    )
+    probe_script.write_text(
+        "import os, signal, subprocess, sys, time\n"
+        "from pathlib import Path\n"
+        "os.setsid()\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "Path(sys.argv[1]).write_text(str(os.getpid()), encoding='utf-8')\n"
+        "subprocess.Popen([sys.executable, sys.argv[2], sys.argv[3]])\n"
+        "time.sleep(60)\n",
+        encoding="utf-8",
+    )
+    root_script.write_text(
+        "import subprocess, sys, time\n"
+        "subprocess.Popen([sys.executable, sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]])\n"
+        "time.sleep(60)\n",
+        encoding="utf-8",
+    )
+    return root_script, probe_script, grandchild_script, probe_pid_path, grandchild_pid_path
+
+
+def _read_pid(path: Path, *, timeout_seconds: float = 5.0) -> int:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if path.exists():
+            return int(path.read_text(encoding="utf-8").strip())
+        time.sleep(0.05)
+    raise AssertionError(f"pid file was not written: {path}")
+
+
+def _assert_process_gone(pid: int, *, timeout_seconds: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"process {pid} survived cancellation")
 
 
 def test_command_runner_continues_when_cancel_callback_fails() -> None:
@@ -103,3 +158,38 @@ def test_command_progress_reports_process_group_resources() -> None:
         assert snapshot["cpu_seconds"] >= 0
         assert snapshot["rss_bytes"] > 0
         assert any(member["command"] in {"bash", "python3"} for member in snapshot["processes"])
+
+
+def test_command_runner_cancel_kills_descendant_new_session_tree() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        work_dir = Path(td) / "work"
+        log_dir = Path(td) / "logs"
+        work_dir.mkdir()
+        root_script, probe_script, grandchild_script, probe_pid_path, grandchild_pid_path = (
+            _write_escaped_session_scripts(work_dir)
+        )
+
+        def cancel_requested() -> bool:
+            return probe_pid_path.exists() and grandchild_pid_path.exists()
+
+        results = run_command_manifest(
+            command_manifest=[
+                {
+                    "name": "spawn_escape",
+                    "run": (
+                        f"python3 {root_script} {probe_script} {probe_pid_path} "
+                        f"{grandchild_script} {grandchild_pid_path}"
+                    ),
+                }
+            ],
+            work_dir=str(work_dir),
+            log_dir=str(log_dir),
+            progress_interval_seconds=1,
+            cancel_requested=cancel_requested,
+        )
+
+        assert len(results) == 1
+        assert results[0].returncode == 130
+        assert results[0].canceled is True
+        _assert_process_gone(_read_pid(probe_pid_path))
+        _assert_process_gone(_read_pid(grandchild_pid_path))

--- a/control_plane/control_plane/tests/test_run_bounded_command.py
+++ b/control_plane/control_plane/tests/test_run_bounded_command.py
@@ -25,6 +25,59 @@ def _load_launcher_module():
     return module
 
 
+def _write_escaped_session_scripts(tmp_path: Path) -> tuple[Path, Path, Path, Path, Path]:
+    probe_pid_path = tmp_path / "probe.pid"
+    grandchild_pid_path = tmp_path / "grandchild.pid"
+    grandchild_script = tmp_path / "grandchild.py"
+    probe_script = tmp_path / "probe.py"
+    root_script = tmp_path / "root.py"
+    grandchild_script.write_text(
+        "import os, signal, sys, time\n"
+        "from pathlib import Path\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "Path(sys.argv[1]).write_text(str(os.getpid()), encoding='utf-8')\n"
+        "time.sleep(60)\n",
+        encoding="utf-8",
+    )
+    probe_script.write_text(
+        "import os, signal, subprocess, sys, time\n"
+        "from pathlib import Path\n"
+        "os.setsid()\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "Path(sys.argv[1]).write_text(str(os.getpid()), encoding='utf-8')\n"
+        "subprocess.Popen([sys.executable, sys.argv[2], sys.argv[3]])\n"
+        "time.sleep(60)\n",
+        encoding="utf-8",
+    )
+    root_script.write_text(
+        "import subprocess, sys, time\n"
+        "subprocess.Popen([sys.executable, sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]])\n"
+        "time.sleep(60)\n",
+        encoding="utf-8",
+    )
+    return root_script, probe_script, grandchild_script, probe_pid_path, grandchild_pid_path
+
+
+def _read_pid(path: Path, *, timeout_seconds: float = 5.0) -> int:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if path.exists():
+            return int(path.read_text(encoding="utf-8").strip())
+        time.sleep(0.05)
+    raise AssertionError(f"pid file was not written: {path}")
+
+
+def _assert_process_gone(pid: int, *, timeout_seconds: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"process {pid} survived termination")
+
+
 def test_parse_cli_requires_separator_and_payload() -> None:
     module = _load_launcher_module()
 
@@ -249,3 +302,34 @@ def test_run_portable_fallback_times_out_and_kills_process_group(tmp_path: Path)
         time.sleep(0.05)
     else:
         pytest.fail(f"grandchild process {grandchild_pid} survived process-group timeout")
+
+
+def test_launcher_sigterm_kills_descendant_new_session_tree(tmp_path: Path) -> None:
+    launcher_path = Path(__file__).resolve().parents[2] / "scripts" / "run_bounded_command.py"
+    root_script, probe_script, grandchild_script, probe_pid_path, grandchild_pid_path = (
+        _write_escaped_session_scripts(tmp_path)
+    )
+
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            str(launcher_path),
+            "--runtime-max-sec",
+            "30",
+            "--",
+            sys.executable,
+            str(root_script),
+            str(probe_script),
+            str(probe_pid_path),
+            str(grandchild_script),
+            str(grandchild_pid_path),
+        ]
+    )
+
+    probe_pid = _read_pid(probe_pid_path)
+    grandchild_pid = _read_pid(grandchild_pid_path)
+    os.kill(process.pid, signal.SIGTERM)
+
+    assert process.wait(timeout=10) == 128 + signal.SIGTERM
+    _assert_process_gone(probe_pid)
+    _assert_process_gone(grandchild_pid)

--- a/control_plane/control_plane/workers/command_runner.py
+++ b/control_plane/control_plane/workers/command_runner.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import ctypes
 import os
 from pathlib import Path
 import signal
 import shlex
 import subprocess
+import sys
 import time
 from typing import Any, Callable
 
@@ -20,6 +22,10 @@ CancelCheck = Callable[[], bool]
 
 _CLOCK_TICKS_PER_SECOND = int(os.sysconf("SC_CLK_TCK"))
 _PAGE_SIZE_BYTES = int(os.sysconf("SC_PAGE_SIZE"))
+_POLL_INTERVAL_SECONDS = 0.05
+_PR_SET_CHILD_SUBREAPER = 36
+_PR_GET_CHILD_SUBREAPER = 37
+_LIBC = ctypes.CDLL(None, use_errno=True) if sys.platform.startswith("linux") else None
 
 
 class CommandExecutionError(RuntimeError):
@@ -37,6 +43,14 @@ class CommandResult:
     timed_out: bool
     stalled: bool
     canceled: bool
+
+
+@dataclass(frozen=True)
+class _ProcInfo:
+    pid: int
+    ppid: int
+    pgid: int
+    sid: int
 
 
 def _command_filename(index: int, name: str) -> str:
@@ -88,26 +102,33 @@ def run_command_manifest(
         with stdout_path.open("w", encoding="utf-8") as stdout_handle, stderr_path.open(
             "w", encoding="utf-8"
         ) as stderr_handle:
-            process = subprocess.Popen(
-                ["bash", "-lc", command],
-                cwd=work_dir,
-                env=env,
-                stdout=stdout_handle,
-                stderr=stderr_handle,
-                text=True,
-                start_new_session=True,
-            )
-            returncode = _monitor_command(
-                command_name=name,
-                process=process,
-                stdout_path=stdout_path,
-                stderr_path=stderr_path,
-                timeout_seconds=timeout_seconds,
-                stall_timeout_seconds=stall_timeout_seconds,
-                progress_interval_seconds=progress_interval_seconds,
-                cancel_requested=cancel_requested,
-                on_command_progress=on_command_progress,
-            )
+            previous_subreaper = _set_child_subreaper(True)
+            process: subprocess.Popen[str] | None = None
+            try:
+                process = subprocess.Popen(
+                    ["bash", "-lc", command],
+                    cwd=work_dir,
+                    env=env,
+                    stdout=stdout_handle,
+                    stderr=stderr_handle,
+                    text=True,
+                    start_new_session=True,
+                )
+                returncode = _monitor_command(
+                    command_name=name,
+                    process=process,
+                    stdout_path=stdout_path,
+                    stderr_path=stderr_path,
+                    timeout_seconds=timeout_seconds,
+                    stall_timeout_seconds=stall_timeout_seconds,
+                    progress_interval_seconds=progress_interval_seconds,
+                    cancel_requested=cancel_requested,
+                    on_command_progress=on_command_progress,
+                )
+            finally:
+                if process is not None:
+                    _reap_descendant_processes(os.getpid(), excluded_pid=process.pid)
+                _restore_child_subreaper(previous_subreaper)
             timed_out = returncode == 124
             stalled = returncode == 125
             canceled = returncode == 130
@@ -153,12 +174,111 @@ def shell_preview(command: str) -> list[str]:
     return shlex.split(command)
 
 
-def _terminate_process_group(process: subprocess.Popen[str], *, force: bool = False) -> None:
-    sig = signal.SIGKILL if force else signal.SIGTERM
-    try:
-        os.killpg(process.pid, sig)
-    except ProcessLookupError:
+def _set_child_subreaper(enabled: bool) -> bool | None:
+    if _LIBC is None:
+        return None
+    current = ctypes.c_int()
+    if _LIBC.prctl(_PR_GET_CHILD_SUBREAPER, ctypes.byref(current), 0, 0, 0) != 0:
+        return None
+    previous = bool(current.value)
+    if _LIBC.prctl(_PR_SET_CHILD_SUBREAPER, int(enabled), 0, 0, 0) != 0:
+        return None
+    return previous
+
+
+def _restore_child_subreaper(previous: bool | None) -> None:
+    if previous is None or _LIBC is None:
         return
+    _LIBC.prctl(_PR_SET_CHILD_SUBREAPER, int(previous), 0, 0, 0)
+
+
+def _snapshot_process_table() -> dict[int, _ProcInfo]:
+    snapshot: dict[int, _ProcInfo] = {}
+    try:
+        proc_entries = Path("/proc").iterdir()
+    except OSError:
+        return snapshot
+    for proc_dir in proc_entries:
+        if not proc_dir.name.isdigit():
+            continue
+        try:
+            stat_text = (proc_dir / "stat").read_text(encoding="utf-8")
+            comm_end = stat_text.rfind(")")
+            if comm_end < 0:
+                continue
+            fields = stat_text[comm_end + 2 :].split()
+            if len(fields) < 4:
+                continue
+            pid = int(proc_dir.name)
+            snapshot[pid] = _ProcInfo(
+                pid=pid,
+                ppid=int(fields[1]),
+                pgid=int(fields[2]),
+                sid=int(fields[3]),
+            )
+        except (FileNotFoundError, OSError, ValueError):
+            continue
+    return snapshot
+
+
+def _collect_descendant_processes(owner_pid: int) -> dict[int, _ProcInfo]:
+    snapshot = _snapshot_process_table()
+    children_by_parent: dict[int, list[_ProcInfo]] = {}
+    for proc in snapshot.values():
+        children_by_parent.setdefault(proc.ppid, []).append(proc)
+    descendants: dict[int, _ProcInfo] = {}
+    pending = [owner_pid]
+    while pending:
+        parent_pid = pending.pop()
+        for child in children_by_parent.get(parent_pid, []):
+            if child.pid in descendants:
+                continue
+            descendants[child.pid] = child
+            pending.append(child.pid)
+    return descendants
+
+
+def _reap_descendant_processes(owner_pid: int, *, excluded_pid: int) -> None:
+    for proc in _collect_descendant_processes(owner_pid).values():
+        if proc.pid == excluded_pid:
+            continue
+        try:
+            os.waitpid(proc.pid, os.WNOHANG)
+        except (ChildProcessError, ProcessLookupError):
+            continue
+
+
+def _signal_descendant_tree(*, owner_pid: int, signal_number: int) -> None:
+    descendants = _collect_descendant_processes(owner_pid)
+    process_groups = sorted({proc.pgid for proc in descendants.values() if proc.pgid > 0})
+    for process_group in process_groups:
+        try:
+            os.killpg(process_group, signal_number)
+        except ProcessLookupError:
+            continue
+    for proc in descendants.values():
+        try:
+            os.kill(proc.pid, signal_number)
+        except ProcessLookupError:
+            continue
+
+
+def _wait_for_descendant_exit(process: subprocess.Popen[str], deadline: float) -> bool:
+    owner_pid = os.getpid()
+    while time.monotonic() < deadline:
+        _reap_descendant_processes(owner_pid, excluded_pid=process.pid)
+        if process.poll() is not None and not _collect_descendant_processes(owner_pid):
+            return True
+        time.sleep(_POLL_INTERVAL_SECONDS)
+    _reap_descendant_processes(owner_pid, excluded_pid=process.pid)
+    return process.poll() is not None and not _collect_descendant_processes(owner_pid)
+
+
+def _terminate_process_group(process: subprocess.Popen[str], *, force: bool = False) -> None:
+    _signal_descendant_tree(
+        owner_pid=os.getpid(),
+        signal_number=signal.SIGKILL if force else signal.SIGTERM,
+    )
 
 
 def _last_output_age_seconds(*, stdout_path: Path, stderr_path: Path) -> float:
@@ -240,30 +360,24 @@ def _monitor_command(
                 canceled = False
             if canceled:
                 _terminate_process_group(process)
-                try:
-                    process.wait(timeout=10)
-                except subprocess.TimeoutExpired:
+                if not _wait_for_descendant_exit(process, time.monotonic() + 10):
                     _terminate_process_group(process, force=True)
-                    process.wait(timeout=5)
+                    _wait_for_descendant_exit(process, time.monotonic() + 5)
                 return 130
 
         if timeout_seconds is not None and now - started >= timeout_seconds:
             _terminate_process_group(process)
-            try:
-                process.wait(timeout=10)
-            except subprocess.TimeoutExpired:
+            if not _wait_for_descendant_exit(process, time.monotonic() + 10):
                 _terminate_process_group(process, force=True)
-                process.wait(timeout=5)
+                _wait_for_descendant_exit(process, time.monotonic() + 5)
             return 124
 
         last_output_age = _last_output_age_seconds(stdout_path=stdout_path, stderr_path=stderr_path)
         if stall_timeout_seconds is not None and last_output_age >= stall_timeout_seconds:
             _terminate_process_group(process)
-            try:
-                process.wait(timeout=10)
-            except subprocess.TimeoutExpired:
+            if not _wait_for_descendant_exit(process, time.monotonic() + 10):
                 _terminate_process_group(process, force=True)
-                process.wait(timeout=5)
+                _wait_for_descendant_exit(process, time.monotonic() + 5)
             return 125
 
         if on_command_progress is not None and now >= next_progress:

--- a/control_plane/operator_runbook.md
+++ b/control_plane/operator_runbook.md
@@ -186,6 +186,15 @@ Request remote evaluator refresh after a control-plane merge:
 
 The command opens or updates a GitHub issue with the target commit, pull/update checklist, daemon restart checklist, and a machine-readable evaluator acknowledgement block. Use it instead of drafting ad hoc evaluator update issues.
 
+## Cancellation Semantics
+
+`cancel-run` is scoped to the leased command subtree only. The worker and the
+bounded launcher first terminate the original command process group, then any
+reparented descendants or descendants that created a new process group/session
+under that same command, and finally escalate to `SIGKILL` after the grace
+window. This stays descendant-scoped; it does not use broad name-based process
+matching on the evaluator host.
+
 ## Managed Daemon Paths
 
 Default managed-daemon diagnostics under the clean evaluator service checkout:

--- a/control_plane/scripts/run_bounded_command.py
+++ b/control_plane/scripts/run_bounded_command.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import ctypes
 from dataclasses import dataclass
 import errno
 import json
@@ -21,6 +22,7 @@ from typing import Any, Sequence
 TIMEOUT_EXIT_CODE = 124
 _SYSTEMD_CHECK_TIMEOUT_SEC = 5.0
 _TERM_GRACE_SEC = 5.0
+_POLL_INTERVAL_SEC = 0.05
 _SIZE_SUFFIXES = {
     "": 1,
     "K": 1024,
@@ -28,6 +30,9 @@ _SIZE_SUFFIXES = {
     "G": 1024**3,
     "T": 1024**4,
 }
+_PR_SET_CHILD_SUBREAPER = 36
+_PR_GET_CHILD_SUBREAPER = 37
+_LIBC = ctypes.CDLL(None, use_errno=True) if sys.platform.startswith("linux") else None
 
 
 @dataclass(frozen=True)
@@ -43,6 +48,33 @@ class LimitSpec:
 class SystemdProbeResult:
     usable: bool
     reason: str
+
+
+@dataclass(frozen=True)
+class _ProcInfo:
+    pid: int
+    ppid: int
+    pgid: int
+    sid: int
+
+
+class _TerminationSignalState:
+    def __init__(self) -> None:
+        self.requested_signal: int | None = None
+        self._previous_handlers: dict[int, Any] = {}
+
+    def install(self, *signals_to_handle: int) -> None:
+        for signal_number in signals_to_handle:
+            self._previous_handlers[signal_number] = signal.getsignal(signal_number)
+            signal.signal(signal_number, self._handle_signal)
+
+    def restore(self) -> None:
+        for signal_number, previous in self._previous_handlers.items():
+            signal.signal(signal_number, previous)
+        self._previous_handlers.clear()
+
+    def _handle_signal(self, signal_number: int, _frame: Any) -> None:
+        self.requested_signal = signal_number
 
 
 def _parse_size(text: str) -> int:
@@ -288,20 +320,112 @@ def _shell_error_code(exc: OSError) -> int:
     return 126
 
 
-def _terminate_process_group(process: subprocess.Popen[Any], *, term_grace_sec: float) -> None:
-    try:
-        os.killpg(process.pid, signal.SIGTERM)
-    except ProcessLookupError:
+def _set_child_subreaper(enabled: bool) -> bool | None:
+    if _LIBC is None:
+        return None
+    current = ctypes.c_int()
+    if _LIBC.prctl(_PR_GET_CHILD_SUBREAPER, ctypes.byref(current), 0, 0, 0) != 0:
+        return None
+    previous = bool(current.value)
+    if _LIBC.prctl(_PR_SET_CHILD_SUBREAPER, int(enabled), 0, 0, 0) != 0:
+        return None
+    return previous
+
+
+def _restore_child_subreaper(previous: bool | None) -> None:
+    if previous is None or _LIBC is None:
         return
-    deadline = time.monotonic() + term_grace_sec
+    _LIBC.prctl(_PR_SET_CHILD_SUBREAPER, int(previous), 0, 0, 0)
+
+
+def _snapshot_process_table() -> dict[int, _ProcInfo]:
+    snapshot: dict[int, _ProcInfo] = {}
+    try:
+        proc_entries = Path("/proc").iterdir()
+    except OSError:
+        return snapshot
+    for proc_dir in proc_entries:
+        if not proc_dir.name.isdigit():
+            continue
+        try:
+            stat_text = (proc_dir / "stat").read_text(encoding="utf-8")
+            comm_end = stat_text.rfind(")")
+            if comm_end < 0:
+                continue
+            fields = stat_text[comm_end + 2 :].split()
+            if len(fields) < 4:
+                continue
+            pid = int(proc_dir.name)
+            snapshot[pid] = _ProcInfo(
+                pid=pid,
+                ppid=int(fields[1]),
+                pgid=int(fields[2]),
+                sid=int(fields[3]),
+            )
+        except (FileNotFoundError, OSError, ValueError):
+            continue
+    return snapshot
+
+
+def _collect_descendant_processes(owner_pid: int) -> dict[int, _ProcInfo]:
+    snapshot = _snapshot_process_table()
+    children_by_parent: dict[int, list[_ProcInfo]] = {}
+    for proc in snapshot.values():
+        children_by_parent.setdefault(proc.ppid, []).append(proc)
+    descendants: dict[int, _ProcInfo] = {}
+    pending = [owner_pid]
+    while pending:
+        parent_pid = pending.pop()
+        for child in children_by_parent.get(parent_pid, []):
+            if child.pid in descendants:
+                continue
+            descendants[child.pid] = child
+            pending.append(child.pid)
+    return descendants
+
+
+def _reap_descendant_processes(owner_pid: int, *, excluded_pid: int) -> None:
+    for proc in _collect_descendant_processes(owner_pid).values():
+        if proc.pid == excluded_pid:
+            continue
+        try:
+            os.waitpid(proc.pid, os.WNOHANG)
+        except (ChildProcessError, ProcessLookupError):
+            continue
+
+
+def _signal_descendant_tree(owner_pid: int, signal_number: int) -> None:
+    descendants = _collect_descendant_processes(owner_pid)
+    process_groups = sorted({proc.pgid for proc in descendants.values() if proc.pgid > 0})
+    for process_group in process_groups:
+        try:
+            os.killpg(process_group, signal_number)
+        except ProcessLookupError:
+            continue
+    for proc in descendants.values():
+        try:
+            os.kill(proc.pid, signal_number)
+        except ProcessLookupError:
+            continue
+
+
+def _wait_for_descendant_exit(owner_pid: int, process: subprocess.Popen[Any], deadline: float) -> bool:
     while time.monotonic() < deadline:
-        if process.poll() is not None:
-            return
-        time.sleep(0.05)
-    try:
-        os.killpg(process.pid, signal.SIGKILL)
-    except ProcessLookupError:
+        _reap_descendant_processes(owner_pid, excluded_pid=process.pid)
+        if process.poll() is not None and not _collect_descendant_processes(owner_pid):
+            return True
+        time.sleep(_POLL_INTERVAL_SEC)
+    _reap_descendant_processes(owner_pid, excluded_pid=process.pid)
+    return process.poll() is not None and not _collect_descendant_processes(owner_pid)
+
+
+def _terminate_process_tree(process: subprocess.Popen[Any], *, term_grace_sec: float) -> None:
+    owner_pid = os.getpid()
+    _signal_descendant_tree(owner_pid, signal.SIGTERM)
+    if _wait_for_descendant_exit(owner_pid, process, time.monotonic() + term_grace_sec):
         return
+    _signal_descendant_tree(owner_pid, signal.SIGKILL)
+    _wait_for_descendant_exit(owner_pid, process, time.monotonic() + term_grace_sec)
 
 
 def _run_systemd_command(spec: LimitSpec, child_command: Sequence[str]) -> int:
@@ -328,25 +452,42 @@ def _run_portable_fallback(
         os.setsid()
         _apply_fallback_limits(spec, allowed_cpus=allowed_cpus)
 
+    previous_subreaper = _set_child_subreaper(True)
+    signal_state = _TerminationSignalState()
+    signal_state.install(signal.SIGTERM, signal.SIGINT)
     try:
         process = subprocess.Popen(child_command, preexec_fn=preexec)
     except OSError as exc:
+        signal_state.restore()
+        _restore_child_subreaper(previous_subreaper)
         return _shell_error_code(exc)
     try:
-        returncode = process.wait(timeout=spec.runtime_max_sec)
-    except subprocess.TimeoutExpired:
-        _emit_diagnostic(
-            {
-                "event": "run_bounded_command_timeout",
-                "backend": "portable_fallback",
-                "runtime_max_sec": spec.runtime_max_sec,
-                "term_grace_sec": term_grace_sec,
-            }
-        )
-        _terminate_process_group(process, term_grace_sec=term_grace_sec)
-        process.wait()
-        return TIMEOUT_EXIT_CODE
-    return _normalize_exit_code(returncode)
+        started = time.monotonic()
+        while True:
+            returncode = process.poll()
+            if returncode is not None:
+                return _normalize_exit_code(returncode)
+            if signal_state.requested_signal is not None:
+                _terminate_process_tree(process, term_grace_sec=term_grace_sec)
+                process.wait()
+                return 128 + signal_state.requested_signal
+            if spec.runtime_max_sec is not None and time.monotonic() - started >= spec.runtime_max_sec:
+                _emit_diagnostic(
+                    {
+                        "event": "run_bounded_command_timeout",
+                        "backend": "portable_fallback",
+                        "runtime_max_sec": spec.runtime_max_sec,
+                        "term_grace_sec": term_grace_sec,
+                    }
+                )
+                _terminate_process_tree(process, term_grace_sec=term_grace_sec)
+                process.wait()
+                return TIMEOUT_EXIT_CODE
+            time.sleep(_POLL_INTERVAL_SEC)
+    finally:
+        _reap_descendant_processes(os.getpid(), excluded_pid=process.pid)
+        signal_state.restore()
+        _restore_child_subreaper(previous_subreaper)
 
 
 def main(argv: Sequence[str] | None = None) -> int:


### PR DESCRIPTION
## Summary
- make the bounded launcher and worker command runner Linux child subreapers while commands are active
- terminate descendants by actual `/proc` ancestry, including children that escape into a new session/process group
- signal scoped descendant PGIDs and PIDs, reap adopted descendants, and avoid broad process-name matching
- preserve timeout/stall/cancel/signal return semantics
- document descendant cleanup in the operator runbook

## Root cause
Canceling the resource-saturated GQA8 `r4` run stopped the worker-visible launcher and marked the DB run failed, but the child probe had started a separate session. It was reparented to PID 1 with three `vvp` children still consuming the full evaluator memory/swap envelope until their exact PGID was killed manually.

## Verification
- focused launcher and worker command-runner tests: 14 passed
- regressions cover a child that calls `setsid()` and spawns a SIGTERM-ignoring grandchild
- `python3 scripts/validate_runs.py --skip_eval_queue`: passed
- py_compile and diff check: passed