### PR TITLE
Fix hexadecimal GQA8 result parsing

### DIFF
--- a/npu/eval/gqa8_fine_compositional_exact.py
+++ b/npu/eval/gqa8_fine_compositional_exact.py
@@ -318,7 +318,7 @@ def _parse_producer(stdout: str) -> tuple[list[JsonDict], list[list[JsonDict]], 
                 "last": bool(int(match.group(6))),
                 "global_max": int(match.group(7)),
                 "exp_sum": int(match.group(8)),
-                "value": list(unpack_numerators(int(match.group(9)))),
+                "value": list(unpack_numerators(int(match.group(9), 16))),
             }
         )
     for match in _PRODUCER_REQUEST_RE.finditer(stdout):
@@ -652,7 +652,7 @@ def _parse_reducer(stdout: str, *, cluster: int) -> tuple[list[JsonDict], JsonDi
             "last": bool(int(match.group(5))),
             "global_max": int(match.group(6)),
             "exp_sum": int(match.group(7)),
-            "value": list(unpack_numerators(int(match.group(8)))),
+            "value": list(unpack_numerators(int(match.group(8), 16))),
         }
         for match in reducer_probe._RESULT_RE.finditer(stdout)
     ]

--- a/npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
+++ b/npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
@@ -1044,7 +1044,7 @@ def _parse_stdout(
                     "last": bool(int(match.group(5))),
                     "global_max": int(match.group(6)),
                     "exp_sum": int(match.group(7)),
-                    "value": list(unpack_numerators(int(match.group(8)))),
+                    "value": list(unpack_numerators(int(match.group(8), 16))),
                 }
             )
         elif match := _ROOT_RESULT_RE.search(line):
@@ -1054,7 +1054,7 @@ def _parse_stdout(
                     "head_id": int(match.group(2)),
                     "slice": int(match.group(3)),
                     "last": bool(int(match.group(4))),
-                    "value": list(unpack_final_values(int(match.group(5)))),
+                    "value": list(unpack_final_values(int(match.group(5), 16))),
                 }
             )
         elif match := _SUMMARY_RE.search(line):

--- a/tests/test_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
+++ b/tests/test_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
@@ -30,6 +30,7 @@ from npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa
     _fill_rows_for_wave,
     _hierarchical_module_names,
     _icarus_compile_command,
+    _parse_stdout,
     _render_text,
     _testbench,
     _verilator_control_file_text,
@@ -53,11 +54,14 @@ from npu.eval.gqa8_fine_compositional_exact import (
     BACKEND as FINE_COMPOSITIONAL_RUNNER_BACKEND,
     _check_request_metadata,
     _check_sram_responses,
+    _parse_producer,
+    _parse_reducer,
     component_module_names,
     producer_testbench,
     sram_testbench,
 )
 from npu.rtlgen.gen_attention_score32_exact_local16_global_tree_cluster_sram_gqa8 import _validate
+from npu.sim.perf.attention_exact_partial import pack_final_values, pack_numerators
 
 
 def _design_dir() -> Path:
@@ -576,6 +580,82 @@ def test_fine_compositional_request_metadata_requires_every_block_and_slice() ->
     assert rejected["passed"] is False
     assert rejected["stream"] == 0
     assert rejected["command"] == 0
+
+
+def test_fine_compositional_producer_parser_decodes_hexadecimal_value() -> None:
+    numerators = [10, 11, 12, 13, 14, 15, 26, -1]
+    packed = pack_numerators(numerators)
+    stdout = (
+        "PRODUCER_RESULT cluster=2 producer=7 cmd=33280 head=3 slice=9 "
+        f"last=0 max=-11 sum=991 value={packed:082x}\n"
+    )
+    assert any(character in f"{packed:082x}" for character in "abcdef")
+
+    rows, requests, summary = _parse_producer(stdout)
+
+    assert rows == [
+        {
+            "command_id": 33280,
+            "head_id": 3,
+            "slice": 9,
+            "last": False,
+            "global_max": -11,
+            "exp_sum": 991,
+            "value": numerators,
+        }
+    ]
+    assert requests == [[], []]
+    assert summary is None
+
+
+def test_fine_compositional_reducer_parser_decodes_hexadecimal_value() -> None:
+    numerators = [15, 14, 13, 12, 11, 10, 31, -2]
+    packed = pack_numerators(numerators)
+    stdout = (
+        "RESULT idx=0 cmd=33280 head=3 slice=9 last=1 max=-8 sum=1012 "
+        f"value={packed:082x} cycle=77\n"
+    )
+
+    rows, summary = _parse_reducer(stdout, cluster=4)
+
+    assert rows == [
+        {
+            "cluster": 4,
+            "command_id": 33280,
+            "head_id": 3,
+            "slice": 9,
+            "last": True,
+            "global_max": -8,
+            "exp_sum": 1012,
+            "value": numerators,
+        }
+    ]
+    assert summary is None
+
+
+def test_composed_stdout_parser_decodes_hexadecimal_cluster_and_root_values() -> None:
+    cluster_values = [10, 11, 12, 13, 14, 15, 26, -1]
+    root_values = [15, 14, 13, 12, 11, 10, 31, -2]
+    stdout = "\n".join(
+        [
+            (
+                "CLUSTER_RESULT cluster=2 cmd=33280 head=3 slice=9 last=0 max=-11 sum=991 "
+                f"value={pack_numerators(cluster_values):082x} cycle=44"
+            ),
+            (
+                "ROOT_RESULT cmd=33280 head=3 slice=9 last=1 "
+                f"value={pack_final_values(root_values):016x} cycle=77"
+            ),
+        ]
+    )
+
+    summary, cluster_summaries, cluster_rows, root_rows, timeout_cycle = _parse_stdout(stdout)
+
+    assert summary == {}
+    assert cluster_summaries == []
+    assert cluster_rows[2][0]["value"] == cluster_values
+    assert root_rows[0]["value"] == root_values
+    assert timeout_cycle is None
 
 
 def test_fine_compositional_sram_audit_checks_metadata_data_and_tag() -> None:


### PR DESCRIPTION
## Summary
- parse `%x` payloads from the fine compositional producer and reducer probes as hexadecimal
- fix the same latent hexadecimal handling in the composed cluster/root stdout parser
- add regressions with payload digits `a-f` and exact unpacked-value assertions

## Root cause
The `r5` remote run reached its first concrete producer replay, but `_parse_producer` passed a `%082x` payload to `int()` with the default decimal base. This raised `ValueError` before any RTL/perf equivalence comparison. Audit found the same mismatch on reducer and adjacent cluster/root result paths. SRAM response data/tag parsing was already base-16.

## Verification
- focused GQA8 probe/guard tests: 40 passed
- `py_compile`: passed
- `python3 scripts/validate_runs.py --skip_eval_queue`: passed
- `git diff --check`: clean

`r5` is superseded as parser-inconclusive. After merge, dispatch corrected remote-only `r6` at the merge SHA.