### PR TITLE
Fix 41-bit GQA8 global sidecar packing

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -10364,6 +10364,10 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equiv
             "Require compositional_components.strict_generated_top_guard=passed",
             "Require compositional_components.producer_replay_parallelism=1",
             (
+                "Require compositional_components.global_sidecar."
+                "value_packing=canonical_pack_numerators"
+            ),
+            (
                 "Require exact totals in report.summary: producer_handshake_count=8192, "
                 "fill_target_accept_count=128, fill_row_accept_count=262144, "
                 "sram_request_accept_count=262144, sram_response_accept_count=262144, "
@@ -10472,6 +10476,10 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotat
             "Require report passed=true, classification=passed, and counts_passed=true",
             "Require compositional_components.strict_generated_top_guard=passed",
             "Require compositional_components.producer_replay_parallelism=1",
+            (
+                "Require compositional_components.global_sidecar."
+                "value_packing=canonical_pack_numerators"
+            ),
             (
                 "Require exact totals in report.summary: producer_handshake_count=32768, "
                 "fill_target_accept_count=512, fill_row_accept_count=1048576, "

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -13807,6 +13807,7 @@ def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_equivalence_evidence()
             assert "--out-md " in run
             assert any("strict_generated_top_guard=passed" in rule for rule in acceptance)
             assert any("producer_replay_parallelism=1" in rule for rule in acceptance)
+            assert any("global_sidecar.value_packing=canonical_pack_numerators" in rule for rule in acceptance)
             assert (
                 "--proposal-id "
                 "prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_"
@@ -13947,6 +13948,7 @@ def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_rotation_equivalence_e
             assert any("completed_command_count=4" in rule for rule in acceptance)
             assert any("strict_generated_top_guard=passed" in rule for rule in acceptance)
             assert any("producer_replay_parallelism=1" in rule for rule in acceptance)
+            assert any("global_sidecar.value_packing=canonical_pack_numerators" in rule for rule in acceptance)
             assert any("report.command_ids=[33280, 33281, 33282, 33283]" in rule for rule in acceptance)
             assert work_item.input_manifest["worker_resources"] == expected_worker_resources
             assert (

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/evaluation_gate.md
@@ -51,6 +51,7 @@ The JSON report must contain:
 - passing structured comparisons for every cluster row and root row
 - `compositional_components.strict_generated_top_guard: passed`
 - `compositional_components.producer_replay_parallelism: 1`
+- `compositional_components.global_sidecar.value_packing: canonical_pack_numerators`
 
 Hashes are diagnostics only. They cannot substitute for structured comparison.
 
@@ -61,6 +62,11 @@ architecture. That includes compile or simulation termination by SIGKILL, shell
 exit `137`, or a bare `Killed` diagnostic from the bounded launcher/runtime.
 Count, protocol, metadata, ordering, or row mismatches are conclusive
 implementation failures and must be fixed before PPA or Llama7B recosting.
+The r6 global-tree row mismatch produced before canonical 41-bit numerator
+packing is a harness-inconclusive result, not an RTL mismatch: that sidecar
+used a 32-bit lane stride for the 328-bit `leaf_value`. Apply the conclusive
+row-mismatch rule only to reruns whose component metadata records
+`global_sidecar.value_packing=canonical_pack_numerators`.
 
 ## Follow-on
 

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/evaluation_gate.md
@@ -61,8 +61,15 @@ Acceptance:
 6. `full_row_audit.passed=true` for all 16 clusters and the root stream
 7. `compositional_components.strict_generated_top_guard=passed`
 8. `compositional_components.producer_replay_parallelism=1`
+9. `compositional_components.global_sidecar.value_packing=canonical_pack_numerators`
 
 Classification policy:
 
 - timeout, OOM, kill, or bounded resource failure, including compile or simulation termination by SIGKILL, shell exit `137`, or a bare `Killed` diagnostic: inconclusive
 - structured row mismatch, metadata mismatch, count mismatch, or protocol error: conclusive
+
+The r6 global-tree mismatch produced with the old 32-bit numerator stride is
+harness-inconclusive, not an RTL failure. The global sidecar carries eight
+41-bit lanes in the 328-bit `leaf_value`; require
+`global_sidecar.value_packing=canonical_pack_numerators` before treating a
+rerun's structured row mismatch as conclusive.

--- a/npu/eval/gqa8_compositional_exact.py
+++ b/npu/eval/gqa8_compositional_exact.py
@@ -15,12 +15,18 @@ from typing import Any
 from npu.eval.check_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_guard import (
     main as strict_guard_main,
 )
+from npu.sim.perf.attention_exact_partial import (
+    PARTIAL_PAYLOAD_BITS,
+    WEIGHTED_NUMERATOR_BITS,
+    pack_numerators,
+)
 
 JsonDict = dict[str, Any]
 
 BACKEND = "compositional_icarus"
 CLUSTER_RUN_JOBS = 3
-GLOBAL_ROW_BITS = 419
+GLOBAL_VALUE_OFFSET = 91
+GLOBAL_ROW_BITS = GLOBAL_VALUE_OFFSET + PARTIAL_PAYLOAD_BITS
 _GLOBAL_SUMMARY_RE = re.compile(
     r"GLOBAL_SUMMARY root_rows=(\d+) root_completed=(\d+) finalizer_accepted=(\d+) "
     r"tree_completed=(\d+) protocol_error=(\d+) first_root=(-?\d+) last_root=(-?\d+) drain=(\d+)"
@@ -316,9 +322,7 @@ def _pack_global_row(row: JsonDict) -> int:
     value |= int(row["exp_sum"]) << 53
     value |= int(row["slice"]) << 86
     value |= int(bool(row["last"])) << 90
-    numerators = row["value"]
-    packed_value = sum((int(lane) & 0xFFFF_FFFF) << (32 * index) for index, lane in enumerate(numerators))
-    value |= packed_value << 91
+    value |= pack_numerators(row["value"]) << GLOBAL_VALUE_OFFSET
     return value
 
 
@@ -329,7 +333,15 @@ def _write_global_sidecar(directory: Path, cluster_rows: list[list[JsonDict]]) -
         raise ValueError("global composition requires 16 equal-length cluster streams")
     words = [_pack_global_row(row) for rows in cluster_rows for row in rows]
     probe._write_memh(directory / "global_rows.memh", words, width_bits=GLOBAL_ROW_BITS)
-    return {"global_row_words": len(words), "rows_per_cluster": len(cluster_rows[0])}
+    return {
+        "global_row_words": len(words),
+        "rows_per_cluster": len(cluster_rows[0]),
+        "row_bits": GLOBAL_ROW_BITS,
+        "value_offset": GLOBAL_VALUE_OFFSET,
+        "numerator_lanes": 8,
+        "numerator_bits": WEIGHTED_NUMERATOR_BITS,
+        "value_packing": "canonical_pack_numerators",
+    }
 
 
 def global_testbench(

--- a/npu/eval/gqa8_fine_compositional_exact.py
+++ b/npu/eval/gqa8_fine_compositional_exact.py
@@ -1160,6 +1160,7 @@ def run_fine_compositional_exact(
             "sram_endpoint_replays": probe.CLUSTERS,
             "reducer_replays": probe.CLUSTERS,
             "global_tree_simulations": 1,
+            "global_sidecar": global_sidecar,
             "compiled_modules": list(component_keys),
             "avoided_modules": ["p54_cluster_wrapper", "p53_cluster_wrapper"],
             "global_counts": {

--- a/tests/test_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
+++ b/tests/test_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
@@ -1,13 +1,19 @@
 import copy
 import json
 from pathlib import Path
+import shutil
+import subprocess
 import sys
+import tempfile
 from typing import Any
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from npu.eval import probe_attention_score32_exact_local16_global_tree_gqa8 as full_probe
 from npu.eval.probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8 import (
     DIAGNOSTIC_TAIL_LIMIT,
     MARKDOWN_DIAGNOSTIC_TAIL_LIMIT,
@@ -46,6 +52,7 @@ from npu.eval.gqa8_compositional_exact import (
     BACKEND as COMPOSITIONAL_RUNNER_BACKEND,
     _pack_global_row,
     _run_process,
+    _write_global_sidecar,
     cluster_testbench,
     extract_module_family,
     global_testbench,
@@ -61,7 +68,13 @@ from npu.eval.gqa8_fine_compositional_exact import (
     sram_testbench,
 )
 from npu.rtlgen.gen_attention_score32_exact_local16_global_tree_cluster_sram_gqa8 import _validate
-from npu.sim.perf.attention_exact_partial import pack_final_values, pack_numerators
+from npu.sim.perf.attention_exact_partial import (
+    ExactPartialBeat,
+    finalize_partial_beats,
+    merge_balanced_partial_streams,
+    pack_final_values,
+    pack_numerators,
+)
 
 
 def _design_dir() -> Path:
@@ -489,6 +502,16 @@ def test_compositional_global_testbench_drives_exact_structured_cluster_rows() -
     assert "ROOT_RESULT" in tb
     assert "GLOBAL_SUMMARY" in tb
 
+    numerators = [
+        (1 << 35) + 5,
+        -((1 << 34) + 7),
+        (1 << 40) - 1,
+        -(1 << 40),
+        (1 << 32) + 0xABCDEF,
+        -((1 << 33) + 0x12345),
+        17,
+        -19,
+    ]
     row = {
         "command_id": 0x8200,
         "head_id": 7,
@@ -496,7 +519,7 @@ def test_compositional_global_testbench_drives_exact_structured_cluster_rows() -
         "exp_sum": 123,
         "slice": 9,
         "last": True,
-        "value": [index - 4 for index in range(8)],
+        "value": numerators,
     }
     packed = _pack_global_row(row)
     assert packed & 0xFFFF == 0x8200
@@ -505,6 +528,127 @@ def test_compositional_global_testbench_drives_exact_structured_cluster_rows() -
     assert (packed >> 53) & ((1 << 33) - 1) == 123
     assert (packed >> 86) & 0xF == 9
     assert (packed >> 90) & 1 == 1
+    decoded = []
+    for lane in range(8):
+        raw = (packed >> (91 + lane * 41)) & ((1 << 41) - 1)
+        decoded.append(raw - (1 << 41) if raw & (1 << 40) else raw)
+    assert decoded == numerators
+    assert packed.bit_length() <= 419
+
+
+def test_concrete_global_tree_matches_canonical_sidecar_rows() -> None:
+    if shutil.which("iverilog") is None or shutil.which("vvp") is None:
+        pytest.skip("Icarus tools are unavailable")
+
+    streams: list[list[ExactPartialBeat]] = []
+    cluster_rows: list[list[dict[str, object]]] = []
+    for cluster in range(16):
+        beats = []
+        rows = []
+        for head in range(8):
+            for value_slice in range(16):
+                numerators = tuple(
+                    (
+                        (1 << 33)
+                        + cluster * 10_000
+                        + head * 1_000
+                        + value_slice * 10
+                        + lane
+                    )
+                    * (-1 if (cluster + lane) % 2 else 1)
+                    for lane in range(8)
+                )
+                beat = ExactPartialBeat(
+                    command_id=0x8200,
+                    head_id=head,
+                    slice_index=value_slice,
+                    last=value_slice == 15,
+                    max_score=cluster - 8,
+                    exp_sum=1_000 + cluster,
+                    numerators=numerators,
+                )
+                beats.append(beat)
+                rows.append(
+                    {
+                        "cluster": cluster,
+                        "command_id": beat.command_id,
+                        "head_id": beat.head_id,
+                        "slice": beat.slice_index,
+                        "last": beat.last,
+                        "global_max": beat.max_score,
+                        "exp_sum": beat.exp_sum,
+                        "value": list(beat.numerators),
+                    }
+                )
+        streams.append(beats)
+        cluster_rows.append(rows)
+    expected = [
+        {
+            "command_id": beat.command_id,
+            "head_id": beat.head_id,
+            "slice": beat.slice_index,
+            "last": beat.last,
+            "value": list(beat.values),
+        }
+        for beat in finalize_partial_beats(merge_balanced_partial_streams(streams))
+    ]
+
+    config = json.loads((_design_dir() / "config.json").read_text(encoding="utf-8"))
+    top_name = f"{config['top_name']}__global_tree"
+    generated_rtl = (_rtl_dir() / "top.v").read_text(encoding="utf-8")
+    with tempfile.TemporaryDirectory(prefix="gqa8_global_sidecar_test_") as temp_name:
+        work_dir = Path(temp_name)
+        rtl_dir = work_dir / "rtl"
+        rtl_dir.mkdir()
+        (rtl_dir / "top.v").write_text(
+            extract_module_family(generated_rtl, prefix=top_name),
+            encoding="utf-8",
+        )
+        sidecar = _write_global_sidecar(work_dir, cluster_rows)
+        assert sidecar["row_bits"] == 419
+        assert sidecar["value_offset"] == 91
+        assert sidecar["numerator_lanes"] == 8
+        assert sidecar["numerator_bits"] == 41
+        assert sidecar["value_packing"] == "canonical_pack_numerators"
+        tb_path = work_dir / "tb.v"
+        tb_path.write_text(
+            global_testbench(
+                top_name=top_name,
+                rows_per_cluster=int(sidecar["rows_per_cluster"]),
+                output_ready_pattern=(True, True, False, True),
+                timeout_cycles=TB_TIMEOUT_CYCLES,
+            ),
+            encoding="ascii",
+        )
+        fakeram_path = work_dir / "fakeram45_2048x39.v"
+        fakeram_path.write_text(full_probe._FAKERAM_MODEL, encoding="ascii")
+        sim_path = work_dir / "sim.out"
+        compile_result = subprocess.run(
+            _icarus_compile_command(
+                rtl_dir=rtl_dir,
+                fakeram_path=fakeram_path,
+                tb_path=tb_path,
+                sim_path=sim_path,
+            ),
+            cwd=work_dir,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        run_result = subprocess.run(
+            [shutil.which("vvp") or "vvp", str(sim_path)],
+            cwd=work_dir,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert run_result.returncode == 0, run_result.stderr
+
+    _, _, _, observed, timeout_cycle = _parse_stdout(run_result.stdout)
+    audit = compare_full_rows(expected, observed)
+    assert timeout_cycle is None
+    assert audit["passed"] is True, audit
 
 
 def test_fine_compositional_boundary_names_are_exact() -> None:


### PR DESCRIPTION
## Summary
- pack global-tree leaf numerators with the canonical 8 x 41-bit `pack_numerators` contract instead of 32-bit lane strides
- derive the global row width from `PARTIAL_PAYLOAD_BITS` and publish explicit packing metadata in compositional reports
- require canonical packing in both one-group and four-group job acceptance gates
- record the prior `r6` root mismatch as probe-harness-inconclusive
- add a concrete global-tree RTL regression with high-bit and negative numerators

## Root cause
`r6` passed all concrete producer, SRAM endpoint, and local-reducer checks, but `_pack_global_row` placed each 41-bit numerator at a 32-bit stride before driving the 328-bit global-tree `leaf_value`. The resulting root mismatch was injected by the test harness, not produced by the RTL datapath.

## Verification
- focused GQA8 probe tests: 41 passed
- focused L2 generator tests: 2 passed
- concrete global-tree RTL regression: 128/128 structured root rows match
- full one-group global-tree reference check: return 0, 128 rows, zero protocol errors
- sidecar audit: no other relevant width/offset mismatch found
- `py_compile`: passed
- `python3 scripts/validate_runs.py --skip_eval_queue`: passed
- `git diff --check`: clean

After merge, rerun the complete remote one-group gate as `r7` at the merge SHA.