### PR TITLE
Rebound four-group GQA8 runtime from r7 measurement

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -10438,7 +10438,7 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotat
         memory_max="8G",
         cpu_quota="300%",
         tasks_max=512,
-        runtime_max_sec=5100,
+        runtime_max_sec=7200,
         child_command=child_command,
     )
     return {
@@ -10468,7 +10468,7 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotat
             "memory_max": "8G",
             "cpu_quota": "300%",
             "tasks_max": 512,
-            "outer_timeout_seconds": 5100,
+            "outer_timeout_seconds": 7200,
             "stall_timeout_seconds": 1500,
         },
         "acceptance": [

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -13912,7 +13912,7 @@ def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_rotation_equivalence_e
                 "memory_max": "8G",
                 "cpu_quota": "300%",
                 "tasks_max": 512,
-                "outer_timeout_seconds": 5100,
+                "outer_timeout_seconds": 7200,
                 "stall_timeout_seconds": 1500,
             }
 
@@ -13923,7 +13923,7 @@ def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_rotation_equivalence_e
             assert (
                 "python3 control_plane/scripts/run_bounded_command.py "
                 "--memory-high 6G --memory-max 8G --cpu-quota 300% "
-                "--tasks-max 512 --runtime-max-sec 5100 --"
+                "--tasks-max 512 --runtime-max-sec 7200 --"
             ) in run
             assert "--sim-backend fine_compositional_icarus" in run
             assert "--compile-timeout-sec 1200" in run

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/README.md
@@ -31,5 +31,9 @@ mismatch. An isolated flat-Verilator p54 compile under 8 GiB `RLIMIT_AS` also
 failed with return 255 and `std::bad_alloc` after 12.3 seconds, with no binary.
 The probe also carries a distinct `--compile-timeout-sec 1200` while the
 simulation timeout remains `--timeout-sec 3600`. The bounded launcher contract
-is widened to a 5100-second outer timeout and a 1500-second stall timeout so a
-quiet component compile is not misclassified as a failed simulation.
+uses a 7200-second outer timeout and a 1500-second stall timeout. The successful
+one-group r7 run measured 1561.7 seconds under the same serial 856-producer
+backend. A linear four-group bound is therefore 6246.8 seconds; 7200 seconds
+adds 953.2 seconds (15.3 percent) for compile, teardown, and runtime variance.
+The per-subprocess simulation timeout remains 3600 seconds. Any outer or
+subprocess timeout remains inconclusive rather than an RTL mismatch.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/evaluation_gate.md
@@ -8,7 +8,7 @@
   - `MemoryMax=8G`
   - `CPUQuota=300%`
   - `TasksMax=512`
-  - outer runtime `5100 s`
+  - outer runtime `7200 s`
   - stall timeout `1500 s`
   - compile timeout `1200 s`
   - probe timeout `3600 s`
@@ -31,6 +31,12 @@ the SRAM request metadata, simulate the concrete p54/p53 SRAM endpoints and
 local reducer/temporal-merge modules, and simulate the concrete global tree
 from observed cluster streams. The bounded JSON report records each component
 phase, serial replay metadata, and separate compile/simulation timeouts.
+
+The outer runtime is measured rather than guessed. The successful one-group r7
+run took 1561.7 seconds with the same serial 856-producer backend. Four groups
+give a linear bound of 6246.8 seconds, and the 7200-second contract adds 953.2
+seconds (15.3 percent) for compile, cleanup, and evaluator variance. This does
+not change the 3600-second per-subprocess timeout or any resource ceiling.
 
 Acceptance:
 


### PR DESCRIPTION
## Summary
- raise the four-group rotation job outer runtime from 5,100 to 7,200 seconds
- preserve the 3,600-second per-subprocess timeout and all memory/CPU/task ceilings
- document the bound from the successful one-group `r7` measurement
- update generator regressions and the rotation evaluation gate

## Measured basis
The one-group fine-compositional run took 1,561.7 seconds with 856 serial producer replays. Linear four-group scaling is 6,246.8 seconds. The 7,200-second envelope adds 953.2 seconds, or 15.3%, for compile, cleanup, and evaluator variance. Timeout remains resource-inconclusive.

## Verification
- focused generator tests: 2 passed
- `py_compile`: passed
- `python3 scripts/validate_runs.py --skip_eval_queue`: passed
- `git diff --check`: clean

After merge, dispatch the four-group rotation gate at the merge SHA on the remote evaluator.