### PR TITLE
Fix exact reduction recost direct execution

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -6349,6 +6349,12 @@ def _decoder_attention_score32_schedule_wrapper_postroute_activity_power_evidenc
 
 def _decoder_attention_score32_exact_reduction_recost_evidence(*, item_id: str) -> dict[str, Any]:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    base_item_id = "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1"
+    canonical_artifact_item_ids = {
+        base_item_id,
+        f"{base_item_id}_r2",
+    }
+    artifact_item_id = base_item_id if item_id in canonical_artifact_item_ids else item_id
     source_recost_json = (
         f"{base}/decoder_attention_composed_datapath_physical_feasibility__"
         "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1.json"
@@ -6356,8 +6362,8 @@ def _decoder_attention_score32_exact_reduction_recost_evidence(*, item_id: str) 
     banked_config = (
         "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b59/config.json"
     )
-    out = f"{base}/decoder_attention_score32_exact_reduction_recost__{item_id}.json"
-    report = f"{base}/decoder_attention_score32_exact_reduction_recost__{item_id}.md"
+    out = f"{base}/decoder_attention_score32_exact_reduction_recost__{artifact_item_id}.json"
+    report = f"{base}/decoder_attention_score32_exact_reduction_recost__{artifact_item_id}.md"
     return {
         "inputs": {
             "attention_score32_exact_reduction_recost_source_json": source_recost_json,

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7369,7 +7369,7 @@ def test_generate_l2_campaign_task_adds_attention_score32_exact_reduction_recost
                 Layer2CampaignGenerateRequest(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
-                    item_id="l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+                    item_id="l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r2",
                     requested_by="@tester",
                     source_commit=source_commit,
                     proposal_id="prop_l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
@@ -7395,6 +7395,7 @@ def test_generate_l2_campaign_task_adds_attention_score32_exact_reduction_recost
             run = commands[0]["run"]
             decoder_inputs = work_item.input_manifest["decoder_contract"]
 
+            assert work_item.item_id == "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r2"
             assert work_item.priority == 98
             assert [command["name"] for command in commands[:2]] == [
                 "audit_decoder_attention_score32_exact_reduction_recost",
@@ -7458,6 +7459,61 @@ def test_generate_l2_campaign_task_adds_attention_score32_exact_reduction_recost
                 "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_attention_score32_exact_reduction_recost__"
                 "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1.md",
+            ]
+
+
+def test_generate_l2_campaign_task_keeps_item_specific_outputs_for_score32_exact_reduction_recost_r3() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r3",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+                    proposal_path="docs/proposals/prop_l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1/proposal.json",
+                    abstraction_layer="decoder_attention_score32_exact_reduction_recost",
+                    evaluation_mode="frontier_detail",
+                    comparison_role="score32_exact_reduction_recost",
+                    paired_baseline_item_id=(
+                        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1"
+                    ),
+                    depends_on_item_ids=[
+                        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1"
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    priority=98,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert work_item.item_id == "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r3"
+            assert decoder_inputs["attention_score32_exact_reduction_recost_out"] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_exact_reduction_recost__"
+                "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r3.json"
+            )
+            assert work_item.task_request.request_payload["task"]["expected_outputs"] == [
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_exact_reduction_recost__"
+                "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r3.json",
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_exact_reduction_recost__"
+                "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r3.md",
             ]
 
 

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
-  "source_commit_note": "Replace with the merge commit that contains this exact-reduction recost implementation after merge and before dispatch. Leave this request pending for manual dispatch only; it must consume merged/materialized inputs, and l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1 must not keep running against the obsolete 141-cycle reduction assumption once this correction artifact exists.",
+  "source_commit_note": "Replace with the merge commit that contains the direct-script bootstrap fix after merge and before dispatch. Preserve the historical v1 failed run as an inconclusive CLI packaging failure, dispatch only the fresh _r2 item, and keep l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1 off the obsolete 141-cycle reduction assumption once the corrected canonical artifact exists.",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
@@ -29,10 +29,45 @@
       },
       "expected_result": {
         "direction": "record_score32_exact_reduction_recost",
-        "reason": "Preserve the merged source contract explicitly, emit the corrected exact b59 reduction schedule, and keep the existing activity-power v1 consumer off the obsolete 141-cycle assumption until its own r2 input swap is merged."
+        "reason": "This historical v1 request failed before argument handling because the direct script could not import `npu` from a disposable repo worktree; preserve the failure record without rewriting historical run data or artifacts."
+      },
+      "status": "inconclusive",
+      "superseded_by_item_id": "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r2",
+      "notes": "Historical v1 dispatch only. Preserve the failed item/run history as an inconclusive CLI packaging failure (`ModuleNotFoundError: No module named 'npu'`). No output artifact was produced, and no historical DB/run data should be rewritten."
+    },
+    {
+      "item_id": "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r2",
+      "task_type": "l2_campaign",
+      "objective": "Correct the score32 schedule-wrapper Llama7B reduction schedule using the exact c16/r2/l8/b59 banked finalized-tree full-wave no-stall service contract.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_exact_reduction_recost",
+      "comparison_role": "score32_exact_reduction_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "priority": 98,
+      "revision": {
+        "reason": "retry_after_direct_script_bootstrap_fix",
+        "preserve_failed_item_id": "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+        "canonical_output_item_id": "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+        "superseded_contract": {
+          "source_item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1",
+          "obsolete_best_requested_cross_tile_reduction_cycles": 141,
+          "replacement_cross_tile_reduction_cycles": 574
+        },
+        "blocked_downstream_item_ids": [
+          "l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1"
+        ]
+      },
+      "expected_result": {
+        "direction": "record_score32_exact_reduction_recost",
+        "reason": "Retry with the direct-script bootstrap fix under a fresh DB item identity while emitting the canonical exact-reduction artifact basename already expected by the merged downstream rerank."
       },
       "status": "pending",
-      "notes": "Manual dispatch only. Run only the new exact-reduction recost audit, commit one JSON and one Markdown artifact, and do not alter DB state or materialize new refs from this request."
+      "notes": "Manual dispatch only. Pin `source_commit` to the bootstrap-fix merge commit at dispatch. Run only the exact-reduction recost audit, commit one JSON and one Markdown artifact named with the canonical `...__l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1` basename, and do not rewrite historical v1 DB/run records."
     }
   ]
 }

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1/proposal.json
@@ -28,6 +28,25 @@
     "preserves the obsolete 141-cycle contract explicitly so downstream consumers can be revised deliberately",
     "forces later score32 work to adopt the exact b59 reduction schedule before claiming tighter wrapper or frontier conclusions"
   ],
+  "revision_record": [
+    {
+      "revision": "v1",
+      "status": "inconclusive",
+      "reason": "cli_packaging_failure",
+      "item_id": "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+      "failure_signature": "ModuleNotFoundError: No module named 'npu'",
+      "historical_decision": "preserve_failed_run_history_without_output_rewrite",
+      "notes": "The direct script was dispatched from a disposable repo worktree without PYTHONPATH and failed before argument handling, so no output artifact was produced. Historical DB/run records remain intact and are not rewritten."
+    },
+    {
+      "revision": "r2",
+      "status": "pending",
+      "item_id": "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r2",
+      "artifact_basename_item_id": "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+      "dispatch_requirement": "pin source_commit to the merge commit that contains the direct-script bootstrap fix before dispatch",
+      "notes": "Retry under a new DB item identity while preserving the canonical output basename already consumed by the merged downstream rerank."
+    }
+  ],
   "risks": [
     "this is still a schedule-only correction and does not close reducer area or activity energy",
     "the current score32 schedule-wrapper postroute activity-power v1 item remains pointed at the obsolete source recost until a follow-on r2 consumer is merged",
@@ -64,8 +83,43 @@
         "direction": "record_score32_exact_reduction_recost",
         "reason": "Preserve the merged schedule-wrapper source contract explicitly, emit the corrected reduction/layer/total/latency terms from the exact b59 service model, and keep the existing activity-power v1 item off the obsolete 141-cycle assumption until its own r2 consumer revision exists."
       },
+      "status": "inconclusive",
+      "superseded_by_item_id": "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r2",
+      "notes": "Historical v1 dispatch failed before argument handling in a disposable repo worktree with `ModuleNotFoundError: No module named 'npu'`. Preserve the failed DB/run history and do not rewrite any historical run data."
+    },
+    {
+      "item_id": "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r2",
+      "task_type": "l2_campaign",
+      "objective": "Correct the score32 schedule-wrapper Llama7B reduction schedule using the exact c16/r2/l8/b59 banked finalized-tree full-wave no-stall service contract.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_exact_reduction_recost",
+      "comparison_role": "score32_exact_reduction_recost",
+      "paired_baseline_item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "priority": 98,
+      "revision": {
+        "reason": "retry_after_direct_script_bootstrap_fix",
+        "preserve_failed_item_id": "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+        "canonical_output_item_id": "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+        "superseded_contract": {
+          "source_item_id": "l2_decoder_attention_composed_datapath_score32_exp_lut_div_schedule_wrapper_recost_llama7b_v1",
+          "obsolete_best_requested_cross_tile_reduction_cycles": 141,
+          "replacement_cross_tile_reduction_cycles": 574
+        },
+        "blocked_downstream_item_ids": [
+          "l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1"
+        ]
+      },
+      "expected_result": {
+        "direction": "record_score32_exact_reduction_recost",
+        "reason": "Retry the exact-reduction recost with the direct-script bootstrap fix, preserve the canonical output basename already referenced by downstream rerank, and keep the existing activity-power v1 item off the obsolete 141-cycle assumption until its own r2 consumer revision exists."
+      },
       "status": "pending",
-      "notes": "Manual dispatch only. This item is evidence-only, depends on merged/materialized inputs, and should land before any downstream score32 wrapper activity-power or frontier consumer is revised to read the corrected reduction artifact."
+      "notes": "Manual dispatch only. Pin `source_commit` to the merge commit that contains the bootstrap fix before dispatch. This retry uses a fresh DB item identity but must emit the canonical `...__l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1.{json,md}` artifact names because the historical v1 run produced no outputs and the merged downstream rerank already expects that basename."
     }
   ],
   "baseline_refs": [

--- a/npu/eval/audit_llm_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank.py
@@ -6,7 +6,12 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import sys
 from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 JsonDict = dict[str, Any]
 

--- a/npu/eval/audit_llm_decoder_attention_score32_exact_reduction_recost.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_exact_reduction_recost.py
@@ -8,7 +8,12 @@ import hashlib
 import json
 import math
 from pathlib import Path
+import sys
 from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 from npu.sim.perf.attention_exact_partial import exact_banked_finalized_tree_full_wave_saturated_service
 

--- a/tests/test_audit_llm_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank.py
+++ b/tests/test_audit_llm_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank.py
@@ -1,6 +1,9 @@
 from argparse import Namespace
 import json
+import os
 from pathlib import Path
+import subprocess
+import sys
 
 import pytest
 
@@ -344,3 +347,25 @@ def test_exact_reduction_full_gqa8_rerank_rejects_source_link_identity_mismatch(
 
     with pytest.raises(ValueError, match="one-group source_links proposal_id must be"):
         build_report(args)
+
+
+def test_exact_reduction_full_gqa8_rerank_direct_script_reaches_argument_handling_without_pythonpath() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/audit_llm_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank.py",
+            "--help",
+        ],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "usage:" in completed.stdout

--- a/tests/test_audit_llm_decoder_attention_score32_exact_reduction_recost.py
+++ b/tests/test_audit_llm_decoder_attention_score32_exact_reduction_recost.py
@@ -1,6 +1,9 @@
 from argparse import Namespace
 import json
+import os
 from pathlib import Path
+import subprocess
+import sys
 
 import pytest
 
@@ -217,3 +220,36 @@ def test_exact_reduction_recost_rejects_non_finite_source_values(tmp_path: Path)
 
     with pytest.raises(ValueError, match="source replica_recost_clock_ns must be a finite number"):
         build_report(args)
+
+
+def test_exact_reduction_recost_direct_script_runs_without_pythonpath(tmp_path: Path) -> None:
+    args = _inputs(tmp_path)
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    out = tmp_path / "report.json"
+    out_md = tmp_path / "report.md"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/audit_llm_decoder_attention_score32_exact_reduction_recost.py",
+            "--source-recost-json",
+            str(args.source_recost_json),
+            "--banked-config",
+            str(args.banked_config),
+            "--out",
+            str(out),
+            "--out-md",
+            str(out_md),
+        ],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["model"] == "llm_decoder_attention_score32_exact_reduction_recost_v1"


### PR DESCRIPTION
## Summary
- bootstrap the repository root for direct execution of the exact-reduction recost and strict rerank audits
- preserve the failed v1 run as inconclusive and define a fresh r2 retry contract
- make only v1/r2 share the canonical artifact basename; future retries retain unique outputs
- add no-PYTHONPATH subprocess and generator regressions

## Validation
- 17 focused tests passed
- both audit scripts reach CLI handling without `PYTHONPATH`
- `scripts/validate_runs.py --skip_eval_queue`
- proposal JSON validation and `git diff --check`

The failed v1 run produced no artifact. After merge, dispatch `l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r2` pinned to the merge commit on the remote evaluator.