### PR TITLE
Recognize exact reduction recost evidence during completion

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -583,6 +583,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_score32_compute_activity_energy_report",
     ),
     (
+        "attention_score32_exact_reduction_recost_out",
+        "attention_score32_exact_reduction_recost_report",
+    ),
+    (
         "attention_score32_exact_reduction_gqa8_full_equivalence_rerank_out",
         "attention_score32_exact_reduction_gqa8_full_equivalence_rerank_report",
     ),

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import copy
 import json
+import os
 from pathlib import Path
+import subprocess
 import tempfile
 from types import SimpleNamespace
 
@@ -19,6 +21,7 @@ from control_plane.models.enums import ExecutorType, FlowName, LayerName, RunSta
 from control_plane.models.runs import Run
 from control_plane.models.task_requests import TaskRequest
 from control_plane.models.work_items import WorkItem
+from control_plane.services.operator_submission import assess_submission_eligibility
 from control_plane.services.l2_result_consumer import (
     Layer2ConsumeRequest,
     _decoder_evidence_paths,
@@ -30,6 +33,26 @@ from control_plane.services.l2_result_consumer import (
 def _write(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
+
+
+def _init_repo(repo_root: Path) -> None:
+    subprocess.run(["git", "-C", str(repo_root), "init", "-b", "master"], check=True, capture_output=True, text=True)
+    _write(repo_root / "README.md", "demo\n")
+    _write(repo_root / ".gitignore", "control_plane/shadow_exports/\n")
+    subprocess.run(["git", "-C", str(repo_root), "add", "README.md", ".gitignore"], check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "-C", str(repo_root), "commit", "-m", "init"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+        },
+    )
 
 
 def test_decoder_evidence_summary_recognizes_two_pass_attention_equivalence() -> None:
@@ -357,6 +380,37 @@ def test_decoder_evidence_paths_recognizes_decode_score_local_cluster_frontier(t
     assert source_refs == {
         "decoder_decode_score_local_cluster_frontier_out": evidence_rel,
         "decoder_decode_score_local_cluster_frontier_report": report_rel,
+    }
+
+
+def test_decoder_evidence_paths_recognizes_score32_exact_reduction_recost_contract(tmp_path: Path) -> None:
+    evidence_rel = (
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_score32_exact_reduction_recost__"
+        "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1.json"
+    )
+    report_rel = (
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_score32_exact_reduction_recost__"
+        "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1.md"
+    )
+    _write(tmp_path / evidence_rel, "{}\n")
+    _write(tmp_path / report_rel, "# score32 exact reduction recost\n")
+    work_item = SimpleNamespace(
+        input_manifest={
+            "decoder_contract": {
+                "attention_score32_exact_reduction_recost_out": evidence_rel,
+                "attention_score32_exact_reduction_recost_report": report_rel,
+            }
+        }
+    )
+
+    evidence_ref, source_refs = _decoder_evidence_paths(repo_root=tmp_path, work_item=work_item)
+
+    assert evidence_ref == evidence_rel
+    assert source_refs == {
+        "decoder_attention_score32_exact_reduction_recost_out": evidence_rel,
+        "decoder_attention_score32_exact_reduction_recost_report": report_rel,
     }
 
 
@@ -7406,6 +7460,189 @@ def test_consume_l2_result_score32_exact_reduction_full_gqa8_rerank_uses_decoder
                 ]
                 == report_rel
             )
+
+
+def test_consume_l2_result_score32_exact_reduction_recost_r2_uses_canonical_v1_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            proposal_dir = (
+                repo_root
+                / "docs"
+                / "proposals"
+                / "prop_l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1"
+            )
+            _write(
+                proposal_dir / "proposal.json",
+                json.dumps(
+                    {
+                        "proposal_id": "prop_l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+                        "kind": "architecture",
+                        "title": "Score32 exact reduction schedule recost",
+                        "direct_comparison": {
+                            "primary_question": (
+                                "How does the score32 schedule-wrapper row change after replacing the obsolete reduction term?"
+                            )
+                        },
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            item_id = "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r2"
+            evidence_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_exact_reduction_recost__"
+                "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1.json"
+            )
+            report_rel = (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_exact_reduction_recost__"
+                "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1.md"
+            )
+            _write(
+                repo_root / evidence_rel,
+                json.dumps(
+                    {
+                        "version": 1,
+                        "model": "llm_decoder_attention_score32_exact_reduction_recost_v1",
+                        "decision": "score32_exact_reduction_schedule_recost_recorded",
+                        "diagnosis": {"decision": "score32_exact_reduction_schedule_recost_recorded"},
+                        "source_contract": {
+                            "cross_tile_reduction_cycles": 141,
+                            "replica_recost_latency_us": 12814.257853,
+                            "token_throughput_per_s": 78.038371946117,
+                        },
+                        "corrected_contract": {
+                            "cross_tile_reduction_cycles": 574,
+                            "replica_recost_latency_us": 13488.364723,
+                            "token_throughput_per_s": 74.137971543343,
+                        },
+                        "best_requested": {
+                            "cross_tile_reduction_cycles": 574,
+                            "replica_recost_layer_cycles": 8664,
+                            "replica_recost_total_cycles": 277248,
+                            "replica_recost_latency_us": 13488.364723,
+                            "adjusted_latency_us_if_feasible": 13488.364723,
+                            "token_throughput_per_s": 74.137971543343,
+                            "exact_reduction_replaces_legacy_component_breakdown": True,
+                        },
+                        "delta_vs_source": {
+                            "replica_recost_latency_us": 674.10687,
+                        },
+                        "remaining_abstractions": [
+                            "Exact reducer PPA remains unclosed; this recost changes schedule cycles only."
+                        ],
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            _write(repo_root / report_rel, "# score32 exact reduction recost\n")
+
+            task_request = TaskRequest(
+                request_key=f"l2_campaign:{item_id}",
+                source="test",
+                requested_by="@tester",
+                title=f"Layer2 {item_id}",
+                description="score32 exact reduction recost retry",
+                layer=LayerName.LAYER2,
+                flow=FlowName.OPENROAD,
+                priority=1,
+                request_payload={
+                    "item_id": item_id,
+                    "layer": "layer2",
+                    "flow": "openroad",
+                    "developer_loop": {
+                        "proposal_id": "prop_l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+                        "proposal_path": (
+                            "docs/proposals/"
+                            "prop_l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1/proposal.json"
+                        ),
+                        "evaluation": {
+                            "mode": "frontier_detail",
+                            "expected_direction": "record_score32_exact_reduction_recost",
+                            "expected_reason": "Retry canonical exact-reduction recost evidence after CLI bootstrap fix.",
+                        },
+                        "comparison": {"role": "score32_exact_reduction_recost"},
+                        "abstraction": {"layer": "decoder_attention_score32_exact_reduction_recost"},
+                    },
+                },
+                source_commit="deadbeef",
+            )
+            session.add(task_request)
+            session.flush()
+            work_item = WorkItem(
+                work_item_key=f"l2_campaign:{item_id}",
+                task_request_id=task_request.id,
+                item_id=item_id,
+                layer=LayerName.LAYER2,
+                flow=FlowName.OPENROAD,
+                platform="nangate45",
+                task_type="l2_campaign",
+                state=WorkItemState.ARTIFACT_SYNC,
+                priority=1,
+                source_mode="src_verilog",
+                input_manifest={
+                    "decoder_contract": {
+                        "attention_score32_exact_reduction_recost_out": evidence_rel,
+                        "attention_score32_exact_reduction_recost_report": report_rel,
+                    }
+                },
+                command_manifest=[],
+                expected_outputs=[evidence_rel, report_rel],
+                acceptance_rules=[],
+                source_commit="deadbeef",
+            )
+            session.add(work_item)
+            session.flush()
+            run = Run(
+                run_key=f"{item_id}_run_1",
+                work_item_id=work_item.id,
+                attempt=1,
+                executor_type=ExecutorType.INTERNAL_WORKER,
+                status=RunStatus.SUCCEEDED,
+                started_at=utcnow(),
+                completed_at=utcnow(),
+                checkout_commit="deadbeef",
+                result_summary="2/2 commands succeeded",
+                result_payload={"queue_result": {"status": "ok"}},
+            )
+            session.add(run)
+            session.commit()
+
+            result = consume_l2_result(
+                session,
+                Layer2ConsumeRequest(repo_root=str(repo_root), item_id=item_id),
+            )
+
+            assert result.recommended_arch_id == "decoder_attention_score32_exact_reduction_recost"
+            assert result.recommended_macro_mode == "evidence_only"
+            assert result.profile_count == 0
+            assert result.work_item_state == "artifact_sync"
+            decision_path = repo_root / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json"
+            decision = json.loads(decision_path.read_text(encoding="utf-8"))
+            assert decision["recommendation"]["source"] == "decoder_evidence"
+            assert decision["proposal_assessment"]["outcome"] == "score32_exact_reduction_schedule_recost_recorded"
+            assert decision["proposal_assessment"]["decoder_evidence_ref"] == evidence_rel
+            assert decision["source_refs"]["decoder_evidence_json"] == evidence_rel
+            assert decision["source_refs"]["decoder_attention_score32_exact_reduction_recost_out"] == evidence_rel
+            assert decision["source_refs"]["decoder_attention_score32_exact_reduction_recost_report"] == report_rel
+            assert "best_point_json" not in decision["source_refs"]
+
+            eligibility = assess_submission_eligibility(
+                session,
+                work_item=session.query(WorkItem).filter_by(item_id=item_id).one(),
+                run=session.query(Run).filter_by(run_key=f"{item_id}_run_1").one(),
+                repo_root=repo_root,
+            )
+            assert eligibility.eligible is True
+            assert eligibility.reason is None
 
 
 def test_consume_l2_result_attention_separated_cluster_equivalence_uses_decoder_evidence() -> None:


### PR DESCRIPTION
## Summary
- register the explicit exact-reduction recost output/report contract with the L2 evidence consumer
- prevent successful recost retries from falling through to the generic `/best_point.json` campaign path
- cover the r2 item with canonical v1 artifact names through decision-proposal creation and submission eligibility

## Validation
- 4 focused consumer/submission tests passed
- `scripts/validate_runs.py --skip_eval_queue`
- diff check passed

The remote r2 evaluation already succeeded. After this merges, its existing outputs can be reprocessed without rerunning the evaluation.