### PR TITLE
Use recovered exact-reduction recost in strict rerank

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank_llama7b_v1/evaluation_requests.json
@@ -11,7 +11,7 @@
       "comparison_role": "score32_exact_reduction_gqa8_full_equivalence_rerank",
       "paired_baseline_item_id": "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1",
       "depends_on_item_ids": [
-        "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+        "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r2",
         "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1",
         "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r7",
         "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1"

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank_llama7b_v1/proposal.json
@@ -32,7 +32,7 @@
       "comparison_role": "score32_exact_reduction_gqa8_full_equivalence_rerank",
       "paired_baseline_item_id": "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1",
       "depends_on_item_ids": [
-        "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+        "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r2",
         "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1",
         "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r7",
         "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1"


### PR DESCRIPTION
## Summary
- replace the failed inconclusive exact-reduction v1 DB dependency with finalized r2 in the strict full-GQA8 rerank proposal and request
- retain the canonical v1 artifact basename intentionally emitted by r2

## Validation
- both JSON documents parse
- `scripts/validate_runs.py --skip_eval_queue`
- diff check passed

After merge, the strict rerank can be generated with four merged/materialized prerequisites and pinned to the merge commit.