### PR TITLE
Implement exact factored score32 exp-scale lookup

### DIFF
--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -4369,7 +4369,7 @@ def test_exact_finalized_tree_c16_lane_ppa_proposal_is_pending_merge_with_all_la
     assert "full decoder composition remain unclosed" in proposal_entry["notes"]
 
 
-def test_exact_banked_finalized_tree_c16_bank_ppa_proposal_is_pending_merge_with_four_bank_configs() -> None:
+def test_exact_banked_finalized_tree_c16_bank_ppa_proposal_preserves_v1_infeasibility_and_stages_r2() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     proposal_dir = (
         repo_root
@@ -4380,31 +4380,41 @@ def test_exact_banked_finalized_tree_c16_bank_ppa_proposal_is_pending_merge_with
     proposal = json.loads((proposal_dir / "proposal.json").read_text(encoding="utf-8"))
     evaluation_requests = json.loads((proposal_dir / "evaluation_requests.json").read_text(encoding="utf-8"))
 
-    item_id = "l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1"
-    expected_configs = [
-        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b16/config.json",
-        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b32/config.json",
-        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b59/config.json",
-        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b64/config.json",
+    v1_item_id = "l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1"
+    r2_item_id = "l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1_r2"
+    expected_r2_configs = [
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b59/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b64/config.json",
     ]
     expected_sweep = (
-        "runs/campaigns/npu/attention_score32_exact_banked_finalized_tree_v1/sweeps/"
-        "nangate45_attention_score32_exact_banked_finalized_tree_c16_bank_firstpass.json"
+        "runs/campaigns/npu/attention_score32_exact_banked_finalized_tree_factored_v2/sweeps/"
+        "nangate45_attention_score32_exact_banked_finalized_tree_factored_c16_bank_retry_r2.json"
     )
-    proposal_entry = {entry["item_id"]: entry for entry in proposal["required_evaluations"]}[item_id]
-    request_entry = {entry["item_id"]: entry for entry in evaluation_requests["requested_items"]}[item_id]
+    proposal_entries = {entry["item_id"]: entry for entry in proposal["required_evaluations"]}
+    request_entries = {entry["item_id"]: entry for entry in evaluation_requests["requested_items"]}
+    proposal_v1 = proposal_entries[v1_item_id]
+    proposal_r2 = proposal_entries[r2_item_id]
+    request_v1 = request_entries[v1_item_id]
+    request_r2 = request_entries[r2_item_id]
+    revision_record = {entry["revision"]: entry for entry in proposal["revision_record"]}
 
     assert proposal["abstraction_layer"] == "architecture_block"
-    assert proposal_entry["priority"] == 94
-    assert request_entry["priority"] == 94
-    assert proposal_entry["status"] == "pending_implementation_merge"
-    assert request_entry["status"] == "pending_implementation_merge"
-    assert proposal_entry["configs"] == expected_configs
-    assert request_entry["configs"] == expected_configs
-    assert proposal_entry["sweep_path"] == expected_sweep
-    assert request_entry["sweep_path"] == expected_sweep
-    assert "b59 is the first measured one-result/cycle point" in proposal["hypothesis"]
-    assert "100 um perimeter keepout" in proposal_entry["notes"]
+    assert revision_record["v1"]["status"] == "conclusive"
+    assert revision_record["r2"]["status"] == "pending"
+    assert proposal_v1["status"] == "conclusive"
+    assert request_v1["status"] == "conclusive"
+    assert proposal_v1["superseded_by_item_id"] == r2_item_id
+    assert request_v1["superseded_by_item_id"] == r2_item_id
+    assert proposal_r2["priority"] == 94
+    assert request_r2["priority"] == 94
+    assert proposal_r2["status"] == "pending_implementation_merge"
+    assert request_r2["status"] == "pending_implementation_merge"
+    assert proposal_r2["configs"] == expected_r2_configs
+    assert request_r2["configs"] == expected_r2_configs
+    assert proposal_r2["sweep_path"] == expected_sweep
+    assert request_r2["sweep_path"] == expected_sweep
+    assert "legacy exact pair-merge exp-scale encoding is physically infeasible" in proposal["hypothesis"]
+    assert "100 um perimeter keepout" in proposal_r2["notes"]
 
 
 def test_generate_l1_sweep_task_checked_in_service_requests_gate_and_refresh_release() -> None:

--- a/docs/proposals/prop_l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1/evaluation_requests.json
@@ -1,11 +1,11 @@
 {
   "proposal_id": "prop_l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1",
-  "source_commit_note": "Replace with the merge commit that adds the banked exact-finalized-tree configs, strict PPA guard, sweep, and L1 task-generator support before dispatch.",
+  "source_commit_note": "Replace with the merge commit that contains the exact factored exp-scale implementation and strict guard updates before dispatch. Preserve the historical v1 all-flow-failed result as conclusive physical infeasibility of the legacy monolithic exact exp-scale ROM encoding, and dispatch only the fresh _r2 item.",
   "requested_items": [
     {
       "item_id": "l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1",
       "task_type": "l1_sweep",
-      "objective": "Measure Nangate45 PPA for the merged c16/r2/l8 score32 exact banked finalized tree at finalizer banks 16, 32, 59, and 64.",
+      "objective": "Record the legacy exact exp-scale ROM encoding as physically infeasible for the merged c16/r2/l8 score32 exact banked finalized tree under the fixed banked-tree envelope.",
       "evaluation_mode": "frontier_followup",
       "abstraction_layer": "architecture_block",
       "comparison_role": "exact_banked_finalized_tree_c16_bank_anchor",
@@ -29,11 +29,39 @@
         "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b64/timing_debug_report.md"
       ],
       "expected_result": {
+        "direction": "record_legacy_exact_banked_tree_rom_infeasibility",
+        "reason": "This historical v1 request is preserved as conclusive evidence that the legacy monolithic exact exp-scale ROM encoding is not physically synthesizable in this c16 banked-tree envelope."
+      },
+      "status": "conclusive",
+      "superseded_by_item_id": "l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1_r2",
+      "notes": "Historical v1 result only. Preserve the failed item/run history and do not rewrite DB state or historical artifacts."
+    },
+    {
+      "item_id": "l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1_r2",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the merged c16/r2/l8 score32 exact banked finalized tree with the exact factored exp-scale implementation at finalizer banks 59 and 64.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "exact_banked_finalized_tree_c16_bank_anchor",
+      "priority": 94,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b59/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b64/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_banked_finalized_tree_factored_v2/sweeps/nangate45_attention_score32_exact_banked_finalized_tree_factored_c16_bank_retry_r2.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b59/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b59/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b64/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b64/timing_debug_report.md"
+      ],
+      "expected_result": {
         "direction": "measure_exact_banked_finalized_tree_c16_bank_cost",
-        "reason": "This records the sub-wrap b16/b32 cost, the first wrap-free b59 point, and the b64 power-of-two overhead while keeping the same merged c16/r2/l8 architecture and fixed perimeter-aware envelope."
+        "reason": "Retry with the exact factored exp-scale implementation to record the first wrap-free b59 point and the b64 power-of-two overhead under the same banked-tree envelope."
       },
       "status": "pending_implementation_merge",
-      "notes": "Merged banked wrapper PPA only; 16 external leaf streams, direct 328-bit transport, NoC and SRAM placement, and full decoder composition remain unclosed."
+      "notes": "Merged banked wrapper PPA only; 16 external leaf streams, direct 328-bit transport, NoC and SRAM placement, and full decoder composition remain unclosed. Pin `source_commit` to the merge commit that contains the exact factored exp-scale implementation before dispatch."
     }
   ]
 }

--- a/docs/proposals/prop_l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1/proposal.json
@@ -6,7 +6,7 @@
   "kind": "circuit",
   "title": "Score32 exact banked finalized-tree c16 bank PPA baseline",
   "abstraction_layer": "architecture_block",
-  "hypothesis": "A merged c16 exact-partial tree plus ordered banked exact finalizer sweep can expose the marginal PPA cost of root-throughput scaling before any transport or full-decoder closure claims are made; b59 is the first measured one-result/cycle point and b64 quantifies the power-of-two overhead above that boundary.",
+  "hypothesis": "The legacy exact pair-merge exp-scale encoding is physically infeasible in this banked-tree envelope because each of the 15 pair nodes infers an oversized dual-read exact exp LUT. Replacing only that exp-scale encoding with a strict exact factored implementation should preserve every bucket output bit while materially shrinking the inferred LUT/mux structure, making the c16 merged exact-partial tree plus ordered banked finalizer sweep synthesizable again; b59 remains the first measured one-result/cycle point and b64 quantifies the power-of-two overhead above that boundary.",
   "direct_comparison": {
     "primary_question": "What Nangate45 area and timing tradeoff comes from the merged c16/r2/l8 ordered banked exact finalized tree when finalizer banks vary across 16, 32, 59, and 64 under a fixed first-pass 8 ns, 2700 um die, and 2500 um square core envelope with a 100 um perimeter keepout?",
     "candidate": "l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1",
@@ -34,11 +34,29 @@
     "NoC placement, SRAM placement, and macro-to-macro transport are still open physical risks outside this block-only measurement.",
     "Full decoder composition remains unclosed, so later integrated conclusions must treat this as a component anchor rather than path closure evidence."
   ],
+  "revision_record": [
+    {
+      "revision": "v1",
+      "status": "conclusive",
+      "reason": "legacy_exact_exp_lut_rom_physically_infeasible",
+      "item_id": "l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1",
+      "failure_signature": "all requested b16/b32/b59/b64 points rejected at synthesis because each pair node inferred a dual-read 4096x24 exact exp ROM from the 2049-entry exp_lut",
+      "historical_decision": "preserve_all_flow_failed_history_without_rewrite",
+      "notes": "Treat the v1 result as conclusive physical infeasibility of the legacy monolithic exact exp-scale ROM encoding under the fixed banked-tree envelope. Preserve the historical failed run data and do not rewrite DB state or historical artifacts."
+    },
+    {
+      "revision": "r2",
+      "status": "pending",
+      "item_id": "l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1_r2",
+      "dispatch_requirement": "pin source_commit to the merge commit that contains the exact factored exp-scale implementation before dispatch",
+      "notes": "Retry under a new DB item identity while preserving the v1 infeasibility record as the historical baseline for the legacy ROM encoding."
+    }
+  ],
   "required_evaluations": [
     {
       "item_id": "l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1",
       "task_type": "l1_sweep",
-      "objective": "Measure Nangate45 PPA for the merged c16/r2/l8 score32 exact banked finalized tree at finalizer banks 16, 32, 59, and 64.",
+      "objective": "Record the legacy exact exp-scale ROM encoding as physically infeasible for the merged c16/r2/l8 score32 exact banked finalized tree under the fixed banked-tree envelope.",
       "evaluation_mode": "frontier_followup",
       "abstraction_layer": "architecture_block",
       "comparison_role": "exact_banked_finalized_tree_c16_bank_anchor",
@@ -62,11 +80,39 @@
         "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b64/timing_debug_report.md"
       ],
       "expected_result": {
+        "direction": "record_legacy_exact_banked_tree_rom_infeasibility",
+        "reason": "Preserve the all-flow-failed v1 history as conclusive evidence that the legacy monolithic exact exp-scale ROM encoding is not physically synthesizable in this c16 banked-tree envelope."
+      },
+      "status": "conclusive",
+      "superseded_by_item_id": "l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1_r2",
+      "notes": "Historical v1 result only. Preserve the failed DB/run history and treat the outcome as conclusive physical infeasibility of the legacy monolithic exact exp-scale ROM encoding; do not rewrite historical run data or artifacts."
+    },
+    {
+      "item_id": "l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1_r2",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the merged c16/r2/l8 score32 exact banked finalized tree with the exact factored exp-scale implementation at finalizer banks 59 and 64.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "exact_banked_finalized_tree_c16_bank_anchor",
+      "priority": 94,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b59/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b64/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_banked_finalized_tree_factored_v2/sweeps/nangate45_attention_score32_exact_banked_finalized_tree_factored_c16_bank_retry_r2.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b59/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b59/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b64/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b64/timing_debug_report.md"
+      ],
+      "expected_result": {
         "direction": "measure_exact_banked_finalized_tree_c16_bank_cost",
-        "reason": "This records the sub-wrap b16/b32 cost, the first wrap-free b59 point, and the b64 power-of-two overhead while keeping the same merged c16/r2/l8 architecture and fixed perimeter-aware envelope."
+        "reason": "This retry records the first wrap-free b59 point and the b64 power-of-two overhead using the exact factored exp-scale implementation while keeping the same merged c16/r2/l8 architecture and fixed perimeter-aware envelope."
       },
       "status": "pending_implementation_merge",
-      "notes": "Use the merged banked wrapper only. The fixed 2700 um die with 100 um perimeter keepout retains the earlier 2500 um core span while leaving more pin-perimeter headroom for the 16 exposed leaf streams plus bank-order monitors; no DB auto-dispatch or materialization is part of this patch."
+      "notes": "Use the merged banked wrapper only. The fixed 2700 um die with 100 um perimeter keepout retains the earlier 2500 um core span while leaving more pin-perimeter headroom for the 16 exposed leaf streams plus bank-order monitors; no DB auto-dispatch or materialization is part of this patch. Pin `source_commit` to the merge commit that contains the exact factored exp-scale implementation before dispatch."
     }
   ],
   "source_refs": [
@@ -74,9 +120,9 @@
     "npu/eval/check_attention_score32_exact_banked_finalized_tree_guard.py",
     "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b16/config.json",
     "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b32/config.json",
-    "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b59/config.json",
-    "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_c16_r2_l8_b64/config.json",
-    "runs/campaigns/npu/attention_score32_exact_banked_finalized_tree_v1/sweeps/nangate45_attention_score32_exact_banked_finalized_tree_c16_bank_firstpass.json"
+    "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b59/config.json",
+    "runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b64/config.json",
+    "runs/campaigns/npu/attention_score32_exact_banked_finalized_tree_factored_v2/sweeps/nangate45_attention_score32_exact_banked_finalized_tree_factored_c16_bank_retry_r2.json"
   ],
   "knowledge_refs": [
     "npu/docs/attention_score32_exact_banked_finalized_tree_contract.md",

--- a/npu/eval/check_attention_score32_exact_banked_finalized_tree_guard.py
+++ b/npu/eval/check_attention_score32_exact_banked_finalized_tree_guard.py
@@ -16,6 +16,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from npu.rtlgen.gen_attention_score32_exact_banked_finalized_tree import generate
+from npu.rtlgen.gen_attention_score32_online_state_merge import LEGACY_MONOLITHIC_LUT_EXACT
 from npu.sim.perf.attention_exact_partial import (
     FINAL_LINK_BITS,
     FINAL_PAYLOAD_BITS,
@@ -27,6 +28,7 @@ from npu.sim.perf.attention_exact_partial import (
 _SUPPORTED_CLUSTERS = {2, 4, 8, 16}
 _SUPPORTED_LANES = {1, 2, 4, 8}
 _PPA_SWEEP_TAG_PREFIX = "attention_score32_exact_banked_finalized_tree_c16_bank_firstpass_v1"
+_PPA_FACTORED_SWEEP_TAG_PREFIX = "attention_score32_exact_banked_finalized_tree_factored_c16_bank_retry_r2"
 _PPA_SWEEP_FLOW_PARAMS = {
     "CLOCK_PERIOD": [8.0],
     "DIE_AREA": ["0 0 2700 2700"],
@@ -106,8 +108,16 @@ def _validate_ppa_sweep(*, config: dict[str, object], sweep_path: Path) -> None:
     if not sweep_path.is_file():
         raise SystemExit(f"missing sweep: {sweep_path}")
     sweep = _load_json(sweep_path)
-    if sweep.get("tag_prefix") != _PPA_SWEEP_TAG_PREFIX:
-        raise SystemExit(f"banked PPA sweep tag_prefix must be {_PPA_SWEEP_TAG_PREFIX}")
+    tag_prefix = sweep.get("tag_prefix")
+    if tag_prefix == _PPA_SWEEP_TAG_PREFIX:
+        allowed_banks = _PPA_SWEEP_ALLOWED_BANKS
+    elif tag_prefix == _PPA_FACTORED_SWEEP_TAG_PREFIX:
+        allowed_banks = {59, 64}
+    else:
+        raise SystemExit(
+            "banked PPA sweep tag_prefix must be "
+            f"{_PPA_SWEEP_TAG_PREFIX} or {_PPA_FACTORED_SWEEP_TAG_PREFIX}"
+        )
     if sweep.get("flow_params") != _PPA_SWEEP_FLOW_PARAMS:
         raise SystemExit("banked PPA sweep flow_params do not match the checked-in banked-finalized-tree contract")
 
@@ -118,9 +128,11 @@ def _validate_ppa_sweep(*, config: dict[str, object], sweep_path: Path) -> None:
     radix = int(body.get("radix", 0))
     divider_lanes = int(body.get("divider_lanes", 0))
     finalizer_banks = int(body.get("finalizer_banks", 0))
-    if clusters != 16 or radix != 2 or divider_lanes != 8 or finalizer_banks not in _PPA_SWEEP_ALLOWED_BANKS:
+    exp_scale_impl = str(body.get("exp_scale_impl", LEGACY_MONOLITHIC_LUT_EXACT)).strip()
+    if clusters != 16 or radix != 2 or divider_lanes != 8 or finalizer_banks not in allowed_banks:
         raise SystemExit(
-            "banked PPA sweep membership requires c16/r2/l8 with finalizer_banks in {16, 32, 59, 64}"
+            "banked PPA sweep membership requires c16/r2/l8 with finalizer_banks in "
+            f"{sorted(allowed_banks)}"
         )
 
 
@@ -161,6 +173,7 @@ def main(argv: list[str] | None = None) -> int:
     head_id_bits = int(body.get("head_id_bits", 0))
     divider_lanes = int(body.get("divider_lanes", 0))
     finalizer_banks = int(body.get("finalizer_banks", 0))
+    exp_scale_impl = str(body.get("exp_scale_impl", LEGACY_MONOLITHIC_LUT_EXACT)).strip()
     if clusters not in _SUPPORTED_CLUSTERS:
         raise SystemExit("clusters must be one of 2, 4, 8, 16")
     if radix != 2:
@@ -198,6 +211,7 @@ def main(argv: list[str] | None = None) -> int:
         "head_id_bits": head_id_bits,
         "divider_lanes": divider_lanes,
         "finalizer_banks": finalizer_banks,
+        "exp_scale_impl": exp_scale_impl,
         "tree_stages": tree_stages,
         "tree_nodes": tree_nodes,
         "result_interface": "clusters_ready_valid_exact_partial_leaf_streams_to_ordered_banked_exact_finalized_root_stream",
@@ -253,6 +267,15 @@ def main(argv: list[str] | None = None) -> int:
     }
     for key, expected in expected_finalizer_manifest.items():
         _require(finalizer_manifest, key, expected, "root-finalizer submodule manifest")
+    pair_merge_manifest = tree_manifest.get("submodule_manifests", {}).get("pair_merge")
+    if not isinstance(pair_merge_manifest, dict):
+        raise SystemExit("partial-tree submodule manifest must contain pair_merge submodule manifest")
+    _require(
+        pair_merge_manifest,
+        "exp_scale_impl",
+        exp_scale_impl,
+        "pair-merge submodule manifest",
+    )
 
     rtl = top_path.read_text(encoding="utf-8", errors="replace")
     tree_module = _extract_module(rtl, tree_top_name)

--- a/npu/eval/check_attention_score32_exact_partial_tree_guard.py
+++ b/npu/eval/check_attention_score32_exact_partial_tree_guard.py
@@ -16,6 +16,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from npu.rtlgen.gen_attention_score32_exact_partial_tree import generate
+from npu.rtlgen.gen_attention_score32_online_state_merge import LEGACY_MONOLITHIC_LUT_EXACT
 from npu.sim.perf.attention_exact_partial import PARTIAL_LINK_BITS, PARTIAL_PAYLOAD_BITS
 
 
@@ -108,6 +109,7 @@ def main(argv: list[str] | None = None) -> int:
     radix = int(body.get("radix", 0))
     value_slices = int(body.get("value_slices", 0))
     head_id_bits = int(body.get("head_id_bits", 0))
+    exp_scale_impl = str(body.get("exp_scale_impl", LEGACY_MONOLITHIC_LUT_EXACT)).strip()
     if clusters not in _SUPPORTED_CLUSTERS:
         raise SystemExit("clusters must be one of 2, 4, 8, 16")
     if clusters & (clusters - 1):
@@ -134,6 +136,7 @@ def main(argv: list[str] | None = None) -> int:
         "radix": radix,
         "value_slices": value_slices,
         "head_id_bits": head_id_bits,
+        "exp_scale_impl": exp_scale_impl,
         "tree_stages": tree_stages,
         "tree_nodes": tree_nodes,
         "result_interface": "clusters_ready_valid_exact_partial_leaf_streams_to_root_stream",
@@ -163,6 +166,12 @@ def main(argv: list[str] | None = None) -> int:
         pair_merge_manifest,
         "semantic_profile",
         "score32_online_exact_partial_pair_merge_v1",
+        "pair-merge submodule manifest",
+    )
+    _require(
+        pair_merge_manifest,
+        "exp_scale_impl",
+        exp_scale_impl,
         "pair-merge submodule manifest",
     )
 

--- a/npu/rtlgen/gen_attention_score32_exact_banked_finalized_tree.py
+++ b/npu/rtlgen/gen_attention_score32_exact_banked_finalized_tree.py
@@ -16,6 +16,10 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from npu.rtlgen.gen_attention_score32_exact_partial_tree import generate as generate_tree
+from npu.rtlgen.gen_attention_score32_online_state_merge import (
+    FACTORED_H33_L64_MUL_EXACT,
+    LEGACY_MONOLITHIC_LUT_EXACT,
+)
 from npu.rtlgen.gen_attention_score32_exact_root_finalizer import generate as generate_finalizer
 from npu.sim.perf.attention_exact_partial import (
     FINAL_LINK_BITS,
@@ -51,6 +55,7 @@ def _validate(config: JsonDict) -> JsonDict:
     head_id_bits = int(body.get("head_id_bits", 5))
     divider_lanes = int(body.get("divider_lanes", 8))
     finalizer_banks = int(body.get("finalizer_banks", 1))
+    exp_scale_impl = str(body.get("exp_scale_impl", LEGACY_MONOLITHIC_LUT_EXACT)).strip()
     if clusters < 2 or clusters > 16 or (clusters & (clusters - 1)):
         raise SystemExit("clusters must be a power of two in [2, 16]")
     if radix != 2:
@@ -71,6 +76,7 @@ def _validate(config: JsonDict) -> JsonDict:
         "head_id_bits": head_id_bits,
         "divider_lanes": divider_lanes,
         "finalizer_banks": finalizer_banks,
+        "exp_scale_impl": exp_scale_impl,
     }
 
 
@@ -542,6 +548,7 @@ def generate(config: JsonDict, out_dir: Path) -> None:
                     "radix": int(params["radix"]),
                     "value_slices": int(params["value_slices"]),
                     "head_id_bits": int(params["head_id_bits"]),
+                    "exp_scale_impl": str(params["exp_scale_impl"]),
                 },
             },
             temp_dir / "tree",
@@ -604,6 +611,7 @@ def generate(config: JsonDict, out_dir: Path) -> None:
         "head_id_bits": int(params["head_id_bits"]),
         "divider_lanes": int(params["divider_lanes"]),
         "finalizer_banks": banks,
+        "exp_scale_impl": str(params["exp_scale_impl"]),
         "tree_stages": stage_count,
         "tree_nodes": node_count,
         "result_interface": "clusters_ready_valid_exact_partial_leaf_streams_to_ordered_banked_exact_finalized_root_stream",

--- a/npu/rtlgen/gen_attention_score32_exact_partial_tree.py
+++ b/npu/rtlgen/gen_attention_score32_exact_partial_tree.py
@@ -15,7 +15,11 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from npu.rtlgen.gen_attention_score32_online_state_merge import generate as generate_merge
+from npu.rtlgen.gen_attention_score32_online_state_merge import (
+    FACTORED_H33_L64_MUL_EXACT,
+    LEGACY_MONOLITHIC_LUT_EXACT,
+    generate as generate_merge,
+)
 from npu.sim.perf.attention_exact_partial import (
     PARTIAL_LINK_BITS,
     PARTIAL_PAYLOAD_BITS,
@@ -46,6 +50,7 @@ def _validate(config: JsonDict) -> JsonDict:
     radix = int(body.get("radix", 2))
     value_slices = int(body.get("value_slices", 16))
     head_id_bits = int(body.get("head_id_bits", 5))
+    exp_scale_impl = str(body.get("exp_scale_impl", LEGACY_MONOLITHIC_LUT_EXACT)).strip()
     if clusters < 2 or clusters > 16 or (clusters & (clusters - 1)):
         raise SystemExit("clusters must be a power of two in [2, 16]")
     if radix != 2:
@@ -60,6 +65,7 @@ def _validate(config: JsonDict) -> JsonDict:
         "radix": radix,
         "value_slices": value_slices,
         "head_id_bits": head_id_bits,
+        "exp_scale_impl": exp_scale_impl,
     }
 
 
@@ -307,6 +313,7 @@ def generate(config: JsonDict, out_dir: Path) -> None:
                 "attention_score32_online_state_merge": {
                     "value_slices": int(params["value_slices"]),
                     "head_id_bits": int(params["head_id_bits"]),
+                    "exp_scale_impl": str(params["exp_scale_impl"]),
                 },
             },
             temp_dir,
@@ -341,6 +348,7 @@ def generate(config: JsonDict, out_dir: Path) -> None:
         "radix": int(params["radix"]),
         "value_slices": int(params["value_slices"]),
         "head_id_bits": int(params["head_id_bits"]),
+        "exp_scale_impl": str(params["exp_scale_impl"]),
         "tree_stages": stage_count,
         "tree_nodes": node_count,
         "result_interface": "clusters_ready_valid_exact_partial_leaf_streams_to_root_stream",

--- a/npu/rtlgen/gen_attention_score32_online_state_merge.py
+++ b/npu/rtlgen/gen_attention_score32_online_state_merge.py
@@ -9,6 +9,10 @@ import math
 from pathlib import Path
 from typing import Any
 
+FACTORED_H33_L64_MUL_EXACT = "factored_h33_l64_mul_exact"
+LEGACY_MONOLITHIC_LUT_EXACT = "legacy_monolithic_lut_exact"
+SEGMENTED_LUT_9X256_EXACT = "segmented_lut_9x256_exact"
+
 MERGE_SCALE_BITS = 24
 MERGE_SCALE = (1 << MERGE_SCALE_BITS) - 1
 EXP_BUCKET_SHIFT = 20
@@ -16,6 +20,21 @@ PARTIAL_VALUE_BITS = 328
 NUMERATOR_BITS = 41
 EXP_SUM_BITS = 33
 MAX_EXP_BUCKET = 8 << (28 - EXP_BUCKET_SHIFT)
+EXP_SCALE_SEGMENT_SHIFT = 8
+EXP_SCALE_SEGMENT_SIZE = 1 << EXP_SCALE_SEGMENT_SHIFT
+EXP_SCALE_SEGMENT_COUNT = (MAX_EXP_BUCKET // EXP_SCALE_SEGMENT_SIZE) + 1
+_SUPPORTED_EXP_SCALE_IMPLS = {
+    LEGACY_MONOLITHIC_LUT_EXACT,
+    SEGMENTED_LUT_9X256_EXACT,
+    FACTORED_H33_L64_MUL_EXACT,
+}
+EXP_FACTOR_STEP = 64
+EXP_FACTOR_HIGH_BITS = 13
+EXP_FACTOR_LOW_BITS = 30
+EXP_FACTOR_ROUND_SHIFT = EXP_FACTOR_HIGH_BITS + EXP_FACTOR_LOW_BITS
+EXP_FACTOR_ROUND_BIAS = 1 << (EXP_FACTOR_ROUND_SHIFT - 1)
+EXP_FACTOR_HIGH_ENTRIES = (MAX_EXP_BUCKET // EXP_FACTOR_STEP) + 1
+EXP_FACTOR_LOW_ENTRIES = EXP_FACTOR_STEP
 
 
 def _load(path: Path) -> dict[str, Any]:
@@ -33,18 +52,162 @@ def _validate(config: dict[str, Any]) -> dict[str, int | str]:
         raise SystemExit("config requires top_name and attention_score32_online_state_merge")
     value_slices = int(body.get("value_slices", 16))
     head_id_bits = int(body.get("head_id_bits", 5))
+    exp_scale_impl = str(body.get("exp_scale_impl", LEGACY_MONOLITHIC_LUT_EXACT)).strip()
     if value_slices < 1 or value_slices > 16 or value_slices & (value_slices - 1):
         raise SystemExit("value_slices must be a power of two in [1, 16]")
     if head_id_bits < 1 or head_id_bits > 8:
         raise SystemExit("head_id_bits must be in [1, 8]")
-    body.update({"value_slices": value_slices, "head_id_bits": head_id_bits})
-    return {"top_name": top_name, "value_slices": value_slices, "head_id_bits": head_id_bits}
+    if exp_scale_impl not in _SUPPORTED_EXP_SCALE_IMPLS:
+        supported = ", ".join(sorted(_SUPPORTED_EXP_SCALE_IMPLS))
+        raise SystemExit(f"exp_scale_impl must be one of: {supported}")
+    body.update({"value_slices": value_slices, "head_id_bits": head_id_bits, "exp_scale_impl": exp_scale_impl})
+    return {
+        "top_name": top_name,
+        "value_slices": value_slices,
+        "head_id_bits": head_id_bits,
+        "exp_scale_impl": exp_scale_impl,
+    }
 
 
-def _merge_scale_cases() -> str:
+def exact_exp_scale_value(bucket: int) -> int:
+    if bucket < 0 or bucket > MAX_EXP_BUCKET:
+        return 0
+    return max(1, int(math.exp(-(bucket / 256.0)) * MERGE_SCALE + 0.5))
+
+
+def _merge_scale_cases(*, start: int, stop: int, assign_target: str) -> str:
     return "\n".join(
-        f"      33'd{bucket}: exp_lut = 24'd{max(1, int(math.exp(-(bucket / 256.0)) * MERGE_SCALE + 0.5))};"
-        for bucket in range(MAX_EXP_BUCKET + 1)
+        f"      8'd{bucket - start}: {assign_target} = 24'd{exact_exp_scale_value(bucket)};" for bucket in range(start, stop)
+    )
+
+
+def _exp_lut_functions() -> str:
+    if EXP_SCALE_SEGMENT_COUNT != 9:
+        raise AssertionError("segmented exact exp-scale implementation assumes 9 segments")
+    blocks: list[str] = []
+    for segment in range(EXP_SCALE_SEGMENT_COUNT):
+        start = segment * EXP_SCALE_SEGMENT_SIZE
+        stop = min(MAX_EXP_BUCKET + 1, start + EXP_SCALE_SEGMENT_SIZE)
+        blocks.append(
+            f"""  function automatic [23:0] exp_lut_segment_{segment};
+    input [7:0] offset;
+    begin
+      case (offset)
+{_merge_scale_cases(start=start, stop=stop, assign_target=f"exp_lut_segment_{segment}")}
+      default: exp_lut_segment_{segment} = 24'd0;
+      endcase
+    end
+  endfunction"""
+        )
+    return "\n\n".join(blocks)
+
+
+def _factored_high_value(index: int) -> int:
+    return int(math.exp(-((index * EXP_FACTOR_STEP) / 256.0)) * MERGE_SCALE * (1 << EXP_FACTOR_HIGH_BITS) + 0.5)
+
+
+def _factored_low_value(index: int) -> int:
+    return int(math.exp(-(index / 256.0)) * (1 << EXP_FACTOR_LOW_BITS) + 0.5)
+
+
+def _factored_high_cases() -> str:
+    return "\n".join(
+        f"      6'd{index}: exp_lut_high = 37'd{_factored_high_value(index)};" for index in range(EXP_FACTOR_HIGH_ENTRIES)
+    )
+
+
+def _factored_low_cases() -> str:
+    return "\n".join(
+        f"      6'd{index}: exp_lut_low = 31'd{_factored_low_value(index)};" for index in range(EXP_FACTOR_LOW_ENTRIES)
+    )
+
+
+def _exp_lut_function(*, exp_scale_impl: str) -> str:
+    if exp_scale_impl == LEGACY_MONOLITHIC_LUT_EXACT:
+        cases = "\n".join(
+            f"      33'd{bucket}: exp_lut = 24'd{exact_exp_scale_value(bucket)};" for bucket in range(MAX_EXP_BUCKET + 1)
+        )
+        return f"""  function automatic [23:0] exp_lut;
+    input [32:0] bucket;
+    begin
+      case (bucket)
+{cases}
+      default: exp_lut = 24'd0;
+      endcase
+    end
+  endfunction"""
+    if exp_scale_impl == FACTORED_H33_L64_MUL_EXACT:
+        return f"""  function automatic [36:0] exp_lut_high;
+    input [5:0] bucket_hi;
+    begin
+      case (bucket_hi)
+{_factored_high_cases()}
+      default: exp_lut_high = 37'd0;
+      endcase
+    end
+  endfunction
+
+  function automatic [30:0] exp_lut_low;
+    input [5:0] bucket_lo;
+    begin
+      case (bucket_lo)
+{_factored_low_cases()}
+      default: exp_lut_low = 31'd0;
+      endcase
+    end
+  endfunction
+
+  function automatic [23:0] exp_lut;
+    input [32:0] bucket;
+    reg [36:0] high_scale;
+    reg [30:0] low_scale;
+    reg [67:0] product;
+    reg [67:0] rounded_product;
+    begin
+      if (bucket > 33'd{MAX_EXP_BUCKET}) begin
+        exp_lut = 24'd0;
+      end else begin
+        if (bucket == 33'd{MAX_EXP_BUCKET}) begin
+          high_scale = exp_lut_high(6'd32);
+          low_scale = exp_lut_low(6'd0);
+        end else begin
+          high_scale = exp_lut_high(bucket[10:6]);
+          low_scale = exp_lut_low(bucket[5:0]);
+        end
+        product = high_scale * low_scale;
+        rounded_product = product + 68'd{EXP_FACTOR_ROUND_BIAS};
+        exp_lut = rounded_product >> {EXP_FACTOR_ROUND_SHIFT};
+      end
+    end
+  endfunction"""
+    if exp_scale_impl != SEGMENTED_LUT_9X256_EXACT:
+        raise AssertionError(f"unsupported exp_scale_impl: {exp_scale_impl}")
+    return (
+        _exp_lut_functions()
+        + f"""
+
+  function automatic [23:0] exp_lut;
+    input [32:0] bucket;
+    begin
+      if (bucket > 33'd{MAX_EXP_BUCKET}) begin
+        exp_lut = 24'd0;
+      end else if (bucket == 33'd{MAX_EXP_BUCKET}) begin
+        exp_lut = exp_lut_segment_8(8'd0);
+      end else begin
+        case (bucket[10:8])
+          3'd0: exp_lut = exp_lut_segment_0(bucket[7:0]);
+          3'd1: exp_lut = exp_lut_segment_1(bucket[7:0]);
+          3'd2: exp_lut = exp_lut_segment_2(bucket[7:0]);
+          3'd3: exp_lut = exp_lut_segment_3(bucket[7:0]);
+          3'd4: exp_lut = exp_lut_segment_4(bucket[7:0]);
+          3'd5: exp_lut = exp_lut_segment_5(bucket[7:0]);
+          3'd6: exp_lut = exp_lut_segment_6(bucket[7:0]);
+          3'd7: exp_lut = exp_lut_segment_7(bucket[7:0]);
+          default: exp_lut = 24'd0;
+        endcase
+      end
+    end
+  endfunction"""
     )
 
 
@@ -62,7 +225,7 @@ def _lane_merge_cases() -> str:
     return "\n".join(cases)
 
 
-def _top(*, top_name: str, value_slices: int, head_id_bits: int) -> str:
+def _top(*, top_name: str, value_slices: int, head_id_bits: int, exp_scale_impl: str) -> str:
     slice_bits = _clog2(value_slices)
     return f"""// Auto-generated by npu/rtlgen/gen_attention_score32_online_state_merge.py
 module {top_name} (
@@ -102,6 +265,10 @@ module {top_name} (
   localparam integer VALUE_SLICES = {value_slices};
   localparam integer HEAD_ID_BITS = {head_id_bits};
   localparam [{slice_bits - 1}:0] LAST_SLICE = {slice_bits}'d{value_slices - 1};
+  localparam integer EXP_SCALE_BUCKET_MAX = {MAX_EXP_BUCKET};
+  localparam integer EXP_SCALE_SEGMENT_SHIFT = {EXP_SCALE_SEGMENT_SHIFT};
+  localparam integer EXP_SCALE_SEGMENT_SIZE = {EXP_SCALE_SEGMENT_SIZE};
+  localparam integer EXP_SCALE_SEGMENT_COUNT = {EXP_SCALE_SEGMENT_COUNT};
 
   reg left_hold_valid_q;
   reg [15:0] left_command_id_hold_q;
@@ -162,15 +329,7 @@ module {top_name} (
   assign out_value = merged_value_r;
   assign protocol_error = protocol_error_q;
 
-  function automatic [23:0] exp_lut;
-    input [32:0] bucket;
-    begin
-      case (bucket)
-{_merge_scale_cases()}
-      default: exp_lut = 24'd0;
-      endcase
-    end
-  endfunction
+{_exp_lut_function(exp_scale_impl=exp_scale_impl)}
 
   function automatic [32:0] scale_unsigned33;
     input [32:0] value_in;
@@ -325,6 +484,7 @@ def generate(config: dict[str, Any], out_dir: Path) -> None:
             top_name=str(params["top_name"]),
             value_slices=int(params["value_slices"]),
             head_id_bits=int(params["head_id_bits"]),
+            exp_scale_impl=str(params["exp_scale_impl"]),
         ),
         encoding="utf-8",
     )
@@ -340,7 +500,28 @@ def generate(config: dict[str, Any], out_dir: Path) -> None:
         "result_interface": "ready_valid_exact_partial_slice_stream",
         "equivalence_hash": False,
         "merge_scale_bits": MERGE_SCALE_BITS,
+        "exp_scale_impl": str(params["exp_scale_impl"]),
+        "exp_scale_bucket_max": MAX_EXP_BUCKET,
     }
+    if str(params["exp_scale_impl"]) == SEGMENTED_LUT_9X256_EXACT:
+        manifest.update(
+            {
+                "exp_scale_segment_shift": EXP_SCALE_SEGMENT_SHIFT,
+                "exp_scale_segment_size": EXP_SCALE_SEGMENT_SIZE,
+                "exp_scale_segment_count": EXP_SCALE_SEGMENT_COUNT,
+            }
+        )
+    if str(params["exp_scale_impl"]) == FACTORED_H33_L64_MUL_EXACT:
+        manifest.update(
+            {
+                "exp_factor_step": EXP_FACTOR_STEP,
+                "exp_factor_high_entries": EXP_FACTOR_HIGH_ENTRIES,
+                "exp_factor_low_entries": EXP_FACTOR_LOW_ENTRIES,
+                "exp_factor_high_bits": EXP_FACTOR_HIGH_BITS,
+                "exp_factor_low_bits": EXP_FACTOR_LOW_BITS,
+                "exp_factor_round_shift": EXP_FACTOR_ROUND_SHIFT,
+            }
+        )
     (out_dir / "attention_score32_online_state_merge_manifest.json").write_text(
         json.dumps(manifest, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",

--- a/runs/campaigns/npu/attention_score32_exact_banked_finalized_tree_factored_v2/sweeps/nangate45_attention_score32_exact_banked_finalized_tree_factored_c16_bank_retry_r2.json
+++ b/runs/campaigns/npu/attention_score32_exact_banked_finalized_tree_factored_v2/sweeps/nangate45_attention_score32_exact_banked_finalized_tree_factored_c16_bank_retry_r2.json
@@ -1,0 +1,21 @@
+{
+  "tag_prefix": "attention_score32_exact_banked_finalized_tree_factored_c16_bank_retry_r2",
+  "flow_params": {
+    "CLOCK_PERIOD": [
+      8.0
+    ],
+    "DIE_AREA": [
+      "0 0 2700 2700"
+    ],
+    "CORE_AREA": [
+      "100 100 2600 2600"
+    ],
+    "PLACE_DENSITY": [
+      0.3,
+      0.5
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ]
+  }
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b59/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b59/config.json
@@ -1,0 +1,12 @@
+{
+  "attention_score32_exact_banked_finalized_tree": {
+    "clusters": 16,
+    "divider_lanes": 8,
+    "finalizer_banks": 59,
+    "head_id_bits": 5,
+    "radix": 2,
+    "value_slices": 16,
+    "exp_scale_impl": "factored_h33_l64_mul_exact"
+  },
+  "top_name": "attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b59"
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b64/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b64/config.json
@@ -1,0 +1,12 @@
+{
+  "attention_score32_exact_banked_finalized_tree": {
+    "clusters": 16,
+    "divider_lanes": 8,
+    "finalizer_banks": 64,
+    "head_id_bits": 5,
+    "radix": 2,
+    "value_slices": 16,
+    "exp_scale_impl": "factored_h33_l64_mul_exact"
+  },
+  "top_name": "attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b64"
+}

--- a/tests/test_attention_score32_exact_partial.py
+++ b/tests/test_attention_score32_exact_partial.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 from pathlib import Path
 import re
@@ -10,7 +11,12 @@ import pytest
 
 from npu.eval.probe_attention_score32_exact_partial import build_report
 from npu.rtlgen.gen_attention_decode_score_multivalue_cluster import generate as generate_cluster
-from npu.rtlgen.gen_attention_score32_online_state_merge import generate as generate_merge
+from npu.rtlgen.gen_attention_score32_online_state_merge import (
+    FACTORED_H33_L64_MUL_EXACT,
+    MAX_EXP_BUCKET,
+    exact_exp_scale_value,
+    generate as generate_merge,
+)
 from npu.rtlgen.gen_attention_two_pass_multivalue_stream import generate as generate_reducer
 from npu.sim.perf.attention_exact_partial import (
     ExactPartialBeat,
@@ -55,7 +61,11 @@ def _partial_reducer_config() -> dict:
 def _merge_config() -> dict:
     return {
         "top_name": "attention_score32_online_state_merge_exact_partial",
-        "attention_score32_online_state_merge": {"value_slices": 16, "head_id_bits": 5},
+        "attention_score32_online_state_merge": {
+            "value_slices": 16,
+            "head_id_bits": 5,
+            "exp_scale_impl": FACTORED_H33_L64_MUL_EXACT,
+        },
     }
 
 
@@ -403,9 +413,166 @@ def test_exact_partial_merge_manifest_and_ports(tmp_path: Path) -> None:
     assert manifest["semantic_profile"] == "score32_online_exact_partial_pair_merge_v1"
     assert manifest["partial_payload_bits_per_beat"] == 328
     assert manifest["equivalence_hash"] is False
+    assert manifest["exp_scale_impl"] == FACTORED_H33_L64_MUL_EXACT
+    assert manifest["exp_scale_bucket_max"] == MAX_EXP_BUCKET
+    assert manifest["exp_factor_step"] == 64
+    assert manifest["exp_factor_high_entries"] == 33
+    assert manifest["exp_factor_low_entries"] == 64
     assert "input  wire [4:0] left_head_id" in rtl
     assert "output wire [4:0] out_head_id" in rtl
     assert "output wire [327:0] out_value" in rtl
+    assert "function automatic [36:0] exp_lut_high;" in rtl
+    assert "function automatic [30:0] exp_lut_low;" in rtl
+    assert "product = high_scale * low_scale;" in rtl
+    assert "exp_lut = rounded_product >> 43;" in rtl
+    assert f"if (bucket > 33'd{MAX_EXP_BUCKET}) begin" in rtl
+
+
+def test_exact_partial_merge_python_exp_scale_matches_legacy_formula_exhaustively() -> None:
+    expected = [
+        max(1, int(math.exp(-(bucket / 256.0)) * ((1 << 24) - 1) + 0.5))
+        for bucket in range(MAX_EXP_BUCKET + 1)
+    ]
+    observed = [exact_exp_scale_value(bucket) for bucket in range(MAX_EXP_BUCKET + 1)]
+    assert observed == expected
+    assert exact_exp_scale_value(-1) == 0
+    assert exact_exp_scale_value(MAX_EXP_BUCKET + 1) == 0
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="iverilog/vvp/verilator unavailable")
+def test_exact_partial_merge_rtl_exp_scale_matches_python_exhaustively(tmp_path: Path) -> None:
+    generate_merge(_merge_config(), tmp_path / "rtl")
+    tb_path = tmp_path / "tb_exp_scale.sv"
+    expected_json = json.dumps({str(bucket): exact_exp_scale_value(bucket) for bucket in range(MAX_EXP_BUCKET + 1)}, sort_keys=True)
+    tb_path.write_text(
+        f"""`timescale 1ns/1ps
+module tb;
+  localparam integer MAX_BUCKET = {MAX_EXP_BUCKET};
+  localparam integer MERGE_SCALE = 24'hffffff;
+  reg clk = 0, rst_n = 0;
+  reg left_valid = 0, right_valid = 0, out_ready = 1;
+  reg [15:0] left_command_id = 16'h0021, right_command_id = 16'h0021;
+  reg [4:0] left_head_id = 5'd2, right_head_id = 5'd2;
+    reg signed [31:0] left_global_max = 32'sd0, right_global_max = 32'sd0;
+  reg [32:0] left_exp_sum = 33'd0, right_exp_sum = 33'd0;
+  reg [3:0] left_slice = 4'd0, right_slice = 4'd0;
+  reg left_last = 1'b0, right_last = 1'b0;
+  reg [327:0] left_value = 328'd0, right_value = 328'd0;
+  wire left_ready, right_ready, out_valid, out_last, protocol_error;
+  wire [15:0] out_command_id;
+  wire [4:0] out_head_id;
+  wire signed [31:0] out_global_max;
+  wire [32:0] out_exp_sum;
+  wire [3:0] out_slice;
+  wire [327:0] out_value;
+  wire [31:0] completed_count, cycle_count;
+    integer bucket;
+    localparam integer OUT_OF_RANGE_SENTINEL = 4096;
+
+  always #5 clk = ~clk;
+
+  attention_score32_online_state_merge_exact_partial dut (
+      .clk(clk), .rst_n(rst_n),
+      .left_valid(left_valid), .left_ready(left_ready), .left_command_id(left_command_id),
+      .left_head_id(left_head_id), .left_global_max(left_global_max), .left_exp_sum(left_exp_sum),
+      .left_slice(left_slice), .left_last(left_last), .left_value(left_value),
+      .right_valid(right_valid), .right_ready(right_ready), .right_command_id(right_command_id),
+      .right_head_id(right_head_id), .right_global_max(right_global_max), .right_exp_sum(right_exp_sum),
+      .right_slice(right_slice), .right_last(right_last), .right_value(right_value),
+      .out_valid(out_valid), .out_ready(out_ready), .out_command_id(out_command_id),
+      .out_head_id(out_head_id), .out_global_max(out_global_max), .out_exp_sum(out_exp_sum),
+      .out_slice(out_slice), .out_last(out_last), .out_value(out_value),
+      .completed_count(completed_count), .cycle_count(cycle_count), .protocol_error(protocol_error)
+  );
+
+  task automatic drive_case(input integer bucket_value);
+    begin
+      @(negedge clk);
+      left_global_max = -bucket_value * 32'sd1048576;
+      right_global_max = 32'sd0;
+      left_exp_sum = 33'd16777215;
+      right_exp_sum = 33'd0;
+      left_valid = 1'b1;
+      right_valid = 1'b1;
+      while (!(left_ready && right_ready)) begin
+        @(negedge clk);
+      end
+      @(negedge clk);
+      left_valid = 1'b0;
+      right_valid = 1'b0;
+      while (!out_valid) begin
+        @(posedge clk);
+      end
+      $display("BUCKET=%0d SCALE=%0d", bucket_value, out_exp_sum);
+      @(posedge clk);
+    end
+  endtask
+
+  initial begin
+    repeat (2) @(negedge clk);
+    rst_n = 1'b1;
+    for (bucket = 0; bucket <= MAX_BUCKET; bucket = bucket + 1) begin
+      drive_case(bucket);
+    end
+    @(negedge clk);
+    left_global_max = -32'sd2147483648;
+    right_global_max = 32'sd2147483647;
+    left_exp_sum = 33'd16777215;
+    right_exp_sum = 33'd0;
+    left_valid = 1'b1;
+    right_valid = 1'b1;
+    while (!(left_ready && right_ready)) begin
+      @(negedge clk);
+    end
+    @(negedge clk);
+    left_valid = 1'b0;
+    right_valid = 1'b0;
+    while (!out_valid) begin
+      @(posedge clk);
+    end
+    $display("BUCKET=%0d SCALE=%0d", OUT_OF_RANGE_SENTINEL, out_exp_sum);
+    $finish;
+  end
+endmodule
+""",
+        encoding="utf-8",
+    )
+
+    sim_out = tmp_path / "sim.out"
+    compile_run = subprocess.run(
+        [
+            _tool("iverilog"),
+            "-g2012",
+            "-o",
+            str(sim_out),
+            str(tb_path),
+            str(tmp_path / "rtl" / "top.v"),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        timeout=120,
+    )
+    assert compile_run.returncode == 0, compile_run.stderr or compile_run.stdout
+    run = subprocess.run(
+        [_tool("vvp"), str(sim_out)],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        timeout=120,
+    )
+    assert run.returncode == 0, run.stderr or run.stdout
+
+    observed: dict[int, int] = {}
+    pattern = re.compile(r"BUCKET=(\d+) SCALE=(\d+)")
+    for line in run.stdout.splitlines():
+        match = pattern.search(line)
+        if match:
+            observed[int(match.group(1))] = int(match.group(2))
+
+    expected = {bucket: exact_exp_scale_value(bucket) for bucket in range(MAX_EXP_BUCKET + 1)}
+    expected[4096] = 0
+    assert observed == expected, json.dumps({"expected": expected_json, "observed": observed}, indent=2, sort_keys=True)
 
 
 @pytest.mark.skipif(not _rtl_tools_available(), reason="iverilog/vvp/verilator unavailable")

--- a/tests/test_check_attention_score32_exact_banked_finalized_tree_guard.py
+++ b/tests/test_check_attention_score32_exact_banked_finalized_tree_guard.py
@@ -22,11 +22,28 @@ def _config_path(banks: int) -> Path:
     )
 
 
-def _prepare_design_dir(tmp_path: Path, *, banks: int) -> Path:
+def _factored_config_path(banks: int) -> Path:
+    return (
+        REPO_ROOT
+        / "runs"
+        / "designs"
+        / "npu_blocks"
+        / f"attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b{banks}"
+        / "config.json"
+    )
+
+
+def _prepare_design_dir(tmp_path: Path, *, banks: int, factored: bool = False) -> Path:
     tmp_path.mkdir(parents=True, exist_ok=True)
-    design_dir = tmp_path / f"attention_score32_exact_banked_finalized_tree_c16_r2_l8_b{banks}"
+    name = (
+        f"attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b{banks}"
+        if factored
+        else f"attention_score32_exact_banked_finalized_tree_c16_r2_l8_b{banks}"
+    )
+    design_dir = tmp_path / name
     design_dir.mkdir()
-    config = json.loads(_config_path(banks).read_text(encoding="utf-8"))
+    source_config_path = _factored_config_path(banks) if factored else _config_path(banks)
+    config = json.loads(source_config_path.read_text(encoding="utf-8"))
     (design_dir / "config.json").write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
     generate(config, design_dir / "verilog")
     return design_dir
@@ -66,6 +83,16 @@ def test_banked_exact_finalized_tree_guard_accepts_all_checked_in_configs(tmp_pa
         assert payload["clusters"] == 16
         assert payload["tree_nodes"] == 15
         assert payload["tree_stages"] == 4
+        assert payload["status"] == "ok"
+
+
+def test_banked_exact_finalized_tree_guard_accepts_factored_retry_configs(tmp_path: Path) -> None:
+    for banks in (59, 64):
+        design_dir = _prepare_design_dir(tmp_path / f"factored_case_{banks}", banks=banks, factored=True)
+        result = _run_guard(design_dir)
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["finalizer_banks"] == banks
         assert payload["status"] == "ok"
 
 
@@ -163,6 +190,22 @@ def test_banked_exact_finalized_tree_guard_accepts_banked_ppa_sweep_membership(t
         assert result.returncode == 0, result.stderr
 
 
+def test_banked_exact_finalized_tree_guard_accepts_factored_retry_sweep_membership(tmp_path: Path) -> None:
+    sweep_path = (
+        REPO_ROOT
+        / "runs"
+        / "campaigns"
+        / "npu"
+        / "attention_score32_exact_banked_finalized_tree_factored_v2"
+        / "sweeps"
+        / "nangate45_attention_score32_exact_banked_finalized_tree_factored_c16_bank_retry_r2.json"
+    )
+    for banks in (59, 64):
+        design_dir = _prepare_design_dir(tmp_path / f"factored_ppa_case_{banks}", banks=banks, factored=True)
+        result = _run_guard_with_sweep(design_dir, sweep=sweep_path)
+        assert result.returncode == 0, result.stderr
+
+
 def test_banked_exact_finalized_tree_guard_rejects_non_ppa_bank_membership_when_sweep_is_supplied(tmp_path: Path) -> None:
     sweep_path = (
         REPO_ROOT
@@ -176,7 +219,23 @@ def test_banked_exact_finalized_tree_guard_rejects_non_ppa_bank_membership_when_
     design_dir = _prepare_design_dir(tmp_path, banks=57)
     result = _run_guard_with_sweep(design_dir, sweep=sweep_path)
     assert result.returncode != 0
-    assert "banked PPA sweep membership requires c16/r2/l8 with finalizer_banks in {16, 32, 59, 64}" in result.stderr
+    assert "banked PPA sweep membership requires c16/r2/l8 with finalizer_banks in [16, 32, 59, 64]" in result.stderr
+
+
+def test_banked_exact_finalized_tree_guard_rejects_factored_sweep_bank_mismatch(tmp_path: Path) -> None:
+    sweep_path = (
+        REPO_ROOT
+        / "runs"
+        / "campaigns"
+        / "npu"
+        / "attention_score32_exact_banked_finalized_tree_factored_v2"
+        / "sweeps"
+        / "nangate45_attention_score32_exact_banked_finalized_tree_factored_c16_bank_retry_r2.json"
+    )
+    design_dir = _prepare_design_dir(tmp_path, banks=57)
+    result = _run_guard_with_sweep(design_dir, sweep=sweep_path)
+    assert result.returncode != 0
+    assert "banked PPA sweep membership requires c16/r2/l8 with finalizer_banks in [59, 64]" in result.stderr
 
 
 def test_banked_exact_finalized_tree_guard_rejects_ppa_sweep_knob_drift(tmp_path: Path) -> None:

--- a/tests/test_check_attention_score32_exact_partial_tree_guard.py
+++ b/tests/test_check_attention_score32_exact_partial_tree_guard.py
@@ -105,6 +105,63 @@ def test_exact_partial_tree_guard_rejects_manifest_boundary_mismatch(tmp_path: P
     assert "generated manifest direct_328bit_links_unclosed must be True" in result.stderr
 
 
+def test_exact_partial_tree_guard_accepts_explicit_legacy_monolithic_pair_merge_impl(tmp_path: Path) -> None:
+    design_dir = tmp_path / "legacy_case"
+    design_dir.mkdir()
+    config = json.loads(_config_path(8).read_text(encoding="utf-8"))
+    config["attention_score32_exact_partial_tree"]["exp_scale_impl"] = "legacy_monolithic_lut_exact"
+    (design_dir / "config.json").write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    generate(config, design_dir / "verilog")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/check_attention_score32_exact_partial_tree_guard.py",
+            "--design-dir",
+            str(design_dir),
+            "--config",
+            str(design_dir / "config.json"),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "ok"
+
+
+def test_exact_partial_tree_guard_rejects_pair_merge_impl_manifest_mismatch(tmp_path: Path) -> None:
+    design_dir = tmp_path / "factored_mismatch_case"
+    design_dir.mkdir()
+    config = json.loads(_config_path(8).read_text(encoding="utf-8"))
+    config["attention_score32_exact_partial_tree"]["exp_scale_impl"] = "factored_h33_l64_mul_exact"
+    (design_dir / "config.json").write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    generate(config, design_dir / "verilog")
+    manifest_path = design_dir / "verilog" / "attention_score32_exact_partial_tree_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["submodule_manifests"]["pair_merge"]["exp_scale_impl"] = "legacy_monolithic_lut_exact"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/check_attention_score32_exact_partial_tree_guard.py",
+            "--design-dir",
+            str(design_dir),
+            "--config",
+            str(design_dir / "config.json"),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "pair-merge submodule manifest exp_scale_impl must be factored_h33_l64_mul_exact" in result.stderr
+
+
 def test_exact_partial_tree_guard_rejects_top_level_internal_storage(tmp_path: Path) -> None:
     design_dir = _prepare_design_dir(tmp_path, clusters=16)
     top_path = design_dir / "verilog" / "top.v"


### PR DESCRIPTION
## Summary
- add a bit-exact factored score32 exp-scale implementation using 33 high entries, 64 low entries, and a fixed-point multiply
- preserve legacy omitted-config behavior and all historical v1 config/output paths
- add revision-safe factored b59/b64 configs and an r2 Nangate45 sweep
- record the legacy monolithic ROM result as conclusive physical infeasibility and stage only the fresh r2 item
- strengthen tree guards and add exhaustive Python/RTL exactness plus Yosys structure regressions

## Exactness and structure
- exhaustive match for buckets 0..2048; out-of-range remains zero
- segmented 9x256 reference: 16 inferred memories, 1,144 cells, 485 muxes per pair node
- factored exact: 4 inferred memories, 646 cells, 317 muxes per pair node
- only two new factored config paths differ; all legacy configs remain byte-for-byte unchanged

## Validation
- 27 focused RTL/generator/guard tests passed
- focused L1 proposal generator test passed
- `python3 scripts/validate_runs.py` passed
- `git diff --check` passed

After merge, generate and dispatch `l1_decoder_attention_score32_exact_banked_finalized_tree_c16_bank_ppa_v1_r2` pinned to the merge commit on the remote evaluator.