### PR TITLE
Fix finalizer bank-control CLI bootstrap

### DIFF
--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -2222,7 +2222,7 @@ def _copy_checked_in_attention_score32_exact_finalizer_bank_control_repo(
         sweep_path,
         "prop_l1_decoder_attention_score32_exact_finalizer_bank_control_ppa_v1",
         proposal_dir,
-        "l1_decoder_attention_score32_exact_finalizer_bank_control_ppa_v1",
+        "l1_decoder_attention_score32_exact_finalizer_bank_control_ppa_v1_r2",
     )
 
 
@@ -4491,7 +4491,7 @@ def test_exact_banked_finalized_tree_c16_bank_ppa_proposal_preserves_v1_infeasib
     assert "prop_l1_decoder_attention_score32_exact_finalizer_bank_control_ppa_v1" in revision_record["r3"]["notes"]
 
 
-def test_exact_finalizer_bank_control_ppa_proposal_is_pending_merge_with_all_bank_configs() -> None:
+def test_exact_finalizer_bank_control_ppa_proposal_revisions_preserve_v1_bootstrap_failure_and_stage_r2() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     proposal_dir = (
         repo_root
@@ -4502,7 +4502,8 @@ def test_exact_finalizer_bank_control_ppa_proposal_is_pending_merge_with_all_ban
     proposal = json.loads((proposal_dir / "proposal.json").read_text(encoding="utf-8"))
     evaluation_requests = json.loads((proposal_dir / "evaluation_requests.json").read_text(encoding="utf-8"))
 
-    item_id = "l1_decoder_attention_score32_exact_finalizer_bank_control_ppa_v1"
+    v1_item_id = "l1_decoder_attention_score32_exact_finalizer_bank_control_ppa_v1"
+    r2_item_id = "l1_decoder_attention_score32_exact_finalizer_bank_control_ppa_v1_r2"
     expected_configs = [
         "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b1/config.json",
         "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b4/config.json",
@@ -4515,17 +4516,31 @@ def test_exact_finalizer_bank_control_ppa_proposal_is_pending_merge_with_all_ban
         "runs/campaigns/npu/attention_score32_exact_finalizer_bank_control_v1/sweeps/"
         "nangate45_attention_score32_exact_finalizer_bank_control_lane8_firstpass.json"
     )
-    proposal_entry = {entry["item_id"]: entry for entry in proposal["required_evaluations"]}[item_id]
-    request_entry = {entry["item_id"]: entry for entry in evaluation_requests["requested_items"]}[item_id]
+    proposal_entries = {entry["item_id"]: entry for entry in proposal["required_evaluations"]}
+    request_entries = {entry["item_id"]: entry for entry in evaluation_requests["requested_items"]}
+    revision_record = {entry["revision"]: entry for entry in proposal["revision_record"]}
+    proposal_v1 = proposal_entries[v1_item_id]
+    request_v1 = request_entries[v1_item_id]
+    proposal_r2 = proposal_entries[r2_item_id]
+    request_r2 = request_entries[r2_item_id]
 
     assert proposal["abstraction_layer"] == "architecture_block"
-    assert proposal_entry["status"] == "pending_implementation_merge"
-    assert request_entry["status"] == "pending_implementation_merge"
-    assert proposal_entry["configs"] == expected_configs
-    assert request_entry["configs"] == expected_configs
-    assert proposal_entry["sweep_path"] == expected_sweep
-    assert request_entry["sweep_path"] == expected_sweep
-    assert "one 0.30 density first pass" in proposal_entry["notes"]
+    assert revision_record["v1"]["status"] == "conclusive"
+    assert revision_record["v1"]["reason"] == "cli_import_bootstrap_failure_before_generation"
+    assert revision_record["r2"]["status"] == "pending"
+    assert proposal["direct_comparison"]["candidate"] == r2_item_id
+    assert proposal_v1["status"] == "conclusive"
+    assert request_v1["status"] == "conclusive"
+    assert proposal_v1["superseded_by_item_id"] == r2_item_id
+    assert request_v1["superseded_by_item_id"] == r2_item_id
+    assert "ModuleNotFoundError" in proposal_v1["notes"]
+    assert proposal_r2["status"] == "pending_implementation_merge"
+    assert request_r2["status"] == "pending_implementation_merge"
+    assert proposal_r2["configs"] == expected_configs
+    assert request_r2["configs"] == expected_configs
+    assert proposal_r2["sweep_path"] == expected_sweep
+    assert request_r2["sweep_path"] == expected_sweep
+    assert "One-density first pass only." in proposal_r2["notes"]
 
 
 def test_generate_l1_sweep_task_checked_in_service_requests_gate_and_refresh_release() -> None:

--- a/docs/proposals/prop_l1_decoder_attention_score32_exact_finalizer_bank_control_ppa_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_exact_finalizer_bank_control_ppa_v1/evaluation_requests.json
@@ -1,9 +1,49 @@
 {
   "proposal_id": "prop_l1_decoder_attention_score32_exact_finalizer_bank_control_ppa_v1",
-  "source_commit_note": "Replace with the merge commit that adds the standalone exact finalizer-bank control RTL, probe, guard, sweep, and proposal before dispatch.",
+  "source_commit_note": "Replace with the merge commit that adds the standalone exact finalizer-bank control RTL, probe, guard, sweep, proposal revision history, and direct-script bootstrap fix before dispatch.",
   "requested_items": [
     {
       "item_id": "l1_decoder_attention_score32_exact_finalizer_bank_control_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Record the original standalone exact ordered finalizer-bank control dispatch as a generate-stage CLI bootstrap failure with no physical evidence.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "exact_finalizer_bank_control_anchor",
+      "priority": 95,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b1/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b4/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b16/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b32/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b59/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_finalizer_bank_control_v1/sweeps/nangate45_attention_score32_exact_finalizer_bank_control_lane8_firstpass.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b1/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b1/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b4/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b4/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b16/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b16/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b32/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b32/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b59/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b59/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "record_generate_stage_bootstrap_failure_only",
+        "reason": "Preserve the historical v1 item identity as a pure CLI bootstrap miss. It does not establish any physical feasibility or infeasibility because generation stopped before synthesis."
+      },
+      "status": "conclusive",
+      "superseded_by_item_id": "l1_decoder_attention_score32_exact_finalizer_bank_control_ppa_v1_r2",
+      "notes": "Historical v1 record only. The direct generator failed from repo root with ModuleNotFoundError before any output artifacts or physical runs were produced. Preserve the history and do not treat it as measurement evidence."
+    },
+    {
+      "item_id": "l1_decoder_attention_score32_exact_finalizer_bank_control_ppa_v1_r2",
       "task_type": "l1_sweep",
       "objective": "Measure Nangate45 PPA for standalone exact ordered finalizer-bank control at representative lane-8 bank counts, excluding the wide payload fanout and root payload mux.",
       "evaluation_mode": "frontier_followup",

--- a/docs/proposals/prop_l1_decoder_attention_score32_exact_finalizer_bank_control_ppa_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_exact_finalizer_bank_control_ppa_v1/proposal.json
@@ -9,7 +9,7 @@
   "hypothesis": "The flat c16+b59 wrapper couples tree, dispatch, ordering, and arithmetic into a single resource-heavy netlist. Extracting the ordered bank-dispatch control as a standalone concrete RTL block should reveal the true control-only area and timing scaling across representative bank counts, while explicitly excluding the wide payload fanout and root payload mux so later hierarchical composition can combine this control anchor with measured lane-8 finalizer macro PPA and the checked-in exact service model.",
   "direct_comparison": {
     "primary_question": "What Nangate45 area and timing boundary is exposed by standalone exact ordered finalizer-bank control at b1, b4, b8, b16, b32, and b59 for lane-8 service under a bounded one-density first pass?",
-    "candidate": "l1_decoder_attention_score32_exact_finalizer_bank_control_ppa_v1",
+    "candidate": "l1_decoder_attention_score32_exact_finalizer_bank_control_ppa_v1_r2",
     "include": [
       "actual attention_score32_exact_finalizer_bank_control RTL generation",
       "strict config, manifest, regeneration, compact transaction-tag control-only probe/equivalence, and PPA-sweep guard before synthesis",
@@ -37,11 +37,69 @@
     "The upstream partial tree is excluded, so later composed conclusions must add measured tree cost rather than treat this as a whole finalized-root macro.",
     "No NoC or SRAM placement closure claim is made here."
   ],
+  "revision_record": [
+    {
+      "revision": "v1",
+      "status": "conclusive",
+      "reason": "cli_import_bootstrap_failure_before_generation",
+      "item_id": "l1_decoder_attention_score32_exact_finalizer_bank_control_ppa_v1",
+      "failure_signature": "generate step failed from repo root with ModuleNotFoundError: No module named 'npu' before any physical run launched",
+      "historical_decision": "preserve_failed_history_without_physical_claims",
+      "notes": "Treat v1 only as a direct CLI bootstrap packaging failure in the generator entrypoint. It produced no generated RTL acceptance and no physical evidence, so downstream conclusions must not treat it as a measured datapoint."
+    },
+    {
+      "revision": "r2",
+      "status": "pending",
+      "item_id": "l1_decoder_attention_score32_exact_finalizer_bank_control_ppa_v1_r2",
+      "dispatch_requirement": "pin source_commit to the merge commit that contains the direct-script bootstrap fix before dispatch",
+      "notes": "Stage a fresh item ID at the same lane-8 bank-control configs and first-pass sweep after the CLI bootstrap fix merges. Preserve the failed v1 history, but do not reuse it as physical evidence because generation never completed."
+    }
+  ],
   "required_evaluations": [
     {
       "item_id": "l1_decoder_attention_score32_exact_finalizer_bank_control_ppa_v1",
       "task_type": "l1_sweep",
-      "objective": "Measure Nangate45 PPA for standalone exact ordered finalizer-bank control at representative lane-8 bank counts.",
+      "objective": "Record the original standalone exact ordered finalizer-bank control dispatch as a generate-stage CLI bootstrap failure with no physical evidence.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "exact_finalizer_bank_control_anchor",
+      "priority": 95,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b1/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b4/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b16/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b32/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b59/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_finalizer_bank_control_v1/sweeps/nangate45_attention_score32_exact_finalizer_bank_control_lane8_firstpass.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b1/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b1/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b4/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b4/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b16/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b16/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b32/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b32/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b59/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_finalizer_bank_control_l8_b59/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "record_generate_stage_bootstrap_failure_only",
+        "reason": "Preserve the historical v1 item identity as a pure CLI bootstrap miss. It does not establish any physical feasibility or infeasibility because generation stopped before synthesis."
+      },
+      "status": "conclusive",
+      "superseded_by_item_id": "l1_decoder_attention_score32_exact_finalizer_bank_control_ppa_v1_r2",
+      "notes": "Historical v1 record only. The direct generator failed from repo root with ModuleNotFoundError before any output artifacts or physical runs were produced. Preserve the history and do not treat it as measurement evidence."
+    },
+    {
+      "item_id": "l1_decoder_attention_score32_exact_finalizer_bank_control_ppa_v1_r2",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for standalone exact ordered finalizer-bank control at representative lane-8 bank counts, excluding the wide payload fanout and root payload mux.",
       "evaluation_mode": "frontier_followup",
       "abstraction_layer": "architecture_block",
       "comparison_role": "exact_finalizer_bank_control_anchor",
@@ -72,10 +130,10 @@
       ],
       "expected_result": {
         "direction": "measure_exact_finalizer_bank_control_cost",
-        "reason": "This isolates the dispatch/order control contribution, excluding the wide payload fanout and root payload mux, so it can later be composed with measured finalizer arithmetic and exact service-model throughput at non-wrap-free and wrap-free bank counts."
+        "reason": "This exposes the control-only scaling contribution, excluding the wide bank payload fanout and root payload mux, for later composition with measured finalizer arithmetic and the existing exact service model."
       },
       "status": "pending_implementation_merge",
-      "notes": "Bound the job count with one 0.30 density first pass because the controller is a scaling study, not a closure search. Representative bank counts include low-throughput reuse points and the first wrap-free b59 point. Wide bank payload wiring and root payload muxing are intentionally deferred to hierarchical composition."
+      "notes": "One-density first pass only. Tree logic, finalizer arithmetic, wide bank payload fanout, and wide root payload mux remain separate measured components for later hierarchical composition."
     }
   ],
   "source_refs": [

--- a/npu/rtlgen/gen_attention_score32_exact_finalizer_bank_control.py
+++ b/npu/rtlgen/gen_attention_score32_exact_finalizer_bank_control.py
@@ -7,7 +7,12 @@ import argparse
 import json
 import math
 from pathlib import Path
+import sys
 from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from npu.sim.perf.attention_exact_partial import (
     FINALIZER_CONTROL_TRANSACTION_ID_BITS,

--- a/tests/test_attention_score32_exact_finalizer_bank_control.py
+++ b/tests/test_attention_score32_exact_finalizer_bank_control.py
@@ -106,6 +106,48 @@ def test_finalizer_bank_control_rejects_invalid_bank_counts(tmp_path: Path) -> N
             generate(_config(banks), tmp_path / f"rtl_{banks}")
 
 
+def test_finalizer_bank_control_cli_runs_from_repo_root_with_checked_in_b1_config(tmp_path: Path) -> None:
+    config_path = (
+        REPO_ROOT
+        / "runs"
+        / "designs"
+        / "npu_blocks"
+        / "attention_score32_exact_finalizer_bank_control_l8_b1"
+        / "config.json"
+    )
+    out_dir = tmp_path / "rtl"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "npu/rtlgen/gen_attention_score32_exact_finalizer_bank_control.py",
+            "--config",
+            str(config_path.relative_to(REPO_ROOT)),
+            "--out",
+            str(out_dir),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert result.returncode == 0, result.stderr
+
+    top_path = out_dir / "top.v"
+    manifest_path = out_dir / "attention_score32_exact_finalizer_bank_control_manifest.json"
+    config_copy_path = out_dir / "config.json"
+    assert top_path.exists()
+    assert manifest_path.exists()
+    assert config_copy_path.exists()
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    copied_config = json.loads(config_copy_path.read_text(encoding="utf-8"))
+    assert manifest["top_name"] == "attention_score32_exact_finalizer_bank_control_l8_b1"
+    assert manifest["finalizer_banks"] == 1
+    assert copied_config["top_name"] == "attention_score32_exact_finalizer_bank_control_l8_b1"
+    assert copied_config["attention_score32_exact_finalizer_bank_control"]["finalizer_banks"] == 1
+
+
 @pytest.mark.skipif(not _rtl_tools_available(), reason="RTL tools unavailable")
 @pytest.mark.parametrize("finalizer_banks", [1, 4, 8, 16, 32, 59])
 def test_finalizer_bank_control_probe_matches_service_model(finalizer_banks: int) -> None:


### PR DESCRIPTION
## Summary
- make the bank-control RTL generator executable directly from repo root by bootstrapping the repository import path
- add a subprocess regression using the checked-in b1 config
- preserve the failed v1 DB item as a generate-stage packaging failure with no physical claim
- stage fresh `l1_decoder_attention_score32_exact_finalizer_bank_control_ppa_v1_r2` proposal/request identities

## Validation
- `16 passed` across generator CLI, RTL/service probe, and guard tests
- `2 passed, 71 deselected` focused control-plane proposal/task-generator tests
- `python3 scripts/validate_runs.py --skip_eval_queue`

The observed v1 failure was `ModuleNotFoundError: No module named 'npu'` before RTL generation or synthesis.