### PR TITLE
Optimize folded exact pair merge with Mersenne quotient

### DIFF
--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -2000,6 +2000,65 @@ def _write_example_attention_score32_exact_partial_pair_merge_folded_repo(
     return str(config_path.relative_to(repo_root)), str(sweep_path.relative_to(repo_root))
 
 
+def _write_example_attention_score32_exact_partial_pair_merge_folded_mersenne_repo(
+    repo_root: Path,
+) -> tuple[str, str]:
+    design_dir = (
+        repo_root
+        / "runs"
+        / "designs"
+        / "npu_blocks"
+        / "attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1"
+    )
+    design_dir.mkdir(parents=True, exist_ok=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1",
+                "attention_score32_exact_partial_pair_merge_folded": {
+                    "value_slices": 16,
+                    "head_id_bits": 5,
+                    "exp_scale_impl": "factored_h33_l64_mul_exact",
+                    "scale_divider_impl": "mersenne24_correction2_exact",
+                    "lane_parallelism": 1,
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    sweep_path = (
+        repo_root
+        / "runs"
+        / "campaigns"
+        / "npu"
+        / "attention_score32_exact_partial_pair_merge_sharedscale_mersenne_v1"
+        / "sweeps"
+        / "nangate45_attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1.json"
+    )
+    sweep_path.parent.mkdir(parents=True, exist_ok=True)
+    sweep_path.write_text(
+        json.dumps(
+            {
+                "tag_prefix": "attention_score32_exact_partial_pair_merge_sharedscale_mersenne_v1",
+                "flow_params": {
+                    "CLOCK_PERIOD": [8.0],
+                    "DIE_AREA": ["0 0 1500 1500"],
+                    "CORE_AREA": ["50 50 1450 1450"],
+                    "PLACE_DENSITY": [0.3],
+                    "SYNTH_HIERARCHICAL": [1],
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return str(config_path.relative_to(repo_root)), str(sweep_path.relative_to(repo_root))
+
+
 def _write_example_attention_score32_exact_finalized_tree_repo(repo_root: Path) -> tuple[str, str]:
     design_dir = repo_root / "runs" / "designs" / "npu_blocks" / "attention_score32_exact_finalized_tree_smoke_c16_r2_l4"
     design_dir.mkdir(parents=True, exist_ok=True)
@@ -3828,6 +3887,66 @@ def test_generate_l1_sweep_task_supports_attention_score32_exact_partial_pair_me
             ]
 
 
+def test_generate_l1_sweep_task_supports_attention_score32_exact_partial_pair_merge_folded_mersenne_configs() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_attention_score32_exact_partial_pair_merge_folded_mersenne_repo(
+            repo_root
+        )
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/npu_blocks",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="architecture_block",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert work_item.command_manifest[0]["run"] == (
+                "export PATH=/oss-cad-suite/bin:$PATH && "
+                "python3 npu/rtlgen/gen_attention_score32_exact_partial_pair_merge_folded.py "
+                "--config "
+                "runs/designs/npu_blocks/attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1/config.json "
+                "--out "
+                "runs/designs/npu_blocks/attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1/verilog"
+            )
+            assert (
+                "--sweep runs/campaigns/npu/attention_score32_exact_partial_pair_merge_sharedscale_mersenne_v1/sweeps/"
+                "nangate45_attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1.json"
+                in work_item.command_manifest[1]["run"]
+            )
+            assert "--top attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1" in (
+                work_item.command_manifest[2]["run"]
+            )
+            assert work_item.expected_outputs == [
+                "runs/designs/npu_blocks/attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1/metrics.csv",
+                "runs/designs/npu_blocks/attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1/"
+                "timing_debug_report.md",
+            ]
+
+
+def _normalize_requested_item(item: dict[str, object]) -> dict[str, object]:
+    ignored = {
+        "status",
+        "notes",
+        "merged_pr_number",
+        "merge_commit",
+        "merged_utc",
+    }
+    return {key: value for key, value in item.items() if key not in ignored}
+
+
 def test_exact_partial_pair_merge_sharedscale_proposal_and_evaluation_requests_match() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     proposal_dir = (
@@ -3840,10 +3959,33 @@ def test_exact_partial_pair_merge_sharedscale_proposal_and_evaluation_requests_m
     evaluation_requests = json.loads((proposal_dir / "evaluation_requests.json").read_text(encoding="utf-8"))
 
     assert evaluation_requests["proposal_id"] == proposal["proposal_id"]
-    assert evaluation_requests["requested_items"] == proposal["required_evaluations"]
+    assert [_normalize_requested_item(item) for item in evaluation_requests["requested_items"]] == [
+        _normalize_requested_item(item) for item in proposal["required_evaluations"]
+    ]
     assert evaluation_requests["requested_items"][0]["priority"] == 95
     assert evaluation_requests["requested_items"][0]["comparison_role"] == (
         "exact_partial_pair_merge_sharedscale_anchor"
+    )
+
+
+def test_exact_partial_pair_merge_sharedscale_mersenne_proposal_and_evaluation_requests_match() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    proposal_dir = (
+        repo_root
+        / "docs"
+        / "proposals"
+        / "prop_l1_decoder_attention_score32_exact_partial_pair_merge_sharedscale_mersenne_ppa_v1"
+    )
+    proposal = json.loads((proposal_dir / "proposal.json").read_text(encoding="utf-8"))
+    evaluation_requests = json.loads((proposal_dir / "evaluation_requests.json").read_text(encoding="utf-8"))
+
+    assert evaluation_requests["proposal_id"] == proposal["proposal_id"]
+    assert [_normalize_requested_item(item) for item in evaluation_requests["requested_items"]] == [
+        _normalize_requested_item(item) for item in proposal["required_evaluations"]
+    ]
+    assert evaluation_requests["requested_items"][0]["priority"] == 96
+    assert evaluation_requests["requested_items"][0]["comparison_role"] == (
+        "exact_partial_pair_merge_sharedscale_mersenne_vs_generic"
     )
 
 

--- a/docs/proposals/prop_l1_decoder_attention_score32_exact_partial_pair_merge_sharedscale_mersenne_ppa_v1/README.md
+++ b/docs/proposals/prop_l1_decoder_attention_score32_exact_partial_pair_merge_sharedscale_mersenne_ppa_v1/README.md
@@ -1,0 +1,4 @@
+# Score32 Exact Partial Pair Merge Explicit-Mersenne Divider PPA
+
+This proposal compares the measured folded exact pair-merge anchor against a
+revision-safe explicit implementation of division by `2^24 - 1`.

--- a/docs/proposals/prop_l1_decoder_attention_score32_exact_partial_pair_merge_sharedscale_mersenne_ppa_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_exact_partial_pair_merge_sharedscale_mersenne_ppa_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l1_decoder_attention_score32_exact_partial_pair_merge_sharedscale_mersenne_ppa_v1",
-  "source_commit": "REPLACE_WITH_MERGE_COMMIT",
+  "source_commit": "",
   "source_commit_note": "Replace with the merge commit that adds the explicit Mersenne-divider folded exact-partial pair-merge RTL, strict structural guard, checked-in config and sweep, and task-generator coverage before dispatch.",
   "requested_items": [
     {

--- a/docs/proposals/prop_l1_decoder_attention_score32_exact_partial_pair_merge_sharedscale_mersenne_ppa_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_exact_partial_pair_merge_sharedscale_mersenne_ppa_v1/evaluation_requests.json
@@ -1,0 +1,31 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_score32_exact_partial_pair_merge_sharedscale_mersenne_ppa_v1",
+  "source_commit": "REPLACE_WITH_MERGE_COMMIT",
+  "source_commit_note": "Replace with the merge commit that adds the explicit Mersenne-divider folded exact-partial pair-merge RTL, strict structural guard, checked-in config and sweep, and task-generator coverage before dispatch.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_score32_exact_partial_pair_merge_sharedscale_mersenne_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the standalone factored-exact shared-scale score32 partial pair merge using the explicit Mersenne divider implementation.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "exact_partial_pair_merge_sharedscale_mersenne_vs_generic",
+      "priority": 96,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_partial_pair_merge_sharedscale_mersenne_v1/sweeps/nangate45_attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "compare_explicit_mersenne_divider_against_generic_anchor",
+        "reason": "This isolates the divider implementation as the next exact-pair frontier and measures whether the explicit quotient removes the dominant generic-division timing cost."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "Standalone one-pair comparison only. Ready for remote evaluation after merge and source-commit substitution."
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_score32_exact_partial_pair_merge_sharedscale_mersenne_ppa_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_exact_partial_pair_merge_sharedscale_mersenne_ppa_v1/proposal.json
@@ -1,0 +1,77 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_score32_exact_partial_pair_merge_sharedscale_mersenne_ppa_v1",
+  "created_utc": "2026-08-01T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "title": "Score32 exact partial pair merge explicit-Mersenne divider PPA comparison",
+  "abstraction_layer": "architecture_block",
+  "hypothesis": "Replacing the folded pair merge's generic `/ (2^24 - 1)` divider with an explicit exact Mersenne-identity quotient should preserve bit-exact behavior and reduce the dominant timing pressure seen in the generic folded anchor, while keeping the same folded launch interval and latency contract.",
+  "direct_comparison": {
+    "primary_question": "How much timing and area movement does the explicit exact Mersenne-divider implementation produce relative to the measured generic-divider folded pair-merge anchor?",
+    "candidate": "l1_decoder_attention_score32_exact_partial_pair_merge_sharedscale_mersenne_ppa_v1",
+    "include": [
+      "dedicated folded exact-partial pair-merge RTL with explicit Mersenne quotient implementation",
+      "strict config, manifest, regeneration, and structural guard that forbids generic division in the Mersenne variant",
+      "boundary-vector arithmetic tests, deterministic random quotient regression, direct RTL helper checks, and full merge RTL/software equivalence",
+      "one standalone hierarchical OpenROAD sweep at 8 ns for direct comparison against the generic folded anchor"
+    ],
+    "exclude": [
+      "no partial tree or multi-node reduction claim",
+      "no root finalizer or bank-control composition claim",
+      "no direct-link, NoC, SRAM, or decoder-wrapper closure claim"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "die_area",
+      "total_power_mw",
+      "stdcell_count",
+      "timing_debug_report"
+    ]
+  },
+  "remaining_abstractions": [
+    "This item measures only the standalone folded exact pair merge under the explicit Mersenne divider implementation.",
+    "Tree composition is still open even if this divider variant improves the primitive timing boundary.",
+    "Finalizer arithmetic and bank control remain separate measured components.",
+    "NoC, SRAM, and HBM service remain outside this Layer 1 block."
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_score32_exact_partial_pair_merge_sharedscale_mersenne_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the standalone factored-exact shared-scale score32 partial pair merge using the explicit Mersenne divider implementation.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "exact_partial_pair_merge_sharedscale_mersenne_vs_generic",
+      "priority": 96,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_partial_pair_merge_sharedscale_mersenne_v1/sweeps/nangate45_attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "compare_explicit_mersenne_divider_against_generic_anchor",
+        "reason": "This isolates the divider implementation as the next exact-pair frontier and measures whether the explicit quotient removes the dominant generic-division timing cost."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "Standalone one-pair comparison only. The item is prepared for remote evaluation after merge but is intentionally not dispatched from this branch."
+    }
+  ],
+  "source_refs": [
+    "npu/rtlgen/gen_attention_score32_exact_partial_pair_merge_folded.py",
+    "npu/eval/check_attention_score32_exact_partial_pair_merge_guard.py",
+    "npu/eval/probe_attention_score32_exact_partial_pair_merge_folded.py",
+    "control_plane/control_plane/services/l1_task_generator.py",
+    "docs/proposals/prop_l1_decoder_attention_score32_exact_partial_pair_merge_sharedscale_mersenne_ppa_v1/evaluation_requests.json",
+    "npu/docs/attention_score32_exact_partial_pair_merge_contract.md",
+    "runs/designs/npu_blocks/attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1/config.json",
+    "runs/campaigns/npu/attention_score32_exact_partial_pair_merge_sharedscale_mersenne_v1/sweeps/nangate45_attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1.json"
+  ],
+  "knowledge_refs": [
+    "npu/docs/attention_score32_exact_partial_pair_merge_contract.md"
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_score32_exact_partial_pair_merge_sharedscale_mersenne_ppa_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_decoder_attention_score32_exact_partial_pair_merge_sharedscale_mersenne_ppa_v1/quality_gate.md
@@ -1,0 +1,7 @@
+# Quality Gate
+
+- microarchitecture profile must remain `score32_online_exact_partial_pair_merge_folded_sharedscale_v1`
+- numerical semantics must remain `score32_online_exact_partial_pair_merge_v1`
+- the folded schedule and service latency contract must remain unchanged
+- `scale_divider_impl = mersenne24_correction2_exact` must forbid raw generic `/ 16777215` division in generated RTL
+- the explicit divider must preserve exact signed and unsigned saturation behavior

--- a/npu/docs/attention_score32_exact_partial_pair_merge_contract.md
+++ b/npu/docs/attention_score32_exact_partial_pair_merge_contract.md
@@ -9,6 +9,11 @@ Contracted implementation points:
 
 - one shared signed `41x24` scale path is invoked per cycle
 - one separately shared unsigned `33x24` scale path handles exp-sum scaling
+- divider selection is explicit through `scale_divider_impl`
+- `generic_exact` preserves the original `/ (2^24 - 1)` implementation
+- `mersenne24_correction2_exact` replaces that divider with the exact
+  Mersenne-identity quotient using `0/1/2` correction and must not change
+  numerical behavior
 - pair capture to the first output handshake opportunity is `20` cycles
 - compute launch to the first output handshake opportunity is `19` cycles
 - compute-launch interval without output backpressure is `20` cycles

--- a/npu/eval/check_attention_score32_exact_partial_pair_merge_guard.py
+++ b/npu/eval/check_attention_score32_exact_partial_pair_merge_guard.py
@@ -16,13 +16,14 @@ if str(REPO_ROOT) not in sys.path:
 
 from npu.rtlgen.gen_attention_score32_exact_partial_pair_merge_folded import (
     FACTORED_H33_L64_MUL_EXACT,
+    GENERIC_SCALE_DIVIDER_EXACT,
+    MERSENNE24_CORRECTION2_SCALE_DIVIDER_EXACT,
     PAIR_CAPTURE_TO_OUTPUT_LATENCY_CYCLES,
     PAIR_COMPUTE_LAUNCH_INTERVAL_CYCLES,
     PAIR_COMPUTE_LAUNCH_TO_OUTPUT_LATENCY_CYCLES,
     generate,
 )
 
-_PPA_SWEEP_TAG_PREFIX = "attention_score32_exact_partial_pair_merge_sharedscale_v1"
 _PPA_SWEEP_FLOW_PARAMS = {
     "CLOCK_PERIOD": [8.0],
     "DIE_AREA": ["0 0 1500 1500"],
@@ -32,6 +33,10 @@ _PPA_SWEEP_FLOW_PARAMS = {
     "PLACE_DENSITY": [0.3],
     "PLACE_PINS_ARGS": ["-min_distance 1"],
     "SYNTH_HIERARCHICAL": [1],
+}
+_PPA_SWEEP_TAG_PREFIX_BY_DIVIDER_IMPL = {
+    GENERIC_SCALE_DIVIDER_EXACT: "attention_score32_exact_partial_pair_merge_sharedscale_v1",
+    MERSENNE24_CORRECTION2_SCALE_DIVIDER_EXACT: "attention_score32_exact_partial_pair_merge_sharedscale_mersenne_v1",
 }
 
 
@@ -59,10 +64,11 @@ def _compare_current_generation(*, config: dict[str, object], rtl_dir: Path) -> 
                 raise SystemExit(f"generated pair-merge artifacts do not match current generator output: {relative_name}")
 
 
-def _validate_sweep(*, sweep_path: Path) -> None:
+def _validate_sweep(*, sweep_path: Path, scale_divider_impl: str) -> None:
     sweep = _load_json(sweep_path)
-    if sweep.get("tag_prefix") != _PPA_SWEEP_TAG_PREFIX:
-        raise SystemExit(f"pair-merge PPA sweep tag_prefix must be {_PPA_SWEEP_TAG_PREFIX}")
+    expected_tag_prefix = _PPA_SWEEP_TAG_PREFIX_BY_DIVIDER_IMPL[scale_divider_impl]
+    if sweep.get("tag_prefix") != expected_tag_prefix:
+        raise SystemExit(f"pair-merge PPA sweep tag_prefix must be {expected_tag_prefix}")
     if sweep.get("flow_params") != _PPA_SWEEP_FLOW_PARAMS:
         raise SystemExit("pair-merge PPA sweep flow_params do not match the checked-in contract")
 
@@ -88,8 +94,6 @@ def main(argv: list[str] | None = None) -> int:
     generated_config = _load_json(generated_config_path)
     if config != generated_config:
         raise SystemExit("generated config does not match source config")
-    if args.sweep is not None:
-        _validate_sweep(sweep_path=args.sweep.resolve())
 
     top_name = str(config.get("top_name") or "").strip()
     if not top_name:
@@ -98,8 +102,15 @@ def main(argv: list[str] | None = None) -> int:
     if not isinstance(body, dict):
         raise SystemExit("config must contain attention_score32_exact_partial_pair_merge_folded object")
     lane_parallelism = int(body.get("lane_parallelism", 0))
+    scale_divider_impl_explicit = "scale_divider_impl" in body
+    scale_divider_impl = str(body.get("scale_divider_impl", GENERIC_SCALE_DIVIDER_EXACT))
     if lane_parallelism != 1:
         raise SystemExit("lane_parallelism must be 1 for the shared-scale exact pair merge")
+    if scale_divider_impl not in _PPA_SWEEP_TAG_PREFIX_BY_DIVIDER_IMPL:
+        supported = ", ".join(sorted(_PPA_SWEEP_TAG_PREFIX_BY_DIVIDER_IMPL))
+        raise SystemExit(f"scale_divider_impl must be one of: {supported}")
+    if args.sweep is not None:
+        _validate_sweep(sweep_path=args.sweep.resolve(), scale_divider_impl=scale_divider_impl)
 
     manifest = _load_json(manifest_path)
     expected_manifest = {
@@ -118,8 +129,12 @@ def main(argv: list[str] | None = None) -> int:
         "output_cycle_event": "first_out_valid_handshake_opportunity",
         "exp_scale_impl": FACTORED_H33_L64_MUL_EXACT,
     }
+    if scale_divider_impl_explicit:
+        expected_manifest["scale_divider_impl"] = scale_divider_impl
     for key, expected in expected_manifest.items():
         _require(manifest, key, expected, "generated manifest")
+    if not scale_divider_impl_explicit and "scale_divider_impl" in manifest:
+        raise SystemExit("legacy absent-key config must not gain manifest scale_divider_impl")
 
     rtl = top_path.read_text(encoding="utf-8", errors="replace")
     for token in (
@@ -141,6 +156,30 @@ def main(argv: list[str] | None = None) -> int:
             raise SystemExit(
                 f"generated RTL must contain exactly one {function_name} invocation; found {call_count}"
             )
+    if scale_divider_impl == GENERIC_SCALE_DIVIDER_EXACT:
+        for token in (
+            "quotient = product / 57'd16777215;",
+            "quotient = product / 65'd16777215;",
+        ):
+            if token not in rtl:
+                raise SystemExit(f"generated generic-divider RTL missing token: {token}")
+    elif scale_divider_impl == MERSENNE24_CORRECTION2_SCALE_DIVIDER_EXACT:
+        for token in (
+            "/ 57'd16777215",
+            "/ 65'd16777215",
+        ):
+            if token in rtl:
+                raise SystemExit(f"generated Mersenne-divider RTL must not contain generic division token: {token}")
+        for token in (
+            "function automatic [33:0] divide_mersenne24_u57;",
+            "function automatic [41:0] divide_mersenne24_u65;",
+            "if (chunk_sum >= 26'd33554430) correction = 2'd2;",
+            "else if (chunk_sum >= 26'd16777215) correction = 2'd1;",
+            "quotient = divide_mersenne24_u57(product);",
+            "quotient = divide_mersenne24_u65(product);",
+        ):
+            if token not in rtl:
+                raise SystemExit(f"generated Mersenne-divider RTL missing token: {token}")
 
     _compare_current_generation(config=config, rtl_dir=rtl_dir)
 

--- a/npu/rtlgen/gen_attention_score32_exact_partial_pair_merge_folded.py
+++ b/npu/rtlgen/gen_attention_score32_exact_partial_pair_merge_folded.py
@@ -17,6 +17,8 @@ if str(REPO_ROOT) not in sys.path:
 FACTORED_H33_L64_MUL_EXACT = "factored_h33_l64_mul_exact"
 LEGACY_MONOLITHIC_LUT_EXACT = "legacy_monolithic_lut_exact"
 SEGMENTED_LUT_9X256_EXACT = "segmented_lut_9x256_exact"
+GENERIC_SCALE_DIVIDER_EXACT = "generic_exact"
+MERSENNE24_CORRECTION2_SCALE_DIVIDER_EXACT = "mersenne24_correction2_exact"
 
 MERGE_SCALE_BITS = 24
 MERGE_SCALE = (1 << MERGE_SCALE_BITS) - 1
@@ -39,6 +41,10 @@ _SUPPORTED_EXP_SCALE_IMPLS = {
     SEGMENTED_LUT_9X256_EXACT,
     FACTORED_H33_L64_MUL_EXACT,
 }
+_SUPPORTED_SCALE_DIVIDER_IMPLS = {
+    GENERIC_SCALE_DIVIDER_EXACT,
+    MERSENNE24_CORRECTION2_SCALE_DIVIDER_EXACT,
+}
 EXP_FACTOR_STEP = 64
 EXP_FACTOR_HIGH_BITS = 13
 EXP_FACTOR_LOW_BITS = 30
@@ -56,7 +62,7 @@ def _clog2(value: int) -> int:
     return max(1, math.ceil(math.log2(max(2, value))))
 
 
-def _validate(config: dict[str, Any]) -> dict[str, int | str]:
+def _validate(config: dict[str, Any]) -> dict[str, int | str | bool]:
     top_name = str(config.get("top_name") or "").strip()
     body = config.get("attention_score32_exact_partial_pair_merge_folded")
     if not top_name or not isinstance(body, dict):
@@ -64,6 +70,8 @@ def _validate(config: dict[str, Any]) -> dict[str, int | str]:
     value_slices = int(body.get("value_slices", 16))
     head_id_bits = int(body.get("head_id_bits", 5))
     exp_scale_impl = str(body.get("exp_scale_impl", FACTORED_H33_L64_MUL_EXACT)).strip()
+    scale_divider_impl_explicit = "scale_divider_impl" in body
+    scale_divider_impl = str(body.get("scale_divider_impl", GENERIC_SCALE_DIVIDER_EXACT)).strip()
     lane_parallelism = int(body.get("lane_parallelism", 1))
     if value_slices < 1 or value_slices > 16 or value_slices & (value_slices - 1):
         raise SystemExit("value_slices must be a power of two in [1, 16]")
@@ -72,6 +80,9 @@ def _validate(config: dict[str, Any]) -> dict[str, int | str]:
     if exp_scale_impl not in _SUPPORTED_EXP_SCALE_IMPLS:
         supported = ", ".join(sorted(_SUPPORTED_EXP_SCALE_IMPLS))
         raise SystemExit(f"exp_scale_impl must be one of: {supported}")
+    if scale_divider_impl not in _SUPPORTED_SCALE_DIVIDER_IMPLS:
+        supported = ", ".join(sorted(_SUPPORTED_SCALE_DIVIDER_IMPLS))
+        raise SystemExit(f"scale_divider_impl must be one of: {supported}")
     if lane_parallelism != 1:
         raise SystemExit("lane_parallelism must be 1 for the shared single-scale exact pair merge")
     body.update(
@@ -79,6 +90,8 @@ def _validate(config: dict[str, Any]) -> dict[str, int | str]:
             "value_slices": value_slices,
             "head_id_bits": head_id_bits,
             "exp_scale_impl": exp_scale_impl,
+            "scale_divider_impl": scale_divider_impl,
+            "scale_divider_impl_explicit": scale_divider_impl_explicit,
             "lane_parallelism": lane_parallelism,
         }
     )
@@ -87,7 +100,9 @@ def _validate(config: dict[str, Any]) -> dict[str, int | str]:
         "value_slices": value_slices,
         "head_id_bits": head_id_bits,
         "exp_scale_impl": exp_scale_impl,
+        "scale_divider_impl": scale_divider_impl,
         "lane_parallelism": lane_parallelism,
+        "scale_divider_impl_explicit": scale_divider_impl_explicit,
     }
 
 
@@ -249,7 +264,135 @@ def _lane_write_cases() -> str:
     return "\n".join(lines)
 
 
-def _top(*, top_name: str, value_slices: int, head_id_bits: int, exp_scale_impl: str) -> str:
+def _scale_divider_functions(*, scale_divider_impl: str) -> str:
+    if scale_divider_impl == GENERIC_SCALE_DIVIDER_EXACT:
+        return f"""  function automatic [32:0] scale_unsigned33;
+    input [32:0] value_in;
+    input [23:0] scale_in;
+    reg [56:0] product;
+    reg [56:0] quotient;
+    begin
+      if (scale_in == 0 || value_in == 0) begin
+        scale_unsigned33 = 33'd0;
+      end else begin
+        product = (value_in * scale_in) + 57'd{MERGE_SCALE // 2};
+        quotient = product / 57'd{MERGE_SCALE};
+        if (quotient > 57'd8589934591) scale_unsigned33 = 33'h1ffff_ffff;
+        else scale_unsigned33 = quotient[32:0];
+      end
+    end
+  endfunction
+
+  function automatic signed [40:0] scale_signed41;
+    input signed [40:0] value_in;
+    input [23:0] scale_in;
+    reg [40:0] magnitude;
+    reg [64:0] product;
+    reg [64:0] quotient;
+    begin
+      if (scale_in == 0 || value_in == 0) begin
+        scale_signed41 = 41'sd0;
+      end else begin
+        magnitude = value_in < 0 ? (~value_in) + 1'b1 : value_in[40:0];
+        product = (magnitude * scale_in) + 65'd{MERGE_SCALE // 2};
+        quotient = product / 65'd{MERGE_SCALE};
+        if (value_in < 0) begin
+          if (quotient >= 65'd1099511627776) scale_signed41 = -41'sd1099511627776;
+          else scale_signed41 = -$signed(quotient[40:0]);
+        end else begin
+          if (quotient > 65'd1099511627775) scale_signed41 = 41'sd1099511627775;
+          else scale_signed41 = $signed(quotient[40:0]);
+        end
+      end
+    end
+  endfunction"""
+    if scale_divider_impl != MERSENNE24_CORRECTION2_SCALE_DIVIDER_EXACT:
+        raise AssertionError(f"unsupported scale_divider_impl: {scale_divider_impl}")
+    return f"""  function automatic [33:0] divide_mersenne24_u57;
+    input [56:0] numerator;
+    reg [23:0] n0;
+    reg [23:0] n1;
+    reg [8:0] n2;
+    reg [25:0] chunk_sum;
+    reg [1:0] correction;
+    reg [33:0] quotient;
+    begin
+      n0 = numerator[23:0];
+      n1 = numerator[47:24];
+      n2 = numerator[56:48];
+      chunk_sum = {{2'b00, n0}} + {{2'b00, n1}} + {{17'b0, n2}};
+      if (chunk_sum >= 26'd33554430) correction = 2'd2;
+      else if (chunk_sum >= 26'd16777215) correction = 2'd1;
+      else correction = 2'd0;
+      quotient = {{10'b0, n1}} + ({{25'b0, n2}} << 24) + {{25'b0, n2}} + {{32'b0, correction}};
+      divide_mersenne24_u57 = quotient;
+    end
+  endfunction
+
+  function automatic [41:0] divide_mersenne24_u65;
+    input [64:0] numerator;
+    reg [23:0] n0;
+    reg [23:0] n1;
+    reg [16:0] n2;
+    reg [25:0] chunk_sum;
+    reg [1:0] correction;
+    reg [41:0] quotient;
+    begin
+      n0 = numerator[23:0];
+      n1 = numerator[47:24];
+      n2 = numerator[64:48];
+      chunk_sum = {{2'b00, n0}} + {{2'b00, n1}} + {{9'b0, n2}};
+      if (chunk_sum >= 26'd33554430) correction = 2'd2;
+      else if (chunk_sum >= 26'd16777215) correction = 2'd1;
+      else correction = 2'd0;
+      quotient = {{18'b0, n1}} + ({{25'b0, n2}} << 24) + {{25'b0, n2}} + {{40'b0, correction}};
+      divide_mersenne24_u65 = quotient;
+    end
+  endfunction
+
+  function automatic [32:0] scale_unsigned33;
+    input [32:0] value_in;
+    input [23:0] scale_in;
+    reg [56:0] product;
+    reg [33:0] quotient;
+    begin
+      if (scale_in == 0 || value_in == 0) begin
+        scale_unsigned33 = 33'd0;
+      end else begin
+        product = (value_in * scale_in) + 57'd{MERGE_SCALE // 2};
+        quotient = divide_mersenne24_u57(product);
+        if (quotient > 34'd8589934591) scale_unsigned33 = 33'h1ffff_ffff;
+        else scale_unsigned33 = quotient[32:0];
+      end
+    end
+  endfunction
+
+  function automatic signed [40:0] scale_signed41;
+    input signed [40:0] value_in;
+    input [23:0] scale_in;
+    reg [40:0] magnitude;
+    reg [64:0] product;
+    reg [41:0] quotient;
+    begin
+      if (scale_in == 0 || value_in == 0) begin
+        scale_signed41 = 41'sd0;
+      end else begin
+        magnitude = value_in < 0 ? (~value_in) + 1'b1 : value_in[40:0];
+        product = (magnitude * scale_in) + 65'd{MERGE_SCALE // 2};
+        quotient = divide_mersenne24_u65(product);
+        if (value_in < 0) begin
+          if (quotient >= 42'd1099511627776) scale_signed41 = -41'sd1099511627776;
+          else scale_signed41 = -$signed(quotient[40:0]);
+        end else begin
+          if (quotient > 42'd1099511627775) scale_signed41 = 41'sd1099511627775;
+          else scale_signed41 = $signed(quotient[40:0]);
+        end
+      end
+    end
+  endfunction"""
+
+
+def _top(*, top_name: str, value_slices: int, head_id_bits: int, exp_scale_impl: str, scale_divider_impl: str) -> str:
     slice_bits = _clog2(value_slices)
     return f"""// Auto-generated by npu/rtlgen/gen_attention_score32_exact_partial_pair_merge_folded.py
 module {top_name} (
@@ -388,46 +531,7 @@ module {top_name} (
 
 {_exp_lut_function(exp_scale_impl=exp_scale_impl)}
 
-  function automatic [32:0] scale_unsigned33;
-    input [32:0] value_in;
-    input [23:0] scale_in;
-    reg [56:0] product;
-    reg [56:0] quotient;
-    begin
-      if (scale_in == 0 || value_in == 0) begin
-        scale_unsigned33 = 33'd0;
-      end else begin
-        product = (value_in * scale_in) + 57'd{MERGE_SCALE // 2};
-        quotient = product / 57'd{MERGE_SCALE};
-        if (quotient > 57'd8589934591) scale_unsigned33 = 33'h1ffff_ffff;
-        else scale_unsigned33 = quotient[32:0];
-      end
-    end
-  endfunction
-
-  function automatic signed [40:0] scale_signed41;
-    input signed [40:0] value_in;
-    input [23:0] scale_in;
-    reg [40:0] magnitude;
-    reg [64:0] product;
-    reg [64:0] quotient;
-    begin
-      if (scale_in == 0 || value_in == 0) begin
-        scale_signed41 = 41'sd0;
-      end else begin
-        magnitude = value_in < 0 ? (~value_in) + 1'b1 : value_in[40:0];
-        product = (magnitude * scale_in) + 65'd{MERGE_SCALE // 2};
-        quotient = product / 65'd{MERGE_SCALE};
-        if (value_in < 0) begin
-          if (quotient >= 65'd1099511627776) scale_signed41 = -41'sd1099511627776;
-          else scale_signed41 = -$signed(quotient[40:0]);
-        end else begin
-          if (quotient > 65'd1099511627775) scale_signed41 = 41'sd1099511627775;
-          else scale_signed41 = $signed(quotient[40:0]);
-        end
-      end
-    end
-  endfunction
+{_scale_divider_functions(scale_divider_impl=scale_divider_impl)}
 
   function automatic signed [40:0] sat_add_signed41;
     input signed [40:0] lhs;
@@ -678,6 +782,7 @@ def generate(config: dict[str, Any], out_dir: Path) -> None:
             value_slices=int(params["value_slices"]),
             head_id_bits=int(params["head_id_bits"]),
             exp_scale_impl=str(params["exp_scale_impl"]),
+            scale_divider_impl=str(params["scale_divider_impl"]),
         ),
         encoding="utf-8",
     )
@@ -728,6 +833,8 @@ def generate(config: dict[str, Any], out_dir: Path) -> None:
                 "exp_factor_round_shift": EXP_FACTOR_ROUND_SHIFT,
             }
         )
+    if bool(params["scale_divider_impl_explicit"]):
+        manifest["scale_divider_impl"] = str(params["scale_divider_impl"])
     (out_dir / "attention_score32_exact_partial_pair_merge_folded_manifest.json").write_text(
         json.dumps(manifest, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",

--- a/runs/campaigns/npu/attention_score32_exact_partial_pair_merge_sharedscale_mersenne_v1/sweeps/nangate45_attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1.json
+++ b/runs/campaigns/npu/attention_score32_exact_partial_pair_merge_sharedscale_mersenne_v1/sweeps/nangate45_attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1.json
@@ -1,0 +1,29 @@
+{
+  "flow_params": {
+    "CLOCK_PERIOD": [
+      8.0
+    ],
+    "CORE_AREA": [
+      "50 50 1450 1450"
+    ],
+    "DIE_AREA": [
+      "0 0 1500 1500"
+    ],
+    "IO_PLACER_H": [
+      "metal3 metal5"
+    ],
+    "IO_PLACER_V": [
+      "metal4 metal6"
+    ],
+    "PLACE_DENSITY": [
+      0.3
+    ],
+    "PLACE_PINS_ARGS": [
+      "-min_distance 1"
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ]
+  },
+  "tag_prefix": "attention_score32_exact_partial_pair_merge_sharedscale_mersenne_v1"
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1/config.json
@@ -1,0 +1,10 @@
+{
+  "attention_score32_exact_partial_pair_merge_folded": {
+    "exp_scale_impl": "factored_h33_l64_mul_exact",
+    "head_id_bits": 5,
+    "lane_parallelism": 1,
+    "scale_divider_impl": "mersenne24_correction2_exact",
+    "value_slices": 16
+  },
+  "top_name": "attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1"
+}

--- a/tests/test_attention_score32_exact_partial_pair_merge_folded.py
+++ b/tests/test_attention_score32_exact_partial_pair_merge_folded.py
@@ -14,7 +14,9 @@ from npu.eval.probe_attention_score32_exact_partial_pair_merge_folded import bui
 from npu.rtlgen.gen_attention_decode_score_multivalue_cluster import generate as generate_cluster
 from npu.rtlgen.gen_attention_score32_exact_partial_pair_merge_folded import (
     FACTORED_H33_L64_MUL_EXACT,
+    GENERIC_SCALE_DIVIDER_EXACT,
     MAX_EXP_BUCKET,
+    MERSENNE24_CORRECTION2_SCALE_DIVIDER_EXACT,
     exact_exp_scale_value,
     generate as generate_merge,
 )
@@ -32,6 +34,9 @@ from npu.sim.perf.attention_exact_partial import (
 
 INT_MAX = (1 << 31) - 1
 INT_MIN = -(1 << 31)
+MERGE_SCALE = (1 << 24) - 1
+SIGNED41_MIN = -(1 << 40)
+SIGNED41_MAX = (1 << 40) - 1
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -63,7 +68,20 @@ def _partial_reducer_config() -> dict:
     }
 
 
-def _merge_config() -> dict:
+def _merge_config(*, scale_divider_impl: str = GENERIC_SCALE_DIVIDER_EXACT) -> dict:
+    return {
+        "top_name": "attention_score32_online_state_merge_exact_partial",
+        "attention_score32_exact_partial_pair_merge_folded": {
+            "value_slices": 16,
+            "head_id_bits": 5,
+            "exp_scale_impl": FACTORED_H33_L64_MUL_EXACT,
+            "scale_divider_impl": scale_divider_impl,
+            "lane_parallelism": 1,
+        },
+    }
+
+
+def _legacy_merge_config_without_divider_impl() -> dict:
     return {
         "top_name": "attention_score32_online_state_merge_exact_partial",
         "attention_score32_exact_partial_pair_merge_folded": {
@@ -73,6 +91,94 @@ def _merge_config() -> dict:
             "lane_parallelism": 1,
         },
     }
+
+
+def _mersenne_divide_reference(numerator: int) -> int:
+    return int(numerator) // MERGE_SCALE
+
+
+def _mersenne_divide_identity(numerator: int) -> int:
+    numerator = int(numerator)
+    n0 = numerator & ((1 << 24) - 1)
+    n1 = (numerator >> 24) & ((1 << 24) - 1)
+    n2 = numerator >> 48
+    chunk_sum = n0 + n1 + n2
+    correction = 2 if chunk_sum >= (2 * MERGE_SCALE) else 1 if chunk_sum >= MERGE_SCALE else 0
+    return n1 + (((1 << 24) + 1) * n2) + correction
+
+
+def _scale_unsigned33_reference(value: int, scale: int) -> int:
+    if value == 0 or scale == 0:
+        return 0
+    product = (int(value) * int(scale)) + (MERGE_SCALE // 2)
+    return min((1 << 33) - 1, _mersenne_divide_reference(product))
+
+
+def _scale_signed41_reference(value: int, scale: int) -> int:
+    if value == 0 or scale == 0:
+        return 0
+    product = (abs(int(value)) * int(scale)) + (MERGE_SCALE // 2)
+    quotient = _mersenne_divide_reference(product)
+    if value < 0:
+        return SIGNED41_MIN if quotient >= (1 << 40) else -quotient
+    return min(SIGNED41_MAX, quotient)
+
+
+def _mersenne_boundary_numerators(width_bits: int) -> list[int]:
+    if width_bits == 57:
+        max_n2 = (1 << 9) - 1
+    elif width_bits == 65:
+        max_n2 = (1 << 17) - 1
+    else:
+        raise ValueError(f"unsupported width_bits: {width_bits}")
+    vectors = [
+        (0, 0, 0),
+        (1, 0, 0),
+        (MERGE_SCALE - 1, 0, 0),
+        (MERGE_SCALE, 0, 0),
+        (0, MERGE_SCALE - 1, 0),
+        (0, MERGE_SCALE, 0),
+        (MERGE_SCALE - 1, 1, 0),
+        (MERGE_SCALE, 1, 0),
+        (MERGE_SCALE, MERGE_SCALE - 1, 0),
+        (MERGE_SCALE, MERGE_SCALE, 0),
+        (MERGE_SCALE, MERGE_SCALE, 1),
+        (0, 0, 1),
+        (MERGE_SCALE, 0, 1),
+        (0, MERGE_SCALE, 1),
+        (MERGE_SCALE, MERGE_SCALE, max_n2),
+        (MERGE_SCALE - 3, MERGE_SCALE - 5, max_n2),
+    ]
+    numerators: list[int] = []
+    for n0, n1, n2 in vectors:
+        numerators.append(n0 + (n1 << 24) + (n2 << 48))
+    numerators.append((1 << width_bits) - 1)
+    return numerators
+
+
+def _direct_mersenne_scale_cases() -> list[tuple[int, int, int]]:
+    return [
+        (0, 0, 0),
+        (1, MERGE_SCALE, 1),
+        ((1 << 33) - 1, MERGE_SCALE, (1 << 33) - 1),
+        ((1 << 33) - 1, MERGE_SCALE - 1, _scale_unsigned33_reference((1 << 33) - 1, MERGE_SCALE - 1)),
+        (1 << 32, MERGE_SCALE // 2, _scale_unsigned33_reference(1 << 32, MERGE_SCALE // 2)),
+        (123456789, 16711935, _scale_unsigned33_reference(123456789, 16711935)),
+    ]
+
+
+def _direct_mersenne_signed_scale_cases() -> list[tuple[int, int, int]]:
+    return [
+        (0, 0, 0),
+        (1, MERGE_SCALE, 1),
+        (-1, MERGE_SCALE, -1),
+        (SIGNED41_MAX, MERGE_SCALE, SIGNED41_MAX),
+        (SIGNED41_MIN, MERGE_SCALE, SIGNED41_MIN),
+        (SIGNED41_MAX, MERGE_SCALE - 1, _scale_signed41_reference(SIGNED41_MAX, MERGE_SCALE - 1)),
+        (SIGNED41_MIN + 1, MERGE_SCALE - 1, _scale_signed41_reference(SIGNED41_MIN + 1, MERGE_SCALE - 1)),
+        (34567890123, 11337711, _scale_signed41_reference(34567890123, 11337711)),
+        (-34567890123, 11337711, _scale_signed41_reference(-34567890123, 11337711)),
+    ]
 
 
 def _rtl_tools_available() -> bool:
@@ -231,7 +337,12 @@ def _random_merge_cases(seed: int, count: int) -> list[tuple[str, ExactPartialBe
     return cases
 
 
-def _run_merge_rtl_cases(tmp_path: Path, valid_cases: list[tuple[str, ExactPartialBeat, ExactPartialBeat, bool]]) -> dict[str, object]:
+def _run_merge_rtl_cases(
+    tmp_path: Path,
+    valid_cases: list[tuple[str, ExactPartialBeat, ExactPartialBeat, bool]],
+    *,
+    scale_divider_impl: str = GENERIC_SCALE_DIVIDER_EXACT,
+) -> dict[str, object]:
     expected_rows = []
     for index, (name, left, right, invalid_last) in enumerate(valid_cases):
         merged = merge_partial_beats(left, right)
@@ -250,7 +361,7 @@ def _run_merge_rtl_cases(tmp_path: Path, valid_cases: list[tuple[str, ExactParti
             }
         )
 
-    generate_merge(_merge_config(), tmp_path / "rtl")
+    generate_merge(_merge_config(scale_divider_impl=scale_divider_impl), tmp_path / "rtl")
     tb_path = tmp_path / "tb.sv"
     left_init = []
     right_init = []
@@ -440,8 +551,10 @@ endmodule
     }
 
 
-def _run_direct_merge_rtl_vectors(tmp_path: Path) -> dict[str, object]:
-    return _run_merge_rtl_cases(tmp_path, _base_merge_cases())
+def _run_direct_merge_rtl_vectors(
+    tmp_path: Path, *, scale_divider_impl: str = GENERIC_SCALE_DIVIDER_EXACT
+) -> dict[str, object]:
+    return _run_merge_rtl_cases(tmp_path, _base_merge_cases(), scale_divider_impl=scale_divider_impl)
 
 
 def test_exact_partial_reducer_manifest_and_ports(tmp_path: Path) -> None:
@@ -494,6 +607,7 @@ def test_exact_partial_merge_manifest_and_ports(tmp_path: Path) -> None:
     assert manifest["partial_payload_bits_per_beat"] == 328
     assert manifest["equivalence_hash"] is False
     assert manifest["exp_scale_impl"] == FACTORED_H33_L64_MUL_EXACT
+    assert manifest["scale_divider_impl"] == GENERIC_SCALE_DIVIDER_EXACT
     assert manifest["exp_scale_bucket_max"] == MAX_EXP_BUCKET
     assert manifest["lane_parallelism"] == 1
     assert manifest["implementation_style"] == "shared_single_scale_folded_exact_v1"
@@ -528,6 +642,8 @@ def test_exact_partial_merge_manifest_and_ports(tmp_path: Path) -> None:
     assert "localparam [2:0] PHASE_LANE_RIGHT = 3'd4;" in rtl
     assert rtl.count("scale_signed41(shared_signed_value_r, shared_signed_scale_r)") == 1
     assert rtl.count("scale_unsigned33(shared_unsigned_value_r, shared_unsigned_scale_r)") == 1
+    assert "quotient = product / 57'd16777215;" in rtl
+    assert "quotient = product / 65'd16777215;" in rtl
     assert "active_scaled_left_lane_q <= shared_signed_scaled_w;" in rtl
     assert "active_scaled_left_exp_sum_q <= shared_unsigned_scaled_w;" in rtl
 
@@ -541,6 +657,51 @@ def test_exact_partial_merge_python_exp_scale_matches_legacy_formula_exhaustivel
     assert observed == expected
     assert exact_exp_scale_value(-1) == 0
     assert exact_exp_scale_value(MAX_EXP_BUCKET + 1) == 0
+
+
+def test_legacy_generic_absent_key_regenerates_origin_master_bytes(tmp_path: Path) -> None:
+    current_out = tmp_path / "current"
+    origin_out = tmp_path / "origin"
+    legacy_config = _legacy_merge_config_without_divider_impl()
+    generate_merge(legacy_config, current_out)
+    show = subprocess.run(
+        [
+            "git",
+            "show",
+            "origin/master:npu/rtlgen/gen_attention_score32_exact_partial_pair_merge_folded.py",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    namespace: dict[str, object] = {
+        "__file__": str(REPO_ROOT / "npu" / "rtlgen" / "gen_attention_score32_exact_partial_pair_merge_folded.py"),
+        "__name__": "origin_master_folded_pair_merge",
+    }
+    exec(compile(show.stdout, namespace["__file__"], "exec"), namespace)
+    namespace["generate"](legacy_config, origin_out)
+    for relative_name in (
+        "top.v",
+        "config.json",
+        "attention_score32_exact_partial_pair_merge_folded_manifest.json",
+    ):
+        assert (current_out / relative_name).read_bytes() == (origin_out / relative_name).read_bytes()
+
+
+def test_mersenne_divide_identity_matches_reference_at_boundaries() -> None:
+    for width_bits in (57, 65):
+        for numerator in _mersenne_boundary_numerators(width_bits):
+            assert _mersenne_divide_identity(numerator) == _mersenne_divide_reference(numerator)
+
+
+def test_mersenne_divide_identity_matches_reference_for_high_volume_random_vectors() -> None:
+    rng = random.Random(20260801)
+    for width_bits in (57, 65):
+        for _ in range(4000):
+            numerator = rng.randrange(0, 1 << width_bits)
+            assert _mersenne_divide_identity(numerator) == _mersenne_divide_reference(numerator)
 
 
 @pytest.mark.skipif(not _rtl_tools_available(), reason="iverilog/vvp/verilator unavailable")
@@ -680,8 +841,159 @@ endmodule
 
 
 @pytest.mark.skipif(not _rtl_tools_available(), reason="iverilog/vvp/verilator unavailable")
-def test_exact_partial_merge_rtl_handles_extreme_and_invalid_last_vectors(tmp_path: Path) -> None:
-    report = _run_direct_merge_rtl_vectors(tmp_path)
+def test_mersenne_divider_rtl_helpers_match_reference(tmp_path: Path) -> None:
+    config = _merge_config(scale_divider_impl=MERSENNE24_CORRECTION2_SCALE_DIVIDER_EXACT)
+    generate_merge(config, tmp_path / "rtl")
+    u57_cases = _mersenne_boundary_numerators(57)
+    u65_cases = _mersenne_boundary_numerators(65)
+    u33_cases = _direct_mersenne_scale_cases()
+    s41_cases = _direct_mersenne_signed_scale_cases()
+    tb_path = tmp_path / "tb_mersenne_helpers.sv"
+
+    u57_lines = [
+        f"    u57_num[{index}] = 57'd{numerator}; u57_expected[{index}] = 34'd{_mersenne_divide_reference(numerator)};"
+        for index, numerator in enumerate(u57_cases)
+    ]
+    u65_lines = [
+        f"    u65_num[{index}] = 65'd{numerator}; u65_expected[{index}] = 42'd{_mersenne_divide_reference(numerator)};"
+        for index, numerator in enumerate(u65_cases)
+    ]
+    u33_lines = [
+        f"    u33_value[{index}] = 33'd{value}; u33_scale[{index}] = 24'd{scale}; u33_expected[{index}] = 33'd{expected};"
+        for index, (value, scale, expected) in enumerate(u33_cases)
+    ]
+    s41_lines = [
+        f"    s41_value[{index}] = {_signed_literal(value, 41)}; s41_scale[{index}] = 24'd{scale}; "
+        f"s41_expected[{index}] = {_signed_literal(expected, 41)};"
+        for index, (value, scale, expected) in enumerate(s41_cases)
+    ]
+    tb_path.write_text(
+        f"""`timescale 1ns/1ps
+module tb;
+  localparam integer U57_COUNT = {len(u57_cases)};
+  localparam integer U65_COUNT = {len(u65_cases)};
+  localparam integer U33_COUNT = {len(u33_cases)};
+  localparam integer S41_COUNT = {len(s41_cases)};
+  reg clk = 0, rst_n = 0;
+  reg left_valid = 0, right_valid = 0, out_ready = 1;
+  reg [15:0] left_command_id = 16'd0, right_command_id = 16'd0;
+  reg [4:0] left_head_id = 5'd0, right_head_id = 5'd0;
+  reg signed [31:0] left_global_max = 32'sd0, right_global_max = 32'sd0;
+  reg [32:0] left_exp_sum = 33'd0, right_exp_sum = 33'd0;
+  reg [3:0] left_slice = 4'd0, right_slice = 4'd0;
+  reg left_last = 1'b0, right_last = 1'b0;
+  reg [327:0] left_value = 328'd0, right_value = 328'd0;
+  wire left_ready, right_ready, out_valid, out_last, protocol_error;
+  wire [15:0] out_command_id;
+  wire [4:0] out_head_id;
+  wire signed [31:0] out_global_max;
+  wire [32:0] out_exp_sum;
+  wire [3:0] out_slice;
+  wire [327:0] out_value;
+  wire [31:0] completed_count, cycle_count;
+  reg [56:0] u57_num [0:U57_COUNT-1];
+  reg [33:0] u57_expected [0:U57_COUNT-1];
+  reg [64:0] u65_num [0:U65_COUNT-1];
+  reg [41:0] u65_expected [0:U65_COUNT-1];
+  reg [32:0] u33_value [0:U33_COUNT-1];
+  reg [23:0] u33_scale [0:U33_COUNT-1];
+  reg [32:0] u33_expected [0:U33_COUNT-1];
+  reg signed [40:0] s41_value [0:S41_COUNT-1];
+  reg [23:0] s41_scale [0:S41_COUNT-1];
+  reg signed [40:0] s41_expected [0:S41_COUNT-1];
+  integer idx;
+  reg [33:0] observed_u57;
+  reg [41:0] observed_u65;
+  reg [32:0] observed_u33;
+  reg signed [40:0] observed_s41;
+
+  always #5 clk = ~clk;
+
+  attention_score32_online_state_merge_exact_partial dut (
+      .clk(clk), .rst_n(rst_n),
+      .left_valid(left_valid), .left_ready(left_ready), .left_command_id(left_command_id),
+      .left_head_id(left_head_id), .left_global_max(left_global_max), .left_exp_sum(left_exp_sum),
+      .left_slice(left_slice), .left_last(left_last), .left_value(left_value),
+      .right_valid(right_valid), .right_ready(right_ready), .right_command_id(right_command_id),
+      .right_head_id(right_head_id), .right_global_max(right_global_max), .right_exp_sum(right_exp_sum),
+      .right_slice(right_slice), .right_last(right_last), .right_value(right_value),
+      .out_valid(out_valid), .out_ready(out_ready), .out_command_id(out_command_id), .out_head_id(out_head_id),
+      .out_global_max(out_global_max), .out_exp_sum(out_exp_sum), .out_slice(out_slice), .out_last(out_last),
+      .out_value(out_value), .completed_count(completed_count), .cycle_count(cycle_count), .protocol_error(protocol_error)
+  );
+
+  initial begin
+{chr(10).join(u57_lines)}
+{chr(10).join(u65_lines)}
+{chr(10).join(u33_lines)}
+{chr(10).join(s41_lines)}
+    #1;
+    for (idx = 0; idx < U57_COUNT; idx = idx + 1) begin
+      observed_u57 = dut.divide_mersenne24_u57(u57_num[idx]);
+      if (observed_u57 !== u57_expected[idx]) begin
+        $fatal(1, "u57 mismatch idx=%0d observed=%0d expected=%0d", idx, observed_u57, u57_expected[idx]);
+      end
+    end
+    for (idx = 0; idx < U65_COUNT; idx = idx + 1) begin
+      observed_u65 = dut.divide_mersenne24_u65(u65_num[idx]);
+      if (observed_u65 !== u65_expected[idx]) begin
+        $fatal(1, "u65 mismatch idx=%0d observed=%0d expected=%0d", idx, observed_u65, u65_expected[idx]);
+      end
+    end
+    for (idx = 0; idx < U33_COUNT; idx = idx + 1) begin
+      observed_u33 = dut.scale_unsigned33(u33_value[idx], u33_scale[idx]);
+      if (observed_u33 !== u33_expected[idx]) begin
+        $fatal(1, "u33 mismatch idx=%0d observed=%0d expected=%0d", idx, observed_u33, u33_expected[idx]);
+      end
+    end
+    for (idx = 0; idx < S41_COUNT; idx = idx + 1) begin
+      observed_s41 = dut.scale_signed41(s41_value[idx], s41_scale[idx]);
+      if (observed_s41 !== s41_expected[idx]) begin
+        $fatal(1, "s41 mismatch idx=%0d observed=%0d expected=%0d", idx, $signed(observed_s41), $signed(s41_expected[idx]));
+      end
+    end
+    $finish;
+  end
+endmodule
+""",
+        encoding="utf-8",
+    )
+
+    sim_out = tmp_path / "sim_helpers.out"
+    compile_run = subprocess.run(
+        [
+            _tool("iverilog"),
+            "-g2012",
+            "-o",
+            str(sim_out),
+            str(tb_path),
+            str(tmp_path / "rtl" / "top.v"),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        timeout=120,
+    )
+    assert compile_run.returncode == 0, compile_run.stderr or compile_run.stdout
+    run = subprocess.run(
+        [_tool("vvp"), str(sim_out)],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        timeout=120,
+    )
+    assert run.returncode == 0, run.stderr or run.stdout
+
+
+@pytest.mark.parametrize(
+    "scale_divider_impl",
+    [GENERIC_SCALE_DIVIDER_EXACT, MERSENNE24_CORRECTION2_SCALE_DIVIDER_EXACT],
+)
+@pytest.mark.skipif(not _rtl_tools_available(), reason="iverilog/vvp/verilator unavailable")
+def test_exact_partial_merge_rtl_handles_extreme_and_invalid_last_vectors(
+    tmp_path: Path, scale_divider_impl: str
+) -> None:
+    report = _run_direct_merge_rtl_vectors(tmp_path, scale_divider_impl=scale_divider_impl)
 
     clean_observed = [{key: value for key, value in row.items() if key != "cycle"} for row in report["observed"]]
     assert clean_observed == [
@@ -696,10 +1008,14 @@ def test_exact_partial_merge_rtl_handles_extreme_and_invalid_last_vectors(tmp_pa
     assert report["summary"]["protocol_error"] is True
 
 
+@pytest.mark.parametrize(
+    "scale_divider_impl",
+    [GENERIC_SCALE_DIVIDER_EXACT, MERSENNE24_CORRECTION2_SCALE_DIVIDER_EXACT],
+)
 @pytest.mark.skipif(not _rtl_tools_available(), reason="iverilog/vvp/verilator unavailable")
-def test_exact_partial_merge_rtl_randomized_matches_python(tmp_path: Path) -> None:
+def test_exact_partial_merge_rtl_randomized_matches_python(tmp_path: Path, scale_divider_impl: str) -> None:
     cases = _random_merge_cases(seed=7, count=12)
-    report = _run_merge_rtl_cases(tmp_path, cases)
+    report = _run_merge_rtl_cases(tmp_path, cases, scale_divider_impl=scale_divider_impl)
 
     clean_observed = [{key: value for key, value in row.items() if key != "cycle"} for row in report["observed"]]
     assert clean_observed == [
@@ -713,10 +1029,16 @@ def test_exact_partial_merge_rtl_randomized_matches_python(tmp_path: Path) -> No
     assert report["summary"]["protocol_error"] is False
 
 
+@pytest.mark.parametrize(
+    "scale_divider_impl",
+    [GENERIC_SCALE_DIVIDER_EXACT, MERSENNE24_CORRECTION2_SCALE_DIVIDER_EXACT],
+)
 @pytest.mark.skipif(not _rtl_tools_available(), reason="iverilog/vvp/verilator unavailable")
-def test_exact_partial_merge_service_contract_matches_rtl_backpressure(tmp_path: Path) -> None:
+def test_exact_partial_merge_service_contract_matches_rtl_backpressure(
+    tmp_path: Path, scale_divider_impl: str
+) -> None:
     cases = _random_merge_cases(seed=11, count=6)
-    report = _run_merge_rtl_cases(tmp_path, cases)
+    report = _run_merge_rtl_cases(tmp_path, cases, scale_divider_impl=scale_divider_impl)
     schedule = simulate_folded_exact_partial_pair_merge_service(
         pair_count=len(cases),
         output_ready_pattern=(True, True, False, True, True),

--- a/tests/test_check_attention_score32_exact_partial_pair_merge_guard.py
+++ b/tests/test_check_attention_score32_exact_partial_pair_merge_guard.py
@@ -4,7 +4,12 @@ from pathlib import Path
 import pytest
 
 from npu.eval.check_attention_score32_exact_partial_pair_merge_guard import main as guard_main
-from npu.rtlgen.gen_attention_score32_exact_partial_pair_merge_folded import FACTORED_H33_L64_MUL_EXACT, generate
+from npu.rtlgen.gen_attention_score32_exact_partial_pair_merge_folded import (
+    FACTORED_H33_L64_MUL_EXACT,
+    GENERIC_SCALE_DIVIDER_EXACT,
+    MERSENNE24_CORRECTION2_SCALE_DIVIDER_EXACT,
+    generate,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CHECKED_IN_DESIGN_DIR = (
@@ -23,23 +28,44 @@ CHECKED_IN_SWEEP = (
     / "sweeps"
     / "nangate45_attention_score32_exact_partial_pair_merge_sharedscale_factored_l1.json"
 )
+CHECKED_IN_MERSENNE_DESIGN_DIR = (
+    REPO_ROOT
+    / "runs"
+    / "designs"
+    / "npu_blocks"
+    / "attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1"
+)
+CHECKED_IN_MERSENNE_SWEEP = (
+    REPO_ROOT
+    / "runs"
+    / "campaigns"
+    / "npu"
+    / "attention_score32_exact_partial_pair_merge_sharedscale_mersenne_v1"
+    / "sweeps"
+    / "nangate45_attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1.json"
+)
 
 
-def _config() -> dict:
+def _config(
+    *,
+    top_name: str = "attention_score32_exact_partial_pair_merge_sharedscale_factored_l1",
+    scale_divider_impl: str = GENERIC_SCALE_DIVIDER_EXACT,
+) -> dict:
     return {
-        "top_name": "attention_score32_exact_partial_pair_merge_sharedscale_factored_l1",
+        "top_name": top_name,
         "attention_score32_exact_partial_pair_merge_folded": {
             "value_slices": 16,
             "head_id_bits": 5,
             "exp_scale_impl": FACTORED_H33_L64_MUL_EXACT,
+            "scale_divider_impl": scale_divider_impl,
             "lane_parallelism": 1,
         },
     }
 
 
-def _sweep() -> dict:
+def _sweep(*, tag_prefix: str = "attention_score32_exact_partial_pair_merge_sharedscale_v1") -> dict:
     return {
-        "tag_prefix": "attention_score32_exact_partial_pair_merge_sharedscale_v1",
+        "tag_prefix": tag_prefix,
         "flow_params": {
             "CLOCK_PERIOD": [8.0],
             "DIE_AREA": ["0 0 1500 1500"],
@@ -86,6 +112,27 @@ def test_pair_merge_guard_accepts_checked_in_config_and_sweep_packaging(tmp_path
     )
 
 
+def test_pair_merge_guard_accepts_checked_in_mersenne_config_and_sweep_packaging(tmp_path: Path) -> None:
+    checked_in_config = CHECKED_IN_MERSENNE_DESIGN_DIR / "config.json"
+    config = json.loads(checked_in_config.read_text(encoding="utf-8"))
+    design_dir = tmp_path / CHECKED_IN_MERSENNE_DESIGN_DIR.name
+    generate(config, design_dir / "verilog")
+
+    assert (
+        guard_main(
+            [
+                "--design-dir",
+                str(design_dir),
+                "--config",
+                str(checked_in_config),
+                "--sweep",
+                str(CHECKED_IN_MERSENNE_SWEEP),
+            ]
+        )
+        == 0
+    )
+
+
 def test_pair_merge_guard_rejects_nonshared_parallelism(tmp_path: Path) -> None:
     design_dir = tmp_path / "design"
     rtl_dir = design_dir / "verilog"
@@ -118,4 +165,28 @@ def test_pair_merge_guard_rejects_second_signed_scale_invocation(tmp_path: Path)
     )
 
     with pytest.raises(SystemExit, match="exactly one scale_signed41 invocation; found 2"):
+        guard_main(["--design-dir", str(design_dir)])
+
+
+def test_pair_merge_guard_rejects_generic_division_inside_mersenne_variant(tmp_path: Path) -> None:
+    design_dir = tmp_path / "design"
+    rtl_dir = design_dir / "verilog"
+    rtl_dir.mkdir(parents=True)
+    config = _config(
+        top_name="attention_score32_exact_partial_pair_merge_sharedscale_factored_mersenne_l1",
+        scale_divider_impl=MERSENNE24_CORRECTION2_SCALE_DIVIDER_EXACT,
+    )
+    generate(config, rtl_dir)
+    (design_dir / "config.json").write_text(json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    top_path = rtl_dir / "top.v"
+    rtl = top_path.read_text(encoding="utf-8")
+    top_path.write_text(
+        rtl.replace(
+            "quotient = divide_mersenne24_u57(product);",
+            "quotient = product / 57'd16777215;",
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit, match="must not contain generic division token"):
         guard_main(["--design-dir", str(design_dir)])


### PR DESCRIPTION
## Summary
- add an explicit exact divide-by-`2^24-1` implementation using the Mersenne quotient identity
- preserve the previously measured generic-divider generator output byte-for-byte when its config key is absent
- retain one shared signed and one shared unsigned scale path and the existing 20-cycle service contract
- stage a direct remote PPA comparison against the 14.1763 ns / 71,005.8 um2 generic anchor

## Exactness
For `B=2^24`, `M=B-1`, and `n=n0+B*n1+B^2*n2`:

`floor(n/M) = n1 + (B+1)*n2 + floor((n0+n1+n2)/M)`

The final correction is exactly 0, 1, or 2 and is implemented with two comparisons. Helper outputs cover the full 57-bit and 65-bit input domains before scale saturation.

## Verification
- 53 folded/generic/tree RTL, perf, guard, service, and compatibility tests passed
- 4 task-generation/proposal metadata tests passed
- direct RTL quotient/scale tests, canonical full-merge equivalence, high-volume deterministic random checks, and origin/master byte identity included
- `git diff --check` passed

Remote PPA is intentionally deferred until merge.