### PR TITLE
Add folded Mersenne exact partial tree frontier

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -1088,7 +1088,7 @@ def _read_config_target(
                     "name": "check_attention_score32_exact_partial_tree_guard",
                     "run": (
                         "python3 npu/eval/check_attention_score32_exact_partial_tree_guard.py "
-                        f"--design-dir {design_dir} --config {config_rel}"
+                        f"--design-dir {design_dir} --config {config_rel} --sweep {{sweep_path}}"
                     ),
                 },
                 {

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -1942,6 +1942,67 @@ def _write_example_attention_score32_exact_partial_tree_repo(repo_root: Path) ->
     return str(config_path.relative_to(repo_root)), str(sweep_path.relative_to(repo_root))
 
 
+def _write_example_attention_score32_exact_partial_tree_folded_mersenne_repo(repo_root: Path) -> tuple[str, str]:
+    design_dir = (
+        repo_root
+        / "runs"
+        / "designs"
+        / "npu_blocks"
+        / "attention_score32_exact_partial_tree_folded_mersenne_smoke_c4_r2"
+    )
+    design_dir.mkdir(parents=True, exist_ok=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": "attention_score32_exact_partial_tree_folded_mersenne_smoke_c4_r2",
+                "attention_score32_exact_partial_tree": {
+                    "clusters": 4,
+                    "radix": 2,
+                    "value_slices": 16,
+                    "head_id_bits": 5,
+                    "exp_scale_impl": "factored_h33_l64_mul_exact",
+                    "pair_node_impl": "folded_sharedscale_mersenne_exact",
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    sweep_path = (
+        repo_root
+        / "runs"
+        / "campaigns"
+        / "npu"
+        / "attention_score32_exact_partial_tree_folded_mersenne_v1"
+        / "sweeps"
+        / "nangate45_attention_score32_exact_partial_tree_folded_mersenne_cluster_v1.json"
+    )
+    sweep_path.parent.mkdir(parents=True, exist_ok=True)
+    sweep_path.write_text(
+        json.dumps(
+            {
+                "tag_prefix": "attention_score32_exact_partial_tree_folded_mersenne_cluster_v1",
+                "flow_params": {
+                    "CLOCK_PERIOD": [8.0],
+                    "DIE_AREA": ["0 0 2500 2500"],
+                    "CORE_AREA": ["50 50 2450 2450"],
+                    "IO_PLACER_H": ["metal3 metal5"],
+                    "IO_PLACER_V": ["metal4 metal6"],
+                    "PLACE_DENSITY": [0.3],
+                    "PLACE_PINS_ARGS": ["-min_distance 1"],
+                    "SYNTH_HIERARCHICAL": [1],
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return str(config_path.relative_to(repo_root)), str(sweep_path.relative_to(repo_root))
+
+
 def _write_example_attention_score32_exact_partial_pair_merge_folded_repo(
     repo_root: Path,
 ) -> tuple[str, str]:
@@ -3813,7 +3874,9 @@ def test_generate_l1_sweep_task_supports_attention_score32_exact_partial_tree_co
             assert work_item.command_manifest[1]["run"] == (
                 "python3 npu/eval/check_attention_score32_exact_partial_tree_guard.py "
                 "--design-dir runs/designs/npu_blocks/attention_score32_exact_partial_tree_smoke_c4_r2 "
-                "--config runs/designs/npu_blocks/attention_score32_exact_partial_tree_smoke_c4_r2/config.json"
+                "--config runs/designs/npu_blocks/attention_score32_exact_partial_tree_smoke_c4_r2/config.json "
+                "--sweep runs/campaigns/npu/attention_score32_exact_partial_tree_v1/sweeps/"
+                "nangate45_attention_score32_exact_partial_tree_cluster_firstpass.json"
             )
             assert "--top attention_score32_exact_partial_tree_smoke_c4_r2" in work_item.command_manifest[2]["run"]
             assert work_item.command_manifest[3]["run"] == (
@@ -3829,6 +3892,44 @@ def test_generate_l1_sweep_task_supports_attention_score32_exact_partial_tree_co
             assert work_item.task_request.request_payload["developer_loop"]["abstraction"] == {
                 "layer": "architecture_block"
             }
+
+
+def test_generate_l1_sweep_task_supports_attention_score32_exact_partial_tree_folded_mersenne_configs() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_attention_score32_exact_partial_tree_folded_mersenne_repo(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/npu_blocks",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="architecture_block",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert work_item.command_manifest[1]["run"] == (
+                "python3 npu/eval/check_attention_score32_exact_partial_tree_guard.py "
+                "--design-dir runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_smoke_c4_r2 "
+                "--config runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_smoke_c4_r2/config.json "
+                "--sweep runs/campaigns/npu/attention_score32_exact_partial_tree_folded_mersenne_v1/sweeps/"
+                "nangate45_attention_score32_exact_partial_tree_folded_mersenne_cluster_v1.json"
+            )
+            assert work_item.expected_outputs == [
+                "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_smoke_c4_r2/metrics.csv",
+                "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_smoke_c4_r2/timing_debug_report.md",
+            ]
 
 
 def test_generate_l1_sweep_task_supports_attention_score32_exact_partial_pair_merge_folded_configs() -> None:
@@ -4678,6 +4779,41 @@ def test_exact_partial_tree_factored_cluster_ppa_proposal_is_pending_merge_with_
     assert proposal_entry["sweep_path"] == expected_sweep
     assert request_entry["sweep_path"] == expected_sweep
     assert "Revision-safe retry on new config/output identities only" in proposal_entry["notes"]
+
+
+def test_exact_partial_tree_folded_mersenne_cluster_ppa_proposal_is_pending_merge_with_all_cluster_configs() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    proposal_dir = (
+        repo_root
+        / "docs"
+        / "proposals"
+        / "prop_l1_decoder_attention_score32_exact_partial_tree_folded_mersenne_cluster_ppa_v1"
+    )
+    proposal = json.loads((proposal_dir / "proposal.json").read_text(encoding="utf-8"))
+    evaluation_requests = json.loads((proposal_dir / "evaluation_requests.json").read_text(encoding="utf-8"))
+
+    item_id = "l1_decoder_attention_score32_exact_partial_tree_folded_mersenne_cluster_ppa_v1"
+    expected_configs = [
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c2_r2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c4_r2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c8_r2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c16_r2/config.json",
+    ]
+    expected_sweep = (
+        "runs/campaigns/npu/attention_score32_exact_partial_tree_folded_mersenne_v1/sweeps/"
+        "nangate45_attention_score32_exact_partial_tree_folded_mersenne_cluster_v1.json"
+    )
+    proposal_entry = {entry["item_id"]: entry for entry in proposal["required_evaluations"]}[item_id]
+    request_entry = {entry["item_id"]: entry for entry in evaluation_requests["requested_items"]}[item_id]
+
+    assert proposal["abstraction_layer"] == "architecture_block"
+    assert proposal_entry["status"] == "pending_implementation_merge"
+    assert request_entry["status"] == "pending_implementation_merge"
+    assert proposal_entry["configs"] == expected_configs
+    assert request_entry["configs"] == expected_configs
+    assert proposal_entry["sweep_path"] == expected_sweep
+    assert request_entry["sweep_path"] == expected_sweep
+    assert "direct 328-bit leaf/root pins" in proposal_entry["notes"]
 
 
 def test_exact_finalized_tree_c16_lane_ppa_proposal_is_pending_merge_with_all_lane_configs() -> None:

--- a/docs/proposals/prop_l1_decoder_attention_score32_exact_partial_tree_folded_mersenne_cluster_ppa_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_exact_partial_tree_folded_mersenne_cluster_ppa_v1/evaluation_requests.json
@@ -1,0 +1,39 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_score32_exact_partial_tree_folded_mersenne_cluster_ppa_v1",
+  "source_commit_note": "Replace with the merge commit that adds the folded-Mersenne exact partial tree selector, service model, guards, staged configs, and proposal before dispatch.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_score32_exact_partial_tree_folded_mersenne_cluster_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for standalone folded-Mersenne exact partial trees at 2, 4, 8, and 16 clusters.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "exact_partial_tree_folded_mersenne_cluster_anchor",
+      "priority": 97,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c2_r2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c4_r2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c8_r2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c16_r2/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_partial_tree_folded_mersenne_v1/sweeps/nangate45_attention_score32_exact_partial_tree_folded_mersenne_cluster_v1.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c2_r2/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c2_r2/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c4_r2/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c4_r2/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c8_r2/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c8_r2/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c16_r2/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c16_r2/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "measure_folded_mersenne_exact_partial_tree_cluster_cost",
+        "reason": "This keeps the folded node change isolated while preserving the explicit wide-pin tree boundary."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "Standalone folded-tree boundary only. Direct 328-bit links remain exposed at the external macro boundary and are not claimed as routed or composed."
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_score32_exact_partial_tree_folded_mersenne_cluster_ppa_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_exact_partial_tree_folded_mersenne_cluster_ppa_v1/proposal.json
@@ -1,0 +1,87 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_score32_exact_partial_tree_folded_mersenne_cluster_ppa_v1",
+  "created_utc": "2026-08-02T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "title": "Score32 exact partial tree folded-Mersenne cluster PPA frontier",
+  "abstraction_layer": "architecture_block",
+  "hypothesis": "Replacing the exact partial tree's fully parallel pair node with the timing-feasible folded shared-scale Mersenne pair node should preserve exact partial numerics while moving the multi-cluster tree back into a revision-safe physical search space. Measuring c2/c4/c8/c16 under the existing 8 ns, 2500 um macro envelope exposes the tree-only scaling boundary before any direct-link, NoC, SRAM, or finalizer composition is claimed.",
+  "direct_comparison": {
+    "primary_question": "What Nangate45 area and timing boundary is exposed by standalone folded-Mersenne exact partial trees at 2, 4, 8, and 16 clusters under the existing 8 ns, 2500 um macro envelope with explicit pin-placement settings?",
+    "candidate": "l1_decoder_attention_score32_exact_partial_tree_folded_mersenne_cluster_ppa_v1",
+    "include": [
+      "dedicated exact partial tree RTL with an explicit folded shared-scale Mersenne pair node selector",
+      "strict regeneration, manifest, structural, and sweep guard coverage for the new folded tree identities",
+      "cycle-accurate folded-tree service evidence and c2/c4 RTL equivalence/backpressure coverage before synthesis",
+      "hierarchical OpenROAD block sweeps at density 0.30 for c2/c4/c8/c16"
+    ],
+    "exclude": [
+      "no claim of direct 328-bit link physical closure across a composed decoder macro",
+      "no NoC, SRAM, HBM, or producer coupling closure claim",
+      "no root finalizer or bank-control composition claim"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "die_area",
+      "total_power_mw",
+      "stdcell_count",
+      "timing_debug_report"
+    ]
+  },
+  "remaining_abstractions": [
+    "This item still measures a standalone macro with direct 328-bit leaf/root links exposed at the top-level pin boundary. No pad ring or inter-macro transport closure is claimed.",
+    "The root still emits exact partial state rather than finalized normalized values.",
+    "NoC, SRAM, HBM, and decoder-wrapper composition remain separate architectural risks even if the folded tree itself becomes physically tractable."
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_score32_exact_partial_tree_folded_mersenne_cluster_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for standalone folded-Mersenne exact partial trees at 2, 4, 8, and 16 clusters.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "exact_partial_tree_folded_mersenne_cluster_anchor",
+      "priority": 97,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c2_r2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c4_r2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c8_r2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c16_r2/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_partial_tree_folded_mersenne_v1/sweeps/nangate45_attention_score32_exact_partial_tree_folded_mersenne_cluster_v1.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c2_r2/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c2_r2/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c4_r2/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c4_r2/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c8_r2/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c8_r2/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c16_r2/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c16_r2/timing_debug_report.md"
+      ],
+      "expected_result": {
+        "direction": "measure_folded_mersenne_exact_partial_tree_cluster_cost",
+        "reason": "This isolates the dedicated folded pair-node timing recovery inside the multi-node tree while keeping the wide external partial links explicit."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "Standalone folded-tree boundary only. The macro still terminates at direct 328-bit leaf/root pins inside the 2500 um envelope, so any composed decoder result must add transport and finalizer costs separately."
+    }
+  ],
+  "source_refs": [
+    "npu/rtlgen/gen_attention_score32_exact_partial_tree.py",
+    "npu/eval/check_attention_score32_exact_partial_tree_guard.py",
+    "npu/eval/probe_attention_score32_exact_partial_tree.py",
+    "npu/sim/perf/attention_exact_partial.py",
+    "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c2_r2/config.json",
+    "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c4_r2/config.json",
+    "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c8_r2/config.json",
+    "runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c16_r2/config.json",
+    "runs/campaigns/npu/attention_score32_exact_partial_tree_folded_mersenne_v1/sweeps/nangate45_attention_score32_exact_partial_tree_folded_mersenne_cluster_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/docs/attention_score32_exact_partial_tree_contract.md",
+    "npu/docs/attention_score32_exact_partial_pair_merge_contract.md"
+  ]
+}

--- a/npu/docs/attention_score32_exact_partial_tree_contract.md
+++ b/npu/docs/attention_score32_exact_partial_tree_contract.md
@@ -9,6 +9,10 @@ tree built from the exact-partial pair primitive.
 - Each beat carries `command_id`, `head_id`, signed `S32` global max, unsigned
   `U33` exponent sum, slice index, `last`, and `8 x signed S41` numerators
   (`328` payload bits).
+- `pair_node_impl` is absent-key legacy by default. The new explicit
+  `folded_sharedscale_mersenne_exact` selector swaps each radix-2 node to the
+  folded shared-scale Mersenne pair microarchitecture without changing the
+  exact-partial numerical contract.
 - The tree preserves left-to-right level-wise pairing. There is no merge path
   through locally normalized values.
 - Each pair node buffers only its current left/right beat. There is no
@@ -28,6 +32,10 @@ tree built from the exact-partial pair primitive.
 ## Probe Evidence
 
 - Quick smoke probes may use smaller head counts for `c2`/`c4` runtime.
+- The folded-Mersenne tree path additionally carries a cycle-accurate service
+  model derived from the node contract: one prefetched pair per side, pair
+  capture-to-output `20`, launch-to-output `19`, and launch interval `20`
+  cycles under parent-driven ready backpressure.
 - The real `c16` regression now runs the full `32`-head workload:
   `512` accepted beats per leaf, `8192` total leaf beats, and `512` root
   outputs under deterministic skew and root backpressure.
@@ -37,7 +45,8 @@ tree built from the exact-partial pair primitive.
 ## Boundaries Still Open
 
 - The links are still direct `328`-bit numerator payload streams with repeated
-  metadata. No NoC or placement closure is claimed here.
+  metadata. The standalone macro exposes those wide links at the external pin
+  boundary; no NoC, transport, or placement closure is claimed here.
 - Final normalization/division is still the next boundary. The root currently
   emits merged exact partial state, not finalized values.
 - Folded/time-multiplexed trees and radix-4 fan-in remain later area

--- a/npu/eval/check_attention_score32_exact_partial_tree_guard.py
+++ b/npu/eval/check_attention_score32_exact_partial_tree_guard.py
@@ -16,16 +16,25 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from npu.rtlgen.gen_attention_score32_exact_partial_tree import generate
+from npu.rtlgen.gen_attention_score32_exact_partial_pair_merge_folded import (
+    MERSENNE24_CORRECTION2_SCALE_DIVIDER_EXACT,
+)
 from npu.rtlgen.gen_attention_score32_online_state_merge import (
     FACTORED_H33_L64_MUL_EXACT,
     LEGACY_MONOLITHIC_LUT_EXACT,
 )
-from npu.sim.perf.attention_exact_partial import PARTIAL_LINK_BITS, PARTIAL_PAYLOAD_BITS
+from npu.sim.perf.attention_exact_partial import (
+    FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL,
+    LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL,
+    PARTIAL_LINK_BITS,
+    PARTIAL_PAYLOAD_BITS,
+)
 
 
 _SUPPORTED_CLUSTERS = {2, 4, 8, 16}
 _PPA_SWEEP_TAG_PREFIX = "attention_score32_exact_partial_tree_cluster_firstpass_v1"
 _PPA_FACTORED_SWEEP_TAG_PREFIX = "attention_score32_exact_partial_tree_factored_cluster_retry_r2"
+_PPA_FOLDED_MERSENNE_SWEEP_TAG_PREFIX = "attention_score32_exact_partial_tree_folded_mersenne_cluster_v1"
 _PPA_SWEEP_FLOW_PARAMS = {
     "CLOCK_PERIOD": [8.0],
     "DIE_AREA": ["0 0 2500 2500"],
@@ -38,6 +47,16 @@ _PPA_FACTORED_SWEEP_FLOW_PARAMS = {
     "IO_PLACER_H": ["metal3 metal5"],
     "IO_PLACER_V": ["metal4 metal6"],
     "PLACE_PINS_ARGS": ["-min_distance 1"],
+}
+_PPA_FOLDED_MERSENNE_SWEEP_FLOW_PARAMS = {
+    "CLOCK_PERIOD": [8.0],
+    "DIE_AREA": ["0 0 2500 2500"],
+    "CORE_AREA": ["50 50 2450 2450"],
+    "IO_PLACER_H": ["metal3 metal5"],
+    "IO_PLACER_V": ["metal4 metal6"],
+    "PLACE_DENSITY": [0.3],
+    "PLACE_PINS_ARGS": ["-min_distance 1"],
+    "SYNTH_HIERARCHICAL": [1],
 }
 
 
@@ -105,6 +124,7 @@ def _validate_ppa_sweep(*, config: dict[str, object], sweep_path: Path) -> None:
         raise SystemExit("config must contain attention_score32_exact_partial_tree object")
     clusters = int(body.get("clusters", 0))
     exp_scale_impl = str(body.get("exp_scale_impl", LEGACY_MONOLITHIC_LUT_EXACT)).strip()
+    pair_node_impl = str(body.get("pair_node_impl", LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL)).strip()
     tag_prefix = sweep.get("tag_prefix")
     if tag_prefix == _PPA_SWEEP_TAG_PREFIX:
         expected_flow_params = _PPA_SWEEP_FLOW_PARAMS
@@ -112,16 +132,32 @@ def _validate_ppa_sweep(*, config: dict[str, object], sweep_path: Path) -> None:
             raise SystemExit(
                 f"legacy partial-tree sweep requires exp_scale_impl {LEGACY_MONOLITHIC_LUT_EXACT}"
             )
+        if pair_node_impl != LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL:
+            raise SystemExit("legacy partial-tree sweep requires the legacy parallel pair node")
     elif tag_prefix == _PPA_FACTORED_SWEEP_TAG_PREFIX:
         expected_flow_params = _PPA_FACTORED_SWEEP_FLOW_PARAMS
         if exp_scale_impl != FACTORED_H33_L64_MUL_EXACT:
             raise SystemExit(
                 f"factored partial-tree sweep requires exp_scale_impl {FACTORED_H33_L64_MUL_EXACT}"
             )
+        if pair_node_impl != LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL:
+            raise SystemExit("factored partial-tree retry sweep requires the legacy parallel pair node")
+    elif tag_prefix == _PPA_FOLDED_MERSENNE_SWEEP_TAG_PREFIX:
+        expected_flow_params = _PPA_FOLDED_MERSENNE_SWEEP_FLOW_PARAMS
+        if exp_scale_impl != FACTORED_H33_L64_MUL_EXACT:
+            raise SystemExit(
+                f"folded Mersenne partial-tree sweep requires exp_scale_impl {FACTORED_H33_L64_MUL_EXACT}"
+            )
+        if pair_node_impl != FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL:
+            raise SystemExit(
+                "folded Mersenne partial-tree sweep requires pair_node_impl "
+                f"{FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL}"
+            )
     else:
         raise SystemExit(
             "partial-tree PPA sweep tag_prefix must be "
-            f"{_PPA_SWEEP_TAG_PREFIX} or {_PPA_FACTORED_SWEEP_TAG_PREFIX}"
+            f"{_PPA_SWEEP_TAG_PREFIX}, {_PPA_FACTORED_SWEEP_TAG_PREFIX}, "
+            f"or {_PPA_FOLDED_MERSENNE_SWEEP_TAG_PREFIX}"
         )
     if sweep.get("flow_params") != expected_flow_params:
         raise SystemExit("partial-tree PPA sweep flow_params do not match the checked-in partial-tree contract")
@@ -164,6 +200,7 @@ def main(argv: list[str] | None = None) -> int:
     value_slices = int(body.get("value_slices", 0))
     head_id_bits = int(body.get("head_id_bits", 0))
     exp_scale_impl = str(body.get("exp_scale_impl", LEGACY_MONOLITHIC_LUT_EXACT)).strip()
+    pair_node_impl = str(body.get("pair_node_impl", LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL)).strip()
     if clusters not in _SUPPORTED_CLUSTERS:
         raise SystemExit("clusters must be one of 2, 4, 8, 16")
     if clusters & (clusters - 1):
@@ -174,6 +211,11 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit("value_slices must be a power of two in [1, 16]")
     if head_id_bits < 1 or head_id_bits > 8:
         raise SystemExit("head_id_bits must be in [1, 8]")
+    if pair_node_impl not in {
+        LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL,
+        FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL,
+    }:
+        raise SystemExit("unsupported pair_node_impl for exact partial tree guard")
 
     tree_nodes = clusters - 1
     tree_stages = int(math.log2(clusters))
@@ -203,6 +245,23 @@ def main(argv: list[str] | None = None) -> int:
     }
     for key, expected in expected_manifest.items():
         _require(manifest, key, expected, "generated manifest")
+    if pair_node_impl == FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL:
+        _require(manifest, "pair_node_impl", pair_node_impl, "generated manifest")
+        _require(manifest["theoretical_full_llama_service_manifest"], "pair_node_impl", pair_node_impl, "service manifest")
+        _require(
+            manifest["theoretical_full_llama_service_manifest"],
+            "pair_node_scale_divider_impl",
+            MERSENNE24_CORRECTION2_SCALE_DIVIDER_EXACT,
+            "service manifest",
+        )
+        _require(manifest["theoretical_full_llama_service_manifest"], "service_model", "cycle_simulated_folded_sharedscale_mersenne_tree_v1", "service manifest")
+    elif "pair_node_impl" in manifest:
+        _require(
+            manifest,
+            "pair_node_impl",
+            LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL,
+            "generated manifest",
+        )
 
     pair_manifest = manifest.get("submodule_manifests")
     if not isinstance(pair_manifest, dict):
@@ -210,26 +269,53 @@ def main(argv: list[str] | None = None) -> int:
     pair_merge_manifest = pair_manifest.get("pair_merge")
     if not isinstance(pair_merge_manifest, dict):
         raise SystemExit("generated manifest must contain pair_merge submodule manifest")
-    _require(
-        pair_merge_manifest,
-        "generator",
-        "npu/rtlgen/gen_attention_score32_online_state_merge.py",
-        "pair-merge submodule manifest",
-    )
-    _require(
-        pair_merge_manifest,
-        "semantic_profile",
-        "score32_online_exact_partial_pair_merge_v1",
-        "pair-merge submodule manifest",
-    )
-    _require(
-        pair_merge_manifest,
-        "exp_scale_impl",
-        exp_scale_impl,
-        "pair-merge submodule manifest",
-    )
+    if pair_node_impl == LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL:
+        _require(
+            pair_merge_manifest,
+            "generator",
+            "npu/rtlgen/gen_attention_score32_online_state_merge.py",
+            "pair-merge submodule manifest",
+        )
+        _require(
+            pair_merge_manifest,
+            "semantic_profile",
+            "score32_online_exact_partial_pair_merge_v1",
+            "pair-merge submodule manifest",
+        )
+        _require(
+            pair_merge_manifest,
+            "exp_scale_impl",
+            exp_scale_impl,
+            "pair-merge submodule manifest",
+        )
+    else:
+        _require(
+            pair_merge_manifest,
+            "generator",
+            "npu/rtlgen/gen_attention_score32_exact_partial_pair_merge_folded.py",
+            "pair-merge submodule manifest",
+        )
+        _require(
+            pair_merge_manifest,
+            "semantic_profile",
+            "score32_online_exact_partial_pair_merge_folded_sharedscale_v1",
+            "pair-merge submodule manifest",
+        )
+        _require(
+            pair_merge_manifest,
+            "exp_scale_impl",
+            exp_scale_impl,
+            "pair-merge submodule manifest",
+        )
+        _require(
+            pair_merge_manifest,
+            "scale_divider_impl",
+            MERSENNE24_CORRECTION2_SCALE_DIVIDER_EXACT,
+            "pair-merge submodule manifest",
+        )
 
     rtl = top_path.read_text(encoding="utf-8", errors="replace")
+    pair_module = _extract_module(rtl, pair_top_name)
     top_module = _extract_module(rtl, top_name)
     top_module_body = top_module.split(");", 1)[1]
 
@@ -310,6 +396,18 @@ def main(argv: list[str] | None = None) -> int:
             "generated RTL",
         )
 
+    if pair_node_impl == FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL:
+        for token in (
+            "wire start_pair = (phase_q == PHASE_IDLE) && !out_valid_q && left_hold_valid_q && right_hold_valid_q;",
+            "function automatic [33:0] divide_mersenne24_u57;",
+            "function automatic [41:0] divide_mersenne24_u65;",
+            "scale_unsigned33(shared_unsigned_value_r, shared_unsigned_scale_r);",
+            "scale_signed41(shared_signed_value_r, shared_signed_scale_r);",
+        ):
+            _require_token(pair_module, token, "folded pair RTL")
+        if "/ 57'd16777215" in pair_module or "/ 65'd16777215" in pair_module:
+            raise SystemExit("folded pair RTL must not contain generic exact division operators")
+
     _compare_current_generation(config=config, rtl_dir=rtl_dir)
 
     print(
@@ -318,6 +416,7 @@ def main(argv: list[str] | None = None) -> int:
                 "design": top_name,
                 "guard": "attention_score32_exact_partial_tree_v1",
                 "clusters": clusters,
+                "pair_node_impl": pair_node_impl,
                 "tree_nodes": tree_nodes,
                 "tree_stages": tree_stages,
                 "status": "ok",

--- a/npu/eval/probe_attention_score32_exact_partial_tree.py
+++ b/npu/eval/probe_attention_score32_exact_partial_tree.py
@@ -22,10 +22,13 @@ if str(REPO_ROOT) not in sys.path:
 from npu.rtlgen.gen_attention_score32_exact_partial_tree import generate as generate_tree
 from npu.sim.perf.attention_exact_partial import (
     ExactPartialBeat,
+    FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL,
+    LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL,
     exact_partial_tree_service_manifest,
     merge_balanced_partial_streams,
     pack_numerators,
     partial_stream_from_blocks,
+    simulate_exact_partial_tree_service,
     unpack_numerators,
 )
 
@@ -164,16 +167,23 @@ def _expected(clusters: int, *, heads: int) -> dict[str, object]:
     }
 
 
-def _config(clusters: int) -> dict[str, object]:
-    return {
-        "top_name": f"attention_score32_exact_partial_tree_c{clusters}_r2",
-        "attention_score32_exact_partial_tree": {
-            "clusters": clusters,
-            "radix": 2,
-            "value_slices": 16,
-            "head_id_bits": 5,
-        },
+def _config(
+    clusters: int,
+    *,
+    pair_node_impl: str = LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL,
+) -> dict[str, object]:
+    body: dict[str, object] = {
+        "clusters": clusters,
+        "radix": 2,
+        "value_slices": 16,
+        "head_id_bits": 5,
     }
+    top_name = f"attention_score32_exact_partial_tree_c{clusters}_r2"
+    if pair_node_impl == FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL:
+        body["exp_scale_impl"] = "factored_h33_l64_mul_exact"
+        body["pair_node_impl"] = pair_node_impl
+        top_name = f"attention_score32_exact_partial_tree_folded_mersenne_c{clusters}_r2"
+    return {"top_name": top_name, "attention_score32_exact_partial_tree": body}
 
 
 def _testbench(*, top_name: str, clusters: int, heads: int, expected: dict[str, object]) -> str:
@@ -397,13 +407,18 @@ endmodule
 """
 
 
-def build_report(clusters: int = 16, heads: int = 32) -> JsonDict:
+def build_report(
+    clusters: int = 16,
+    heads: int = 32,
+    *,
+    pair_node_impl: str = LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL,
+) -> JsonDict:
     expected = _expected(clusters, heads=heads)
     with tempfile.TemporaryDirectory(prefix=f"score32_exact_partial_tree_c{clusters}_") as temp_dir_name:
         temp_dir = Path(temp_dir_name)
-        generate_tree(_config(clusters), temp_dir / "rtl")
+        generate_tree(_config(clusters, pair_node_impl=pair_node_impl), temp_dir / "rtl")
         tb_path = temp_dir / "tb.sv"
-        top_name = str(_config(clusters)["top_name"])
+        top_name = str(_config(clusters, pair_node_impl=pair_node_impl)["top_name"])
         tb_path.write_text(
             _testbench(top_name=top_name, clusters=clusters, heads=heads, expected=expected),
             encoding="utf-8",
@@ -487,7 +502,11 @@ def build_report(clusters: int = 16, heads: int = 32) -> JsonDict:
     first_output_cycle = int(summary["first_output_cycle"])
     last_output_cycle = int(summary["last_output_cycle"])
     sustained_window = max(1, (last_output_cycle - first_output_cycle) + 1)
-    measured_workload_manifest = exact_partial_tree_service_manifest(clusters=clusters, heads=heads)
+    measured_workload_manifest = exact_partial_tree_service_manifest(
+        clusters=clusters,
+        heads=heads,
+        pair_node_impl=pair_node_impl,
+    )
     measured_workload_manifest.update(
         {
             "leaf_accepts_per_leaf": len(expected["root"]),
@@ -502,7 +521,20 @@ def build_report(clusters: int = 16, heads: int = 32) -> JsonDict:
             "protocol_error": bool(summary["protocol_error"]),
         }
     )
-    theoretical_full_llama_service_manifest = exact_partial_tree_service_manifest(clusters=clusters, heads=32)
+    theoretical_full_llama_service_manifest = exact_partial_tree_service_manifest(
+        clusters=clusters,
+        heads=32,
+        pair_node_impl=pair_node_impl,
+    )
+    service_simulation = None
+    if pair_node_impl == FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL:
+        service_simulation = simulate_exact_partial_tree_service(
+            (_leaf_stream(leaf, heads=heads) for leaf in range(clusters)),
+            output_ready_pattern=tuple(
+                ((cycle % 5) != 2) and ((cycle % 11) != 7) for cycle in range(55)
+            ),
+            pair_node_impl=pair_node_impl,
+        )
     passed = (
         observed_rows == expected["root"]
         and leaf_summary == expected["leaf_accept_count"]
@@ -518,6 +550,7 @@ def build_report(clusters: int = 16, heads: int = 32) -> JsonDict:
     return {
         "clusters": clusters,
         "heads": heads,
+        "pair_node_impl": pair_node_impl,
         "decision": "pass" if passed else "fail",
         "equivalence_pass": passed,
         "leaf_input_hash": expected["leaf_hash"],
@@ -533,6 +566,7 @@ def build_report(clusters: int = 16, heads: int = 32) -> JsonDict:
         "summary": summary,
         "measured_workload_manifest": measured_workload_manifest,
         "theoretical_full_llama_service_manifest": theoretical_full_llama_service_manifest,
+        "service_simulation": service_simulation,
         "expected": {
             "heads": expected["heads"],
             "leaf_accept_count": expected["leaf_accept_count"],
@@ -548,9 +582,17 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--clusters", type=int, choices=(2, 4, 8, 16), default=16)
     parser.add_argument("--heads", type=int, choices=tuple(range(1, 33)), default=32)
+    parser.add_argument(
+        "--pair-node-impl",
+        choices=(
+            LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL,
+            FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL,
+        ),
+        default=LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL,
+    )
     parser.add_argument("--out", type=Path, required=True)
     args = parser.parse_args()
-    payload = build_report(clusters=args.clusters, heads=args.heads)
+    payload = build_report(clusters=args.clusters, heads=args.heads, pair_node_impl=args.pair_node_impl)
     args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return 0 if payload["equivalence_pass"] else 1
 

--- a/npu/rtlgen/gen_attention_score32_exact_partial_tree.py
+++ b/npu/rtlgen/gen_attention_score32_exact_partial_tree.py
@@ -20,7 +20,13 @@ from npu.rtlgen.gen_attention_score32_online_state_merge import (
     LEGACY_MONOLITHIC_LUT_EXACT,
     generate as generate_merge,
 )
+from npu.rtlgen.gen_attention_score32_exact_partial_pair_merge_folded import (
+    MERSENNE24_CORRECTION2_SCALE_DIVIDER_EXACT,
+    generate as generate_folded_merge,
+)
 from npu.sim.perf.attention_exact_partial import (
+    FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL,
+    LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL,
     PARTIAL_LINK_BITS,
     PARTIAL_PAYLOAD_BITS,
     exact_partial_tree_service_manifest,
@@ -51,6 +57,8 @@ def _validate(config: JsonDict) -> JsonDict:
     value_slices = int(body.get("value_slices", 16))
     head_id_bits = int(body.get("head_id_bits", 5))
     exp_scale_impl = str(body.get("exp_scale_impl", LEGACY_MONOLITHIC_LUT_EXACT)).strip()
+    pair_node_impl_explicit = "pair_node_impl" in body
+    pair_node_impl = str(body.get("pair_node_impl", LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL)).strip()
     if clusters < 2 or clusters > 16 or (clusters & (clusters - 1)):
         raise SystemExit("clusters must be a power of two in [2, 16]")
     if radix != 2:
@@ -59,6 +67,22 @@ def _validate(config: JsonDict) -> JsonDict:
         raise SystemExit("value_slices must be a power of two in [1, 16]")
     if head_id_bits < 1 or head_id_bits > 8:
         raise SystemExit("head_id_bits must be in [1, 8]")
+    if pair_node_impl not in {
+        LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL,
+        FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL,
+    }:
+        raise SystemExit(
+            "pair_node_impl must be absent or one of "
+            f"{LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL}, "
+            f"{FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL}"
+        )
+    if (
+        pair_node_impl == FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL
+        and exp_scale_impl != FACTORED_H33_L64_MUL_EXACT
+    ):
+        raise SystemExit(
+            "folded_sharedscale_mersenne_exact requires exp_scale_impl factored_h33_l64_mul_exact"
+        )
     return {
         "top_name": top_name,
         "clusters": clusters,
@@ -66,6 +90,8 @@ def _validate(config: JsonDict) -> JsonDict:
         "value_slices": value_slices,
         "head_id_bits": head_id_bits,
         "exp_scale_impl": exp_scale_impl,
+        "pair_node_impl": pair_node_impl,
+        "pair_node_impl_explicit": pair_node_impl_explicit,
     }
 
 
@@ -307,21 +333,36 @@ def generate(config: JsonDict, out_dir: Path) -> None:
     pair_top_name = f"{params['top_name']}__pair_node"
     with tempfile.TemporaryDirectory(prefix="score32_exact_partial_tree_pair_") as temp_dir_name:
         temp_dir = Path(temp_dir_name)
-        generate_merge(
-            {
-                "top_name": pair_top_name,
-                "attention_score32_online_state_merge": {
-                    "value_slices": int(params["value_slices"]),
-                    "head_id_bits": int(params["head_id_bits"]),
-                    "exp_scale_impl": str(params["exp_scale_impl"]),
+        if params["pair_node_impl"] == LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL:
+            generate_merge(
+                {
+                    "top_name": pair_top_name,
+                    "attention_score32_online_state_merge": {
+                        "value_slices": int(params["value_slices"]),
+                        "head_id_bits": int(params["head_id_bits"]),
+                        "exp_scale_impl": str(params["exp_scale_impl"]),
+                    },
                 },
-            },
-            temp_dir,
-        )
+                temp_dir,
+            )
+            pair_manifest_name = "attention_score32_online_state_merge_manifest.json"
+        else:
+            generate_folded_merge(
+                {
+                    "top_name": pair_top_name,
+                    "attention_score32_exact_partial_pair_merge_folded": {
+                        "value_slices": int(params["value_slices"]),
+                        "head_id_bits": int(params["head_id_bits"]),
+                        "exp_scale_impl": str(params["exp_scale_impl"]),
+                        "scale_divider_impl": MERSENNE24_CORRECTION2_SCALE_DIVIDER_EXACT,
+                        "lane_parallelism": 1,
+                    },
+                },
+                temp_dir,
+            )
+            pair_manifest_name = "attention_score32_exact_partial_pair_merge_folded_manifest.json"
         pair_rtl = (temp_dir / "top.v").read_text(encoding="utf-8")
-        pair_manifest = json.loads(
-            (temp_dir / "attention_score32_online_state_merge_manifest.json").read_text(encoding="utf-8")
-        )
+        pair_manifest = json.loads((temp_dir / pair_manifest_name).read_text(encoding="utf-8"))
 
     top_text = _top(
         top_name=str(params["top_name"]),
@@ -336,6 +377,7 @@ def generate(config: JsonDict, out_dir: Path) -> None:
     theoretical_full_llama_service_manifest = exact_partial_tree_service_manifest(
         clusters=int(params["clusters"]),
         heads=32,
+        pair_node_impl=str(params["pair_node_impl"]),
     )
     node_count = int(params["clusters"]) - 1
     stage_count = int(math.log2(int(params["clusters"])))
@@ -368,6 +410,8 @@ def generate(config: JsonDict, out_dir: Path) -> None:
         "theoretical_full_llama_service_manifest": theoretical_full_llama_service_manifest,
         "submodule_manifests": {"pair_merge": pair_manifest},
     }
+    if bool(params["pair_node_impl_explicit"]):
+        manifest["pair_node_impl"] = str(params["pair_node_impl"])
     (out_dir / "attention_score32_exact_partial_tree_manifest.json").write_text(
         json.dumps(manifest, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",

--- a/npu/sim/perf/attention_exact_partial.py
+++ b/npu/sim/perf/attention_exact_partial.py
@@ -45,6 +45,8 @@ FOLDED_PAIR_COMPUTE_LAUNCH_TO_OUTPUT_LATENCY_CYCLES = 19
 FOLDED_PAIR_COMPUTE_LAUNCH_INTERVAL_CYCLES = 20
 FOLDED_PAIR_EXP_SUM_SCALE_CYCLES = 2
 FOLDED_PAIR_NUMERATOR_SCALE_CYCLES = 16
+LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL = "legacy_parallel_exact"
+FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL = "folded_sharedscale_mersenne_exact"
 
 
 def _clamp_signed(value: int, bits: int) -> int:
@@ -347,6 +349,264 @@ def simulate_folded_exact_partial_pair_merge_service(
     }
 
 
+@dataclass
+class _FoldedTreeNodeServiceState:
+    left_hold: ExactPartialBeat | None = None
+    right_hold: ExactPartialBeat | None = None
+    active_result: ExactPartialBeat | None = None
+    active_remaining: int = 0
+    out_beat: ExactPartialBeat | None = None
+    completed_count: int = 0
+
+
+def _build_exact_partial_tree_node_levels(clusters: int) -> tuple[tuple[dict[str, object], ...], ...]:
+    previous: list[tuple[str, int]] = [("leaf", index) for index in range(clusters)]
+    next_node_index = 0
+    levels: list[tuple[dict[str, object], ...]] = []
+    while len(previous) > 1:
+        level: list[dict[str, object]] = []
+        for slot in range(0, len(previous), 2):
+            level.append(
+                {
+                    "node_index": next_node_index,
+                    "left": previous[slot],
+                    "right": previous[slot + 1],
+                }
+            )
+            next_node_index += 1
+        levels.append(tuple(level))
+        previous = [("node", int(node["node_index"])) for node in level]
+    return tuple(levels)
+
+
+def _ready_pattern_value(pattern: tuple[bool, ...], cycle: int) -> bool:
+    if not pattern:
+        return True
+    return pattern[cycle % len(pattern)]
+
+
+def _service_leaf_streams(*, clusters: int, heads: int) -> tuple[tuple[ExactPartialBeat, ...], ...]:
+    if heads < 1:
+        raise ValueError("heads must be positive")
+    leaf_streams: list[tuple[ExactPartialBeat, ...]] = []
+    for leaf_index in range(clusters):
+        beats: list[ExactPartialBeat] = []
+        for head_id in range(heads):
+            command_id = 0x6000 + head_id
+            for slice_index in range(VALUE_SLICES):
+                numerators = tuple(
+                    _clamp_signed(
+                        ((leaf_index * 97) + (head_id * 31) + (slice_index * 17) + (lane * 7)) % 1024 - 512,
+                        WEIGHTED_NUMERATOR_BITS,
+                    )
+                    for lane in range(SLICE_LANES)
+                )
+                beats.append(
+                    ExactPartialBeat(
+                        command_id=command_id,
+                        head_id=head_id,
+                        slice_index=slice_index,
+                        last=slice_index == VALUE_SLICES - 1,
+                        max_score=((leaf_index * 19) + (head_id * 11) + (slice_index * 5)) % 255 - 127,
+                        exp_sum=1 + ((leaf_index * 41) + (head_id * 13) + (slice_index * 3)) % ((1 << EXP_SUM_BITS) - 1),
+                        numerators=numerators,
+                    )
+                )
+        leaf_streams.append(tuple(beats))
+    return tuple(leaf_streams)
+
+
+def simulate_exact_partial_tree_service(
+    streams: Iterable[Iterable[ExactPartialBeat]],
+    *,
+    output_ready_pattern: Iterable[bool] | None = None,
+    pair_node_impl: str = FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL,
+) -> dict[str, object]:
+    if pair_node_impl != FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL:
+        raise ValueError(f"unsupported exact partial tree pair_node_impl: {pair_node_impl}")
+    leaf_streams = tuple(tuple(stream) for stream in streams)
+    if not leaf_streams:
+        raise ValueError("expected at least one partial stream")
+    clusters = len(leaf_streams)
+    if clusters < 2 or clusters > 16 or (clusters & (clusters - 1)):
+        raise ValueError("stream count must be a power of two in [2, 16]")
+    beat_count = len(leaf_streams[0])
+    if beat_count == 0:
+        raise ValueError("partial streams must be non-empty")
+    if any(len(stream) != beat_count for stream in leaf_streams):
+        raise ValueError("all partial streams must contain the same beat count")
+    ready_pattern = tuple(bool(value) for value in output_ready_pattern) if output_ready_pattern is not None else ()
+    if ready_pattern and not any(ready_pattern):
+        raise ValueError("output_ready_pattern must contain at least one ready cycle")
+
+    levels = _build_exact_partial_tree_node_levels(clusters)
+    node_count = clusters - 1
+    root_index = node_count - 1
+    states = [_FoldedTreeNodeServiceState() for _ in range(node_count)]
+    node_descriptors = [node for level in levels for node in level]
+    node_descriptor_by_index = {int(node["node_index"]): node for node in node_descriptors}
+
+    source_to_sink: dict[tuple[str, int], tuple[int, str]] = {}
+    for node in node_descriptors:
+        node_index = int(node["node_index"])
+        for side in ("left", "right"):
+            source = node[side]
+            if not isinstance(source, tuple):
+                continue
+            source_to_sink[source] = (node_index, side)
+
+    leaf_positions = [0] * clusters
+    leaf_accept_cycles: list[list[int]] = [[] for _ in range(clusters)]
+    node_launch_cycles: list[list[int]] = [[] for _ in range(node_count)]
+    node_output_fire_cycles: list[list[int]] = [[] for _ in range(node_count)]
+    node_outputs: list[list[ExactPartialBeat]] = [[] for _ in range(node_count)]
+    root_output_fire_cycles: list[int] = []
+    cycle = 0
+    timeout_cycles = max(4096, clusters * beat_count * FOLDED_PAIR_CAPTURE_TO_OUTPUT_LATENCY_CYCLES * 4)
+    stage_node_indices = [[int(node["node_index"]) for node in level] for level in levels]
+    canonical_levels = merge_balanced_partial_stream_levels(leaf_streams)
+    launch_to_output_countdown = folded_exact_partial_pair_merge_compute_launch_to_output_latency_cycles() - 1
+
+    while True:
+        left_ready = [state.left_hold is None for state in states]
+        right_ready = [state.right_hold is None for state in states]
+        out_valid = [state.out_beat is not None for state in states]
+
+        root_ready = _ready_pattern_value(ready_pattern, cycle)
+        output_ready: list[bool] = [False] * node_count
+        for node_index in range(node_count):
+            if node_index == root_index:
+                output_ready[node_index] = root_ready
+                continue
+            parent_index, parent_side = source_to_sink[("node", node_index)]
+            output_ready[node_index] = left_ready[parent_index] if parent_side == "left" else right_ready[parent_index]
+
+        node_output_fires = [out_valid[node_index] and output_ready[node_index] for node_index in range(node_count)]
+
+        leaf_fires = [False] * clusters
+        leaf_beats: list[ExactPartialBeat | None] = [None] * clusters
+        for leaf_index in range(clusters):
+            sink_index, sink_side = source_to_sink[("leaf", leaf_index)]
+            ready = left_ready[sink_index] if sink_side == "left" else right_ready[sink_index]
+            if leaf_positions[leaf_index] < beat_count and ready:
+                leaf_fires[leaf_index] = True
+                leaf_beats[leaf_index] = leaf_streams[leaf_index][leaf_positions[leaf_index]]
+
+        next_states: list[_FoldedTreeNodeServiceState] = []
+        for node_index in range(node_count):
+            state = states[node_index]
+            descriptor = node_descriptor_by_index[node_index]
+            next_state = _FoldedTreeNodeServiceState(
+                left_hold=state.left_hold,
+                right_hold=state.right_hold,
+                active_result=state.active_result,
+                active_remaining=state.active_remaining,
+                out_beat=state.out_beat,
+                completed_count=state.completed_count,
+            )
+
+            if node_output_fires[node_index]:
+                assert state.out_beat is not None
+                node_outputs[node_index].append(state.out_beat)
+                node_output_fire_cycles[node_index].append(cycle)
+                if node_index == root_index:
+                    root_output_fire_cycles.append(cycle)
+                next_state.out_beat = None
+                next_state.completed_count += 1
+
+            for side in ("left", "right"):
+                source_kind, source_index = descriptor[side]
+                source_beat: ExactPartialBeat | None
+                if source_kind == "leaf":
+                    source_beat = leaf_beats[source_index] if leaf_fires[source_index] else None
+                else:
+                    source_beat = states[source_index].out_beat if node_output_fires[source_index] else None
+                if source_beat is None:
+                    continue
+                if side == "left":
+                    if next_state.left_hold is not None:
+                        raise RuntimeError("left hold overflow in exact partial tree service model")
+                    next_state.left_hold = source_beat
+                else:
+                    if next_state.right_hold is not None:
+                        raise RuntimeError("right hold overflow in exact partial tree service model")
+                    next_state.right_hold = source_beat
+
+            start_pair = (
+                state.active_remaining == 0
+                and state.out_beat is None
+                and state.left_hold is not None
+                and state.right_hold is not None
+            )
+
+            if state.active_remaining > 0:
+                next_state.active_remaining = state.active_remaining - 1
+                if next_state.active_remaining == 0:
+                    next_state.out_beat = state.active_result
+                    next_state.active_result = None
+
+            if start_pair:
+                next_state.left_hold = None
+                next_state.right_hold = None
+                next_state.active_result = merge_partial_beats(state.left_hold, state.right_hold)
+                next_state.active_remaining = launch_to_output_countdown
+                node_launch_cycles[node_index].append(cycle)
+
+            next_states.append(next_state)
+
+        for leaf_index, fired in enumerate(leaf_fires):
+            if fired:
+                leaf_accept_cycles[leaf_index].append(cycle)
+                leaf_positions[leaf_index] += 1
+
+        states = next_states
+        drained = (
+            all(position == beat_count for position in leaf_positions)
+            and all(
+                state.left_hold is None
+                and state.right_hold is None
+                and state.active_result is None
+                and state.active_remaining == 0
+                and state.out_beat is None
+                for state in states
+            )
+        )
+        if drained:
+            break
+        cycle += 1
+        if cycle > timeout_cycles:
+            raise RuntimeError("timeout while simulating exact partial tree service")
+
+    observed_levels: list[tuple[tuple[ExactPartialBeat, ...], ...]] = []
+    for indices in stage_node_indices:
+        observed_levels.append(tuple(tuple(node_outputs[index]) for index in indices))
+
+    return {
+        "pair_node_impl": pair_node_impl,
+        "clusters": clusters,
+        "beats_per_leaf": beat_count,
+        "leaf_accept_cycles": tuple(tuple(cycles) for cycles in leaf_accept_cycles),
+        "node_launch_cycles": tuple(tuple(cycles) for cycles in node_launch_cycles),
+        "node_output_fire_cycles": tuple(tuple(cycles) for cycles in node_output_fire_cycles),
+        "root_output_fire_cycles": tuple(root_output_fire_cycles),
+        "first_root_output_cycle": root_output_fire_cycles[0] if root_output_fire_cycles else None,
+        "last_root_output_cycle": root_output_fire_cycles[-1] if root_output_fire_cycles else None,
+        "drain_cycle": cycle,
+        "leaf_accept_count": tuple(len(cycles) for cycles in leaf_accept_cycles),
+        "node_completed_count": tuple(state.completed_count for state in states),
+        "stage_completed_count": tuple(sum(states[index].completed_count for index in indices) for indices in stage_node_indices),
+        "observed_stage_streams": tuple(observed_levels),
+        "canonical_stage_streams": canonical_levels,
+        "root_stream": tuple(node_outputs[root_index]),
+        "capture_to_output_latency_cycles": folded_exact_partial_pair_merge_capture_to_output_latency_cycles(),
+        "compute_launch_to_output_latency_cycles": folded_exact_partial_pair_merge_compute_launch_to_output_latency_cycles(),
+        "compute_launch_interval_cycles": folded_exact_partial_pair_merge_compute_launch_interval_cycles(),
+        "service_cycle_definition": "active_edge_preupdate_handshake_v1",
+        "stage_backpressure_mode": "parent_ready_propagated_to_child_output",
+        "slice_count": VALUE_SLICES,
+    }
+
+
 def finalize_partial_stream(stream: Iterable[ExactPartialBeat]) -> tuple[tuple[int, ...], ...]:
     return tuple(finalize_value(beat.as_stats()) for beat in stream)
 
@@ -500,7 +760,9 @@ def _merge_equal_partial_streams(
     return tuple(merge_partial_beats(left_beats[index], right_beats[index]) for index in range(len(left_beats)))
 
 
-def merge_balanced_partial_streams(streams: Iterable[Iterable[ExactPartialBeat]]) -> tuple[ExactPartialBeat, ...]:
+def merge_balanced_partial_stream_levels(
+    streams: Iterable[Iterable[ExactPartialBeat]],
+) -> tuple[tuple[tuple[ExactPartialBeat, ...], ...], ...]:
     level = [tuple(stream) for stream in streams]
     if not level:
         raise ValueError("expected at least one partial stream")
@@ -511,6 +773,7 @@ def merge_balanced_partial_streams(streams: Iterable[Iterable[ExactPartialBeat]]
         raise ValueError("partial streams must be non-empty")
     if any(len(stream) != expected_beats for stream in level):
         raise ValueError("all partial streams must contain the same beat count")
+    levels: list[tuple[tuple[ExactPartialBeat, ...], ...]] = []
     while len(level) > 1:
         next_level: list[tuple[ExactPartialBeat, ...]] = []
         for index in range(0, len(level), 2):
@@ -520,8 +783,18 @@ def merge_balanced_partial_streams(streams: Iterable[Iterable[ExactPartialBeat]]
                     for beat_index in range(expected_beats)
                 )
             )
+        levels.append(tuple(next_level))
         level = next_level
-    return level[0]
+    return tuple(levels)
+
+
+def merge_balanced_partial_streams(streams: Iterable[Iterable[ExactPartialBeat]]) -> tuple[ExactPartialBeat, ...]:
+    level = [tuple(stream) for stream in streams]
+    if not level:
+        raise ValueError("expected at least one partial stream")
+    if len(level) == 1:
+        return level[0]
+    return merge_balanced_partial_stream_levels(level)[-1][0]
 
 
 def merge_staged_partial_streams(streams: Iterable[Iterable[ExactPartialBeat]]) -> tuple[ExactPartialBeat, ...]:
@@ -695,7 +968,12 @@ def normalized_merge_guard_case() -> tuple[tuple[ExactPartialBeat, ...], tuple[E
     return left, right
 
 
-def exact_partial_tree_service_manifest(*, clusters: int, heads: int = 32) -> dict[str, int | bool | str]:
+def exact_partial_tree_service_manifest(
+    *,
+    clusters: int,
+    heads: int = 32,
+    pair_node_impl: str = LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL,
+) -> dict[str, int | bool | str]:
     cluster_count = int(clusters)
     head_count = int(heads)
     if cluster_count < 2 or cluster_count > 16 or (cluster_count & (cluster_count - 1)):
@@ -706,7 +984,7 @@ def exact_partial_tree_service_manifest(*, clusters: int, heads: int = 32) -> di
     nodes = cluster_count - 1
     exact_state_bytes_per_cluster = (EXACT_STATE_BITS_PER_HEAD * head_count) // 8
     leaf_stream_bytes_per_cluster = (PARTIAL_LINK_BITS * VALUE_SLICES * head_count) // 8
-    return {
+    manifest: dict[str, int | bool | str] = {
         "clusters": cluster_count,
         "heads": head_count,
         "radix": 2,
@@ -724,6 +1002,34 @@ def exact_partial_tree_service_manifest(*, clusters: int, heads: int = 32) -> di
         "finalizer_boundary": "next_phase",
         "future_area_sensitivity": "folded_or_radix4_tree",
     }
+    if pair_node_impl == LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL:
+        return manifest
+    if pair_node_impl != FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL:
+        raise ValueError(f"unsupported exact partial tree pair_node_impl: {pair_node_impl}")
+    service = simulate_exact_partial_tree_service(
+        _service_leaf_streams(clusters=cluster_count, heads=head_count),
+        pair_node_impl=pair_node_impl,
+    )
+    root_fire_cycles = tuple(int(value) for value in service["root_output_fire_cycles"])
+    manifest.update(
+        {
+            "pair_node_impl": pair_node_impl,
+            "pair_node_scale_divider_impl": "mersenne24_correction2_exact",
+            "pair_capture_to_output_latency_cycles": int(service["capture_to_output_latency_cycles"]),
+            "pair_compute_launch_to_output_latency_cycles": int(service["compute_launch_to_output_latency_cycles"]),
+            "pair_compute_launch_interval_cycles": int(service["compute_launch_interval_cycles"]),
+            "leaf_stream_beats_per_cluster": int(service["beats_per_leaf"]),
+            "total_leaf_stream_beats": cluster_count * int(service["beats_per_leaf"]),
+            "full_wave_root_outputs": len(root_fire_cycles),
+            "full_wave_first_root_output_cycle": int(service["first_root_output_cycle"]),
+            "full_wave_last_root_output_cycle": int(service["last_root_output_cycle"]),
+            "full_wave_drain_cycle": int(service["drain_cycle"]),
+            "service_model": "cycle_simulated_folded_sharedscale_mersenne_tree_v1",
+            "service_cycle_definition": str(service["service_cycle_definition"]),
+            "stage_backpressure_mode": str(service["stage_backpressure_mode"]),
+        }
+    )
+    return manifest
 
 
 def exact_partial_staged_tree_service_manifest(*, producers: int, heads: int = 32) -> dict[str, int | bool | str]:
@@ -1515,10 +1821,12 @@ __all__ = [
     "ExactLocalGlobalGqa8Composition",
     "ExactLocalTemporalClusterComposition",
     "ExactPartialBeat",
+    "FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL",
     "FINALIZER_CONTROL_TRANSACTION_ID_BITS",
     "FINAL_PAYLOAD_BITS",
     "FINAL_LINK_BITS",
     "HEAD_ID_BITS",
+    "LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL",
     "LOCAL_TEMPORAL_WAVES",
     "LOCAL_CLUSTER_GQA8_HEAD_BASES",
     "LEAF_STREAM_BYTES_PER_CLUSTER_32_HEADS",
@@ -1553,6 +1861,7 @@ __all__ = [
     "finalize_partial_beat",
     "finalize_partial_beats",
     "finalize_partial_stream",
+    "merge_balanced_partial_stream_levels",
     "merge_balanced_partial_streams",
     "merge_staged_partial_streams",
     "merge_partial_beats",
@@ -1563,6 +1872,7 @@ __all__ = [
     "partial_stream_from_blocks",
     "pack_final_values",
     "simulate_folded_exact_partial_pair_merge_service",
+    "simulate_exact_partial_tree_service",
     "simulate_exact_finalizer",
     "simulate_exact_banked_finalizer",
     "reduce_local_temporal_partial_waves",

--- a/runs/campaigns/npu/attention_score32_exact_partial_tree_folded_mersenne_v1/sweeps/nangate45_attention_score32_exact_partial_tree_folded_mersenne_cluster_v1.json
+++ b/runs/campaigns/npu/attention_score32_exact_partial_tree_folded_mersenne_v1/sweeps/nangate45_attention_score32_exact_partial_tree_folded_mersenne_cluster_v1.json
@@ -1,0 +1,29 @@
+{
+  "flow_params": {
+    "CLOCK_PERIOD": [
+      8.0
+    ],
+    "CORE_AREA": [
+      "50 50 2450 2450"
+    ],
+    "DIE_AREA": [
+      "0 0 2500 2500"
+    ],
+    "IO_PLACER_H": [
+      "metal3 metal5"
+    ],
+    "IO_PLACER_V": [
+      "metal4 metal6"
+    ],
+    "PLACE_DENSITY": [
+      0.3
+    ],
+    "PLACE_PINS_ARGS": [
+      "-min_distance 1"
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ]
+  },
+  "tag_prefix": "attention_score32_exact_partial_tree_folded_mersenne_cluster_v1"
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c16_r2/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c16_r2/config.json
@@ -1,0 +1,11 @@
+{
+  "attention_score32_exact_partial_tree": {
+    "clusters": 16,
+    "exp_scale_impl": "factored_h33_l64_mul_exact",
+    "head_id_bits": 5,
+    "pair_node_impl": "folded_sharedscale_mersenne_exact",
+    "radix": 2,
+    "value_slices": 16
+  },
+  "top_name": "attention_score32_exact_partial_tree_folded_mersenne_c16_r2"
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c2_r2/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c2_r2/config.json
@@ -1,0 +1,11 @@
+{
+  "attention_score32_exact_partial_tree": {
+    "clusters": 2,
+    "exp_scale_impl": "factored_h33_l64_mul_exact",
+    "head_id_bits": 5,
+    "pair_node_impl": "folded_sharedscale_mersenne_exact",
+    "radix": 2,
+    "value_slices": 16
+  },
+  "top_name": "attention_score32_exact_partial_tree_folded_mersenne_c2_r2"
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c4_r2/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c4_r2/config.json
@@ -1,0 +1,11 @@
+{
+  "attention_score32_exact_partial_tree": {
+    "clusters": 4,
+    "exp_scale_impl": "factored_h33_l64_mul_exact",
+    "head_id_bits": 5,
+    "pair_node_impl": "folded_sharedscale_mersenne_exact",
+    "radix": 2,
+    "value_slices": 16
+  },
+  "top_name": "attention_score32_exact_partial_tree_folded_mersenne_c4_r2"
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c8_r2/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_partial_tree_folded_mersenne_c8_r2/config.json
@@ -1,0 +1,11 @@
+{
+  "attention_score32_exact_partial_tree": {
+    "clusters": 8,
+    "exp_scale_impl": "factored_h33_l64_mul_exact",
+    "head_id_bits": 5,
+    "pair_node_impl": "folded_sharedscale_mersenne_exact",
+    "radix": 2,
+    "value_slices": 16
+  },
+  "top_name": "attention_score32_exact_partial_tree_folded_mersenne_c8_r2"
+}

--- a/tests/test_attention_score32_exact_partial_tree.py
+++ b/tests/test_attention_score32_exact_partial_tree.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 from pathlib import Path
 import re
@@ -10,21 +11,37 @@ import pytest
 
 from npu.eval.probe_attention_score32_exact_partial_tree import build_report
 from npu.rtlgen.gen_attention_score32_exact_partial_tree import generate as generate_tree
-from npu.sim.perf.attention_exact_partial import ExactPartialBeat, merge_partial_beats, pack_numerators, unpack_numerators
+from npu.sim.perf.attention_exact_partial import (
+    ExactPartialBeat,
+    FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL,
+    LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL,
+    merge_balanced_partial_stream_levels,
+    merge_partial_beats,
+    pack_numerators,
+    simulate_exact_partial_tree_service,
+    unpack_numerators,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
-def _tree_config(clusters: int) -> dict[str, object]:
-    return {
-        "top_name": f"attention_score32_exact_partial_tree_c{clusters}_r2",
-        "attention_score32_exact_partial_tree": {
-            "clusters": clusters,
-            "radix": 2,
-            "value_slices": 16,
-            "head_id_bits": 5,
-        },
+def _tree_config(
+    clusters: int,
+    *,
+    pair_node_impl: str = LEGACY_PARALLEL_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL,
+) -> dict[str, object]:
+    body: dict[str, object] = {
+        "clusters": clusters,
+        "radix": 2,
+        "value_slices": 16,
+        "head_id_bits": 5,
     }
+    top_name = f"attention_score32_exact_partial_tree_c{clusters}_r2"
+    if pair_node_impl == FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL:
+        top_name = f"attention_score32_exact_partial_tree_folded_mersenne_c{clusters}_r2"
+        body["exp_scale_impl"] = "factored_h33_l64_mul_exact"
+        body["pair_node_impl"] = pair_node_impl
+    return {"top_name": top_name, "attention_score32_exact_partial_tree": body}
 
 
 def _rtl_tools_available() -> bool:
@@ -64,6 +81,279 @@ def _beat(
         exp_sum=exp_sum,
         numerators=numerators,
     )
+
+
+def _folded_tree_leaf_stream(leaf: int, *, heads: int) -> tuple[ExactPartialBeat, ...]:
+    beats: list[ExactPartialBeat] = []
+    for head_id in range(heads):
+        command_id = 0x6100 + head_id
+        for slice_index in range(16):
+            beats.append(
+                _beat(
+                    command_id=command_id,
+                    head_id=head_id,
+                    slice_index=slice_index,
+                    last=slice_index == 15,
+                    max_score=((leaf * 23) + (head_id * 19) + (slice_index * 11)) % 255 - 127,
+                    exp_sum=1 + ((leaf * 37) + (head_id * 13) + (slice_index * 5)) % ((1 << 33) - 1),
+                    numerators=tuple(
+                        ((leaf * 71) + (head_id * 29) + (slice_index * 17) + (lane * 7)) % 1023 - 511
+                        for lane in range(8)
+                    ),
+                )
+            )
+    return tuple(beats)
+
+
+def _root_ready_pattern(cycle: int) -> bool:
+    return (cycle % 7) not in {2, 5}
+
+
+ROOT_READY_PATTERN_PERIOD = tuple(_root_ready_pattern(cycle) for cycle in range(7))
+
+
+def _run_folded_tree_cycle_service_vectors(tmp_path: Path, *, clusters: int, heads: int) -> dict[str, object]:
+    streams = tuple(_folded_tree_leaf_stream(leaf, heads=heads) for leaf in range(clusters))
+    beat_count = len(streams[0])
+    design_dir = tmp_path / "rtl"
+    generate_tree(
+        _tree_config(clusters, pair_node_impl=FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL),
+        design_dir,
+    )
+    top_name = _tree_config(
+        clusters, pair_node_impl=FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL
+    )["top_name"]
+    tb_path = tmp_path / "tb.sv"
+    init_lines: list[str] = []
+    for leaf, stream in enumerate(streams):
+        for beat_index, beat in enumerate(stream):
+            flat_index = (leaf * beat_count) + beat_index
+            init_lines.append(
+                f"    leaf_cmd_mem[{flat_index}] = 16'h{beat.command_id:04x}; "
+                f"leaf_head_mem[{flat_index}] = 5'd{beat.head_id}; "
+                f"leaf_max_mem[{flat_index}] = {_signed_literal(beat.max_score, 32)}; "
+                f"leaf_sum_mem[{flat_index}] = 33'd{beat.exp_sum}; "
+                f"leaf_slice_mem[{flat_index}] = 4'd{beat.slice_index}; "
+                f"leaf_last_mem[{flat_index}] = 1'b{1 if beat.last else 0}; "
+                f"leaf_value_mem[{flat_index}] = 328'h{pack_numerators(beat.numerators):082x};"
+            )
+    tb_path.write_text(
+        f"""`timescale 1ns/1ps
+module tb;
+  localparam integer CLUSTERS = {clusters};
+  localparam integer TOTAL_RESULTS = {beat_count};
+  localparam integer MEM_DEPTH = CLUSTERS * TOTAL_RESULTS;
+  reg clk = 0, rst_n = 0;
+  reg [CLUSTERS-1:0] leaf_valid;
+  wire [CLUSTERS-1:0] leaf_ready;
+  reg [(CLUSTERS*16)-1:0] leaf_command_id;
+  reg [(CLUSTERS*5)-1:0] leaf_head_id;
+  reg [(CLUSTERS*32)-1:0] leaf_global_max;
+  reg [(CLUSTERS*33)-1:0] leaf_exp_sum;
+  reg [(CLUSTERS*4)-1:0] leaf_slice;
+  reg [CLUSTERS-1:0] leaf_last;
+  reg [(CLUSTERS*328)-1:0] leaf_value;
+  wire root_valid;
+  reg root_ready;
+  wire [15:0] root_command_id;
+  wire [4:0] root_head_id;
+  wire signed [31:0] root_global_max;
+  wire [32:0] root_exp_sum;
+  wire [3:0] root_slice;
+  wire root_last;
+  wire [327:0] root_value;
+  wire [31:0] cycle_count;
+  wire [31:0] root_completed_count;
+  wire [{(clusters - 1) * 32 - 1}:0] node_completed_count;
+  wire [{int(math.log2(clusters)) * 32 - 1}:0] stage_completed_count;
+  wire [{clusters - 2}:0] node_protocol_error;
+  wire [{int(math.log2(clusters)) - 1}:0] stage_protocol_error;
+  wire protocol_error;
+  reg [15:0] leaf_cmd_mem [0:MEM_DEPTH-1];
+  reg [4:0] leaf_head_mem [0:MEM_DEPTH-1];
+  reg signed [31:0] leaf_max_mem [0:MEM_DEPTH-1];
+  reg [32:0] leaf_sum_mem [0:MEM_DEPTH-1];
+  reg [3:0] leaf_slice_mem [0:MEM_DEPTH-1];
+  reg leaf_last_mem [0:MEM_DEPTH-1];
+  reg [327:0] leaf_value_mem [0:MEM_DEPTH-1];
+  reg [31:0] leaf_issue [0:CLUSTERS-1];
+  integer cycle = 0;
+  integer root_seen = 0;
+  integer init_index;
+  integer leaf_index;
+
+  always #5 clk = ~clk;
+
+  {top_name} dut (
+      .clk(clk),
+      .rst_n(rst_n),
+      .leaf_valid(leaf_valid),
+      .leaf_ready(leaf_ready),
+      .leaf_command_id(leaf_command_id),
+      .leaf_head_id(leaf_head_id),
+      .leaf_global_max(leaf_global_max),
+      .leaf_exp_sum(leaf_exp_sum),
+      .leaf_slice(leaf_slice),
+      .leaf_last(leaf_last),
+      .leaf_value(leaf_value),
+      .root_valid(root_valid),
+      .root_ready(root_ready),
+      .root_command_id(root_command_id),
+      .root_head_id(root_head_id),
+      .root_global_max(root_global_max),
+      .root_exp_sum(root_exp_sum),
+      .root_slice(root_slice),
+      .root_last(root_last),
+      .root_value(root_value),
+      .cycle_count(cycle_count),
+      .root_completed_count(root_completed_count),
+      .node_completed_count(node_completed_count),
+      .stage_completed_count(stage_completed_count),
+      .node_protocol_error(node_protocol_error),
+      .stage_protocol_error(stage_protocol_error),
+      .protocol_error(protocol_error)
+  );
+
+  always @* begin
+    leaf_valid = {{CLUSTERS{{1'b0}}}};
+    leaf_command_id = {{(CLUSTERS*16){{1'b0}}}};
+    leaf_head_id = {{(CLUSTERS*5){{1'b0}}}};
+    leaf_global_max = {{(CLUSTERS*32){{1'b0}}}};
+    leaf_exp_sum = {{(CLUSTERS*33){{1'b0}}}};
+    leaf_slice = {{(CLUSTERS*4){{1'b0}}}};
+    leaf_last = {{CLUSTERS{{1'b0}}}};
+    leaf_value = {{(CLUSTERS*328){{1'b0}}}};
+    root_ready = ((cycle % 7) != 2) && ((cycle % 7) != 5);
+    for (leaf_index = 0; leaf_index < CLUSTERS; leaf_index = leaf_index + 1) begin
+      if (leaf_issue[leaf_index] < TOTAL_RESULTS) begin
+        leaf_valid[leaf_index] = 1'b1;
+        leaf_command_id[(leaf_index * 16) +: 16] =
+            leaf_cmd_mem[(leaf_index * TOTAL_RESULTS) + leaf_issue[leaf_index]];
+        leaf_head_id[(leaf_index * 5) +: 5] =
+            leaf_head_mem[(leaf_index * TOTAL_RESULTS) + leaf_issue[leaf_index]];
+        leaf_global_max[(leaf_index * 32) +: 32] =
+            leaf_max_mem[(leaf_index * TOTAL_RESULTS) + leaf_issue[leaf_index]];
+        leaf_exp_sum[(leaf_index * 33) +: 33] =
+            leaf_sum_mem[(leaf_index * TOTAL_RESULTS) + leaf_issue[leaf_index]];
+        leaf_slice[(leaf_index * 4) +: 4] =
+            leaf_slice_mem[(leaf_index * TOTAL_RESULTS) + leaf_issue[leaf_index]];
+        leaf_last[leaf_index] =
+            leaf_last_mem[(leaf_index * TOTAL_RESULTS) + leaf_issue[leaf_index]];
+        leaf_value[(leaf_index * 328) +: 328] =
+            leaf_value_mem[(leaf_index * TOTAL_RESULTS) + leaf_issue[leaf_index]];
+      end
+    end
+  end
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      cycle <= 0;
+      root_seen <= 0;
+      for (leaf_index = 0; leaf_index < CLUSTERS; leaf_index = leaf_index + 1) begin
+        leaf_issue[leaf_index] <= 32'd0;
+      end
+    end else begin
+      cycle <= cycle + 1;
+      for (leaf_index = 0; leaf_index < CLUSTERS; leaf_index = leaf_index + 1) begin
+        if (leaf_valid[leaf_index] && leaf_ready[leaf_index]) begin
+          $display("LEAF_ACCEPT leaf=%0d cycle=%0d", leaf_index, cycle);
+          leaf_issue[leaf_index] <= leaf_issue[leaf_index] + 1;
+        end
+      end
+      if (root_valid && root_ready) begin
+        $display("ROOT_RESULT cmd=%0d head=%0d slice=%0d last=%0d max=%0d sum=%0d value=%082x cycle=%0d",
+                 root_command_id, root_head_id, root_slice, root_last, $signed(root_global_max), root_exp_sum, root_value, cycle);
+        root_seen <= root_seen + 1;
+      end
+      if (root_seen == TOTAL_RESULTS) begin
+        $display("SUMMARY outputs=%0d dut_cycle=%0d tb_cycle=%0d protocol_error=%0d root_completed=%0d",
+                 root_seen, cycle_count, cycle, protocol_error, root_completed_count);
+        #1 $finish;
+      end
+      if (cycle > {max(3000, clusters * beat_count * 32)}) $fatal(1, "timeout");
+    end
+  end
+
+  initial begin
+    for (init_index = 0; init_index < MEM_DEPTH; init_index = init_index + 1) begin
+      leaf_cmd_mem[init_index] = 16'd0;
+      leaf_head_mem[init_index] = 5'd0;
+      leaf_max_mem[init_index] = 32'sd0;
+      leaf_sum_mem[init_index] = 33'd0;
+      leaf_slice_mem[init_index] = 4'd0;
+      leaf_last_mem[init_index] = 1'b0;
+      leaf_value_mem[init_index] = 328'd0;
+    end
+{chr(10).join(init_lines)}
+    repeat (3) @(posedge clk);
+    @(negedge clk);
+    rst_n = 1'b1;
+  end
+endmodule
+""",
+        encoding="utf-8",
+    )
+    simv = tmp_path / "simv"
+    compiled = subprocess.run(
+        [
+            _tool("iverilog"),
+            "-g2012",
+            "-s",
+            "tb",
+            "-o",
+            str(simv),
+            str(design_dir / "top.v"),
+            str(tb_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert compiled.returncode == 0, compiled.stderr
+    run = subprocess.run([_tool("vvp"), str(simv)], capture_output=True, text=True, timeout=300)
+    assert run.returncode == 0, run.stdout + run.stderr
+    root_rows: list[dict[str, object]] = []
+    root_cycles: list[int] = []
+    leaf_cycles: list[list[int]] = [[] for _ in range(clusters)]
+    summary: dict[str, int] | None = None
+    root_re = re.compile(
+        r"ROOT_RESULT cmd=(\d+) head=(\d+) slice=(\d+) last=(\d+) max=(-?\d+) sum=(\d+) value=([0-9a-fA-F]+) cycle=(\d+)"
+    )
+    leaf_re = re.compile(r"LEAF_ACCEPT leaf=(\d+) cycle=(\d+)")
+    summary_re = re.compile(r"SUMMARY outputs=(\d+) dut_cycle=(\d+) tb_cycle=(\d+) protocol_error=(\d+) root_completed=(\d+)")
+    for line in run.stdout.splitlines():
+        stripped = line.strip()
+        if match := root_re.fullmatch(stripped):
+            root_rows.append(
+                {
+                    "command_id": int(match.group(1)),
+                    "head_id": int(match.group(2)),
+                    "slice_index": int(match.group(3)),
+                    "last": bool(int(match.group(4))),
+                    "max_score": int(match.group(5)),
+                    "exp_sum": int(match.group(6)),
+                    "numerators": unpack_numerators(int(match.group(7), 16)),
+                }
+            )
+            root_cycles.append(int(match.group(8)))
+        elif match := leaf_re.fullmatch(stripped):
+            leaf_cycles[int(match.group(1))].append(int(match.group(2)))
+        elif match := summary_re.fullmatch(stripped):
+            summary = {
+                "outputs": int(match.group(1)),
+                "dut_cycle": int(match.group(2)),
+                "tb_cycle": int(match.group(3)),
+                "protocol_error": int(match.group(4)),
+                "root_completed": int(match.group(5)),
+            }
+    assert summary is not None
+    return {
+        "streams": streams,
+        "root_rows": tuple(root_rows),
+        "root_cycles": tuple(root_cycles),
+        "leaf_cycles": tuple(tuple(values) for values in leaf_cycles),
+        "summary": summary,
+    }
 
 
 def _run_protocol_vectors(tmp_path: Path) -> dict[str, object]:
@@ -445,6 +735,28 @@ def test_exact_partial_tree_manifest_and_ports(tmp_path: Path) -> None:
     assert "output wire [14:0] node_protocol_error" in rtl
 
 
+def test_exact_partial_tree_folded_mersenne_manifest_and_service_contract(tmp_path: Path) -> None:
+    generate_tree(
+        _tree_config(4, pair_node_impl=FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL),
+        tmp_path,
+    )
+    manifest = json.loads((tmp_path / "attention_score32_exact_partial_tree_manifest.json").read_text(encoding="utf-8"))
+    rtl = (tmp_path / "top.v").read_text(encoding="utf-8")
+
+    assert manifest["pair_node_impl"] == FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL
+    assert (
+        manifest["submodule_manifests"]["pair_merge"]["generator"]
+        == "npu/rtlgen/gen_attention_score32_exact_partial_pair_merge_folded.py"
+    )
+    assert manifest["submodule_manifests"]["pair_merge"]["scale_divider_impl"] == "mersenne24_correction2_exact"
+    assert manifest["theoretical_full_llama_service_manifest"]["service_model"] == "cycle_simulated_folded_sharedscale_mersenne_tree_v1"
+    assert manifest["theoretical_full_llama_service_manifest"]["leaf_stream_beats_per_cluster"] == 512
+    assert manifest["theoretical_full_llama_service_manifest"]["full_wave_root_outputs"] == 512
+    assert manifest["theoretical_full_llama_service_manifest"]["pair_compute_launch_interval_cycles"] == 20
+    assert "function automatic [33:0] divide_mersenne24_u57;" in rtl
+    assert "function automatic [41:0] divide_mersenne24_u65;" in rtl
+
+
 @pytest.mark.skipif(not _rtl_tools_available(), reason="iverilog/vvp/verilator unavailable")
 def test_exact_partial_tree_protocol_errors_are_sticky_and_localized(tmp_path: Path) -> None:
     report = _run_protocol_vectors(tmp_path)
@@ -483,6 +795,50 @@ def test_exact_partial_tree_probe_quick_passes(clusters: int, heads: int, stage_
     assert report["theoretical_full_llama_service_manifest"]["total_leaf_stream_bytes"] == clusters * 26816
     assert report["measured_workload_manifest"]["first_output_cycle"] >= 0
     assert report["measured_workload_manifest"]["last_output_cycle"] >= report["measured_workload_manifest"]["first_output_cycle"]
+
+
+def test_exact_partial_tree_folded_service_matches_canonical_stage_streams() -> None:
+    for clusters in (2, 4):
+        streams = tuple(_folded_tree_leaf_stream(leaf, heads=3) for leaf in range(clusters))
+        service = simulate_exact_partial_tree_service(
+            streams,
+            output_ready_pattern=ROOT_READY_PATTERN_PERIOD,
+            pair_node_impl=FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL,
+        )
+        canonical_levels = merge_balanced_partial_stream_levels(streams)
+        assert service["canonical_stage_streams"] == canonical_levels
+        assert service["observed_stage_streams"] == canonical_levels
+        assert service["root_stream"] == canonical_levels[-1][0]
+        assert service["leaf_accept_count"] == (48,) * clusters
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="iverilog/vvp/verilator unavailable")
+@pytest.mark.parametrize("clusters", [2, 4])
+def test_exact_partial_tree_folded_rtl_matches_service_cycles_and_outputs(tmp_path: Path, clusters: int) -> None:
+    rtl_report = _run_folded_tree_cycle_service_vectors(tmp_path, clusters=clusters, heads=3)
+    service = simulate_exact_partial_tree_service(
+        rtl_report["streams"],
+        output_ready_pattern=ROOT_READY_PATTERN_PERIOD,
+        pair_node_impl=FOLDED_SHARED_SCALE_MERSENNE_EXACT_PARTIAL_TREE_PAIR_NODE_IMPL,
+    )
+    expected_root = tuple(
+        {
+            "command_id": beat.command_id,
+            "head_id": beat.head_id,
+            "slice_index": beat.slice_index,
+            "last": beat.last,
+            "max_score": beat.max_score,
+            "exp_sum": beat.exp_sum,
+            "numerators": beat.numerators,
+        }
+        for beat in service["root_stream"]
+    )
+    assert rtl_report["root_rows"] == expected_root
+    assert rtl_report["root_cycles"] == service["root_output_fire_cycles"]
+    assert rtl_report["leaf_cycles"] == service["leaf_accept_cycles"]
+    assert rtl_report["summary"]["protocol_error"] == 0
+    assert rtl_report["summary"]["outputs"] == len(expected_root)
+    assert rtl_report["summary"]["root_completed"] == len(expected_root)
 
 
 @pytest.mark.skipif(not _rtl_tools_available(), reason="iverilog/vvp/verilator unavailable")

--- a/tests/test_check_attention_score32_exact_partial_tree_guard.py
+++ b/tests/test_check_attention_score32_exact_partial_tree_guard.py
@@ -32,16 +32,30 @@ def _factored_config_path(clusters: int) -> Path:
     )
 
 
-def _prepare_design_dir(tmp_path: Path, *, clusters: int, factored: bool = False) -> Path:
-    tmp_path.mkdir(parents=True, exist_ok=True)
-    name = (
-        f"attention_score32_exact_partial_tree_factored_c{clusters}_r2"
-        if factored
-        else f"attention_score32_exact_partial_tree_c{clusters}_r2"
+def _folded_mersenne_config_path(clusters: int) -> Path:
+    return (
+        REPO_ROOT
+        / "runs"
+        / "designs"
+        / "npu_blocks"
+        / f"attention_score32_exact_partial_tree_folded_mersenne_c{clusters}_r2"
+        / "config.json"
     )
+
+
+def _prepare_design_dir(tmp_path: Path, *, clusters: int, factored: bool = False, folded_mersenne: bool = False) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    if folded_mersenne:
+        name = f"attention_score32_exact_partial_tree_folded_mersenne_c{clusters}_r2"
+        source_config = _folded_mersenne_config_path(clusters)
+    elif factored:
+        name = f"attention_score32_exact_partial_tree_factored_c{clusters}_r2"
+        source_config = _factored_config_path(clusters)
+    else:
+        name = f"attention_score32_exact_partial_tree_c{clusters}_r2"
+        source_config = _config_path(clusters)
     design_dir = tmp_path / name
     design_dir.mkdir()
-    source_config = _factored_config_path(clusters) if factored else _config_path(clusters)
     config = json.loads(source_config.read_text(encoding="utf-8"))
     (design_dir / "config.json").write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
     generate(config, design_dir / "verilog")
@@ -290,3 +304,63 @@ def test_exact_partial_tree_guard_rejects_factored_sweep_for_legacy_impl(tmp_pat
     )
     assert result.returncode != 0
     assert "factored partial-tree sweep requires exp_scale_impl factored_h33_l64_mul_exact" in result.stderr
+
+
+def test_exact_partial_tree_guard_accepts_folded_mersenne_cluster_configs_and_sweep(tmp_path: Path) -> None:
+    sweep_path = (
+        REPO_ROOT
+        / "runs"
+        / "campaigns"
+        / "npu"
+        / "attention_score32_exact_partial_tree_folded_mersenne_v1"
+        / "sweeps"
+        / "nangate45_attention_score32_exact_partial_tree_folded_mersenne_cluster_v1.json"
+    )
+    for clusters in (2, 4, 8, 16):
+        design_dir = _prepare_design_dir(
+            tmp_path / f"folded_mersenne_{clusters}", clusters=clusters, folded_mersenne=True
+        )
+        result = subprocess.run(
+            [
+                sys.executable,
+                "npu/eval/check_attention_score32_exact_partial_tree_guard.py",
+                "--design-dir",
+                str(design_dir),
+                "--config",
+                str(design_dir / "config.json"),
+                "--sweep",
+                str(sweep_path),
+            ],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["pair_node_impl"] == "folded_sharedscale_mersenne_exact"
+
+
+def test_exact_partial_tree_guard_rejects_folded_manifest_divider_mismatch(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, clusters=4, folded_mersenne=True)
+    manifest_path = design_dir / "verilog" / "attention_score32_exact_partial_tree_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["submodule_manifests"]["pair_merge"]["scale_divider_impl"] = "generic_exact"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/check_attention_score32_exact_partial_tree_guard.py",
+            "--design-dir",
+            str(design_dir),
+            "--config",
+            str(design_dir / "config.json"),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "pair-merge submodule manifest scale_divider_impl must be mersenne24_correction2_exact" in result.stderr


### PR DESCRIPTION
## Summary
- add an explicit folded shared-scale Mersenne pair-node implementation for exact partial reduction trees while preserving the historical generator default
- add a cycle-accurate ready/valid service model and RTL equivalence/backpressure coverage for c2 and c4 trees
- add strict regeneration/sweep guards and staged c2/c4/c8/c16 Nangate45 evaluation configs
- add the proposal and evaluation request for the standalone physical scaling boundary

## Why
The fully parallel exact pair-node tree exceeded the practical synthesis-memory boundary. The previously measured folded Mersenne pair node is timing-feasible, but its multi-level tree PPA and service cadence must be measured before composing it into the Llama7B reduction hierarchy.

## Compatibility
Regenerated `top.v`, `config.json`, and manifest files for all eight historical exact-tree configs are byte-identical to the `5c97068c` baseline.

## Validation
- `PYTHONPATH=. pytest -q tests/test_attention_score32_exact_partial_tree.py tests/test_check_attention_score32_exact_partial_tree_guard.py` (21 passed)
- `PYTHONPATH=control_plane:. pytest -q control_plane/control_plane/tests/test_l1_task_generator.py -k exact_partial_tree` (6 passed, 73 deselected)
- `git show --check HEAD`

Physical evaluation is intentionally not run in this developer container. After merge, the c2/c4/c8/c16 sweep will be dispatched to `eval-daemon-b7c2d9c80c1c` using the merge commit as the required source revision.