### PR TITLE
Resolve evaluator proposal linkage against authoritative Git refs

### DIFF
--- a/control_plane/control_plane/services/docs_paths.py
+++ b/control_plane/control_plane/services/docs_paths.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import json
+import subprocess
 
 
 def _resolve_path(repo_root: Path, path_text: str) -> Path:
@@ -11,6 +12,16 @@ def _resolve_path(repo_root: Path, path_text: str) -> Path:
     if path.is_absolute():
         return path
     return repo_root / path
+
+
+def _resolve_rel_path(repo_root: Path, path_text: str) -> str | None:
+    path = Path(path_text)
+    if path.is_absolute():
+        try:
+            return str(path.resolve().relative_to(repo_root.resolve()))
+        except ValueError:
+            return None
+    return str(path)
 
 
 def _dedupe_paths(paths: list[Path]) -> list[Path]:
@@ -25,39 +36,71 @@ def _dedupe_paths(paths: list[Path]) -> list[Path]:
     return result
 
 
-def proposal_dir_candidates(repo_root: Path, proposal_path: str | None = None, proposal_id: str | None = None) -> list[Path]:
-    candidates: list[Path] = []
+def _dedupe_rel_paths(paths: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for path in paths:
+        key = str(path).strip()
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        result.append(key)
+    return result
+
+
+def proposal_rel_dir_candidates(
+    repo_root: Path,
+    proposal_path: str | None = None,
+    proposal_id: str | None = None,
+) -> list[str]:
+    candidates: list[str] = []
     proposal_path_text = str(proposal_path or "").strip()
     proposal_id_text = str(proposal_id or "").strip()
 
     if proposal_path_text:
-        candidates.extend(_proposal_path_candidates(repo_root, proposal_path_text))
+        candidates.extend(_proposal_rel_path_candidates(repo_root, proposal_path_text))
 
     if proposal_id_text:
-        candidates.append(repo_root / 'docs' / 'proposals' / proposal_id_text)
-        candidates.append(repo_root / 'docs' / 'developer_loop' / proposal_id_text)
+        candidates.append(str(Path("docs") / "proposals" / proposal_id_text))
+        candidates.append(str(Path("docs") / "developer_loop" / proposal_id_text))
 
-    return _dedupe_paths(candidates)
+    return _dedupe_rel_paths(candidates)
+
+
+def proposal_dir_candidates(repo_root: Path, proposal_path: str | None = None, proposal_id: str | None = None) -> list[Path]:
+    return _dedupe_paths([repo_root / rel_path for rel_path in proposal_rel_dir_candidates(
+        repo_root,
+        proposal_path=proposal_path,
+        proposal_id=proposal_id,
+    )])
 
 
 def _proposal_path_candidates(repo_root: Path, proposal_path_text: str) -> list[Path]:
-    candidates: list[Path] = []
-    resolved = _resolve_path(repo_root, proposal_path_text)
-    if resolved.name == 'proposal.json':
-        candidates.append(resolved.parent)
-    else:
-        candidates.append(resolved)
+    return _dedupe_paths([repo_root / rel_path for rel_path in _proposal_rel_path_candidates(repo_root, proposal_path_text)])
 
-    rel_text = proposal_path_text
+
+def _proposal_rel_path_candidates(repo_root: Path, proposal_path_text: str) -> list[str]:
+    candidates: list[str] = []
+    resolved = _resolve_rel_path(repo_root, proposal_path_text)
+    if resolved is None:
+        return candidates
+
+    resolved_path = Path(resolved)
+    if resolved_path.name == 'proposal.json':
+        candidates.append(str(resolved_path.parent))
+    else:
+        candidates.append(str(resolved_path))
+
+    rel_text = resolved
     if rel_text.startswith('docs/developer_loop/'):
         mapped = rel_text.replace('docs/developer_loop/', 'docs/proposals/', 1)
-        mapped_path = _resolve_path(repo_root, mapped)
-        candidates.append(mapped_path.parent if mapped_path.name == 'proposal.json' else mapped_path)
+        mapped_path = Path(mapped)
+        candidates.append(str(mapped_path.parent if mapped_path.name == 'proposal.json' else mapped_path))
     elif rel_text.startswith('docs/proposals/'):
         mapped = rel_text.replace('docs/proposals/', 'docs/developer_loop/', 1)
-        mapped_path = _resolve_path(repo_root, mapped)
-        candidates.append(mapped_path.parent if mapped_path.name == 'proposal.json' else mapped_path)
-    return _dedupe_paths(candidates)
+        mapped_path = Path(mapped)
+        candidates.append(str(mapped_path.parent if mapped_path.name == 'proposal.json' else mapped_path))
+    return _dedupe_rel_paths(candidates)
 
 
 def resolve_proposal_dir(repo_root: Path, proposal_path: str | None = None, proposal_id: str | None = None) -> Path | None:
@@ -93,11 +136,81 @@ def resolve_proposal_file(repo_root: Path, proposal_path: str | None = None, pro
     return proposal_dir / 'proposal.json'
 
 
-def proposal_placeholder_reason(proposal_json: Path) -> str | None:
-    try:
-        payload = json.loads(proposal_json.read_text(encoding="utf-8"))
-    except Exception:
+def git_ref_exists(repo_root: Path, ref: str | None) -> bool:
+    ref_text = str(ref or "").strip()
+    if not ref_text:
+        return False
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "--verify", "--quiet", f"{ref_text}^{{commit}}"],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def path_exists_at_ref(repo_root: Path, ref: str | None, rel_path: str) -> bool:
+    ref_text = str(ref or "").strip()
+    rel_text = str(rel_path or "").strip()
+    if not ref_text or not rel_text:
+        return False
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "cat-file", "-e", f"{ref_text}:{rel_text}"],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def resolve_proposal_file_at_ref(
+    repo_root: Path,
+    ref: str | None,
+    proposal_path: str | None = None,
+    proposal_id: str | None = None,
+) -> str | None:
+    if not git_ref_exists(repo_root, ref):
         return None
+    proposal_path_text = str(proposal_path or "").strip()
+    if proposal_path_text:
+        candidates = _proposal_rel_path_candidates(repo_root, proposal_path_text)
+    else:
+        candidates = proposal_rel_dir_candidates(repo_root, proposal_id=proposal_id)
+
+    for candidate in candidates:
+        proposal_rel = candidate if Path(candidate).name == "proposal.json" else str(Path(candidate) / "proposal.json")
+        if path_exists_at_ref(repo_root, ref, proposal_rel):
+            return proposal_rel
+    return None
+
+
+def proposal_context_files_at_ref(
+    repo_root: Path,
+    ref: str | None,
+    proposal_path: str | None = None,
+    proposal_id: str | None = None,
+) -> list[str]:
+    proposal_rel = resolve_proposal_file_at_ref(
+        repo_root,
+        ref,
+        proposal_path=proposal_path,
+        proposal_id=proposal_id,
+    )
+    if proposal_rel is None:
+        return []
+    proposal_dir_rel = str(Path(proposal_rel).parent)
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "ls-tree", "-r", "--name-only", str(ref), "--", proposal_dir_rel],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return [proposal_rel]
+    files = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    if proposal_rel not in files:
+        files.append(proposal_rel)
+    return _dedupe_rel_paths(files)
+
+
+def _proposal_placeholder_reason_payload(payload: object) -> str | None:
     if not isinstance(payload, dict):
         return None
 
@@ -126,6 +239,46 @@ def proposal_placeholder_reason(proposal_json: Path) -> str | None:
     if any(placeholders):
         return "developer_loop proposal is still a template placeholder"
     return None
+
+
+def proposal_placeholder_reason_from_text(text: str) -> str | None:
+    try:
+        payload = json.loads(text)
+    except Exception:
+        return None
+    return _proposal_placeholder_reason_payload(payload)
+
+
+def proposal_placeholder_reason(proposal_json: Path) -> str | None:
+    try:
+        text = proposal_json.read_text(encoding="utf-8")
+    except Exception:
+        return None
+    return proposal_placeholder_reason_from_text(text)
+
+
+def proposal_placeholder_reason_at_ref(
+    repo_root: Path,
+    ref: str | None,
+    proposal_path: str | None = None,
+    proposal_id: str | None = None,
+) -> str | None:
+    proposal_rel = resolve_proposal_file_at_ref(
+        repo_root,
+        ref,
+        proposal_path=proposal_path,
+        proposal_id=proposal_id,
+    )
+    if proposal_rel is None:
+        return None
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "show", f"{ref}:{proposal_rel}"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return proposal_placeholder_reason_from_text(result.stdout)
 
 
 def canonicalize_proposal_path(repo_root: Path, proposal_path: str | None = None, proposal_id: str | None = None) -> str | None:

--- a/control_plane/control_plane/services/operator_submission.py
+++ b/control_plane/control_plane/services/operator_submission.py
@@ -36,7 +36,14 @@ from control_plane.services.review_publisher import (
 )
 from control_plane.services.submission_bridge import SubmissionPrepareError, SubmissionPrepareRequest, prepare_submission_branch
 from control_plane.services.submission_executor import SubmissionExecuteError, SubmissionExecuteRequest, execute_submission
-from control_plane.services.docs_paths import proposal_placeholder_reason, resolve_proposal_file
+from control_plane.services.docs_paths import (
+    git_ref_exists,
+    path_exists_at_ref,
+    proposal_placeholder_reason,
+    proposal_placeholder_reason_at_ref,
+    resolve_proposal_file,
+    resolve_proposal_file_at_ref,
+)
 
 
 class OperatorSubmissionError(RuntimeError):
@@ -380,8 +387,36 @@ def _proposal_linkage_reason(*, repo_root: Path, work_item: WorkItem) -> str | N
     proposal_path = str(developer_loop.get("proposal_path", "")).strip() or None
     if proposal_id is None and proposal_path is None:
         return "missing developer_loop proposal linkage"
+    proposal_ref = str(work_item.source_commit or "").strip()
+    if not proposal_ref and work_item.task_request is not None:
+        proposal_ref = str(work_item.task_request.source_commit or "").strip()
+
+    if proposal_ref and git_ref_exists(repo_root, proposal_ref):
+        proposal_rel = resolve_proposal_file_at_ref(
+            repo_root,
+            proposal_ref,
+            proposal_path=proposal_path,
+            proposal_id=proposal_id,
+        )
+        if proposal_rel is not None:
+            placeholder_reason = proposal_placeholder_reason_at_ref(
+                repo_root,
+                proposal_ref,
+                proposal_path=proposal_path,
+                proposal_id=proposal_id,
+            )
+            if placeholder_reason is not None:
+                return placeholder_reason
+            return None
+
     proposal_json = resolve_proposal_file(repo_root, proposal_path=proposal_path, proposal_id=proposal_id)
     if proposal_json is None or not proposal_json.exists():
+        return "developer_loop proposal linkage does not resolve to a proposal"
+    try:
+        proposal_rel = str(proposal_json.resolve().relative_to(repo_root.resolve()))
+    except ValueError:
+        proposal_rel = None
+    if proposal_ref and git_ref_exists(repo_root, proposal_ref) and proposal_rel and path_exists_at_ref(repo_root, "HEAD", proposal_rel):
         return "developer_loop proposal linkage does not resolve to a proposal"
     placeholder_reason = proposal_placeholder_reason(proposal_json)
     if placeholder_reason is not None:

--- a/control_plane/control_plane/services/submission_bridge.py
+++ b/control_plane/control_plane/services/submission_bridge.py
@@ -18,7 +18,14 @@ from control_plane.models.enums import ArtifactStorageMode
 from control_plane.models.run_events import RunEvent
 from control_plane.models.runs import Run
 from control_plane.models.work_items import WorkItem
-from control_plane.services.docs_paths import proposal_placeholder_reason, resolve_proposal_file
+from control_plane.services.docs_paths import (
+    path_exists_at_ref,
+    proposal_context_files_at_ref,
+    proposal_placeholder_reason,
+    proposal_placeholder_reason_at_ref,
+    resolve_proposal_file,
+    resolve_proposal_file_at_ref,
+)
 from control_plane.services.review_publisher import ReviewPublishRequest, publish_review_package
 from control_plane.workers.artifact_stage import collect_linked_results_artifacts
 
@@ -117,12 +124,34 @@ def _collect_existing_file_refs(*, repo_root: Path, value: Any, files: list[str]
     files.append(rel_path)
 
 
-def _proposal_file(*, repo_root: Path, package_payload: dict[str, Any]) -> Path | None:
+def _proposal_file(
+    *,
+    repo_root: Path,
+    package_payload: dict[str, Any],
+    proposal_ref: str | None = None,
+) -> Path | None:
     developer_loop = package_payload.get("developer_loop")
     if not isinstance(developer_loop, dict):
         return None
     proposal_id = str(developer_loop.get("proposal_id", "")).strip() or None
     proposal_path = str(developer_loop.get("proposal_path", "")).strip() or None
+    proposal_rel = resolve_proposal_file_at_ref(
+        repo_root,
+        proposal_ref,
+        proposal_path=proposal_path,
+        proposal_id=proposal_id,
+    )
+    if proposal_rel is not None:
+        placeholder_reason = proposal_placeholder_reason_at_ref(
+            repo_root,
+            proposal_ref,
+            proposal_path=proposal_path,
+            proposal_id=proposal_id,
+        )
+        if placeholder_reason is not None:
+            raise SubmissionPrepareError(placeholder_reason)
+        return repo_root / proposal_rel
+
     proposal_file = resolve_proposal_file(repo_root, proposal_path=proposal_path, proposal_id=proposal_id)
     if proposal_file is None or not proposal_file.exists() or proposal_file.name != "proposal.json":
         if proposal_id or proposal_path:
@@ -134,7 +163,36 @@ def _proposal_file(*, repo_root: Path, package_payload: dict[str, Any]) -> Path 
     return proposal_file
 
 
-def _proposal_context_files(*, repo_root: Path, package_payload: dict[str, Any]) -> list[str]:
+def _proposal_context_files(
+    *,
+    repo_root: Path,
+    package_payload: dict[str, Any],
+    proposal_ref: str | None = None,
+) -> list[str]:
+    developer_loop = package_payload.get("developer_loop")
+    proposal_id = None
+    proposal_path = None
+    if isinstance(developer_loop, dict):
+        proposal_id = str(developer_loop.get("proposal_id", "")).strip() or None
+        proposal_path = str(developer_loop.get("proposal_path", "")).strip() or None
+    if proposal_ref:
+        ref_files = proposal_context_files_at_ref(
+            repo_root,
+            proposal_ref,
+            proposal_path=proposal_path,
+            proposal_id=proposal_id,
+        )
+        if ref_files:
+            placeholder_reason = proposal_placeholder_reason_at_ref(
+                repo_root,
+                proposal_ref,
+                proposal_path=proposal_path,
+                proposal_id=proposal_id,
+            )
+            if placeholder_reason is not None:
+                raise SubmissionPrepareError(placeholder_reason)
+            return ref_files
+
     proposal_file = _proposal_file(repo_root=repo_root, package_payload=package_payload)
     if proposal_file is None:
         return []
@@ -147,24 +205,6 @@ def _proposal_context_files(*, repo_root: Path, package_payload: dict[str, Any])
             continue
         files.append(rel_path)
     return files
-
-
-def _path_exists_at_ref(repo_root: Path, ref: str, rel_path: str) -> bool:
-    result = subprocess.run(
-        ["git", "-C", str(repo_root), "cat-file", "-e", f"{ref}:{rel_path}"],
-        capture_output=True,
-        text=True,
-    )
-    return result.returncode == 0
-
-
-def _path_tracked_at_head(repo_root: Path, rel_path: str) -> bool:
-    result = subprocess.run(
-        ["git", "-C", str(repo_root), "ls-files", "--error-unmatch", rel_path],
-        capture_output=True,
-        text=True,
-    )
-    return result.returncode == 0
 
 
 def _review_linked_supporting_files(*, repo_root: Path, package_payload: dict[str, Any]) -> list[str]:
@@ -392,14 +432,22 @@ def prepare_submission_branch(session: Session, request: SubmissionPrepareReques
             existing=[*evidence_files, *supporting_files],
         )
     )
-    source_proposal_file = _proposal_file(repo_root=repo_root, package_payload=package_payload)
-    source_proposal_context = _proposal_context_files(repo_root=repo_root, package_payload=package_payload)
     submission_base_ref, submission_base_commit = _resolve_submission_base(repo_root, request.pr_base)
+    source_proposal_file = _proposal_file(
+        repo_root=repo_root,
+        package_payload=package_payload,
+        proposal_ref=submission_base_ref,
+    )
+    source_proposal_context = _proposal_context_files(
+        repo_root=repo_root,
+        package_payload=package_payload,
+        proposal_ref=submission_base_ref,
+    )
     proposal_files_to_copy: list[str] = []
     if source_proposal_file is not None:
         proposal_rel = str(source_proposal_file.resolve().relative_to(repo_root.resolve()))
-        if not _path_exists_at_ref(repo_root, submission_base_ref, proposal_rel):
-            if _path_tracked_at_head(repo_root, proposal_rel):
+        if not path_exists_at_ref(repo_root, submission_base_ref, proposal_rel):
+            if path_exists_at_ref(repo_root, "HEAD", proposal_rel):
                 raise SubmissionPrepareError(
                     f"developer_loop proposal was removed from current submission base: {proposal_rel}"
                 )

--- a/control_plane/control_plane/tests/test_operator_submission.py
+++ b/control_plane/control_plane/tests/test_operator_submission.py
@@ -75,6 +75,23 @@ def _init_repo(repo_root: Path) -> None:
     )
 
 
+def _commit(repo_root: Path, message: str, *paths: str) -> None:
+    _git(repo_root, "add", *paths)
+    subprocess.run(
+        ["git", "-C", str(repo_root), "commit", "-m", message],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+        },
+    )
+
+
 def _seed_l2_reviewable(session: Session, repo_root: Path) -> tuple[str, str]:
     campaign_dir = repo_root / "control_plane" / "shadow_exports" / "campaigns" / "demo_l2"
     design_metrics_rel = "control_plane/shadow_exports/designs/demo_nm1/metrics.csv"
@@ -484,6 +501,130 @@ def test_assess_submission_eligibility_rejects_template_proposal_linkage() -> No
                 run=session.query(Run).filter_by(run_key=run_key).one(),
                 repo_root=repo_root,
             )
+            assert eligibility.eligible is False
+            assert eligibility.reason == "developer_loop proposal is still a template placeholder"
+
+
+def test_assess_submission_eligibility_uses_source_commit_proposal_when_repo_checkout_is_older() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_repo(repo_root)
+
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            item_id, run_key = _seed_l1_reviewable(session, repo_root)
+            _commit(
+                repo_root,
+                "commit l1 evidence",
+                "runs/index.csv",
+                "runs/designs/activations/softmax_rowwise_int8_r4_wrapper/metrics.csv",
+            )
+            evidence_commit = _git(repo_root, "rev-parse", "HEAD")
+            _commit(repo_root, "commit l1 proposal", "docs/proposals/prop_l1_operate_demo")
+            source_commit = _git(repo_root, "rev-parse", "HEAD")
+
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            work_item.source_commit = source_commit
+            work_item.task_request.source_commit = source_commit
+            session.commit()
+
+            _git(repo_root, "checkout", evidence_commit)
+            metrics_path = repo_root / "runs/designs/activations/softmax_rowwise_int8_r4_wrapper/metrics.csv"
+            metrics_path.write_text(metrics_path.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+
+            eligibility = assess_submission_eligibility(
+                session,
+                work_item=session.query(WorkItem).filter_by(item_id=item_id).one(),
+                run=session.query(Run).filter_by(run_key=run_key).one(),
+                repo_root=repo_root,
+            )
+
+            assert eligibility.eligible is True
+            assert eligibility.reason is None
+
+
+def test_assess_submission_eligibility_rejects_tracked_proposal_missing_at_source_commit() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_repo(repo_root)
+
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            item_id, run_key = _seed_l1_reviewable(session, repo_root)
+            _commit(
+                repo_root,
+                "commit l1 evidence",
+                "runs/index.csv",
+                "runs/designs/activations/softmax_rowwise_int8_r4_wrapper/metrics.csv",
+            )
+            source_commit = _git(repo_root, "rev-parse", "HEAD")
+            _commit(repo_root, "commit l1 proposal", "docs/proposals/prop_l1_operate_demo")
+
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            work_item.source_commit = source_commit
+            work_item.task_request.source_commit = source_commit
+            session.commit()
+
+            metrics_path = repo_root / "runs/designs/activations/softmax_rowwise_int8_r4_wrapper/metrics.csv"
+            metrics_path.write_text(metrics_path.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+
+            eligibility = assess_submission_eligibility(
+                session,
+                work_item=session.query(WorkItem).filter_by(item_id=item_id).one(),
+                run=session.query(Run).filter_by(run_key=run_key).one(),
+                repo_root=repo_root,
+            )
+
+            assert eligibility.eligible is False
+            assert eligibility.reason == "developer_loop proposal linkage does not resolve to a proposal"
+
+
+def test_assess_submission_eligibility_rejects_placeholder_proposal_at_source_commit() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_repo(repo_root)
+
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            item_id, run_key = _seed_l1_reviewable(session, repo_root)
+            _commit(
+                repo_root,
+                "commit l1 evidence",
+                "runs/index.csv",
+                "runs/designs/activations/softmax_rowwise_int8_r4_wrapper/metrics.csv",
+            )
+            evidence_commit = _git(repo_root, "rev-parse", "HEAD")
+
+            proposal_json = repo_root / "docs/proposals/prop_l1_operate_demo/proposal.json"
+            payload = json.loads(proposal_json.read_text(encoding="utf-8"))
+            payload["title"] = "Example proposal title"
+            payload["hypothesis"] = "Replace this with a bounded engineering hypothesis."
+            proposal_json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+            _commit(repo_root, "commit placeholder proposal", "docs/proposals/prop_l1_operate_demo")
+            source_commit = _git(repo_root, "rev-parse", "HEAD")
+
+            work_item = session.query(WorkItem).filter_by(item_id=item_id).one()
+            work_item.source_commit = source_commit
+            work_item.task_request.source_commit = source_commit
+            session.commit()
+
+            _git(repo_root, "checkout", evidence_commit)
+            metrics_path = repo_root / "runs/designs/activations/softmax_rowwise_int8_r4_wrapper/metrics.csv"
+            metrics_path.write_text(metrics_path.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+
+            eligibility = assess_submission_eligibility(
+                session,
+                work_item=session.query(WorkItem).filter_by(item_id=item_id).one(),
+                run=session.query(Run).filter_by(run_key=run_key).one(),
+                repo_root=repo_root,
+            )
+
             assert eligibility.eligible is False
             assert eligibility.reason == "developer_loop proposal is still a template placeholder"
 

--- a/control_plane/control_plane/tests/test_submission_bridge.py
+++ b/control_plane/control_plane/tests/test_submission_bridge.py
@@ -587,6 +587,152 @@ def test_prepare_submission_branch_preserves_newer_proposal_state_from_current_b
             assert not any(path.startswith("docs/proposals/prop_l2_submit_demo/") for path in changed_paths)
 
 
+def test_prepare_submission_branch_uses_proposal_from_current_base_when_repo_checkout_is_older() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_repo(repo_root)
+
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            item_id, _run_key = _seed_l2_reviewable(session, repo_root)
+            proposal_dir = "docs/proposals/prop_l2_submit_demo"
+            _commit(
+                repo_root,
+                "commit l2 non-proposal state",
+                "runs/campaigns/demo_l2/artifacts/mapper/fp16_nm1_demo/demo_model/schedule.yml",
+                "runs/campaigns/demo_l2/artifacts/mapper/fp16_nm1_demo/relu_model/schedule.yml",
+            )
+            checkout_commit = _git(repo_root, "rev-parse", "HEAD")
+            _commit(repo_root, "commit l2 proposal", proposal_dir)
+            base_commit = _git(repo_root, "rev-parse", "HEAD")
+
+            _git(repo_root, "checkout", checkout_commit)
+            result = prepare_submission_branch(
+                session,
+                SubmissionPrepareRequest(
+                    repo_root=str(repo_root),
+                    item_id=item_id,
+                    evaluator_id="cpbot",
+                    session_id="s20260310t080014z",
+                    host="cp-host",
+                    worktree_root=str(repo_root / "tmp_submit"),
+                ),
+            )
+
+            manifest = json.loads(
+                (repo_root / "control_plane" / "shadow_exports" / "review" / item_id / "submission_manifest.json").read_text()
+            )
+            assert manifest["submission_base_commit"] == base_commit
+            assert "docs/proposals/prop_l2_submit_demo/proposal.json" in manifest["proposal_context_paths"]
+            assert "docs/proposals/prop_l2_submit_demo/evaluation_requests.json" in manifest["proposal_context_paths"]
+            assert (Path(result.worktree_path) / "docs/proposals/prop_l2_submit_demo/proposal.json").exists()
+            assert (Path(result.worktree_path) / "docs/proposals/prop_l2_submit_demo/evaluation_requests.json").exists()
+
+
+def test_prepare_submission_branch_rejects_placeholder_proposal_from_current_base() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_repo(repo_root)
+
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            item_id, _run_key = _seed_l2_reviewable(session, repo_root)
+            proposal_dir = repo_root / "docs/proposals/prop_l2_submit_demo"
+            _commit(
+                repo_root,
+                "commit l2 non-proposal state",
+                "runs/campaigns/demo_l2/artifacts/mapper/fp16_nm1_demo/demo_model/schedule.yml",
+                "runs/campaigns/demo_l2/artifacts/mapper/fp16_nm1_demo/relu_model/schedule.yml",
+            )
+            checkout_commit = _git(repo_root, "rev-parse", "HEAD")
+
+            proposal_json = proposal_dir / "proposal.json"
+            payload = json.loads(proposal_json.read_text(encoding="utf-8"))
+            payload["title"] = "Example proposal title"
+            payload["direct_comparison"] = {
+                "primary_question": "What focused comparison directly tests this proposal?",
+            }
+            proposal_json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+            _commit(repo_root, "commit placeholder proposal", "docs/proposals/prop_l2_submit_demo")
+
+            _git(repo_root, "checkout", checkout_commit)
+            try:
+                prepare_submission_branch(
+                    session,
+                    SubmissionPrepareRequest(
+                        repo_root=str(repo_root),
+                        item_id=item_id,
+                        evaluator_id="cpbot",
+                        session_id="s20260310t080015z",
+                        host="cp-host",
+                        worktree_root=str(repo_root / "tmp_submit"),
+                    ),
+                )
+            except SubmissionPrepareError as exc:
+                assert str(exc) == "developer_loop proposal is still a template placeholder"
+            else:
+                raise AssertionError("expected SubmissionPrepareError")
+
+
+def test_prepare_submission_branch_rejects_proposal_removed_from_current_base() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_repo(repo_root)
+
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            item_id, _run_key = _seed_l2_reviewable(session, repo_root)
+            _commit(
+                repo_root,
+                "commit l2 state with proposal",
+                "runs/campaigns/demo_l2/artifacts/mapper/fp16_nm1_demo/demo_model/schedule.yml",
+                "runs/campaigns/demo_l2/artifacts/mapper/fp16_nm1_demo/relu_model/schedule.yml",
+                "docs/proposals/prop_l2_submit_demo",
+            )
+            checkout_commit = _git(repo_root, "rev-parse", "HEAD")
+            _git(repo_root, "rm", "-r", "docs/proposals/prop_l2_submit_demo")
+            subprocess.run(
+                ["git", "-C", str(repo_root), "commit", "-m", "remove proposal from base"],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={
+                    **__import__("os").environ,
+                    "GIT_AUTHOR_NAME": "Test",
+                    "GIT_AUTHOR_EMAIL": "test@example.com",
+                    "GIT_COMMITTER_NAME": "Test",
+                    "GIT_COMMITTER_EMAIL": "test@example.com",
+                },
+            )
+
+            _git(repo_root, "checkout", checkout_commit)
+            try:
+                prepare_submission_branch(
+                    session,
+                    SubmissionPrepareRequest(
+                        repo_root=str(repo_root),
+                        item_id=item_id,
+                        evaluator_id="cpbot",
+                        session_id="s20260310t080016z",
+                        host="cp-host",
+                        worktree_root=str(repo_root / "tmp_submit"),
+                    ),
+                )
+            except SubmissionPrepareError as exc:
+                assert str(exc) == (
+                    "developer_loop proposal was removed from current submission base: "
+                    "docs/proposals/prop_l2_submit_demo/proposal.json"
+                )
+            else:
+                raise AssertionError("expected SubmissionPrepareError")
+
+
 def test_prepare_submission_branch_rejects_broad_proposal_path() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"


### PR DESCRIPTION
## Summary
- validate submission eligibility against the queued work item source commit even when the daemon checkout is older
- validate submission preparation against the fetched current base ref without mutating the long-lived evaluator checkout
- preserve the existing rule that stale tracked proposal state from an execution checkout is never copied over newer base state
- retain legacy fallback for genuinely uncommitted proposal scaffolding
- add positive old-checkout/source-ref and old-checkout/base-ref tests plus missing, placeholder, removed, broad, and stale negative cases

## Root cause
Physical execution now uses isolated source-pinned worktrees. The evaluator daemon can therefore remain on an older stable checkout. Proposal eligibility and submission preparation still resolved `developer_loop.proposal_path` only from that checkout's filesystem, producing a false `developer_loop proposal linkage does not resolve to a proposal` after a successful run.

## Validation
Focused source-ref/base-ref cases and existing resolver guards pass. Running all of `test_docs_paths.py`, `test_operator_submission.py`, and `test_submission_bridge.py` produced 31 passing tests and the same seven unrelated failures present on the exact parent commit; no new full-file failures were introduced. `git show --check` and `py_compile` pass.

## Recovery evidence
The affected folded-Mersenne tree run was recovered without rerunning OpenROAD by submitting from a separate clean worktree at its current base; result PR #1523 passed CI and merged.