### PR TITLE
l2: depend folded recost on merged baseline retry

### DIFF
--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -7543,9 +7543,9 @@ def test_generate_l2_campaign_task_adds_folded_global_exact_reduction_recost_evi
                     abstraction_layer="decoder_attention_score32_folded_global_exact_reduction_recost",
                     evaluation_mode="frontier_detail",
                     comparison_role="score32_folded_global_exact_reduction_recost",
-                    paired_baseline_item_id="l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+                    paired_baseline_item_id="l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r2",
                     depends_on_item_ids=[
-                        "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+                        "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r2",
                     ],
                     requires_merged_inputs=True,
                     requires_materialized_refs=True,
@@ -7612,11 +7612,11 @@ def test_generate_l2_campaign_task_adds_folded_global_exact_reduction_recost_evi
                 },
                 "comparison": {
                     "role": "score32_folded_global_exact_reduction_recost",
-                    "paired_baseline_item_id": "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+                    "paired_baseline_item_id": "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r2",
                 },
                 "dependencies": {
                     "item_ids": [
-                        "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+                        "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r2",
                     ],
                     "requires_merged_inputs": True,
                     "requires_materialized_refs": True,

--- a/docs/proposals/prop_l2_decoder_attention_score32_folded_global_exact_reduction_recost_llama7b_v2/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_folded_global_exact_reduction_recost_llama7b_v2/evaluation_requests.json
@@ -9,9 +9,9 @@
       "evaluation_mode": "frontier_detail",
       "abstraction_layer": "decoder_attention_score32_folded_global_exact_reduction_recost",
       "comparison_role": "score32_folded_global_exact_reduction_recost",
-      "paired_baseline_item_id": "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r2",
       "depends_on_item_ids": [
-        "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1"
+        "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r2"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,

--- a/docs/proposals/prop_l2_decoder_attention_score32_folded_global_exact_reduction_recost_llama7b_v2/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_folded_global_exact_reduction_recost_llama7b_v2/proposal.json
@@ -35,9 +35,9 @@
       "evaluation_mode": "frontier_detail",
       "abstraction_layer": "decoder_attention_score32_folded_global_exact_reduction_recost",
       "comparison_role": "score32_folded_global_exact_reduction_recost",
-      "paired_baseline_item_id": "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r2",
       "depends_on_item_ids": [
-        "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1"
+        "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r2"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,


### PR DESCRIPTION
## Summary
- point the folded recost comparison and eligibility dependency at the successful merged `_v1_r2` baseline work item
- preserve the canonical historical `v1` artifact identity used by the audit
- update the task-generation contract test

The original `v1` work item is terminal `FAILED`; `_v1_r2` is `MERGED` and produced the canonical v1 evidence artifact. This correction prevents a false dependency eligibility block before dispatch.

## Verification
- focused L2 task-generator test passed
- `python3 scripts/validate_runs.py --skip_eval_queue` passed
- `git diff --check` passed