### PR TITLE
eval: retry GQA8 local reducer without Yosys share

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/evaluation_requests.json
@@ -1,7 +1,7 @@
 {
   "proposal_id": "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1",
   "proposal_path": "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json",
-  "source_commit_note": "Generate the DB task only after this job-prep change is merged, and pin source_requirement.required_sha to the then-current origin/master commit containing both the harness and task-generator support.",
+  "source_commit_note": "Preserve the original v1 bounded SHARE failure as immutable history. Generate only the fresh r2 DB task after this job-prep change is merged, and pin source_requirement.required_sha to the then-current origin/master commit containing the no-share retry sweep plus proposal/task-generator support.",
   "requested_items": [
     {
       "item_id": "l1_decoder_attention_score32_local_temporal_reducer_gqa8_ppa_v1",
@@ -40,7 +40,47 @@
         "direction": "measure_gqa8_local_temporal_reducer_boundary",
         "reason": "The corrected merged GQA8 harness establishes whether the 53/54-way eight-wave local hierarchy remains physically explorable before producer fan-in and global c16 composition consume it."
       },
-      "notes": "Replacement remote OpenROAD request for the corrected GQA8 harness. The harness is structural-only, the reducer-vs-source_only delta is nonlinear until producer fan-in and global c16 closure exist, and the queued payload must carry exact developer_loop proposal linkage plus a queue-time source_requirement pin to the merged job-prep commit."
+      "status": "failed_before_pnr",
+      "notes": "Historical bounded failure only. Preserve this v1 item and sweep as immutable evidence: the run was bounded-canceled after Yosys stayed in `6.13 SHARE (SAT-based resource sharing)` for more than 7 minutes at roughly full CPU. Do not dispatch or mutate this item again."
+    },
+    {
+      "item_id": "l1_decoder_attention_score32_local_temporal_reducer_gqa8_ppa_v1_r2",
+      "task_type": "l1_sweep",
+      "title": "Layer 1 GQA8 score32 local temporal reducer physical harness boundary sweep no-share retry",
+      "proposal_id": "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1",
+      "proposal_path": "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json",
+      "objective": "Retry the Nangate45 PPA boundary sweep for the corrected merged GQA8 score32 exact local temporal reducer physical harness at p53/p54 in reducer and source_only modes using the same bounded macro-style hierarchy points, but with `SYNTH_ARGS=-noshare` to skip only Yosys's SAT-based resource-sharing pass while preserving the RTL architecture and explicit staged sharing already encoded in the design.",
+      "status": "pending",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_score32_local_temporal_reducer_gqa8",
+      "comparison_role": "functional_gqa8_local_hierarchy_anchor",
+      "paired_baseline_item_id": "l1_decoder_attention_score32_exact_partial_gqa8_dual_stream_producer_ppa_v1",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_source_only_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_noshare_r2.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_source_only_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_source_only_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/timing_debug_report.md"
+      ],
+      "acceptance_notes": "Run the GQA8 physical-harness generator, guard, run_block_sweep, and timing-summary commands for each config. Keep the sweep bounded, make no I/O pad assumptions, and accept ok, flow_failed, and timeout-class rows as explicit boundary evidence. Treat the structural-only reducer-vs-source_only delta as nonlinear until producer fan-in and global c16 composition are physically closed. `-noshare` removes only Yosys's SAT-based resource-sharing optimization; it does not change RTL logic and is appropriate here because the architecture already encodes the intended staged sharing explicitly.",
+      "expected_result": {
+        "direction": "measure_gqa8_local_temporal_reducer_boundary_without_yosys_share",
+        "reason": "The retry preserves the exact bounded physical envelope while changing only synthesis flow identity to avoid a known Yosys SHARE-stage explosion that is orthogonal to the explicit reducer/source sharing already present in RTL."
+      },
+      "notes": "Fresh immutable retry. Use the new no-share sweep identity, not the original v1 sweep, so `make_run_id` and the parameter hash differ and `--skip_existing` cannot reuse the bounded SHARE failure. The queued payload must carry exact developer_loop proposal linkage plus a queue-time source_requirement pin to the merged job-prep commit."
     }
   ]
 }

--- a/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json
@@ -19,16 +19,16 @@
       "128-bank temporal exact state across 8 heads x 16 slices",
       "explicit head-base plus lane contract validation",
       "producer-compatible head-major slice-minor local-root ordering",
-      "ideal-interface service and separate stressed ready/valid evidence",
-      "structured RTL/perf equivalence for every emitted beat"
-    ],
-    "exclude": [
-      "producer-to-reducer physical fan-in closure",
-      "NoC and SRAM physical closure",
-      "global c16 integration PPA",
-      "frontier promotion from functional simulation alone",
-      "new sweep or evaluation dispatch in this change"
-    ],
+        "ideal-interface service and separate stressed ready/valid evidence",
+        "structured RTL/perf equivalence for every emitted beat"
+      ],
+      "exclude": [
+        "producer-to-reducer physical fan-in closure",
+        "NoC and SRAM physical closure",
+        "global c16 integration PPA",
+        "frontier promotion from functional simulation alone",
+        "remote queue dispatch and physical execution in this change"
+      ],
     "metrics": [
       "functional_exact_partial_protocol",
       "validated_gqa8_wave_terminal_contract",
@@ -81,8 +81,46 @@
         "direction": "measure_gqa8_local_temporal_reducer_boundary",
         "reason": "The corrected merged GQA8 harness establishes whether the 53/54-way eight-wave local hierarchy remains physically explorable before producer fan-in and global c16 composition consume it."
       },
+      "status": "failed_before_pnr",
+      "notes": "Historical bounded failure: preserve this v1 item and sweep as immutable evidence. The run was bounded-canceled after Yosys stayed in `6.13 SHARE (SAT-based resource sharing)` for more than 7 minutes at roughly full CPU, so no reducer/source_only PPA row from this item is promotable. Do not mutate or reuse this sweep identity for retries."
+    },
+    {
+      "item_id": "l1_decoder_attention_score32_local_temporal_reducer_gqa8_ppa_v1_r2",
+      "task_type": "l1_sweep",
+      "proposal_id": "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1",
+      "proposal_path": "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json",
+      "objective": "Retry the Nangate45 PPA boundary sweep for the corrected merged GQA8 score32 exact local temporal reducer physical harness at p53/p54 in reducer and source_only modes using the same bounded macro-style hierarchy points, but with `SYNTH_ARGS=-noshare` to skip only Yosys's SAT-based resource-sharing pass while preserving the RTL architecture and explicit staged sharing already encoded in the design.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_score32_local_temporal_reducer_gqa8",
+      "comparison_role": "functional_gqa8_local_hierarchy_anchor",
+      "paired_baseline_item_id": "l1_decoder_attention_score32_exact_partial_gqa8_dual_stream_producer_ppa_v1",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_source_only_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_noshare_r2.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_source_only_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_source_only_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/timing_debug_report.md"
+      ],
+      "acceptance_notes": "Run the GQA8 physical-harness generator, guard, run_block_sweep, and timing-summary commands for each config. Keep the sweep bounded, make no I/O pad assumptions, and accept ok, flow_failed, and timeout-class rows as explicit boundary evidence. Treat the structural-only reducer-vs-source_only delta as nonlinear until producer fan-in and global c16 composition are physically closed. `-noshare` removes only Yosys's SAT-based resource-sharing optimization; it does not change RTL logic and is appropriate here because the architecture already encodes the intended staged sharing explicitly.",
+      "expected_result": {
+        "direction": "measure_gqa8_local_temporal_reducer_boundary_without_yosys_share",
+        "reason": "The retry preserves the exact bounded physical envelope while changing only synthesis flow identity to avoid a known Yosys SHARE-stage explosion that is orthogonal to the explicit reducer/source sharing already present in RTL."
+      },
       "status": "pending",
-      "notes": "Replacement remote OpenROAD request for the corrected GQA8 harness. Generate the work item only after this job-prep change is merged, with developer_loop proposal linkage and source_requirement.required_sha pinned at queue time to the merged origin/master commit."
+      "notes": "Fresh immutable retry. Use the new no-share sweep identity, not the original v1 sweep, so `make_run_id` and the parameter hash differ and `--skip_existing` cannot reuse the bounded SHARE failure. Generate the work item only after this job-prep change is merged, with developer_loop proposal linkage and source_requirement.required_sha pinned at queue time to the merged origin/master commit."
     }
   ],
   "source_refs": [
@@ -98,6 +136,7 @@
     "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_w8/config.json",
     "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/config.json",
     "runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary.json",
+    "runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_noshare_r2.json",
     "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/evaluation_requests.json"
   ],
   "knowledge_refs": [

--- a/runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_noshare_r2.json
+++ b/runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_noshare_r2.json
@@ -1,0 +1,24 @@
+{
+  "tag_prefix": "attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_noshare_v1_r2",
+  "flow_params": {
+    "CLOCK_PERIOD": [
+      8.0,
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2200 2200"
+    ],
+    "CORE_AREA": [
+      "80 80 2120 2120"
+    ],
+    "PLACE_DENSITY": [
+      0.35
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_ARGS": [
+      "-noshare"
+    ]
+  }
+}

--- a/tests/test_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_noshare_retry.py
+++ b/tests/test_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_noshare_retry.py
@@ -1,0 +1,79 @@
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROPOSAL_PATH = (
+    REPO_ROOT
+    / "docs"
+    / "proposals"
+    / "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1"
+    / "proposal.json"
+)
+REQUESTS_PATH = (
+    REPO_ROOT
+    / "docs"
+    / "proposals"
+    / "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1"
+    / "evaluation_requests.json"
+)
+BASE_SWEEP_PATH = (
+    REPO_ROOT
+    / "runs"
+    / "campaigns"
+    / "npu"
+    / "attention_score32_local_temporal_reducer_gqa8_v1"
+    / "sweeps"
+    / "nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary.json"
+)
+RETRY_SWEEP_PATH = (
+    REPO_ROOT
+    / "runs"
+    / "campaigns"
+    / "npu"
+    / "attention_score32_local_temporal_reducer_gqa8_v1"
+    / "sweeps"
+    / "nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_noshare_r2.json"
+)
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_gqa8_physical_harness_noshare_retry_uses_distinct_sweep_identity() -> None:
+    base = _load_json(BASE_SWEEP_PATH)
+    retry = _load_json(RETRY_SWEEP_PATH)
+
+    assert base["tag_prefix"] != retry["tag_prefix"]
+    assert base["flow_params"] != retry["flow_params"]
+    assert retry["flow_params"]["SYNTH_ARGS"] == ["-noshare"]
+    assert "SYNTH_ARGS" not in base["flow_params"]
+    for key in ("CLOCK_PERIOD", "DIE_AREA", "CORE_AREA", "PLACE_DENSITY", "SYNTH_HIERARCHICAL"):
+        assert retry["flow_params"][key] == base["flow_params"][key]
+
+
+def test_gqa8_physical_harness_noshare_retry_docs_preserve_v1_history() -> None:
+    proposal = _load_json(PROPOSAL_PATH)
+    requests = _load_json(REQUESTS_PATH)
+
+    proposal_items = {item["item_id"]: item for item in proposal["required_evaluations"]}
+    request_items = {item["item_id"]: item for item in requests["requested_items"]}
+
+    historical = proposal_items["l1_decoder_attention_score32_local_temporal_reducer_gqa8_ppa_v1"]
+    retry = proposal_items["l1_decoder_attention_score32_local_temporal_reducer_gqa8_ppa_v1_r2"]
+    requested_retry = request_items["l1_decoder_attention_score32_local_temporal_reducer_gqa8_ppa_v1_r2"]
+
+    assert historical["status"] == "failed_before_pnr"
+    assert "SHARE (SAT-based resource sharing)" in historical["notes"]
+    assert "Do not mutate or reuse this sweep identity for retries." in historical["notes"]
+
+    assert retry["sweep_path"] == str(RETRY_SWEEP_PATH.relative_to(REPO_ROOT))
+    assert retry["status"] == "pending"
+    assert request_items["l1_decoder_attention_score32_local_temporal_reducer_gqa8_ppa_v1"]["status"] == (
+        "failed_before_pnr"
+    )
+    assert requested_retry["sweep_path"] == retry["sweep_path"]
+    assert "SAT-based resource-sharing pass" in retry["objective"]
+    assert "`SYNTH_ARGS=-noshare`" in retry["objective"]
+    assert "make_run_id" in retry["notes"]


### PR DESCRIPTION
## Summary
- preserve the bounded v1 Yosys SHARE-stage failure as immutable evidence
- add a distinct r2 sweep using SYNTH_ARGS=-noshare
- add regression coverage for sweep and proposal identity

## Rationale
The RTL already encodes explicit staged sharing. Disabling Yosys SAT resource sharing avoids synthesis-time explosion without changing RTL semantics.

## Validation
- pytest tests/test_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_noshare_retry.py
- PYTHONPATH=.:control_plane python scripts/validate_runs.py --skip_eval_queue
- git diff --check