### PR TITLE
eval: allow GQA8 reducer persistent state synthesis

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/evaluation_requests.json
@@ -1,7 +1,7 @@
 {
   "proposal_id": "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1",
   "proposal_path": "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json",
-  "source_commit_note": "Preserve the original v1 bounded SHARE failure as immutable history. Generate only the fresh r2 DB task after this job-prep change is merged, and pin source_requirement.required_sha to the then-current origin/master commit containing the no-share retry sweep plus proposal/task-generator support.",
+  "source_commit_note": "Preserve the original v1 bounded SHARE failure and the finalized r2 bounded memory-guard evidence as immutable history. Generate only the fresh r3 DB task after this job-prep change is merged, and pin source_requirement.required_sha to the then-current origin/master commit containing the no-share memory-guard retry sweep plus proposal/task-generator support.",
   "requested_items": [
     {
       "item_id": "l1_decoder_attention_score32_local_temporal_reducer_gqa8_ppa_v1",
@@ -79,10 +79,49 @@
         "direction": "measure_gqa8_local_temporal_reducer_boundary_without_yosys_share",
         "reason": "The retry preserves the exact bounded physical envelope while changing only synthesis flow identity to avoid a known Yosys SHARE-stage explosion that is orthogonal to the explicit reducer/source sharing already present in RTL."
       },
-      "notes": "Fresh immutable retry. Use the new no-share sweep identity, not the original v1 sweep, so `make_run_id` and the parameter hash differ and `--skip_existing` cannot reuse the bounded SHARE failure. The queued payload must carry exact developer_loop proposal linkage plus a queue-time source_requirement pin to the merged job-prep commit. Merged via PR #1531 and merge 3afd7e718343e7a84a4b3bf158b5a4a6128dcaf8 at 2026-08-03T10:22:05.177708Z.",
+      "notes": "Historical bounded memory-guard evidence. `SYNTH_ARGS=-noshare` successfully bypassed the prior Yosys SHARE explosion, but the reducer objective did not reach PNR: p53 reducer 8ns/10ns failed at 71.08s/71.30s and p54 reducer 8ns/10ns failed at 69.01s/73.47s, each with `Error: Synthesized memory size 4096 exceeds SYNTH_MEMORY_MAX_BITS`. Source_only controls closed separately: p53 8ns cp 0.8517 area 10794.3 cells 19522 power 0.00302; p53 10ns cp 0.8663 area 10796.4 cells 19527 power 0.00245; p54 8ns cp 0.8785 area 10560.2 cells 19367 power 0.00255; p54 10ns cp 0.9874 area 10559.7 cells 19365 power 0.00209. This shows the surrounding harness is viable and the remaining abort is the reducer-state guard. Finalized via PR #1531 and merge 3afd7e718343e7a84a4b3bf158b5a4a6128dcaf8 at 2026-08-03T10:22:05.177708Z.",
       "merged_pr_number": 1531,
       "merge_commit": "3afd7e718343e7a84a4b3bf158b5a4a6128dcaf8",
       "merged_utc": "2026-08-03T10:22:05.177708Z"
+    },
+    {
+      "item_id": "l1_decoder_attention_score32_local_temporal_reducer_gqa8_ppa_v1_r3",
+      "task_type": "l1_sweep",
+      "title": "Layer 1 GQA8 score32 local temporal reducer physical harness boundary sweep no-share memory-guard retry",
+      "proposal_id": "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1",
+      "proposal_path": "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json",
+      "objective": "Retry the Nangate45 PPA boundary sweep for the corrected merged GQA8 score32 exact local temporal reducer physical harness at p53/p54 in reducer and source_only modes using the same bounded macro-style hierarchy points, retaining `SYNTH_ARGS=-noshare` and adding `SYNTH_MEMORY_MAX_BITS=65536` so synthesis can legalize the required 4096-bit persistent state. This changes only the synthesis memory guard and does not alter RTL semantics.",
+      "status": "pending",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_score32_local_temporal_reducer_gqa8",
+      "comparison_role": "functional_gqa8_local_hierarchy_anchor",
+      "paired_baseline_item_id": "l1_decoder_attention_score32_exact_partial_gqa8_dual_stream_producer_ppa_v1",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_source_only_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_noshare_memguard_r3.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_source_only_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_source_only_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/timing_debug_report.md"
+      ],
+      "acceptance_notes": "Run the GQA8 physical-harness generator, guard, run_block_sweep, and timing-summary commands for each config. Keep the sweep bounded, make no I/O pad assumptions, and accept ok, flow_failed, and timeout-class rows as explicit boundary evidence. Treat the structural-only reducer-vs-source_only delta as nonlinear until producer fan-in and global c16 composition are physically closed. Retain `-noshare` because it bypasses only Yosys's SAT-based resource-sharing optimization without changing RTL logic. Set `SYNTH_MEMORY_MAX_BITS=65536` only to permit synthesis of the required 4096-bit persistent state, consistent with existing repo physical-flow precedent that already uses a 65536-bit guard.",
+      "expected_result": {
+        "direction": "measure_gqa8_local_temporal_reducer_boundary_without_yosys_share_or_memory_guard_abort",
+        "reason": "The retry preserves the exact bounded physical envelope while changing only synthesis flow guard identity so the already-proven no-share path can continue past the 4096-bit persistent-state memory check and expose the next real physical boundary."
+      },
+      "notes": "Fresh immutable retry. Use the new no-share memory-guard sweep identity, not the original v1 or r2 sweeps, so `make_run_id` and the parameter hash differ and `--skip_existing` cannot reuse either preserved failure. The queued payload must carry exact developer_loop proposal linkage plus a queue-time source_requirement pin to the merged job-prep commit."
     }
   ],
   "source_commit": "5ee47712c0586b02d1fb38e714b59c86082fe955"

--- a/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json
@@ -119,8 +119,46 @@
         "direction": "measure_gqa8_local_temporal_reducer_boundary_without_yosys_share",
         "reason": "The retry preserves the exact bounded physical envelope while changing only synthesis flow identity to avoid a known Yosys SHARE-stage explosion that is orthogonal to the explicit reducer/source sharing already present in RTL."
       },
+      "status": "failed_before_pnr",
+      "notes": "Historical bounded memory-guard failure: preserve this r2 item and sweep as immutable evidence. `SYNTH_ARGS=-noshare` successfully bypassed the prior Yosys SHARE explosion, but the reducer objective did not reach PNR: p53 reducer 8ns/10ns failed at 71.08s/71.30s and p54 reducer 8ns/10ns failed at 69.01s/73.47s, each with `Error: Synthesized memory size 4096 exceeds SYNTH_MEMORY_MAX_BITS`. Source_only controls closed separately: p53 8ns cp 0.8517 area 10794.3 cells 19522 power 0.00302; p53 10ns cp 0.8663 area 10796.4 cells 19527 power 0.00245; p54 8ns cp 0.8785 area 10560.2 cells 19367 power 0.00255; p54 10ns cp 0.9874 area 10559.7 cells 19365 power 0.00209. This shows the surrounding harness is viable and the remaining abort is the reducer-state guard. Keep status `failed_before_pnr`. Do not mutate or reuse this sweep identity for retries."
+    },
+    {
+      "item_id": "l1_decoder_attention_score32_local_temporal_reducer_gqa8_ppa_v1_r3",
+      "task_type": "l1_sweep",
+      "proposal_id": "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1",
+      "proposal_path": "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json",
+      "objective": "Retry the Nangate45 PPA boundary sweep for the corrected merged GQA8 score32 exact local temporal reducer physical harness at p53/p54 in reducer and source_only modes using the same bounded macro-style hierarchy points, retaining `SYNTH_ARGS=-noshare` and adding `SYNTH_MEMORY_MAX_BITS=65536` so synthesis can legalize the required 4096-bit persistent state. This changes only the synthesis memory guard and does not alter RTL semantics.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_score32_local_temporal_reducer_gqa8",
+      "comparison_role": "functional_gqa8_local_hierarchy_anchor",
+      "paired_baseline_item_id": "l1_decoder_attention_score32_exact_partial_gqa8_dual_stream_producer_ppa_v1",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_source_only_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_noshare_memguard_r3.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_source_only_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_source_only_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/timing_debug_report.md"
+      ],
+      "acceptance_notes": "Run the GQA8 physical-harness generator, guard, run_block_sweep, and timing-summary commands for each config. Keep the sweep bounded, make no I/O pad assumptions, and accept ok, flow_failed, and timeout-class rows as explicit boundary evidence. Treat the structural-only reducer-vs-source_only delta as nonlinear until producer fan-in and global c16 composition are physically closed. Retain `-noshare` because it bypasses only Yosys's SAT-based resource-sharing optimization without changing RTL logic. Set `SYNTH_MEMORY_MAX_BITS=65536` only to permit synthesis of the required 4096-bit persistent state, consistent with existing repo physical-flow precedent that already uses a 65536-bit guard.",
+      "expected_result": {
+        "direction": "measure_gqa8_local_temporal_reducer_boundary_without_yosys_share_or_memory_guard_abort",
+        "reason": "The retry preserves the exact bounded physical envelope while changing only synthesis flow guard identity so the already-proven no-share path can continue past the 4096-bit persistent-state memory check and expose the next real physical boundary."
+      },
       "status": "pending",
-      "notes": "Fresh immutable retry. Use the new no-share sweep identity, not the original v1 sweep, so `make_run_id` and the parameter hash differ and `--skip_existing` cannot reuse the bounded SHARE failure. Generate the work item only after this job-prep change is merged, with developer_loop proposal linkage and source_requirement.required_sha pinned at queue time to the merged origin/master commit."
+      "notes": "Fresh immutable retry. Use the new no-share memory-guard sweep identity, not the original v1 or r2 sweeps, so `make_run_id` and the parameter hash differ and `--skip_existing` cannot reuse either preserved failure. Generate the work item only after this job-prep change is merged, with developer_loop proposal linkage and source_requirement.required_sha pinned at queue time to the merged origin/master commit."
     }
   ],
   "source_refs": [
@@ -137,6 +175,7 @@
     "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/config.json",
     "runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary.json",
     "runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_noshare_r2.json",
+    "runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_noshare_memguard_r3.json",
     "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/evaluation_requests.json"
   ],
   "knowledge_refs": [

--- a/runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_noshare_memguard_r3.json
+++ b/runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_noshare_memguard_r3.json
@@ -1,0 +1,27 @@
+{
+  "tag_prefix": "attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_noshare_memguard_v1_r3",
+  "flow_params": {
+    "CLOCK_PERIOD": [
+      8.0,
+      10.0
+    ],
+    "DIE_AREA": [
+      "0 0 2200 2200"
+    ],
+    "CORE_AREA": [
+      "80 80 2120 2120"
+    ],
+    "PLACE_DENSITY": [
+      0.35
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_ARGS": [
+      "-noshare"
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  }
+}

--- a/tests/test_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_memory_guard_retry.py
+++ b/tests/test_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_memory_guard_retry.py
@@ -1,0 +1,93 @@
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROPOSAL_PATH = (
+    REPO_ROOT
+    / "docs"
+    / "proposals"
+    / "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1"
+    / "proposal.json"
+)
+REQUESTS_PATH = (
+    REPO_ROOT
+    / "docs"
+    / "proposals"
+    / "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1"
+    / "evaluation_requests.json"
+)
+R2_SWEEP_PATH = (
+    REPO_ROOT
+    / "runs"
+    / "campaigns"
+    / "npu"
+    / "attention_score32_local_temporal_reducer_gqa8_v1"
+    / "sweeps"
+    / "nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_noshare_r2.json"
+)
+R3_SWEEP_PATH = (
+    REPO_ROOT
+    / "runs"
+    / "campaigns"
+    / "npu"
+    / "attention_score32_local_temporal_reducer_gqa8_v1"
+    / "sweeps"
+    / "nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_noshare_memguard_r3.json"
+)
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_gqa8_physical_harness_memory_guard_retry_uses_distinct_sweep_identity() -> None:
+    r2 = _load_json(R2_SWEEP_PATH)
+    r3 = _load_json(R3_SWEEP_PATH)
+
+    assert r2["tag_prefix"] != r3["tag_prefix"]
+    assert r2["flow_params"] != r3["flow_params"]
+    assert r3["flow_params"]["SYNTH_ARGS"] == ["-noshare"]
+    assert r3["flow_params"]["SYNTH_MEMORY_MAX_BITS"] == [65536]
+    assert "SYNTH_MEMORY_MAX_BITS" not in r2["flow_params"]
+    for key in ("CLOCK_PERIOD", "DIE_AREA", "CORE_AREA", "PLACE_DENSITY", "SYNTH_HIERARCHICAL"):
+        assert r3["flow_params"][key] == r2["flow_params"][key]
+
+
+def test_gqa8_physical_harness_memory_guard_retry_docs_preserve_history() -> None:
+    proposal = _load_json(PROPOSAL_PATH)
+    requests = _load_json(REQUESTS_PATH)
+
+    proposal_items = {item["item_id"]: item for item in proposal["required_evaluations"]}
+    request_items = {item["item_id"]: item for item in requests["requested_items"]}
+
+    r2 = proposal_items["l1_decoder_attention_score32_local_temporal_reducer_gqa8_ppa_v1_r2"]
+    r3 = proposal_items["l1_decoder_attention_score32_local_temporal_reducer_gqa8_ppa_v1_r3"]
+    requested_r3 = request_items["l1_decoder_attention_score32_local_temporal_reducer_gqa8_ppa_v1_r3"]
+
+    assert r2["status"] == "failed_before_pnr"
+    assert "Synthesized memory size 4096 exceeds SYNTH_MEMORY_MAX_BITS" in r2["notes"]
+    assert "p53 reducer 8ns/10ns failed at 71.08s/71.30s" in r2["notes"]
+    assert "p54 reducer 8ns/10ns failed at 69.01s/73.47s" in r2["notes"]
+    assert "p53 8ns cp 0.8517 area 10794.3 cells 19522 power 0.00302" in r2["notes"]
+    assert "p53 10ns cp 0.8663 area 10796.4 cells 19527 power 0.00245" in r2["notes"]
+    assert "p54 8ns cp 0.8785 area 10560.2 cells 19367 power 0.00255" in r2["notes"]
+    assert "p54 10ns cp 0.9874 area 10559.7 cells 19365 power 0.00209" in r2["notes"]
+    assert "surrounding harness is viable" in r2["notes"]
+    assert "remaining abort is the reducer-state guard" in r2["notes"]
+    assert "Keep status `failed_before_pnr`." in r2["notes"]
+    assert "Do not mutate or reuse this sweep identity for retries." in r2["notes"]
+
+    assert r3["sweep_path"] == str(R3_SWEEP_PATH.relative_to(REPO_ROOT))
+    assert r3["status"] == "pending"
+    assert requested_r3["sweep_path"] == r3["sweep_path"]
+    requested_r2 = request_items["l1_decoder_attention_score32_local_temporal_reducer_gqa8_ppa_v1_r2"]
+    assert requested_r2["status"] == "merged"
+    assert requested_r2["merged_pr_number"] == 1531
+    assert requested_r2["merge_commit"] == "3afd7e718343e7a84a4b3bf158b5a4a6128dcaf8"
+    assert requested_r2["merged_utc"] == "2026-08-03T10:22:05.177708Z"
+    assert "Finalized via PR #1531" in requested_r2["notes"]
+    assert "`SYNTH_MEMORY_MAX_BITS=65536`" in r3["objective"]
+    assert "does not alter RTL semantics" in r3["objective"]
+    assert "required 4096-bit persistent state" in r3["acceptance_notes"]
+    assert "65536-bit guard" in r3["acceptance_notes"]

--- a/tests/test_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_noshare_retry.py
+++ b/tests/test_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_noshare_retry.py
@@ -69,11 +69,13 @@ def test_gqa8_physical_harness_noshare_retry_docs_preserve_v1_history() -> None:
     assert "Do not mutate or reuse this sweep identity for retries." in historical["notes"]
 
     assert retry["sweep_path"] == str(RETRY_SWEEP_PATH.relative_to(REPO_ROOT))
-    assert retry["status"] == "pending"
+    assert retry["status"] == "failed_before_pnr"
     assert request_items["l1_decoder_attention_score32_local_temporal_reducer_gqa8_ppa_v1"]["status"] == (
         "failed_before_pnr"
     )
+    assert request_items["l1_decoder_attention_score32_local_temporal_reducer_gqa8_ppa_v1_r2"]["status"] == "merged"
     assert requested_retry["sweep_path"] == retry["sweep_path"]
     assert "SAT-based resource-sharing pass" in retry["objective"]
     assert "`SYNTH_ARGS=-noshare`" in retry["objective"]
-    assert "make_run_id" in retry["notes"]
+    assert "Synthesized memory size 4096 exceeds SYNTH_MEMORY_MAX_BITS" in retry["notes"]
+    assert "Finalized via PR #1531" in requested_retry["notes"]


### PR DESCRIPTION
## Summary
- preserve v1 SHARE and r2 memory-guard boundaries
- add immutable r3 sweep with SYNTH_ARGS=-noshare and SYNTH_MEMORY_MAX_BITS=65536
- record source-only physical controls and add identity regressions

## Rationale
The reducer requires 4096 bits of persistent state. Raising the synthesis guard uses existing project precedent and changes no RTL semantics.

## Validation
- 4 focused pytest cases passed
- validate_runs --skip_eval_queue passed
- git diff --check passed