### PR TITLE
npu: factor exact GQA8 reducer exp lookup

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/evaluation_requests.json
@@ -1,7 +1,7 @@
 {
   "proposal_id": "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1",
   "proposal_path": "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json",
-  "source_commit_note": "Preserve the original v1 bounded SHARE failure and the finalized r2 bounded memory-guard evidence as immutable history. Generate only the fresh r3 DB task after this job-prep change is merged, and pin source_requirement.required_sha to the then-current origin/master commit containing the no-share memory-guard retry sweep plus proposal/task-generator support.",
+  "source_commit_note": "Preserve the original v1 bounded SHARE failure and the finalized r2/r3 evidence as immutable history. Generate only the fresh r4 DB task after this job-prep change is merged, and pin source_requirement.required_sha to the then-current merged commit containing the factorized reducer configs, fresh no-share sweep, and legacy-LUT diagnostic. Interpret the r3 reducer abort as a legacy monolithic exp-LUT encoding boundary, not as a persistent-state-size requirement.",
   "requested_items": [
     {
       "item_id": "l1_decoder_attention_score32_local_temporal_reducer_gqa8_ppa_v1",
@@ -125,7 +125,40 @@
       "merged_pr_number": 1533,
       "merge_commit": "d96c3379c3af228606f9b266142529255fd12699",
       "merged_utc": "2026-08-03T10:58:06.037636Z"
+    },
+    {
+      "item_id": "l1_decoder_attention_score32_local_temporal_reducer_gqa8_factored_ppa_v1",
+      "task_type": "l1_sweep",
+      "title": "Layer 1 GQA8 score32 local temporal reducer factorized-exp boundary sweep",
+      "proposal_id": "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1",
+      "proposal_path": "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json",
+      "objective": "Measure Nangate45 PPA for the factorized-exp-scale GQA8 score32 exact local temporal reducer physical harness at p53/p54 in reducer mode only, using a fresh bounded macro-style hierarchy sweep with `SYNTH_ARGS=-noshare` and no memory-guard override so the factorized implementation must clear the default synthesis guard on its own.",
+      "status": "pending",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_score32_local_temporal_reducer_gqa8",
+      "comparison_role": "functional_gqa8_local_hierarchy_anchor",
+      "paired_baseline_item_id": "l1_decoder_attention_score32_exact_partial_gqa8_dual_stream_producer_ppa_v1",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_factored_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_factored_w8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_factored_r4.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_factored_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_factored_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_factored_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_factored_w8/timing_debug_report.md"
+      ],
+      "acceptance_notes": "Run the factorized GQA8 physical-harness generator, guard, run_block_sweep, and timing-summary commands for each config. Preserve the finalized r3 metadata exactly, but interpret r3 as a legacy-LUT encoding boundary revealed by evaluator mem.json and generator structure, not as a persistent-state requirement. Do not rerun source_only controls because `exp_scale_impl` is irrelevant there and r2/r3 already closed those controls. Keep the fresh sweep immutable, retain `-noshare`, and do not add `SYNTH_MEMORY_MAX_BITS`; if synthesis still trips a memory guard, treat that as a factored-regression signal rather than relaxing the guard again.",
+      "expected_result": {
+        "direction": "measure_factored_gqa8_local_temporal_reducer_boundary_without_memory_guard_override",
+        "reason": "The factorized exp-scale implementation should remove the legacy monolithic LUT replication identified in r3 and expose the next real physical boundary for the reducer itself."
+      },
+      "notes": "Fresh immutable r4 retry. This item isolates the factorized reducer-only datapath at p53/p54, keeps the historical v1/r2/r3 sweep identities untouched, and expects the default synthesis memory guard to remain in force. Generate the DB item only after this job-prep change is merged, with developer_loop proposal linkage and source_requirement.required_sha pinned at queue time to the merged origin/master commit that contains the factorized configs, sweep, and diagnostic evidence."
     }
   ],
-  "source_commit": "c733716b4756afe2eaf41e4feccb060a4de29f2c"
+  "source_commit": "379b4e723cb2a8ee61ce82bcb027b8bec9e7e0db"
 }

--- a/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/legacy_lut_memory_boundary_r3_diagnostic.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/legacy_lut_memory_boundary_r3_diagnostic.json
@@ -1,0 +1,56 @@
+{
+  "diagnostic_id": "legacy_lut_memory_boundary_r3",
+  "proposal_id": "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1",
+  "related_item_id": "l1_decoder_attention_score32_local_temporal_reducer_gqa8_ppa_v1_r3",
+  "merge_commit": "d96c3379c3af228606f9b266142529255fd12699",
+  "r3_source_commit": "c733716b4756afe2eaf41e4feccb060a4de29f2c",
+  "summary": "The r3 reducer abort was a legacy monolithic exp-LUT encoding boundary, not a persistent-state-size boundary.",
+  "legacy_monolithic_exp_lut": {
+    "per_memory_kind": "$mem_v2",
+    "depth": 4096,
+    "width_bits": 24,
+    "bits_per_memory": 98304
+  },
+  "cases": {
+    "p53": {
+      "producers": 53,
+      "local_merge_nodes": 52,
+      "temporal_merge_nodes": 1,
+      "exp_lut_evaluations_per_merge": 2,
+      "inferred_memories": 106,
+      "all_memories_match_4096x24": true,
+      "total_bits": 10420224
+    },
+    "p54": {
+      "producers": 54,
+      "local_merge_nodes": 53,
+      "temporal_merge_nodes": 1,
+      "exp_lut_evaluations_per_merge": 2,
+      "inferred_memories": 108,
+      "all_memories_match_4096x24": true,
+      "total_bits": 10616832
+    }
+  },
+  "derivation": {
+    "formula": "2 exp LUT evaluations x ((producers - 1) local merge nodes + 1 temporal merge)",
+    "source": [
+      "evaluator Yosys mem.json",
+      "npu/rtlgen/gen_attention_score32_exact_local_reducer.py",
+      "npu/rtlgen/gen_attention_score32_exact_local_temporal_reducer_gqa8.py",
+      "npu/rtlgen/gen_attention_score32_online_state_merge.py"
+    ]
+  },
+  "source_identification": {
+    "evaluator_machine_key": "eval-daemon-b7c2d9c80c1c",
+    "result_mem_json_paths": [
+      "/orfs/flow/results/nangate45/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/base/mem.json",
+      "/orfs/flow/results/nangate45/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_w8/base/mem.json"
+    ]
+  },
+  "failure_text_observation": {
+    "text": "Error: Synthesized memory size 65536 exceeds SYNTH_MEMORY_MAX_BITS",
+    "actual_max_instance_bits": 98304,
+    "mem_dump_behavior": "ORFS mem_dump.py prints args.max_bits, the configured threshold, not the offending instance size.",
+    "meaning": "The emitted failure text reports the configured threshold comparison, not the aggregate replicated memory footprint or the offending instance multiplicity."
+  }
+}

--- a/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json
@@ -159,6 +159,38 @@
       },
       "status": "pending",
       "notes": "Fresh immutable retry. Use the new no-share memory-guard sweep identity, not the original v1 or r2 sweeps, so `make_run_id` and the parameter hash differ and `--skip_existing` cannot reuse either preserved failure. Generate the work item only after this job-prep change is merged, with developer_loop proposal linkage and source_requirement.required_sha pinned at queue time to the merged origin/master commit."
+    },
+    {
+      "item_id": "l1_decoder_attention_score32_local_temporal_reducer_gqa8_factored_ppa_v1",
+      "task_type": "l1_sweep",
+      "proposal_id": "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1",
+      "proposal_path": "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json",
+      "objective": "Measure Nangate45 PPA for the factorized-exp-scale GQA8 score32 exact local temporal reducer physical harness at p53/p54 in reducer mode only, using a fresh bounded macro-style hierarchy sweep with `SYNTH_ARGS=-noshare` and no memory-guard override so the factorized implementation must clear the default synthesis guard on its own.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_score32_local_temporal_reducer_gqa8",
+      "comparison_role": "functional_gqa8_local_hierarchy_anchor",
+      "paired_baseline_item_id": "l1_decoder_attention_score32_exact_partial_gqa8_dual_stream_producer_ppa_v1",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_factored_w8/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_factored_w8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_factored_r4.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_factored_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_factored_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_factored_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_factored_w8/timing_debug_report.md"
+      ],
+      "acceptance_notes": "Run the factorized GQA8 physical-harness generator, guard, run_block_sweep, and timing-summary commands for each config. Preserve the finalized r3 metadata exactly, but interpret r3 as a legacy-LUT encoding boundary revealed by evaluator mem.json and generator structure, not as a persistent-state requirement. Do not rerun source_only controls because `exp_scale_impl` is irrelevant there and r2/r3 already closed those controls. Keep the fresh sweep immutable, retain `-noshare`, and do not add `SYNTH_MEMORY_MAX_BITS`; if synthesis still trips a memory guard, treat that as a factored-regression signal rather than relaxing the guard again.",
+      "expected_result": {
+        "direction": "measure_factored_gqa8_local_temporal_reducer_boundary_without_memory_guard_override",
+        "reason": "The factorized exp-scale implementation should remove the legacy monolithic LUT replication identified in r3 and expose the next real physical boundary for the reducer itself."
+      },
+      "status": "pending",
+      "notes": "Fresh immutable r4 retry. This item isolates the factorized reducer-only datapath at p53/p54, keeps the historical v1/r2/r3 sweep identities untouched, and expects the default synthesis memory guard to remain in force. Generate the DB item only after this job-prep change is merged, with developer_loop proposal linkage and source_requirement.required_sha pinned at queue time to the merged origin/master commit that contains the factorized configs, sweep, and diagnostic evidence."
     }
   ],
   "source_refs": [
@@ -173,9 +205,13 @@
     "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_source_only_w8/config.json",
     "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_w8/config.json",
     "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_source_only_w8/config.json",
+    "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_factored_w8/config.json",
+    "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_factored_w8/config.json",
     "runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary.json",
     "runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_noshare_r2.json",
     "runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_noshare_memguard_r3.json",
+    "runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_factored_r4.json",
+    "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/legacy_lut_memory_boundary_r3_diagnostic.json",
     "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/evaluation_requests.json"
   ],
   "knowledge_refs": [

--- a/npu/eval/check_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_guard.py
+++ b/npu/eval/check_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_guard.py
@@ -15,6 +15,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from npu.rtlgen.gen_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness import generate
+from npu.rtlgen.gen_attention_score32_online_state_merge import LEGACY_MONOLITHIC_LUT_EXACT
 
 _CONFIG_KEY = "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness"
 _MANIFEST_NAME = "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_manifest.json"
@@ -97,6 +98,7 @@ def main(argv: list[str] | None = None) -> int:
     producers = int(body.get("producers", 0))
     mode = str(body.get("mode", "")).strip()
     waves = int(body.get("waves", 0))
+    exp_scale_impl = str(body.get("exp_scale_impl", LEGACY_MONOLITHIC_LUT_EXACT)).strip()
     if producers not in {53, 54}:
         raise SystemExit("producers must remain exactly 53 or 54")
     if mode not in {"reducer", "source_only"}:
@@ -112,6 +114,7 @@ def main(argv: list[str] | None = None) -> int:
         "producers": producers,
         "mode": mode,
         "waves": 8,
+        "exp_scale_impl": exp_scale_impl,
         "command_count": 2,
         "query_heads_per_group": 8,
         "head_group_bases": [0, 8],
@@ -159,6 +162,19 @@ def main(argv: list[str] | None = None) -> int:
             "gqa8 reducer submodule manifest",
         )
         _require(gqa8_reducer_manifest, "query_heads_per_group", 8, "gqa8 reducer submodule manifest")
+        _require(gqa8_reducer_manifest, "exp_scale_impl", exp_scale_impl, "gqa8 reducer submodule manifest")
+        local_reducer_manifest = gqa8_reducer_manifest.get("submodule_manifests", {}).get("local_reducer")
+        temporal_merge_manifest = gqa8_reducer_manifest.get("submodule_manifests", {}).get("temporal_merge")
+        if not isinstance(local_reducer_manifest, dict):
+            raise SystemExit("gqa8 reducer manifest must include local_reducer submodule manifest")
+        if not isinstance(temporal_merge_manifest, dict):
+            raise SystemExit("gqa8 reducer manifest must include temporal_merge submodule manifest")
+        _require(local_reducer_manifest, "exp_scale_impl", exp_scale_impl, "local reducer submodule manifest")
+        pair_manifest = local_reducer_manifest.get("submodule_manifests", {}).get("pair_merge")
+        if not isinstance(pair_manifest, dict):
+            raise SystemExit("local reducer manifest must include pair_merge submodule manifest")
+        _require(pair_manifest, "exp_scale_impl", exp_scale_impl, "pair_merge submodule manifest")
+        _require(temporal_merge_manifest, "exp_scale_impl", exp_scale_impl, "temporal_merge submodule manifest")
     elif gqa8_reducer_manifest is not None:
         raise SystemExit("source_only mode must not include gqa8 reducer manifest")
 

--- a/npu/rtlgen/gen_attention_score32_exact_local_reducer.py
+++ b/npu/rtlgen/gen_attention_score32_exact_local_reducer.py
@@ -15,7 +15,12 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from npu.rtlgen.gen_attention_score32_online_state_merge import generate as generate_merge
+from npu.rtlgen.gen_attention_score32_online_state_merge import (
+    FACTORED_H33_L64_MUL_EXACT,
+    LEGACY_MONOLITHIC_LUT_EXACT,
+    SEGMENTED_LUT_9X256_EXACT,
+    generate as generate_merge,
+)
 from npu.sim.perf.attention_exact_partial import (
     PARTIAL_LINK_BITS,
     PARTIAL_PAYLOAD_BITS,
@@ -23,6 +28,11 @@ from npu.sim.perf.attention_exact_partial import (
 )
 
 JsonDict = dict[str, Any]
+_SUPPORTED_EXP_SCALE_IMPLS = {
+    LEGACY_MONOLITHIC_LUT_EXACT,
+    SEGMENTED_LUT_9X256_EXACT,
+    FACTORED_H33_L64_MUL_EXACT,
+}
 
 
 def _load(path: Path) -> JsonDict:
@@ -45,17 +55,22 @@ def _validate(config: JsonDict) -> JsonDict:
     producers = int(body.get("producers", 53))
     value_slices = int(body.get("value_slices", 16))
     head_id_bits = int(body.get("head_id_bits", 5))
+    exp_scale_impl = str(body.get("exp_scale_impl", LEGACY_MONOLITHIC_LUT_EXACT)).strip()
     if producers < 2 or producers > 64:
         raise SystemExit("producers must be in [2, 64]")
     if value_slices < 1 or value_slices > 16 or (value_slices & (value_slices - 1)):
         raise SystemExit("value_slices must be a power of two in [1, 16]")
     if head_id_bits < 1 or head_id_bits > 8:
         raise SystemExit("head_id_bits must be in [1, 8]")
+    if exp_scale_impl not in _SUPPORTED_EXP_SCALE_IMPLS:
+        supported = ", ".join(sorted(_SUPPORTED_EXP_SCALE_IMPLS))
+        raise SystemExit(f"exp_scale_impl must be one of: {supported}")
     return {
         "top_name": top_name,
         "producers": producers,
         "value_slices": value_slices,
         "head_id_bits": head_id_bits,
+        "exp_scale_impl": exp_scale_impl,
     }
 
 
@@ -313,6 +328,7 @@ def generate(config: JsonDict, out_dir: Path) -> None:
                 "attention_score32_online_state_merge": {
                     "value_slices": int(params["value_slices"]),
                     "head_id_bits": int(params["head_id_bits"]),
+                    "exp_scale_impl": str(params["exp_scale_impl"]),
                 },
             },
             temp_dir,
@@ -346,6 +362,7 @@ def generate(config: JsonDict, out_dir: Path) -> None:
         "producers": int(params["producers"]),
         "value_slices": int(params["value_slices"]),
         "head_id_bits": int(params["head_id_bits"]),
+        "exp_scale_impl": str(params["exp_scale_impl"]),
         "tree_stages": stage_count,
         "tree_nodes": node_count,
         "result_interface": "arbitrary_count_ready_valid_exact_partial_leaf_streams_to_root_stream",

--- a/npu/rtlgen/gen_attention_score32_exact_local_temporal_reducer_gqa8.py
+++ b/npu/rtlgen/gen_attention_score32_exact_local_temporal_reducer_gqa8.py
@@ -15,7 +15,12 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from npu.rtlgen.gen_attention_score32_exact_local_reducer import generate as generate_local_reducer
-from npu.rtlgen.gen_attention_score32_online_state_merge import generate as generate_merge
+from npu.rtlgen.gen_attention_score32_online_state_merge import (
+    FACTORED_H33_L64_MUL_EXACT,
+    LEGACY_MONOLITHIC_LUT_EXACT,
+    SEGMENTED_LUT_9X256_EXACT,
+    generate as generate_merge,
+)
 from npu.sim.perf.attention_exact_partial import (
     LOCAL_TEMPORAL_WAVES,
     PARTIAL_LINK_BITS,
@@ -26,6 +31,11 @@ from npu.sim.perf.attention_exact_partial import (
 JsonDict = dict[str, Any]
 _CONFIG_KEY = "attention_score32_exact_local_temporal_reducer_gqa8"
 _MANIFEST_NAME = "attention_score32_exact_local_temporal_reducer_gqa8_manifest.json"
+_SUPPORTED_EXP_SCALE_IMPLS = {
+    LEGACY_MONOLITHIC_LUT_EXACT,
+    SEGMENTED_LUT_9X256_EXACT,
+    FACTORED_H33_L64_MUL_EXACT,
+}
 
 
 def _load(path: Path) -> JsonDict:
@@ -52,6 +62,7 @@ def _validate(config: JsonDict) -> JsonDict:
     value_slices = int(body.get("value_slices", 16))
     head_id_bits = int(body.get("head_id_bits", 5))
     persistent_waves = int(body.get("persistent_waves", LOCAL_TEMPORAL_WAVES))
+    exp_scale_impl = str(body.get("exp_scale_impl", LEGACY_MONOLITHIC_LUT_EXACT)).strip()
     if producers not in {53, 54}:
         raise SystemExit("producers must be exactly 53 or 54")
     if value_slices != 16:
@@ -60,12 +71,16 @@ def _validate(config: JsonDict) -> JsonDict:
         raise SystemExit("head_id_bits must remain fixed at 5")
     if persistent_waves != LOCAL_TEMPORAL_WAVES:
         raise SystemExit(f"persistent_waves must remain fixed at {LOCAL_TEMPORAL_WAVES}")
+    if exp_scale_impl not in _SUPPORTED_EXP_SCALE_IMPLS:
+        supported = ", ".join(sorted(_SUPPORTED_EXP_SCALE_IMPLS))
+        raise SystemExit(f"exp_scale_impl must be one of: {supported}")
     return {
         "top_name": top_name,
         "producers": producers,
         "value_slices": value_slices,
         "head_id_bits": head_id_bits,
         "persistent_waves": persistent_waves,
+        "exp_scale_impl": exp_scale_impl,
     }
 
 
@@ -451,6 +466,7 @@ def generate(config: JsonDict, out_dir: Path) -> None:
                     "producers": int(params["producers"]),
                     "value_slices": int(params["value_slices"]),
                     "head_id_bits": int(params["head_id_bits"]),
+                    "exp_scale_impl": str(params["exp_scale_impl"]),
                 },
             },
             reducer_dir,
@@ -461,6 +477,7 @@ def generate(config: JsonDict, out_dir: Path) -> None:
                 "attention_score32_online_state_merge": {
                     "value_slices": int(params["value_slices"]),
                     "head_id_bits": int(params["head_id_bits"]),
+                    "exp_scale_impl": str(params["exp_scale_impl"]),
                 },
             },
             merge_dir,
@@ -506,6 +523,7 @@ def generate(config: JsonDict, out_dir: Path) -> None:
         "value_slices": int(params["value_slices"]),
         "head_id_bits": int(params["head_id_bits"]),
         "persistent_waves": int(params["persistent_waves"]),
+        "exp_scale_impl": str(params["exp_scale_impl"]),
         "query_heads_per_group": 8,
         "result_interface": "local_exact_partial_gqa8_group_streams_to_128_beat_aggregate_after_8_waves",
         "partial_payload_bits_per_beat": PARTIAL_PAYLOAD_BITS,

--- a/npu/rtlgen/gen_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness.py
+++ b/npu/rtlgen/gen_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness.py
@@ -15,6 +15,11 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from npu.rtlgen.gen_attention_score32_exact_local_temporal_reducer_gqa8 import generate as generate_reducer
+from npu.rtlgen.gen_attention_score32_online_state_merge import (
+    FACTORED_H33_L64_MUL_EXACT,
+    LEGACY_MONOLITHIC_LUT_EXACT,
+    SEGMENTED_LUT_9X256_EXACT,
+)
 from npu.sim.perf.attention_exact_partial import LOCAL_TEMPORAL_WAVES, PARTIAL_PAYLOAD_BITS
 
 JsonDict = dict[str, Any]
@@ -22,6 +27,11 @@ _CONFIG_KEY = "attention_score32_exact_local_temporal_reducer_gqa8_physical_harn
 _MANIFEST_NAME = "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_manifest.json"
 _PROPOSAL_ID = "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1"
 _PROPOSAL_PATH = "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json"
+_SUPPORTED_EXP_SCALE_IMPLS = {
+    LEGACY_MONOLITHIC_LUT_EXACT,
+    SEGMENTED_LUT_9X256_EXACT,
+    FACTORED_H33_L64_MUL_EXACT,
+}
 
 
 def _load(path: Path) -> JsonDict:
@@ -40,17 +50,22 @@ def _validate(config: JsonDict) -> JsonDict:
     producers = int(body.get("producers", 53))
     mode = str(body.get("mode", "reducer")).strip()
     waves = int(body.get("waves", LOCAL_TEMPORAL_WAVES))
+    exp_scale_impl = str(body.get("exp_scale_impl", LEGACY_MONOLITHIC_LUT_EXACT)).strip()
     if producers not in {53, 54}:
         raise SystemExit("producers must be exactly 53 or 54")
     if mode not in {"reducer", "source_only"}:
         raise SystemExit("mode must be reducer or source_only")
     if waves != LOCAL_TEMPORAL_WAVES:
         raise SystemExit(f"waves must remain fixed at {LOCAL_TEMPORAL_WAVES}")
+    if exp_scale_impl not in _SUPPORTED_EXP_SCALE_IMPLS:
+        supported = ", ".join(sorted(_SUPPORTED_EXP_SCALE_IMPLS))
+        raise SystemExit(f"exp_scale_impl must be one of: {supported}")
     return {
         "top_name": top_name,
         "producers": producers,
         "mode": mode,
         "waves": waves,
+        "exp_scale_impl": exp_scale_impl,
     }
 
 
@@ -409,13 +424,14 @@ def generate(config: JsonDict, out_dir: Path) -> None:
                 {
                     "top_name": reducer_top,
                     "attention_score32_exact_local_temporal_reducer_gqa8": {
-                        "producers": int(params["producers"]),
-                        "value_slices": 16,
-                        "head_id_bits": 5,
-                        "persistent_waves": int(params["waves"]),
-                    },
-                    "probe_defaults": {
-                        "heads": 16,
+                    "producers": int(params["producers"]),
+                    "value_slices": 16,
+                    "head_id_bits": 5,
+                    "persistent_waves": int(params["waves"]),
+                    "exp_scale_impl": str(params["exp_scale_impl"]),
+                },
+                "probe_defaults": {
+                    "heads": 16,
                         "command_count": 2,
                         "head_bases": [0, 8],
                         "seed": 23,
@@ -449,6 +465,7 @@ def generate(config: JsonDict, out_dir: Path) -> None:
         "producers": int(params["producers"]),
         "mode": mode,
         "waves": int(params["waves"]),
+        "exp_scale_impl": str(params["exp_scale_impl"]),
         "command_count": 2,
         "query_heads_per_group": 8,
         "head_group_bases": [0, 8],

--- a/runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_factored_r4.json
+++ b/runs/campaigns/npu/attention_score32_local_temporal_reducer_gqa8_v1/sweeps/nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_factored_r4.json
@@ -1,0 +1,24 @@
+{
+  "tag_prefix": "attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_factored_v1_r4",
+  "flow_params": {
+    "CLOCK_PERIOD": [
+      15.0,
+      20.0
+    ],
+    "DIE_AREA": [
+      "0 0 3000 3000"
+    ],
+    "CORE_AREA": [
+      "80 80 2920 2920"
+    ],
+    "PLACE_DENSITY": [
+      0.55
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_ARGS": [
+      "-noshare"
+    ]
+  }
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_factored_w8/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_factored_w8/config.json
@@ -1,0 +1,13 @@
+{
+  "top_name": "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_factored_w8",
+  "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness": {
+    "producers": 53,
+    "mode": "reducer",
+    "waves": 8,
+    "exp_scale_impl": "factored_h33_l64_mul_exact"
+  },
+  "report_links": {
+    "proposal_id": "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1",
+    "proposal_path": "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json"
+  }
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_factored_w8/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_factored_w8/config.json
@@ -1,0 +1,13 @@
+{
+  "top_name": "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_factored_w8",
+  "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness": {
+    "producers": 54,
+    "mode": "reducer",
+    "waves": 8,
+    "exp_scale_impl": "factored_h33_l64_mul_exact"
+  },
+  "report_links": {
+    "proposal_id": "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1",
+    "proposal_path": "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/proposal.json"
+  }
+}

--- a/tests/test_attention_score32_exact_local_temporal_reducer_gqa8.py
+++ b/tests/test_attention_score32_exact_local_temporal_reducer_gqa8.py
@@ -12,6 +12,10 @@ if str(REPO_ROOT) not in sys.path:
 
 from npu.eval.probe_attention_score32_exact_local_temporal_reducer_gqa8 import build_report
 from npu.rtlgen.gen_attention_score32_exact_local_temporal_reducer_gqa8 import generate
+from npu.rtlgen.gen_attention_score32_online_state_merge import (
+    FACTORED_H33_L64_MUL_EXACT,
+    LEGACY_MONOLITHIC_LUT_EXACT,
+)
 
 
 def _rtl_tools_available() -> bool:
@@ -55,6 +59,7 @@ def test_local_temporal_reducer_gqa8_manifest_and_verilator_lint_p53(tmp_path: P
     )
     assert manifest["producers"] == 53
     assert manifest["persistent_waves"] == 8
+    assert manifest["exp_scale_impl"] == LEGACY_MONOLITHIC_LUT_EXACT
     assert manifest["query_heads_per_group"] == 8
     assert manifest["partial_payload_bits_per_beat"] == 328
     assert (
@@ -85,9 +90,17 @@ def test_local_temporal_reducer_gqa8_manifest_and_verilator_lint_p53(tmp_path: P
     assert manifest["service_model"]["beats_per_output_group"] == 128
     assert manifest["service_model"]["query_head_groups"] == 2
     assert manifest["submodule_manifests"]["local_reducer"]["producers"] == 53
+    assert manifest["submodule_manifests"]["local_reducer"]["exp_scale_impl"] == LEGACY_MONOLITHIC_LUT_EXACT
+    assert (
+        manifest["submodule_manifests"]["local_reducer"]["submodule_manifests"]["pair_merge"]["exp_scale_impl"]
+        == LEGACY_MONOLITHIC_LUT_EXACT
+    )
+    assert manifest["submodule_manifests"]["temporal_merge"]["exp_scale_impl"] == LEGACY_MONOLITHIC_LUT_EXACT
     assert manifest["submodule_manifests"]["temporal_merge"]["result_interface"] == (
         "ready_valid_exact_partial_slice_stream"
     )
+    rtl = (tmp_path / "rtl" / "top.v").read_text(encoding="utf-8")
+    assert "case (bucket)" in rtl
 
     lint = subprocess.run(
         [
@@ -104,6 +117,32 @@ def test_local_temporal_reducer_gqa8_manifest_and_verilator_lint_p53(tmp_path: P
         timeout=180,
     )
     assert lint.returncode == 0, lint.stderr
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="RTL tools unavailable")
+def test_local_temporal_reducer_gqa8_factored_exp_scale_propagates_and_removes_monolithic_lut(tmp_path: Path) -> None:
+    config = _load_config(53)
+    config["attention_score32_exact_local_temporal_reducer_gqa8"]["exp_scale_impl"] = FACTORED_H33_L64_MUL_EXACT
+    generate(config, tmp_path / "rtl")
+
+    manifest = json.loads(
+        (tmp_path / "rtl" / "attention_score32_exact_local_temporal_reducer_gqa8_manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert manifest["exp_scale_impl"] == FACTORED_H33_L64_MUL_EXACT
+    assert manifest["submodule_manifests"]["local_reducer"]["exp_scale_impl"] == FACTORED_H33_L64_MUL_EXACT
+    assert (
+        manifest["submodule_manifests"]["local_reducer"]["submodule_manifests"]["pair_merge"]["exp_scale_impl"]
+        == FACTORED_H33_L64_MUL_EXACT
+    )
+    assert manifest["submodule_manifests"]["temporal_merge"]["exp_scale_impl"] == FACTORED_H33_L64_MUL_EXACT
+
+    rtl = (tmp_path / "rtl" / "top.v").read_text(encoding="utf-8")
+    assert "case (bucket)" not in rtl
+    assert rtl.count("case (bucket_hi)") == 2
+    assert rtl.count("case (bucket_lo)") == 2
+    assert "33'd4096: exp_lut = 24'd" not in rtl
 
 
 def test_local_temporal_reducer_gqa8_rejects_invalid_producer_count(tmp_path: Path) -> None:
@@ -178,4 +217,22 @@ def test_local_temporal_reducer_gqa8_probe_matches_reference_p54_ideal() -> None
     assert report["completed_command_count"] == 2
     assert report["protocol_error"] is False
     assert report["group_contract_error"] is False
+    assert report["observed_rows"] == report["expected_rows"]
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="RTL tools unavailable")
+def test_local_temporal_reducer_gqa8_probe_matches_reference_p53_factored_ideal() -> None:
+    config = _load_config(53)
+    config["attention_score32_exact_local_temporal_reducer_gqa8"]["exp_scale_impl"] = FACTORED_H33_L64_MUL_EXACT
+    report = build_report(config=config)
+
+    assert report["passed"] is True
+    assert report["producers"] == 53
+    assert report["outputs"] == 256
+    assert report["expected_outputs"] == 256
+    assert report["completed_command_count"] == 2
+    assert report["protocol_error"] is False
+    assert report["group_contract_error"] is False
+    assert report["local_tree_protocol_error"] is False
+    assert report["temporal_merge_protocol_error"] is False
     assert report["observed_rows"] == report["expected_rows"]

--- a/tests/test_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness.py
+++ b/tests/test_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness.py
@@ -11,6 +11,10 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from npu.rtlgen.gen_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness import generate
+from npu.rtlgen.gen_attention_score32_online_state_merge import (
+    FACTORED_H33_L64_MUL_EXACT,
+    LEGACY_MONOLITHIC_LUT_EXACT,
+)
 
 
 def _rtl_tools_available() -> bool:
@@ -62,6 +66,7 @@ def test_gqa8_physical_harness_manifest_and_verilator_lint(tmp_path: Path, produ
     assert manifest["producers"] == producers
     assert manifest["mode"] == mode
     assert manifest["waves"] == 8
+    assert manifest["exp_scale_impl"] == LEGACY_MONOLITHIC_LUT_EXACT
     assert manifest["command_count"] == 2
     assert manifest["query_heads_per_group"] == 8
     assert manifest["head_group_bases"] == [0, 8]
@@ -98,6 +103,7 @@ def test_gqa8_physical_harness_manifest_and_verilator_lint(tmp_path: Path, produ
         assert f"{{24'd0, leaf_value_w[{index * 328 + 320} +: 8]}}" in harness_text
     if mode == "reducer":
         assert manifest["submodule_manifests"]["gqa8_reducer"]["producers"] == producers
+        assert manifest["submodule_manifests"]["gqa8_reducer"]["exp_scale_impl"] == LEGACY_MONOLITHIC_LUT_EXACT
         assert "u_reducer" in top_text
         assert "(reducer_out_command_id_w == 16'h7b01)" in harness_text
         assert "(reducer_out_head_id_w == 5'd15)" in harness_text
@@ -121,6 +127,36 @@ def test_gqa8_physical_harness_manifest_and_verilator_lint(tmp_path: Path, produ
         timeout=300,
     )
     assert lint.returncode == 0, lint.stderr
+
+
+@pytest.mark.skipif(not _rtl_tools_available(), reason="RTL tools unavailable")
+def test_gqa8_physical_harness_factored_exp_scale_propagates_to_reducer_and_temporal_merge(tmp_path: Path) -> None:
+    config = _load_config(53, "reducer")
+    config["attention_score32_exact_local_temporal_reducer_gqa8_physical_harness"][
+        "exp_scale_impl"
+    ] = FACTORED_H33_L64_MUL_EXACT
+    generate(config, tmp_path / "rtl")
+
+    manifest = json.loads(
+        (
+            tmp_path / "rtl" / "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_manifest.json"
+        ).read_text(encoding="utf-8")
+    )
+    reducer_manifest = manifest["submodule_manifests"]["gqa8_reducer"]
+    assert manifest["exp_scale_impl"] == FACTORED_H33_L64_MUL_EXACT
+    assert reducer_manifest["exp_scale_impl"] == FACTORED_H33_L64_MUL_EXACT
+    assert reducer_manifest["submodule_manifests"]["local_reducer"]["exp_scale_impl"] == FACTORED_H33_L64_MUL_EXACT
+    assert (
+        reducer_manifest["submodule_manifests"]["local_reducer"]["submodule_manifests"]["pair_merge"]["exp_scale_impl"]
+        == FACTORED_H33_L64_MUL_EXACT
+    )
+    assert reducer_manifest["submodule_manifests"]["temporal_merge"]["exp_scale_impl"] == FACTORED_H33_L64_MUL_EXACT
+
+    rtl = (tmp_path / "rtl" / "top.v").read_text(encoding="utf-8")
+    assert "case (bucket)" not in rtl
+    assert rtl.count("case (bucket_hi)") == 2
+    assert rtl.count("case (bucket_lo)") == 2
+    assert "33'd4096: exp_lut = 24'd" not in rtl
 
 
 def test_gqa8_physical_harness_rejects_invalid_mode(tmp_path: Path) -> None:

--- a/tests/test_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_factored_r4_prep.py
+++ b/tests/test_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_factored_r4_prep.py
@@ -1,0 +1,178 @@
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROPOSAL_PATH = (
+    REPO_ROOT
+    / "docs"
+    / "proposals"
+    / "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1"
+    / "proposal.json"
+)
+REQUESTS_PATH = (
+    REPO_ROOT
+    / "docs"
+    / "proposals"
+    / "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1"
+    / "evaluation_requests.json"
+)
+DIAGNOSTIC_PATH = (
+    REPO_ROOT
+    / "docs"
+    / "proposals"
+    / "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1"
+    / "legacy_lut_memory_boundary_r3_diagnostic.json"
+)
+R3_SWEEP_PATH = (
+    REPO_ROOT
+    / "runs"
+    / "campaigns"
+    / "npu"
+    / "attention_score32_local_temporal_reducer_gqa8_v1"
+    / "sweeps"
+    / "nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_noshare_memguard_r3.json"
+)
+R4_SWEEP_PATH = (
+    REPO_ROOT
+    / "runs"
+    / "campaigns"
+    / "npu"
+    / "attention_score32_local_temporal_reducer_gqa8_v1"
+    / "sweeps"
+    / "nangate45_attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_factored_r4.json"
+)
+P53_CONFIG_PATH = (
+    REPO_ROOT
+    / "runs"
+    / "designs"
+    / "npu_blocks"
+    / "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_factored_w8"
+    / "config.json"
+)
+P54_CONFIG_PATH = (
+    REPO_ROOT
+    / "runs"
+    / "designs"
+    / "npu_blocks"
+    / "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_factored_w8"
+    / "config.json"
+)
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_gqa8_factored_r4_configs_are_reducer_only() -> None:
+    p53 = _load_json(P53_CONFIG_PATH)
+    p54 = _load_json(P54_CONFIG_PATH)
+
+    for config, producers in ((p53, 53), (p54, 54)):
+        body = config["attention_score32_exact_local_temporal_reducer_gqa8_physical_harness"]
+        assert body["producers"] == producers
+        assert body["mode"] == "reducer"
+        assert body["waves"] == 8
+        assert body["exp_scale_impl"] == "factored_h33_l64_mul_exact"
+        assert config["report_links"]["proposal_id"] == "prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1"
+
+
+def test_gqa8_factored_r4_sweep_keeps_no_share_without_memory_override() -> None:
+    r3 = _load_json(R3_SWEEP_PATH)
+    r4 = _load_json(R4_SWEEP_PATH)
+
+    assert r4["tag_prefix"] == "attention_score32_local_temporal_reducer_gqa8_physical_harness_boundary_factored_v1_r4"
+    assert r4["tag_prefix"] != r3["tag_prefix"]
+    assert r4["flow_params"] == {
+        "CLOCK_PERIOD": [15.0, 20.0],
+        "DIE_AREA": ["0 0 3000 3000"],
+        "CORE_AREA": ["80 80 2920 2920"],
+        "PLACE_DENSITY": [0.55],
+        "SYNTH_HIERARCHICAL": [1],
+        "SYNTH_ARGS": ["-noshare"],
+    }
+    assert "SYNTH_MEMORY_MAX_BITS" not in r4["flow_params"]
+    assert r3["flow_params"]["SYNTH_MEMORY_MAX_BITS"] == [65536]
+
+
+def test_gqa8_factored_r4_docs_link_job_and_preserve_r3_metadata() -> None:
+    proposal = _load_json(PROPOSAL_PATH)
+    requests = _load_json(REQUESTS_PATH)
+
+    proposal_items = {item["item_id"]: item for item in proposal["required_evaluations"]}
+    request_items = {item["item_id"]: item for item in requests["requested_items"]}
+
+    r3 = request_items["l1_decoder_attention_score32_local_temporal_reducer_gqa8_ppa_v1_r3"]
+    r4 = proposal_items["l1_decoder_attention_score32_local_temporal_reducer_gqa8_factored_ppa_v1"]
+    requested_r4 = request_items["l1_decoder_attention_score32_local_temporal_reducer_gqa8_factored_ppa_v1"]
+
+    assert r3["status"] == "merged"
+    assert r3["merged_pr_number"] == 1533
+    assert r3["merge_commit"] == "d96c3379c3af228606f9b266142529255fd12699"
+    assert r3["merged_utc"] == "2026-08-03T10:58:06.037636Z"
+
+    assert requests["source_commit"] == "379b4e723cb2a8ee61ce82bcb027b8bec9e7e0db"
+    assert "legacy monolithic exp-LUT encoding boundary" in requests["source_commit_note"]
+
+    assert r4["status"] == "pending"
+    assert requested_r4["status"] == "pending"
+    assert r4["configs"] == requested_r4["configs"] == [
+        str(P53_CONFIG_PATH.relative_to(REPO_ROOT)),
+        str(P54_CONFIG_PATH.relative_to(REPO_ROOT)),
+    ]
+    assert r4["sweep_path"] == requested_r4["sweep_path"] == str(R4_SWEEP_PATH.relative_to(REPO_ROOT))
+    assert r4["expected_outputs"] == requested_r4["expected_outputs"] == [
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_factored_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_factored_w8/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_factored_w8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_factored_w8/timing_debug_report.md",
+    ]
+    assert "do not add `SYNTH_MEMORY_MAX_BITS`" in r4["acceptance_notes"]
+    assert "Do not rerun source_only controls" in r4["acceptance_notes"]
+    assert "factorized configs, sweep, and diagnostic evidence" in requested_r4["notes"]
+
+    for ref in (
+        str(P53_CONFIG_PATH.relative_to(REPO_ROOT)),
+        str(P54_CONFIG_PATH.relative_to(REPO_ROOT)),
+        str(R4_SWEEP_PATH.relative_to(REPO_ROOT)),
+        str(DIAGNOSTIC_PATH.relative_to(REPO_ROOT)),
+    ):
+        assert ref in proposal["source_refs"]
+
+
+def test_gqa8_factored_r4_diagnostic_arithmetic_matches_generator_structure() -> None:
+    diagnostic = _load_json(DIAGNOSTIC_PATH)
+
+    assert diagnostic["merge_commit"] == "d96c3379c3af228606f9b266142529255fd12699"
+    assert diagnostic["r3_source_commit"] == "c733716b4756afe2eaf41e4feccb060a4de29f2c"
+    assert diagnostic["source_identification"]["evaluator_machine_key"] == "eval-daemon-b7c2d9c80c1c"
+    assert diagnostic["source_identification"]["result_mem_json_paths"] == [
+        "/orfs/flow/results/nangate45/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p53_reducer_w8/base/mem.json",
+        "/orfs/flow/results/nangate45/attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_p54_reducer_w8/base/mem.json",
+    ]
+    assert diagnostic["legacy_monolithic_exp_lut"]["per_memory_kind"] == "$mem_v2"
+    assert diagnostic["legacy_monolithic_exp_lut"]["depth"] == 4096
+    assert diagnostic["legacy_monolithic_exp_lut"]["width_bits"] == 24
+    assert diagnostic["legacy_monolithic_exp_lut"]["bits_per_memory"] == 4096 * 24
+    assert diagnostic["failure_text_observation"]["text"] == (
+        "Error: Synthesized memory size 65536 exceeds SYNTH_MEMORY_MAX_BITS"
+    )
+    assert diagnostic["failure_text_observation"]["actual_max_instance_bits"] == 98304
+    assert "prints args.max_bits" in diagnostic["failure_text_observation"]["mem_dump_behavior"]
+    assert "configured threshold comparison" in diagnostic["failure_text_observation"]["meaning"]
+
+    for name, producers, expected_memories, expected_total_bits in (
+        ("p53", 53, 106, 10420224),
+        ("p54", 54, 108, 10616832),
+    ):
+        case = diagnostic["cases"][name]
+        local_nodes = producers - 1
+        temporal_nodes = 1
+        exp_lut_evals = 2
+        assert case["producers"] == producers
+        assert case["local_merge_nodes"] == local_nodes
+        assert case["temporal_merge_nodes"] == temporal_nodes
+        assert case["exp_lut_evaluations_per_merge"] == exp_lut_evals
+        assert case["inferred_memories"] == expected_memories == exp_lut_evals * (local_nodes + temporal_nodes)
+        assert case["all_memories_match_4096x24"] is True
+        assert case["total_bits"] == expected_total_bits == expected_memories * 4096 * 24

--- a/tests/test_check_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_guard.py
+++ b/tests/test_check_attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_guard.py
@@ -94,3 +94,17 @@ def test_gqa8_physical_harness_guard_rejects_missing_source_token(tmp_path: Path
     result = _run_guard(design_dir)
     assert result.returncode != 0
     assert "generated RTL missing semantic token: if (shared_beat_count_q == 12'd2047) begin" in result.stderr
+
+
+def test_gqa8_physical_harness_guard_rejects_exp_scale_impl_mismatch(tmp_path: Path) -> None:
+    design_dir = _prepare_design_dir(tmp_path, producers=53, mode="reducer")
+    manifest_path = design_dir / "verilog" / "attention_score32_exact_local_temporal_reducer_gqa8_physical_harness_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["submodule_manifests"]["gqa8_reducer"]["submodule_manifests"]["temporal_merge"][
+        "exp_scale_impl"
+    ] = "factored_h33_l64_mul_exact"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    result = _run_guard(design_dir)
+    assert result.returncode != 0
+    assert "temporal_merge submodule manifest exp_scale_impl must be legacy_monolithic_lut_exact" in result.stderr


### PR DESCRIPTION
## Summary
- propagate the existing factored exact exp-scale implementation through local and temporal GQA8 reducers
- preserve legacy defaults and exact ready/valid behavior
- record the r3 replicated-ROM diagnosis and prepare a bounded p53/p54 physical sweep

## Evidence
- p53 structured RTL/perf equivalence remains exact
- generated factored RTL removes the monolithic 4096-entry LUT pattern
- r3 diagnosis identifies 106/108 replicated 4096x24 ROMs for p53/p54

## Validation
- 23 focused tests passed
- r4 prep tests passed after evidence correction
- validate_runs --skip_eval_queue passed
- git diff --check passed