### PR TITLE
npu: compare measured multivalue service frontier

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -84,6 +84,12 @@ _MULTIVALUE_SERVICE_MEASURED_FRONTIER_C1_ONLY_DEFAULT_ITEM = (
 _MULTIVALUE_SERVICE_MEASURED_FRONTIER_C1_C2_DEFAULT_ITEM = (
     "l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v2"
 )
+_ONLINE_EXACT_MEASURED_REDUCER_BASE_ITEM = (
+    "l2_decoder_attention_score32_local_reducer_measured_recost_llama7b_v1"
+)
+_ONLINE_EXACT_MEASURED_REDUCER_DEFAULT_ITEM = (
+    "l2_decoder_attention_score32_local_reducer_measured_recost_llama7b_v1_r1"
+)
 
 
 @dataclass(frozen=True)
@@ -274,6 +280,20 @@ def _multivalue_service_activity_power_item_for_consumer(
             if cluster_count == 1
             else _MULTIVALUE_SERVICE_C2_ACTIVITY_POWER_DEFAULT_ITEM
         )
+    return max(candidate_item_ids, key=_item_version_retry_rank)
+
+
+def _online_exact_measured_reducer_item_for_consumer(
+    *, depends_on_item_ids: list[str] | None
+) -> str:
+    prefix = _ONLINE_EXACT_MEASURED_REDUCER_BASE_ITEM
+    candidate_item_ids = [
+        str(dep).strip()
+        for dep in (depends_on_item_ids or [])
+        if str(dep).strip() == prefix or str(dep).strip().startswith(f"{prefix}_r")
+    ]
+    if not candidate_item_ids:
+        return _ONLINE_EXACT_MEASURED_REDUCER_DEFAULT_ITEM
     return max(candidate_item_ids, key=_item_version_retry_rank)
 
 
@@ -7775,6 +7795,13 @@ def _decoder_attention_decode_score_multivalue_service_measured_frontier_evidenc
         f"{base}/decoder_attention_decode_score_multivalue_cluster_frontier__"
         f"{prior_cluster_frontier_item}.json"
     )
+    online_exact_measured_reducer_item = _online_exact_measured_reducer_item_for_consumer(
+        depends_on_item_ids=depends_on_item_ids
+    )
+    online_exact_measured_reducer = (
+        f"{base}/decoder_attention_score32_local_reducer_measured_recost__"
+        f"{online_exact_measured_reducer_item}.json"
+    )
     service_activity_power_item_c1 = _multivalue_service_activity_power_item_for_consumer(
         depends_on_item_ids=depends_on_item_ids,
         cluster_count=1,
@@ -7801,24 +7828,30 @@ def _decoder_attention_decode_score_multivalue_service_measured_frontier_evidenc
     report = f"{base}/decoder_attention_decode_score_multivalue_service_measured_frontier__{item_id}.md"
     scope = (
         "Replace the prior shared-score multivalue cluster frontier area/energy proxy with measured "
-        "composed-service c1 and c2 anchors only. Compare c1 and c2 using measured latency/area/dynamic/"
-        "leakage, scale whole-service measured windows with ceil(sequence_length / 24) and then "
-        "cluster_waves_per_layer * layers instead of heads * layers, preserve the exact integer "
-        "precision contract unchanged, do not claim total-token energy, and leave broader SRAM, "
-        "NoC, HBM, producer, and dense energy outside while c3+ remain blocked/unpromoted."
+        "composed-service c1 and c2 anchors only. Compare them against the merged online-exact "
+        "measured-reducer recost for full-token latency/throughput, keep energy explicitly "
+        "non-comparable across the two reports, scale whole-service measured windows with "
+        "ceil(sequence_length / 24) and then cluster_waves_per_layer * layers instead of heads * "
+        "layers, preserve the exact integer precision contract unchanged, do not claim total-token "
+        "energy, keep 128 tokens as capacity rather than the scaling divisor, and leave broader "
+        "SRAM, NoC, HBM, producer, and dense energy outside while c3+ remain blocked/unpromoted."
         if c2_enabled
         else (
             "Replace the prior shared-score multivalue cluster frontier area/energy proxy with the "
             "measured composed-service c1 anchor only. Keep c2+ service points blocked/unpromoted, "
-            "scale the direct routed microkernel service-window activity explicitly into the "
-            "Llama7B context, preserve the exact integer precision contract unchanged, do not claim "
-            "total-token energy, and leave broader SRAM, NoC, HBM, producer, and dense energy "
-            "outside this measured-service frontier."
+            "compare the c1 measured anchor against the merged online-exact measured-reducer recost "
+            "for full-token latency/throughput, scale the direct routed microkernel service-window "
+            "activity explicitly into the Llama7B context with ceil(sequence_length / 24) while "
+            "keeping 128 tokens as capacity rather than the scaling divisor, preserve the exact "
+            "integer precision contract unchanged, do not claim total-token energy, and leave "
+            "broader SRAM, NoC, HBM, producer, and dense energy outside this measured-service "
+            "frontier."
         )
     )
     command = (
         "python3 -m npu.eval.audit_attention_decode_score_multivalue_service_measured_frontier "
         f"--prior-cluster-frontier-json {prior_cluster_frontier} "
+        f"--online-exact-measured-reducer-json {online_exact_measured_reducer} "
         f"--service-activity-power-json {service_activity_power_c1} "
         + (
             f"--service-activity-power-json {service_activity_power_c2} "
@@ -7831,6 +7864,9 @@ def _decoder_attention_decode_score_multivalue_service_measured_frontier_evidenc
         "inputs": {
             "decode_score_multivalue_service_measured_frontier_prior_cluster_frontier": (
                 prior_cluster_frontier
+            ),
+            "decode_score_multivalue_service_measured_frontier_online_exact_measured_reducer": (
+                online_exact_measured_reducer
             ),
             "decode_score_multivalue_service_measured_frontier_service_activity_power": service_activity_power_c1,
             "decode_score_multivalue_service_measured_frontier_service_activity_powers": [

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -8901,6 +8901,7 @@ def test_service_measured_frontier_request_manifests_remain_dependency_gated() -
     expected_depends = {
         "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
         "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
+        "l2_decoder_attention_score32_local_reducer_measured_recost_llama7b_v1_r1",
     }
 
     for manifest_name, items_key in (
@@ -8915,6 +8916,7 @@ def test_service_measured_frontier_request_manifests_remain_dependency_gated() -
             assert "pending implementation/dependency merge" in note
             assert "only c1 is a measured composed-service anchor" in note
             assert "c2+ remain blocked/unpromoted" in note
+            assert "online-exact measured-reducer recost" in note
         item = manifest[items_key][0]
         assert (
             item["item_id"]
@@ -8929,11 +8931,13 @@ def test_service_measured_frontier_request_manifests_remain_dependency_gated() -
         assert "July 25, 2026" in item["notes"]
         assert "only c1 is a measured composed-service anchor" in item["notes"]
         assert "c2+ remain blocked/unpromoted" in item["notes"]
+        assert "online-exact measured-reducer recost" in item["notes"]
         expected_reason = item["expected_result"]["reason"]
         assert "24-active-context-token" in expected_reason
         assert "ceil(sequence_length / 24)" in expected_reason
         assert "final partial window" in expected_reason
         assert "128 tokens labeled only as capacity" in expected_reason
+        assert "online-exact measured-reducer recost" in expected_reason
         assert "c2+ blocked/unpromoted" in item["expected_result"]["reason"]
         assert "exact integer precision unchanged" in item["expected_result"]["reason"]
         assert "broader SRAM/NoC/HBM/producer/dense energy remains outside" in item[
@@ -8987,6 +8991,7 @@ def test_service_measured_frontier_v2_request_manifests_remain_dependency_gated(
         "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
         "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
         "l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1",
+        "l2_decoder_attention_score32_local_reducer_measured_recost_llama7b_v1_r1",
     }
 
     for manifest_name, items_key in (
@@ -8998,6 +9003,7 @@ def test_service_measured_frontier_v2_request_manifests_remain_dependency_gated(
             note = manifest["source_commit_note"]
             assert "Sunday, July 26, 2026" in note
             assert "c3+ remain blocked/unpromoted" in note
+            assert "online-exact measured-reducer recost" in note
         item = manifest[items_key][0]
         assert (
             item["item_id"]
@@ -9011,6 +9017,8 @@ def test_service_measured_frontier_v2_request_manifests_remain_dependency_gated(
         assert "cluster_waves_per_layer * layers" in item["expected_result"]["reason"]
         assert "instead of heads * layers" in item["expected_result"]["reason"]
         assert "c3+ blocked/unpromoted" in item["notes"]
+        assert "online-exact measured-reducer recost" in item["notes"]
+        assert "online-exact measured-reducer recost" in item["expected_result"]["reason"]
 
 
 def test_gqa_folded_activity_request_manifests_require_cluster_activity_power_v16() -> None:
@@ -9827,6 +9835,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_measured
                     depends_on_item_ids=[
                         "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
                         "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
+                        "l2_decoder_attention_score32_local_reducer_measured_recost_llama7b_v1_r1",
                     ],
                     run_physical=False,
                 ),
@@ -9857,10 +9866,21 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_measured
                 "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1.json"
                 in run
             )
+            assert (
+                "--online-exact-measured-reducer-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_local_reducer_measured_recost__"
+                "l2_decoder_attention_score32_local_reducer_measured_recost_llama7b_v1_r1.json"
+                in run
+            )
             assert decoder_inputs[
                 "decode_score_multivalue_service_measured_frontier_prior_cluster_frontier"
             ].endswith(
                 "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1.json"
+            )
+            assert decoder_inputs[
+                "decode_score_multivalue_service_measured_frontier_online_exact_measured_reducer"
+            ].endswith(
+                "l2_decoder_attention_score32_local_reducer_measured_recost_llama7b_v1_r1.json"
             )
             assert decoder_inputs[
                 "decode_score_multivalue_service_measured_frontier_service_activity_power"
@@ -9871,6 +9891,15 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_measured
                 decoder_inputs["decode_score_multivalue_service_measured_frontier_scope"]
             )
             assert "Keep c2+ service points blocked/unpromoted" in decoder_inputs[
+                "decode_score_multivalue_service_measured_frontier_scope"
+            ]
+            assert "online-exact measured-reducer recost" in decoder_inputs[
+                "decode_score_multivalue_service_measured_frontier_scope"
+            ]
+            assert "ceil(sequence_length / 24)" in decoder_inputs[
+                "decode_score_multivalue_service_measured_frontier_scope"
+            ]
+            assert "128 tokens as capacity rather than the scaling divisor" in decoder_inputs[
                 "decode_score_multivalue_service_measured_frontier_scope"
             ]
             assert "direct routed microkernel service-window activity explicitly into the Llama7B context" in (
@@ -9925,6 +9954,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_measured
                         "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
                         "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
                         "l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1",
+                        "l2_decoder_attention_score32_local_reducer_measured_recost_llama7b_v1_r1",
                     ],
                     run_physical=False,
                 ),
@@ -9943,6 +9973,19 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_measured
                 "l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1.json"
                 in run
             )
+            assert (
+                "--online-exact-measured-reducer-json runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_local_reducer_measured_recost__"
+                "l2_decoder_attention_score32_local_reducer_measured_recost_llama7b_v1_r1.json"
+                in run
+            )
+            assert decoder_inputs[
+                "decode_score_multivalue_service_measured_frontier_online_exact_measured_reducer"
+            ] == (
+                "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                "decoder_attention_score32_local_reducer_measured_recost__"
+                "l2_decoder_attention_score32_local_reducer_measured_recost_llama7b_v1_r1.json"
+            )
             assert decoder_inputs[
                 "decode_score_multivalue_service_measured_frontier_service_activity_powers"
             ] == [
@@ -9952,6 +9995,12 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_measured
                 "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_attention_decode_score_multivalue_service_activity_power__"
                 "l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1.json",
+            ]
+            assert "online-exact measured-reducer recost" in decoder_inputs[
+                "decode_score_multivalue_service_measured_frontier_scope"
+            ]
+            assert "cluster_waves_per_layer * layers instead of heads * layers" in decoder_inputs[
+                "decode_score_multivalue_service_measured_frontier_scope"
             ]
             assert "cluster_waves_per_layer * layers" in decoder_inputs[
                 "decode_score_multivalue_service_measured_frontier_scope"

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1",
-  "source_commit_note": "Replace with the merge commit that contains this measured c1 service-frontier wiring before dispatch. As of July 25, 2026, this request remains pending implementation/dependency merge because only c1 is a measured composed-service anchor, c2+ remain blocked/unpromoted, and the measured-service frontier audit CLI plus both dependency artifacts are not all merged/materialized.",
+  "source_commit_note": "Replace with the merge commit that contains this measured c1 service-frontier wiring before dispatch. As of July 25, 2026, this request remains pending implementation/dependency merge because only c1 is a measured composed-service anchor, c2+ remain blocked/unpromoted, and the measured-service frontier audit CLI, the online-exact measured-reducer recost baseline, and both dependency artifacts are not all merged/materialized.",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1",
@@ -12,16 +12,17 @@
       "paired_baseline_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
-        "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1"
+        "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
+        "l2_decoder_attention_score32_local_reducer_measured_recost_llama7b_v1_r1"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "replace_multivalue_cluster_area_energy_with_measured_c1_service_anchor",
-        "reason": "Replace rather than add the old cluster area/energy proxy, use only the measured composed-service c1 anchor, scale the direct routed 24-active-context-token window with ceil(sequence_length / 24), conservatively charge the final partial window, keep 128 tokens labeled only as capacity, keep c2+ blocked/unpromoted, preserve exact integer precision unchanged, and withhold any total-token energy claim while broader SRAM/NoC/HBM/producer/dense energy remains outside."
+        "reason": "Replace rather than add the old cluster area/energy proxy, use only the measured composed-service c1 anchor, compare full-token latency/throughput against the merged online-exact measured-reducer recost while keeping energy explicitly non-comparable across the two reports, scale the direct routed 24-active-context-token window with ceil(sequence_length / 24), conservatively charge the final partial window, keep 128 tokens labeled only as capacity, keep c2+ blocked/unpromoted, preserve exact integer precision unchanged, and withhold any total-token energy claim while broader SRAM/NoC/HBM/producer/dense energy remains outside."
       },
       "status": "pending_implementation_merge",
-      "notes": "This request remains dependency-gated and pending implementation/dependency merge. As of July 25, 2026, only c1 is a measured composed-service anchor, c2+ remain blocked/unpromoted, and the measured-service frontier audit CLI plus both dependency artifacts must merge/materialize before normal dispatch."
+      "notes": "This request remains dependency-gated and pending implementation/dependency merge. As of July 25, 2026, only c1 is a measured composed-service anchor, c2+ remain blocked/unpromoted, and the measured-service frontier audit CLI, the online-exact measured-reducer recost baseline, and both dependency artifacts must merge/materialize before normal dispatch."
     }
   ]
 }

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v1/proposal.json
@@ -6,7 +6,7 @@
   "kind": "architecture",
   "title": "Measured c1 composed-service frontier replacement for multivalue Llama7B",
   "abstraction_layer": "decoder_attention_decode_score_multivalue_service_measured_frontier",
-  "hypothesis": "Once the service-aware shared-score multivalue cluster frontier r1 and the strict c1 composed-service activity-power audit are both merged/materialized, the Llama7B frontier can replace rather than add the old cluster area/energy proxy with a measured composed-service c1 anchor while keeping c2+ blocked/unpromoted, preserving exact integer precision, and keeping broader system energy outside.",
+  "hypothesis": "Once the service-aware shared-score multivalue cluster frontier r1, the strict c1 composed-service activity-power audit, and the merged online-exact measured-reducer recost are all merged/materialized, the Llama7B frontier can replace rather than add the old cluster area/energy proxy with a measured composed-service c1 anchor while keeping c2+ blocked/unpromoted, preserving exact integer precision, and keeping broader system energy outside.",
   "direct_comparison": {
     "primary_question": "How does the shared-score multivalue Llama7B frontier change when the prior cluster area/energy proxy is replaced with the measured composed-service c1 anchor and the direct routed 24-active-context-token microkernel activity is scaled into the Llama7B context while 128 tokens remains explicitly a capacity bound?",
     "baseline": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
@@ -14,6 +14,7 @@
       "only c1 as the measured composed-service anchor",
       "the prior service-aware shared-score multivalue cluster frontier structure from l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
       "strict c1 direct routed service-window activity from l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
+      "merged online-exact measured-reducer recost from l2_decoder_attention_score32_local_reducer_measured_recost_llama7b_v1_r1 as the comparison baseline for full-token latency/throughput only",
       "explicit ceil(sequence_length / 24) scaling from the routed 24-active-context-token microkernel measurement into the Llama7B context, with the final partial window conservatively charged",
       "exact integer precision unchanged from the inherited equivalence-backed frontier contract",
       "repo-portable JSON and Markdown outputs only from an evidence-only evaluator"
@@ -43,7 +44,7 @@
     "a c1-only measured anchor may worsen the retained frontier relative to the prior cluster proxy",
     "c2 and higher service points remain blocked/unpromoted until they have their own measured anchors",
     "this frontier replacement still excludes broader SRAM, NoC, HBM, producer, and dense energy, so it is not a total-token energy result",
-    "the request remains pending implementation/dependency merge until the new audit CLI and both dependency artifacts are merged/materialized"
+    "the request remains pending implementation/dependency merge until the new audit CLI, the online-exact measured-reducer recost baseline, and both dependency artifacts are merged/materialized"
   ],
   "required_evaluations": [
     {
@@ -56,23 +57,26 @@
       "paired_baseline_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
-        "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1"
+        "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
+        "l2_decoder_attention_score32_local_reducer_measured_recost_llama7b_v1_r1"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "replace_multivalue_cluster_area_energy_with_measured_c1_service_anchor",
-        "reason": "Use only the measured composed-service c1 anchor to replace the old cluster area/energy proxy, scale the direct routed 24-active-context-token window with ceil(sequence_length / 24), conservatively charge the final partial window, keep 128 tokens labeled only as capacity, keep c2+ blocked/unpromoted, preserve exact integer precision unchanged, and withhold any total-token energy claim while broader SRAM/NoC/HBM/producer/dense energy remains outside."
+        "reason": "Use only the measured composed-service c1 anchor to replace the old cluster area/energy proxy, compare full-token latency/throughput against the merged online-exact measured-reducer recost while keeping energy explicitly non-comparable across the two reports, scale the direct routed 24-active-context-token window with ceil(sequence_length / 24), conservatively charge the final partial window, keep 128 tokens labeled only as capacity, keep c2+ blocked/unpromoted, preserve exact integer precision unchanged, and withhold any total-token energy claim while broader SRAM/NoC/HBM/producer/dense energy remains outside."
       },
       "status": "pending_implementation_merge",
-      "notes": "This request remains dependency-gated and pending implementation/dependency merge. As of July 25, 2026, only c1 is a measured composed-service anchor, c2+ remain blocked/unpromoted, and the measured-service frontier audit CLI plus both dependency artifacts must merge/materialize before normal dispatch."
+      "notes": "This request remains dependency-gated and pending implementation/dependency merge. As of July 25, 2026, only c1 is a measured composed-service anchor, c2+ remain blocked/unpromoted, and the measured-service frontier audit CLI, the online-exact measured-reducer recost baseline, and both dependency artifacts must merge/materialize before normal dispatch."
     }
   ],
   "baseline_refs": [
     "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_frontier__l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1.json",
     "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_activity_power__l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_local_reducer_measured_recost__l2_decoder_attention_score32_local_reducer_measured_recost_llama7b_v1_r1.json",
     "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/proposal.json",
-    "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1/proposal.json"
+    "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_attention_score32_local_reducer_measured_recost_llama7b_v1/proposal.json"
   ],
   "knowledge_refs": [
     "npu/eval/audit_attention_decode_score_multivalue_service_measured_frontier.py",

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v2/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v2/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v2",
-  "source_commit_note": "Replace with the merge commit that contains this measured c1/c2 service-frontier wiring before dispatch. As of Sunday, July 26, 2026, this request remains pending implementation/dependency merge because measured c1/c2 anchors, the revised frontier audit CLI, and the dependency artifacts are not all merged/materialized, and c3+ remain blocked/unpromoted.",
+  "source_commit_note": "Replace with the merge commit that contains this measured c1/c2 service-frontier wiring before dispatch. As of Sunday, July 26, 2026, this request remains pending implementation/dependency merge because measured c1/c2 anchors, the revised frontier audit CLI, the online-exact measured-reducer recost baseline, and the dependency artifacts are not all merged/materialized, and c3+ remain blocked/unpromoted.",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v2",
@@ -13,16 +13,17 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
         "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
-        "l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1"
+        "l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1",
+        "l2_decoder_attention_score32_local_reducer_measured_recost_llama7b_v1_r1"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "replace_multivalue_cluster_area_energy_with_measured_c1_c2_service_anchors",
-        "reason": "Replace rather than add the old cluster area/energy proxy, use measured composed-service c1 and c2 anchors only, scale the direct routed 24-active-context-token window with ceil(sequence_length / 24), conservatively charge the final partial window, keep 128 tokens labeled only as capacity, account c2 as a whole two-cluster service window scaled by cluster_waves_per_layer * layers instead of heads * layers, preserve exact integer precision unchanged, and withhold any total-token energy claim while broader SRAM/NoC/HBM/producer/dense energy remains outside."
+        "reason": "Replace rather than add the old cluster area/energy proxy, use measured composed-service c1 and c2 anchors only, compare full-token latency/throughput against the merged online-exact measured-reducer recost while keeping energy explicitly non-comparable across the two reports, scale the direct routed 24-active-context-token window with ceil(sequence_length / 24), conservatively charge the final partial window, keep 128 tokens labeled only as capacity, account c2 as a whole two-cluster service window scaled by cluster_waves_per_layer * layers instead of heads * layers, preserve exact integer precision unchanged, and withhold any total-token energy claim while broader SRAM/NoC/HBM/producer/dense energy remains outside."
       },
       "status": "pending_implementation_merge",
-      "notes": "This request remains dependency-gated and pending implementation/dependency merge. As of Sunday, July 26, 2026, the measured-service frontier revision, the strict c2 activity-power artifact, and the dependency artifacts must all merge/materialize before normal dispatch; c3+ blocked/unpromoted."
+      "notes": "This request remains dependency-gated and pending implementation/dependency merge. As of Sunday, July 26, 2026, the measured-service frontier revision, the merged online-exact measured-reducer recost baseline, the strict c2 activity-power artifact, and the dependency artifacts must all merge/materialize before normal dispatch; c3+ blocked/unpromoted."
     }
   ]
 }

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v2/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_measured_frontier_llama7b_v2/proposal.json
@@ -6,7 +6,7 @@
   "kind": "architecture",
   "title": "Measured c1/c2 composed-service frontier replacement for multivalue Llama7B",
   "abstraction_layer": "decoder_attention_decode_score_multivalue_service_measured_frontier",
-  "hypothesis": "Once the service-aware shared-score multivalue cluster frontier r1 and the strict c1 and c2 composed-service activity-power audits are all merged/materialized, the Llama7B frontier can replace rather than add the old cluster area/energy proxy with measured composed-service c1 and c2 anchors while keeping c3+ blocked, preserving exact integer precision, and keeping broader system energy outside.",
+  "hypothesis": "Once the service-aware shared-score multivalue cluster frontier r1, the strict c1 and c2 composed-service activity-power audits, and the merged online-exact measured-reducer recost are all merged/materialized, the Llama7B frontier can replace rather than add the old cluster area/energy proxy with measured composed-service c1 and c2 anchors while keeping c3+ blocked, preserving exact integer precision, and keeping broader system energy outside.",
   "direct_comparison": {
     "primary_question": "How does the shared-score multivalue Llama7B frontier change when the prior cluster area/energy proxy is replaced with measured composed-service c1 and c2 anchors, scaling whole-service measured windows with ceil(sequence_length / 24) and cluster waves instead of multiplying c2 by heads?",
     "baseline": "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
@@ -15,6 +15,7 @@
       "the prior service-aware shared-score multivalue cluster frontier structure from l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
       "strict c1 direct routed service-window activity from l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
       "strict c2 direct routed whole-service window activity from l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1",
+      "merged online-exact measured-reducer recost from l2_decoder_attention_score32_local_reducer_measured_recost_llama7b_v1_r1 as the comparison baseline for full-token latency/throughput only",
       "explicit ceil(sequence_length / 24) scaling from the routed 24-active-context-token microkernel measurement into the Llama7B context, with the final partial window conservatively charged",
       "whole-service energy accounting for c2 using cluster_waves_per_layer * layers rather than heads * layers",
       "exact integer precision unchanged from the inherited equivalence-backed frontier contract",
@@ -45,7 +46,8 @@
   "risks": [
     "the c2 measured anchor may still lose on area or timing relative to the prior proxy frontier",
     "c3 and higher service points remain blocked/unpromoted until they have their own measured anchors",
-    "this frontier replacement still excludes broader SRAM, NoC, HBM, producer, and dense energy, so it is not a total-token energy result"
+    "this frontier replacement still excludes broader SRAM, NoC, HBM, producer, and dense energy, so it is not a total-token energy result",
+    "the request remains pending implementation/dependency merge until the revised measured-service frontier CLI, the online-exact measured-reducer recost baseline, and all dependency artifacts are merged/materialized"
   ],
   "required_evaluations": [
     {
@@ -59,25 +61,28 @@
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
         "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
-        "l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1"
+        "l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1",
+        "l2_decoder_attention_score32_local_reducer_measured_recost_llama7b_v1_r1"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "replace_multivalue_cluster_area_energy_with_measured_c1_c2_service_anchors",
-        "reason": "Replace rather than add the old cluster area/energy proxy, use measured composed-service c1 and c2 anchors only, scale the direct routed 24-active-context-token window with ceil(sequence_length / 24), conservatively charge the final partial window, keep 128 tokens labeled only as capacity, account c2 as a whole two-cluster service window scaled by cluster_waves_per_layer * layers instead of heads * layers, preserve exact integer precision unchanged, and withhold any total-token energy claim while broader SRAM/NoC/HBM/producer/dense energy remains outside."
+        "reason": "Replace rather than add the old cluster area/energy proxy, use measured composed-service c1 and c2 anchors only, compare full-token latency/throughput against the merged online-exact measured-reducer recost while keeping energy explicitly non-comparable across the two reports, scale the direct routed 24-active-context-token window with ceil(sequence_length / 24), conservatively charge the final partial window, keep 128 tokens labeled only as capacity, account c2 as a whole two-cluster service window scaled by cluster_waves_per_layer * layers instead of heads * layers, preserve exact integer precision unchanged, and withhold any total-token energy claim while broader SRAM/NoC/HBM/producer/dense energy remains outside."
       },
       "status": "pending_implementation_merge",
-      "notes": "This request remains dependency-gated and pending implementation/dependency merge. As of Sunday, July 26, 2026, the measured-service frontier revision, the strict c2 activity-power artifact, and the dependency artifacts must all merge/materialize before normal dispatch; c3+ blocked/unpromoted."
+      "notes": "This request remains dependency-gated and pending implementation/dependency merge. As of Sunday, July 26, 2026, the measured-service frontier revision, the merged online-exact measured-reducer recost baseline, the strict c2 activity-power artifact, and the dependency artifacts must all merge/materialize before normal dispatch; c3+ blocked/unpromoted."
     }
   ],
   "baseline_refs": [
     "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_frontier__l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1.json",
     "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_activity_power__l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1.json",
     "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_activity_power__l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_local_reducer_measured_recost__l2_decoder_attention_score32_local_reducer_measured_recost_llama7b_v1_r1.json",
     "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1/proposal.json",
     "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1/proposal.json",
-    "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1/proposal.json"
+    "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_c2_activity_power_llama7b_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_attention_score32_local_reducer_measured_recost_llama7b_v1/proposal.json"
   ],
   "knowledge_refs": [
     "npu/eval/audit_attention_decode_score_multivalue_service_measured_frontier.py",

--- a/npu/eval/audit_attention_decode_score_multivalue_service_measured_frontier.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_service_measured_frontier.py
@@ -34,6 +34,8 @@ _EXPECTED_HEADS = 32
 _EXPECTED_KV_HEADS = 4
 _EXPECTED_LAYERS = 32
 _EXPECTED_SERVICE_CLOCK_NS = 10.0
+_EXPECTED_ONLINE_EXACT_MODEL = "llm_decoder_attention_score32_local_reducer_measured_recost_v1"
+_EXPECTED_ONLINE_EXACT_DECISION = "score32_local_reducer_measured_bounded_recost_recorded"
 _EXPECTED_WORKLOAD_CONTRACT = {
     "command_block_count": 3,
     "context_tokens_per_block": 8,
@@ -185,6 +187,96 @@ def _service_case(case_id: str) -> JsonDict:
     if contract is None:
         raise ValueError(f"unsupported measured-service case_id: {case_id}")
     return {"case_id": str(case_id).strip(), **dict(contract)}
+
+
+def _validated_online_exact_measured_reducer(payload: JsonDict) -> JsonDict:
+    if _string(payload.get("model"), "online-exact measured-reducer model") != _EXPECTED_ONLINE_EXACT_MODEL:
+        raise ValueError("online-exact measured-reducer report has an unexpected model")
+    if _string(payload.get("decision"), "online-exact measured-reducer decision") != _EXPECTED_ONLINE_EXACT_DECISION:
+        raise ValueError("online-exact measured-reducer report has an unexpected decision")
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        raise ValueError("online-exact measured-reducer report lacks summary")
+    best_requested = payload.get("best_requested")
+    if not isinstance(best_requested, dict):
+        raise ValueError("online-exact measured-reducer report lacks best_requested")
+    routed_component_ppa = payload.get("routed_component_ppa")
+    if not isinstance(routed_component_ppa, dict):
+        raise ValueError("online-exact measured-reducer report lacks routed_component_ppa")
+    macro_only_scaled = routed_component_ppa.get("macro_only_sum_scaled_16_clusters")
+    if not isinstance(macro_only_scaled, dict):
+        raise ValueError("online-exact measured-reducer report lacks scaled macro-only PPA")
+    synthesis_scaled = routed_component_ppa.get("synthesis_area_lower_bound_scaled_16_clusters")
+    if not isinstance(synthesis_scaled, dict):
+        raise ValueError("online-exact measured-reducer report lacks scaled synthesis lower bound")
+    if best_requested.get("local_reducer_measured_recost_replaces_unresolved_local_reducer_timing") is not True:
+        raise ValueError("online-exact measured-reducer report must replace unresolved local-reducer timing")
+    embodied_area_um2 = (
+        _positive(
+            best_requested.get("replica_recost_logic_area_required_um2"),
+            "online-exact replica_recost_logic_area_required_um2",
+        )
+        + _nonnegative(
+            best_requested.get("measured_shared_sram_used_area_um2"),
+            "online-exact measured_shared_sram_used_area_um2",
+        )
+        + _nonnegative(
+            best_requested.get("measured_tile_local_sram_area_um2"),
+            "online-exact measured_tile_local_sram_area_um2",
+        )
+    )
+    return {
+        "model": _EXPECTED_ONLINE_EXACT_MODEL,
+        "decision": _EXPECTED_ONLINE_EXACT_DECISION,
+        "single_clock_strict_latency_upper_bound_us": _positive(
+            summary.get("single_clock_strict_latency_upper_bound_us"),
+            "online-exact single_clock_strict_latency_upper_bound_us",
+        ),
+        "single_clock_strict_throughput_lower_bound_per_s": _positive(
+            summary.get("single_clock_strict_throughput_lower_bound_per_s"),
+            "online-exact single_clock_strict_throughput_lower_bound_per_s",
+        ),
+        "dual_clock_strict_latency_upper_bound_us": _positive(
+            summary.get("dual_clock_strict_latency_upper_bound_us"),
+            "online-exact dual_clock_strict_latency_upper_bound_us",
+        ),
+        "dual_clock_strict_throughput_lower_bound_per_s": _positive(
+            summary.get("dual_clock_strict_throughput_lower_bound_per_s"),
+            "online-exact dual_clock_strict_throughput_lower_bound_per_s",
+        ),
+        "replica_recost_clock_ns": _positive(
+            best_requested.get("replica_recost_clock_ns"),
+            "online-exact replica_recost_clock_ns",
+        ),
+        "replica_recost_clock_origin": _string(
+            best_requested.get("replica_recost_clock_origin"),
+            "online-exact replica_recost_clock_origin",
+        ),
+        "replica_recost_compute_power_mw": _positive(
+            best_requested.get("replica_recost_compute_power_mw"),
+            "online-exact replica_recost_compute_power_mw",
+        ),
+        "replica_recost_embodied_logic_plus_existing_shared_tile_sram_area_mm2": round(
+            embodied_area_um2 / 1.0e6,
+            9,
+        ),
+        "macro_only_area_mm2_scaled_16_clusters": _positive(
+            macro_only_scaled.get("die_area_mm2"),
+            "online-exact macro_only_area_mm2_scaled_16_clusters",
+        ),
+        "macro_only_power_mw_scaled_16_clusters": _positive(
+            macro_only_scaled.get("total_power_mw"),
+            "online-exact macro_only_power_mw_scaled_16_clusters",
+        ),
+        "synthesis_area_lower_bound_mm2_scaled_16_clusters": _positive(
+            synthesis_scaled.get("total_hierarchy_area_mm2"),
+            "online-exact synthesis_area_lower_bound_mm2_scaled_16_clusters",
+        ),
+        "remaining_abstractions": [
+            _string(item, "online-exact remaining_abstractions item")
+            for item in payload.get("remaining_abstractions", [])
+        ],
+    }
 
 
 def _service_macro_profile(case_contract: JsonDict) -> str:
@@ -601,6 +693,7 @@ def _measured_row(
     dense_qkv_tile: JsonDict,
     prior_row: JsonDict,
     service_activity: JsonDict,
+    online_exact_baseline: JsonDict,
 ) -> JsonDict:
     case_id = str(service_activity["case_id"])
     cluster_count = int(service_activity["cluster_count"])
@@ -628,6 +721,18 @@ def _measured_row(
     service_area_um2 = _positive(
         service_activity["authoritative_service_ppa"].get("instance_area_um2"),
         "authoritative service area",
+    )
+    service_power_mw = _positive(
+        service_activity["authoritative_service_ppa"].get("total_power_mw"),
+        "authoritative service total_power_mw",
+    )
+    service_critical_path_ns = _positive(
+        service_activity["authoritative_service_ppa"].get("critical_path_ns"),
+        "authoritative service critical_path_ns",
+    )
+    service_die_area_um2 = _positive(
+        service_activity["authoritative_service_ppa"].get("die_area"),
+        "authoritative service die_area",
     )
     (
         dense_count,
@@ -695,6 +800,63 @@ def _measured_row(
     component_leakage_j = full_context_leakage_per_service_wave_j * full_service_wave_count
     component_total_j = full_context_component_per_service_wave_j * full_service_wave_count
     prior_cluster_area_mm2 = _positive(prior_row.get("cluster_area_mm2"), f"prior c{cluster_count} cluster_area_mm2")
+    token_throughput_per_s = round(1.0e6 / latency_us, 12) if latency_us else None
+    comparison = {
+        "baseline_model": online_exact_baseline["model"],
+        "baseline_decision": online_exact_baseline["decision"],
+        "full_token_latency_directly_comparable": latency_us is not None,
+        "full_token_throughput_directly_comparable": token_throughput_per_s is not None,
+        "energy_directly_comparable": False,
+        "power_scope_note": (
+            "This row carries composed-service routed total_power_mw and service-window average power, while the "
+            "online-exact baseline carries compute power and local-reducer macro-only power; no direct total-token "
+            "power comparison is claimed."
+        ),
+        "latency_ratio_vs_online_exact_single_clock_strict_upper_bound": (
+            round(latency_us / online_exact_baseline["single_clock_strict_latency_upper_bound_us"], 12)
+            if latency_us is not None
+            else None
+        ),
+        "throughput_ratio_vs_online_exact_single_clock_strict_lower_bound": (
+            round(
+                token_throughput_per_s / online_exact_baseline["single_clock_strict_throughput_lower_bound_per_s"],
+                12,
+            )
+            if token_throughput_per_s is not None
+            else None
+        ),
+        "latency_ratio_vs_online_exact_dual_clock_strict_upper_bound": (
+            round(latency_us / online_exact_baseline["dual_clock_strict_latency_upper_bound_us"], 12)
+            if latency_us is not None
+            else None
+        ),
+        "throughput_ratio_vs_online_exact_dual_clock_strict_lower_bound": (
+            round(
+                token_throughput_per_s / online_exact_baseline["dual_clock_strict_throughput_lower_bound_per_s"],
+                12,
+            )
+            if token_throughput_per_s is not None
+            else None
+        ),
+        "embodied_area_ratio_vs_online_exact_replica_recost_embodied_area": round(
+            ((logic_area_um2 + shared_sram_um2 + tile_sram_um2) / 1.0e6)
+            / online_exact_baseline["replica_recost_embodied_logic_plus_existing_shared_tile_sram_area_mm2"],
+            12,
+        ),
+        "service_instance_area_ratio_vs_online_exact_macro_only_area_scaled_16_clusters": round(
+            (service_area_um2 / 1.0e6) / online_exact_baseline["macro_only_area_mm2_scaled_16_clusters"],
+            12,
+        ),
+        "service_total_power_ratio_vs_online_exact_macro_only_power_scaled_16_clusters": round(
+            service_power_mw / online_exact_baseline["macro_only_power_mw_scaled_16_clusters"],
+            12,
+        ),
+        "service_total_power_ratio_vs_online_exact_replica_recost_compute_power": round(
+            service_power_mw / online_exact_baseline["replica_recost_compute_power_mw"],
+            12,
+        ),
+        "online_exact_energy_comparison_status": "not_available_no_total_token_energy_claim_in_online_exact_baseline",
+    }
 
     row = {
         "candidate_id": f"decode_score_multivalue_service_measured_c{cluster_count}",
@@ -729,9 +891,12 @@ def _measured_row(
         "measured_service_clock_ns": _EXPECTED_SERVICE_CLOCK_NS,
         "clock_ns": clock_ns,
         "latency_us": round(latency_us, 6) if latency_us is not None else None,
-        "token_throughput_per_s": round(1.0e6 / latency_us, 12) if latency_us else None,
+        "token_throughput_per_s": token_throughput_per_s,
         "prior_cluster_area_mm2": round(prior_cluster_area_mm2, 9),
         "authoritative_composed_service_area_mm2": round(service_area_um2 / 1.0e6, 9),
+        "authoritative_composed_service_die_area_mm2": round(service_die_area_um2 / 1.0e6, 9),
+        "authoritative_composed_service_total_power_mw": round(service_power_mw, 9),
+        "authoritative_composed_service_critical_path_ns": round(service_critical_path_ns, 9),
         "area_replacement_delta_mm2": round(service_area_um2 / 1.0e6 - prior_cluster_area_mm2, 9),
         "dense_qkv_area_mm2": round(
             dense_count * _positive(dense_qkv_tile.get("area_um2"), "dense_qkv_tile area_um2") / 1.0e6,
@@ -769,6 +934,11 @@ def _measured_row(
         "full_context_service_wave_count": full_service_wave_count,
         "service_window_dynamic_energy_j": dynamic_j,
         "service_window_leakage_energy_j": leakage_j,
+        "service_window_average_dynamic_power_mw": dynamic_j / microkernel_duration_s * 1.0e3,
+        "service_window_average_leakage_power_mw": leakage_j / microkernel_duration_s * 1.0e3,
+        "service_window_average_dynamic_plus_leakage_power_mw": (dynamic_j + leakage_j)
+        / microkernel_duration_s
+        * 1.0e3,
         "full_context_dynamic_energy_j_per_service_wave": full_context_dynamic_per_service_wave_j,
         "full_context_leakage_energy_j_per_service_wave": full_context_leakage_per_service_wave_j,
         "service_component_dynamic_energy_mj_per_token": component_dynamic_j * 1.0e3,
@@ -786,6 +956,7 @@ def _measured_row(
             "broader SRAM and NoC energy are excluded",
             "producer and dense QKV activity energy are excluded",
         ],
+        "comparison_to_online_exact_measured_reducer": comparison,
     }
     if cluster_count == 1:
         row["full_context_dynamic_energy_j_per_head_command"] = full_context_dynamic_per_service_wave_j
@@ -835,10 +1006,12 @@ def _blocked_row(row: JsonDict, *, blocker: str | None = None) -> JsonDict:
 def build_report(
     *,
     prior_cluster_frontier_json: Path,
+    online_exact_measured_reducer_json: Path,
     service_activity_power_json: Path | None = None,
     service_activity_power_jsons: list[Path] | None = None,
 ) -> JsonDict:
     prior = _load(prior_cluster_frontier_json)
+    online_exact_baseline = _validated_online_exact_measured_reducer(_load(online_exact_measured_reducer_json))
     selected_service_paths = list(service_activity_power_jsons or [])
     if service_activity_power_json is not None:
         selected_service_paths.append(service_activity_power_json)
@@ -877,6 +1050,7 @@ def build_report(
         dense_qkv_tile=dense_qkv_tile,
         prior_row=prior_rows_by_cluster[1],
         service_activity=validated_service_activities[1],
+        online_exact_baseline=online_exact_baseline,
     )
     if not c1_measured["compute_budget_area_fit"] or not c1_measured["timing_feasible"]:
         raise ValueError("recomputed c1 measured anchor is not feasible for promotion")
@@ -906,6 +1080,7 @@ def build_report(
             dense_qkv_tile=dense_qkv_tile,
             prior_row=prior_row,
             service_activity=service_activity,
+            online_exact_baseline=online_exact_baseline,
         )
         if measured_row["compute_budget_area_fit"] and measured_row["timing_feasible"]:
             rows.append(measured_row)
@@ -968,6 +1143,7 @@ def build_report(
         ),
         "inputs": {
             "prior_cluster_frontier_json": _portable_path(prior_cluster_frontier_json),
+            "online_exact_measured_reducer_json": _portable_path(online_exact_measured_reducer_json),
             "service_activity_power_json": portable_service_inputs[0],
             "service_activity_power_jsons": portable_service_inputs,
             "source_schedule_json": schedule_source,
@@ -1004,6 +1180,27 @@ def build_report(
         },
         "selected_service_activity_candidate": selected_candidates["c1"],
         "selected_service_activity_candidates": selected_candidates,
+        "online_exact_measured_reducer_baseline": online_exact_baseline,
+        "online_exact_measured_reducer_comparison": {
+            "dependency_job_sequence": [
+                "c1 PNR",
+                "c1 activity power",
+                "measured frontier",
+            ],
+            "baseline_scope": (
+                "merged online-exact measured-reducer recost with strict single-clock and dual-clock upper/lower "
+                "throughput bounds plus routed macro-only area/power."
+            ),
+            "full_token_latency_comparison_scope": "direct",
+            "full_token_throughput_comparison_scope": "direct",
+            "energy_comparison_scope": "not_directly_comparable",
+            "power_comparison_scope": "service_power_vs_baseline_component_power_only",
+            "preserved_measured_window_scaling": (
+                "The measured c1 service window is scaled with ceil(sequence_length / 24), while the 128-token context "
+                "capacity remains reported separately and is not used as the scaling divisor."
+            ),
+            "promoted_candidate_ids": [row["candidate_id"] for row in promoted_rows],
+        },
         "precision": {
             "status": _EXPECTED_SERVICE_PRECISION_STATUS,
             "decision": _EXPECTED_PRIOR_PRECISION_DECISION,
@@ -1034,6 +1231,8 @@ def build_report(
             ),
             "The activity-backed energy is a microkernel-scaled composed-service component estimate, not direct total-token energy.",
             "Measured whole-service window energy is scaled with ceil(sequence_length / 24) and then multiplied by cluster_waves_per_layer * layers; c2 must not be multiplied by heads * layers.",
+            "The 128-token measured window capacity remains a distinct capacity fact; it does not replace the explicit ceil(sequence_length / 24) scaling divisor.",
+            "Comparison against the merged online-exact measured-reducer recost is direct for full-token latency/throughput, but energy is not directly comparable because the online-exact baseline does not claim total-token energy.",
             "HBM/DRAM, broader SRAM/NoC, producer, and dense-QKV activity energy remain outside this report.",
             "The 16KiB service value store remains counted inside the service instance area, while broader schedule SRAM remains separately charged.",
             (
@@ -1056,10 +1255,18 @@ def _write_markdown(payload: JsonDict, path: Path) -> None:
         f"- clock ns: `{anchor['clock_ns']}`",
         f"- latency us: `{anchor['latency_us']}`",
         f"- dense QKV tiles: `{anchor['dense_qkv_tile_count']}`",
+        f"- service routed total power mW: `{anchor['authoritative_composed_service_total_power_mw']}`",
+        f"- service-window avg dynamic+leakage power mW: `{anchor['service_window_average_dynamic_plus_leakage_power_mw']}`",
         (
             "- area replacement: prior cluster `{prior}` mm2 -> composed service `{new}` mm2".format(
                 prior=anchor["prior_cluster_area_mm2"],
                 new=anchor["authoritative_composed_service_area_mm2"],
+            )
+        ),
+        (
+            "- online-exact dual-clock strict upper/lower baseline: `{lat}` us / `{thr}` token/s".format(
+                lat=payload["online_exact_measured_reducer_baseline"]["dual_clock_strict_latency_upper_bound_us"],
+                thr=payload["online_exact_measured_reducer_baseline"]["dual_clock_strict_throughput_lower_bound_per_s"],
             )
         ),
         (
@@ -1099,12 +1306,14 @@ def _write_markdown(payload: JsonDict, path: Path) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--prior-cluster-frontier-json", type=Path, required=True)
+    parser.add_argument("--online-exact-measured-reducer-json", type=Path, required=True)
     parser.add_argument("--service-activity-power-json", type=Path, action="append", required=True)
     parser.add_argument("--out", type=Path, required=True)
     parser.add_argument("--out-md", type=Path, required=True)
     args = parser.parse_args()
     payload = build_report(
         prior_cluster_frontier_json=args.prior_cluster_frontier_json,
+        online_exact_measured_reducer_json=args.online_exact_measured_reducer_json,
         service_activity_power_jsons=args.service_activity_power_json,
     )
     args.out.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_attention_decode_score_multivalue_service_measured_frontier.py
+++ b/tests/test_attention_decode_score_multivalue_service_measured_frontier.py
@@ -449,12 +449,51 @@ def _service_activity_power_c2(tmp_path: Path) -> Path:
     )
 
 
+def _online_exact_measured_reducer(tmp_path: Path) -> Path:
+    return _write(
+        tmp_path / "online_exact_measured_reducer.json",
+        {
+            "model": "llm_decoder_attention_score32_local_reducer_measured_recost_v1",
+            "decision": "score32_local_reducer_measured_bounded_recost_recorded",
+            "summary": {
+                "single_clock_strict_latency_upper_bound_us": 172387.653024,
+                "single_clock_strict_throughput_lower_bound_per_s": 5.800879485614,
+                "dual_clock_strict_latency_upper_bound_us": 50588.450822,
+                "dual_clock_strict_throughput_lower_bound_per_s": 19.767357642925,
+            },
+            "best_requested": {
+                "replica_recost_clock_ns": 48.6509,
+                "replica_recost_clock_origin": "inherited_single_clock_composed_compute_bound",
+                "replica_recost_compute_power_mw": 25979.6,
+                "replica_recost_logic_area_required_um2": 297277823.9308,
+                "measured_shared_sram_used_area_um2": 50000000.0,
+                "measured_tile_local_sram_area_um2": 30000000.0,
+                "local_reducer_measured_recost_replaces_unresolved_local_reducer_timing": True,
+            },
+            "routed_component_ppa": {
+                "macro_only_sum_scaled_16_clusters": {
+                    "die_area_mm2": 92.3472,
+                    "total_power_mw": 203.52,
+                },
+                "synthesis_area_lower_bound_scaled_16_clusters": {
+                    "total_hierarchy_area_mm2": 52.753805,
+                },
+            },
+            "remaining_abstractions": [
+                "No total-token energy is claimed in this online-exact measured-reducer baseline.",
+            ],
+        },
+    )
+
+
 def test_build_report_success_recomputes_latency_area_and_component_energy(tmp_path: Path) -> None:
     prior = _prior_frontier(tmp_path)
     service = _service_activity_power(tmp_path)
+    online_exact = _online_exact_measured_reducer(tmp_path)
 
     payload = build_report(
         prior_cluster_frontier_json=prior,
+        online_exact_measured_reducer_json=online_exact,
         service_activity_power_json=service,
     )
 
@@ -481,10 +520,34 @@ def test_build_report_success_recomputes_latency_area_and_component_energy(tmp_p
     assert row["service_component_leakage_energy_mj_per_token"] == pytest.approx(0.2048)
     assert row["service_component_energy_mj_per_token"] == pytest.approx(2684.88704)
     assert row["direct_total_token_energy"] is False
+    assert row["authoritative_composed_service_total_power_mw"] == pytest.approx(12.75)
+    assert row["service_window_average_dynamic_plus_leakage_power_mw"] == pytest.approx(350.0)
     assert row["full_measured_window_count"] == 5462
     assert row["full_measured_window_count_exact"] == 5461
     assert row["final_partial_tokens"] == 8
     assert row["final_partial_window_conservatively_charged_as_full_measured_window"] is True
+    comparison = row["comparison_to_online_exact_measured_reducer"]
+    assert comparison["full_token_latency_directly_comparable"] is True
+    assert comparison["full_token_throughput_directly_comparable"] is True
+    assert comparison["energy_directly_comparable"] is False
+    assert comparison["latency_ratio_vs_online_exact_single_clock_strict_upper_bound"] == pytest.approx(
+        4263.68 / 172387.653024
+    )
+    assert comparison["latency_ratio_vs_online_exact_dual_clock_strict_upper_bound"] == pytest.approx(
+        4263.68 / 50588.450822
+    )
+    assert comparison["service_total_power_ratio_vs_online_exact_macro_only_power_scaled_16_clusters"] == pytest.approx(
+        12.75 / 203.52
+    )
+    baseline = payload["online_exact_measured_reducer_baseline"]
+    assert baseline["replica_recost_embodied_logic_plus_existing_shared_tile_sram_area_mm2"] == pytest.approx(
+        377.277823931
+    )
+    assert payload["online_exact_measured_reducer_comparison"]["dependency_job_sequence"] == [
+        "c1 PNR",
+        "c1 activity power",
+        "measured frontier",
+    ]
     assert (
         payload["selected_service_activity_candidate"]["integrated_service_hashes"]["score_hash"]
         == "integrated-c1-score-hash"
@@ -498,9 +561,11 @@ def test_build_report_success_recomputes_latency_area_and_component_energy(tmp_p
 def test_build_report_prevents_old_cluster_and_service_area_double_count(tmp_path: Path) -> None:
     prior = _prior_frontier(tmp_path)
     service = _service_activity_power(tmp_path)
+    online_exact = _online_exact_measured_reducer(tmp_path)
 
     payload = build_report(
         prior_cluster_frontier_json=prior,
+        online_exact_measured_reducer_json=online_exact,
         service_activity_power_json=service,
     )
 
@@ -513,9 +578,11 @@ def test_build_report_prevents_old_cluster_and_service_area_double_count(tmp_pat
 def test_build_report_accepts_distinct_integrated_hash_domain(tmp_path: Path) -> None:
     prior = _prior_frontier(tmp_path)
     service = _service_activity_power(tmp_path)
+    online_exact = _online_exact_measured_reducer(tmp_path)
 
     payload = build_report(
         prior_cluster_frontier_json=prior,
+        online_exact_measured_reducer_json=online_exact,
         service_activity_power_json=service,
     )
 
@@ -533,6 +600,7 @@ def test_build_report_accepts_distinct_integrated_hash_domain(tmp_path: Path) ->
 def test_build_report_rejects_cycle_mismatch(tmp_path: Path) -> None:
     prior = _prior_frontier(tmp_path)
     service = _service_activity_power(tmp_path)
+    online_exact = _online_exact_measured_reducer(tmp_path)
     payload = json.loads(service.read_text(encoding="utf-8"))
     payload["activity_contract"]["cycle_count"] = 161
     payload["best"]["component_service_window_energy"]["cycle_count"] = 161
@@ -542,6 +610,7 @@ def test_build_report_rejects_cycle_mismatch(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="microkernel cycle_count"):
         build_report(
             prior_cluster_frontier_json=prior,
+            online_exact_measured_reducer_json=online_exact,
             service_activity_power_json=service,
         )
 
@@ -549,6 +618,7 @@ def test_build_report_rejects_cycle_mismatch(tmp_path: Path) -> None:
 def test_build_report_rejects_structural_macro_gate_failure(tmp_path: Path) -> None:
     prior = _prior_frontier(tmp_path)
     service = _service_activity_power(tmp_path)
+    online_exact = _online_exact_measured_reducer(tmp_path)
     payload = json.loads(service.read_text(encoding="utf-8"))
     payload["macro_activity_contract"]["macro_classes"]["fakeram45_64x32"]["assignment_count"] = 4607
     service.write_text(json.dumps(payload), encoding="utf-8")
@@ -556,6 +626,7 @@ def test_build_report_rejects_structural_macro_gate_failure(tmp_path: Path) -> N
     with pytest.raises(ValueError, match="assignment_count mismatch"):
         build_report(
             prior_cluster_frontier_json=prior,
+            online_exact_measured_reducer_json=online_exact,
             service_activity_power_json=service,
         )
 
@@ -563,6 +634,7 @@ def test_build_report_rejects_structural_macro_gate_failure(tmp_path: Path) -> N
 def test_build_report_rejects_precision_gate_mismatch(tmp_path: Path) -> None:
     prior = _prior_frontier(tmp_path)
     service = _service_activity_power(tmp_path)
+    online_exact = _online_exact_measured_reducer(tmp_path)
     payload = json.loads(service.read_text(encoding="utf-8"))
     payload["dependency_contract"]["cluster_equivalence"]["final_tensor_hash"] = "wrong-hash"
     service.write_text(json.dumps(payload), encoding="utf-8")
@@ -570,6 +642,7 @@ def test_build_report_rejects_precision_gate_mismatch(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="final_tensor_hash mismatch"):
         build_report(
             prior_cluster_frontier_json=prior,
+            online_exact_measured_reducer_json=online_exact,
             service_activity_power_json=service,
         )
 
@@ -577,6 +650,7 @@ def test_build_report_rejects_precision_gate_mismatch(tmp_path: Path) -> None:
 def test_build_report_rejects_workload_contract_schema_drift(tmp_path: Path) -> None:
     prior = _prior_frontier(tmp_path)
     service = _service_activity_power(tmp_path)
+    online_exact = _online_exact_measured_reducer(tmp_path)
     payload = json.loads(service.read_text(encoding="utf-8"))
     payload["activity_contract"]["workload_contract"]["active_context_tokens"] = 25
     service.write_text(json.dumps(payload), encoding="utf-8")
@@ -584,6 +658,7 @@ def test_build_report_rejects_workload_contract_schema_drift(tmp_path: Path) -> 
     with pytest.raises(ValueError, match="workload_contract"):
         build_report(
             prior_cluster_frontier_json=prior,
+            online_exact_measured_reducer_json=online_exact,
             service_activity_power_json=service,
         )
 
@@ -591,9 +666,11 @@ def test_build_report_rejects_workload_contract_schema_drift(tmp_path: Path) -> 
 def test_build_report_uses_24_token_measured_window_ceil_and_partial_charge(tmp_path: Path) -> None:
     prior = _prior_frontier(tmp_path, sequence_length=131000)
     service = _service_activity_power(tmp_path)
+    online_exact = _online_exact_measured_reducer(tmp_path)
 
     payload = build_report(
         prior_cluster_frontier_json=prior,
+        online_exact_measured_reducer_json=online_exact,
         service_activity_power_json=service,
     )
 
@@ -615,10 +692,12 @@ def test_build_report_rejects_recomputed_infeasible_c1(tmp_path: Path) -> None:
     source_payload["source_schedule"]["compute_budget_um2"] = 3_500_000
     source.write_text(json.dumps(source_payload), encoding="utf-8")
     service = _service_activity_power(tmp_path)
+    online_exact = _online_exact_measured_reducer(tmp_path)
 
     with pytest.raises(ValueError, match="not feasible for promotion"):
         build_report(
             prior_cluster_frontier_json=prior,
+            online_exact_measured_reducer_json=online_exact,
             service_activity_power_json=service,
         )
 
@@ -626,9 +705,11 @@ def test_build_report_rejects_recomputed_infeasible_c1(tmp_path: Path) -> None:
 def test_build_report_keeps_c2_blocked_unpromoted(tmp_path: Path) -> None:
     prior = _prior_frontier(tmp_path)
     service = _service_activity_power(tmp_path)
+    online_exact = _online_exact_measured_reducer(tmp_path)
 
     payload = build_report(
         prior_cluster_frontier_json=prior,
+        online_exact_measured_reducer_json=online_exact,
         service_activity_power_json=service,
     )
 
@@ -647,9 +728,11 @@ def test_build_report_promotes_c2_with_whole_service_window_accounting(tmp_path:
     prior = _prior_frontier(tmp_path)
     service_c1 = _service_activity_power(tmp_path)
     service_c2 = _service_activity_power_c2(tmp_path)
+    online_exact = _online_exact_measured_reducer(tmp_path)
 
     payload = build_report(
         prior_cluster_frontier_json=prior,
+        online_exact_measured_reducer_json=online_exact,
         service_activity_power_jsons=[service_c1, service_c2],
     )
 
@@ -678,9 +761,11 @@ def test_build_report_c2_regression_guard_rejects_head_count_double_count(tmp_pa
     prior = _prior_frontier(tmp_path)
     service_c1 = _service_activity_power(tmp_path)
     service_c2 = _service_activity_power_c2(tmp_path)
+    online_exact = _online_exact_measured_reducer(tmp_path)
 
     payload = build_report(
         prior_cluster_frontier_json=prior,
+        online_exact_measured_reducer_json=online_exact,
         service_activity_power_jsons=[service_c1, service_c2],
     )
 
@@ -693,6 +778,7 @@ def test_build_report_rejects_c2_cycle_mismatch(tmp_path: Path) -> None:
     prior = _prior_frontier(tmp_path)
     service_c1 = _service_activity_power(tmp_path)
     service_c2 = _service_activity_power_c2(tmp_path)
+    online_exact = _online_exact_measured_reducer(tmp_path)
     payload = json.loads(service_c2.read_text(encoding="utf-8"))
     payload["activity_contract"]["cycle_count"] = 8864
     payload["best"]["component_service_window_energy"]["cycle_count"] = 8864
@@ -702,5 +788,6 @@ def test_build_report_rejects_c2_cycle_mismatch(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="service activity cycle_count"):
         build_report(
             prior_cluster_frontier_json=prior,
+            online_exact_measured_reducer_json=online_exact,
             service_activity_power_jsons=[service_c1, service_c2],
         )


### PR DESCRIPTION
Extends the existing measured c1/c2 composed-service frontier audit with a required merged online-exact measured-reducer baseline. Reports same-workload latency/throughput and area comparisons, preserves the explicit 24-token service-window scaling and 128-token capacity distinction, and keeps energy non-comparable where total-token evidence is absent. Wires the new dependency through control-plane task generation and v1/v2 proposal eligibility.\n\nValidation: 13 measured-frontier tests passed; 4 focused L2 task-generator tests passed; scripts/validate_runs.py --skip_eval_queue passed.