### PR TITLE
control_plane: resolve multivalue service PNR retries

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -283,6 +283,24 @@ def _multivalue_service_activity_power_item_for_consumer(
     return max(candidate_item_ids, key=_item_version_retry_rank)
 
 
+def _multivalue_service_pnr_item_for_consumer(
+    *, depends_on_item_ids: list[str] | None, cluster_count: int = 1
+) -> str:
+    prefix = (
+        _MULTIVALUE_SERVICE_C1_PNR_ITEM
+        if cluster_count == 1
+        else _MULTIVALUE_SERVICE_C2_PNR_ITEM
+    )
+    candidate_item_ids = [
+        str(dep).strip()
+        for dep in (depends_on_item_ids or [])
+        if str(dep).strip() == prefix or str(dep).strip().startswith(f"{prefix}_r")
+    ]
+    if not candidate_item_ids:
+        return prefix
+    return max(candidate_item_ids, key=_item_version_retry_rank)
+
+
 def _online_exact_measured_reducer_item_for_consumer(
     *, depends_on_item_ids: list[str] | None
 ) -> str:
@@ -7713,21 +7731,26 @@ def _decoder_attention_decode_score_multivalue_service_activity_power_evidence(
     activity_dir = f"/tmp/rtlgen_multivalue_service_{case_id.split('_', 1)[0]}_activity"
     out = f"{base}/decoder_attention_decode_score_multivalue_service_activity_power__{item_id}.json"
     report = f"{base}/decoder_attention_decode_score_multivalue_service_activity_power__{item_id}.md"
-    pnr_item = _MULTIVALUE_SERVICE_C2_PNR_ITEM if is_c2 else _MULTIVALUE_SERVICE_C1_PNR_ITEM
+    pnr_item = _multivalue_service_pnr_item_for_consumer(
+        depends_on_item_ids=depends_on_item_ids,
+        cluster_count=2 if is_c2 else 1,
+    )
     config_key_prefix = f"decode_score_multivalue_service_{case_id.split('_', 1)[0]}"
     scope = (
         "Audit strict c2 routed composed-service activity power after merged/materialized "
-        "integrated-service c2, c2 PNR, and shared-score multivalue cluster-equivalence evidence. "
-        "Measure only direct routed whole-service window energy, inherit the exact integer precision "
-        "contract from the merged equivalence proof, require complete relevant FakeRAM macro-class "
-        "annotation, keep VCD/ODB/SPEF evaluator-local, and do not claim total-token energy."
+        f"integrated-service c2, c2 PNR ({pnr_item}), and shared-score multivalue "
+        "cluster-equivalence evidence. Measure only direct routed whole-service window energy, "
+        "inherit the exact integer precision contract from the merged equivalence proof, require "
+        "complete relevant FakeRAM macro-class annotation, keep VCD/ODB/SPEF evaluator-local, and "
+        "do not claim total-token energy."
         if is_c2
         else (
             "Audit strict c1 routed composed-service activity power after merged/materialized "
-            "integrated-service, c1 PNR, and shared-score multivalue cluster-equivalence evidence. "
-            "Measure only direct routed component service-window energy, inherit the exact integer "
-            "precision contract from the merged equivalence proof, do not force bank3 activity, keep "
-            "VCD/ODB/SPEF evaluator-local, and do not claim total-token energy."
+            f"integrated-service, c1 PNR ({pnr_item}), and shared-score multivalue "
+            "cluster-equivalence evidence. Measure only direct routed component service-window "
+            "energy, inherit the exact integer precision contract from the merged equivalence "
+            "proof, do not force bank3 activity, keep VCD/ODB/SPEF evaluator-local, and do not "
+            "claim total-token energy."
         )
     )
     promotion_gate = (

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -20,6 +20,7 @@ from control_plane.services.l2_task_generator import (
     Layer2TaskGenerationError,
     _cluster_activity_power_item_for_consumer,
     _multivalue_integrated_service_item_for_consumer,
+    _multivalue_service_pnr_item_for_consumer,
     generate_l2_campaign_task,
 )
 
@@ -8818,6 +8819,28 @@ def test_multivalue_integrated_service_item_for_consumer_prefers_latest_retry() 
     ) == "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r2"
 
 
+def test_multivalue_service_pnr_item_for_consumer_prefers_latest_retry() -> None:
+    assert _multivalue_service_pnr_item_for_consumer(
+        depends_on_item_ids=None,
+        cluster_count=1,
+    ) == "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1"
+    assert _multivalue_service_pnr_item_for_consumer(
+        depends_on_item_ids=[
+            "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1",
+            "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r2",
+            "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
+        ],
+        cluster_count=1,
+    ) == "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r2"
+    assert _multivalue_service_pnr_item_for_consumer(
+        depends_on_item_ids=[
+            "l1_decoder_attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_pnr_v1_r1",
+            "l1_decoder_attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_pnr_v1",
+        ],
+        cluster_count=2,
+    ) == "l1_decoder_attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_pnr_v1_r1"
+
+
 def test_multivalue_cluster_frontier_request_manifests_remain_dependency_gated() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     proposal_dir = (
@@ -8861,7 +8884,7 @@ def test_service_activity_power_request_manifests_remain_dependency_gated() -> N
     )
     expected_depends = {
         "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
-        "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1",
+        "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r2",
         "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
     }
 
@@ -8873,22 +8896,29 @@ def test_service_activity_power_request_manifests_remain_dependency_gated() -> N
         if manifest_name == "evaluation_requests.json":
             note = manifest["source_commit_note"]
             assert "Replace with the merge commit" in note
-            assert "July 25, 2026" in note
-            assert "not materialized in the repository checkout" in note
+            assert "August 5, 2026" in note
+            assert "does not claim that r2 has passed" in note
+            assert "later retries resolve dynamically" in note
         item = manifest[items_key][0]
         assert (
             item["item_id"]
             == "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1"
         )
         assert set(item["depends_on_item_ids"]) == expected_depends
+        assert item["paired_baseline_item_id"] == (
+            "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r2"
+        )
         assert item["requires_merged_inputs"] is True
         assert item["requires_materialized_refs"] is True
         assert item["status"] == "pending_implementation_merge"
         assert "dependency-gated" in item["notes"]
         assert "not ready for normal dispatch" in item["notes"]
-        assert "July 25, 2026" in item["notes"]
+        assert "August 5, 2026" in item["notes"]
+        assert "does not claim that r2 has passed" in item["notes"]
+        assert "later retries" in item["notes"]
         assert "shared-score multivalue cluster-equivalence JSON path" in item["notes"]
         assert "direct routed service-window energy" in item["expected_result"]["reason"]
+        assert "dynamically selected retry" in item["expected_result"]["reason"]
         assert "bank3 inactivity unforced" in item["expected_result"]["reason"]
 
 
@@ -9639,6 +9669,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_activity
                     depends_on_item_ids=[
                         "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
                         "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1",
+                        "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r2",
                         "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
                     ],
                     run_physical=False,
@@ -9688,8 +9719,11 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_activity
             assert "--clock-period-ns 10" in run
             assert "--activity-dir /tmp/rtlgen_multivalue_service_c1_activity" in run
             assert decoder_inputs["decode_score_multivalue_service_c1_source_pnr_item_id"] == (
-                "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1"
+                "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r2"
             )
+            assert "c1 PNR (l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r2)" in decoder_inputs[
+                "decode_score_multivalue_service_activity_power_scope"
+            ]
             assert decoder_inputs["decode_score_multivalue_service_activity_power_out"] == (
                 "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_attention_decode_score_multivalue_service_activity_power__"
@@ -9741,6 +9775,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_c2_activ
                     depends_on_item_ids=[
                         "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
                         "l1_decoder_attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_pnr_v1",
+                        "l1_decoder_attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_pnr_v1_r3",
                         "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
                     ],
                     run_physical=False,
@@ -9756,8 +9791,11 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_c2_activ
             assert "--case-id c2_p128_b4_rr" in run
             assert "--activity-dir /tmp/rtlgen_multivalue_service_c2_activity" in run
             assert decoder_inputs["decode_score_multivalue_service_c2_source_pnr_item_id"] == (
-                "l1_decoder_attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_pnr_v1"
+                "l1_decoder_attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_pnr_v1_r3"
             )
+            assert "c2 PNR (l1_decoder_attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_pnr_v1_r3)" in decoder_inputs[
+                "decode_score_multivalue_service_activity_power_scope"
+            ]
             assert "cycle count matches case c2_p128_b4_rr" in decoder_inputs[
                 "decode_score_multivalue_service_activity_power_promotion_gate"
             ]

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
-  "source_commit_note": "Replace with the merge commit that contains this strict c1 composed-service activity-power wiring before dispatch. As of July 25, 2026, this request remains dependency-gated because the integrated-service r1 JSON and the c1 composed-service metrics row are not materialized in the repository checkout; do not dispatch until all three dependency outputs are merged/materialized.",
+  "source_commit_note": "Replace with the merge commit that contains this strict c1 composed-service activity-power wiring before dispatch. As of August 5, 2026, this request remains dependency-gated; the current dependency pin is the c1 PNR retry candidate l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r2, but this does not claim that r2 has passed, and later retries resolve dynamically from depends_on_item_ids after merge/materialization.",
   "requested_items": [
     {
       "item_id": "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1",
@@ -9,20 +9,20 @@
       "evaluation_mode": "frontier_detail",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_service_activity_power",
       "comparison_role": "strict_c1_service_activity_power_gate",
-      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r2",
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
-        "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1",
+        "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r2",
         "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "record_strict_c1_composed_service_activity_power",
-        "reason": "Require merged/materialized integrated-service r1, composed c1 PNR, and shared-score multivalue cluster-equivalence evidence before dispatch; then measure only direct routed service-window energy at 10 ns, preserve exact inherited precision, leave bank3 inactivity unforced, and withhold total-token energy."
+        "reason": "Require merged/materialized integrated-service r1, the currently pinned c1 PNR retry candidate r2 or any later dynamically selected retry, and shared-score multivalue cluster-equivalence evidence before dispatch; then measure only direct routed service-window energy at 10 ns, preserve exact inherited precision, leave bank3 inactivity unforced, and withhold total-token energy."
       },
       "status": "pending_implementation_merge",
-      "notes": "This request remains dependency-gated and is not ready for normal dispatch. As of July 25, 2026, the integrated-service r1 JSON and the c1 composed-service metrics row are not materialized in the repository checkout, and both must merge/materialize before dispatch even though the shared-score multivalue cluster-equivalence JSON path is already the same repo path used by related audits."
+      "notes": "This request remains dependency-gated and is not ready for normal dispatch. As of August 5, 2026, the current dependency pin is the c1 PNR retry candidate l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r2, but this request does not claim that r2 has passed; later retries resolve dynamically by the task generator once merged/materialized. The integrated-service r1 JSON and the selected c1 composed-service metrics row must still be materialized before dispatch even though the shared-score multivalue cluster-equivalence JSON path is already the same repo path used by related audits."
     }
   ]
 }

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1/proposal.json
@@ -9,7 +9,7 @@
   "hypothesis": "Once the compact integrated-service r1 probe, the merged c1 composed-service PNR row, and the shared-score multivalue cluster-equivalence evidence are all merged and materialized, a strict c1 routed audit can report only direct composed service-window energy with exact inherited precision and without forcing bank3 activity or making any total-token energy claim.",
   "direct_comparison": {
     "primary_question": "Does the routed c1 composed service remain physically interesting once the merged c1 PNR row is combined with strict integrated-service and cluster-equivalence gates plus evaluator-local switching evidence, while reporting only direct service-window energy?",
-    "baseline": "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1 as the authoritative composed c1 PPA row, with integrated-service r1 and shared-score multivalue cluster-equivalence evidence as strict dependency gates.",
+    "baseline": "Current dependency pin is l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r2 as the latest known authoritative c1 PNR retry candidate, while later retries resolve dynamically from depends_on_item_ids at task-generation time; integrated-service r1 and shared-score multivalue cluster-equivalence evidence remain strict dependency gates.",
     "include": [
       "strict c1 p128/b4/q4/rl2/round_robin composed-service routed row at 10 ns",
       "merged/materialized integrated-service c1 exact hash/protocol/count evidence from l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
@@ -55,20 +55,20 @@
       "evaluation_mode": "frontier_detail",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_service_activity_power",
       "comparison_role": "strict_c1_service_activity_power_gate",
-      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r2",
       "depends_on_item_ids": [
         "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
-        "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1",
+        "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r2",
         "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "record_strict_c1_composed_service_activity_power",
-        "reason": "Require merged/materialized integrated-service r1, composed c1 PNR, and shared-score multivalue cluster-equivalence evidence before dispatch; then measure only direct routed service-window energy at 10 ns, preserve exact inherited precision, leave bank3 inactivity unforced, and withhold total-token energy."
+        "reason": "Require merged/materialized integrated-service r1, the currently pinned c1 PNR retry candidate r2 or any later dynamically selected retry, and shared-score multivalue cluster-equivalence evidence before dispatch; then measure only direct routed service-window energy at 10 ns, preserve exact inherited precision, leave bank3 inactivity unforced, and withhold total-token energy."
       },
       "status": "pending_implementation_merge",
-      "notes": "This request is dependency-gated and not ready for normal dispatch. As of July 25, 2026, the repository checkout does not contain the integrated-service r1 JSON or the c1 composed-service metrics row, so both dependencies must merge/materialize before dispatch even though the shared-score multivalue cluster-equivalence JSON path is already the same repo path used by related audits."
+      "notes": "This request is dependency-gated and not ready for normal dispatch. As of August 5, 2026, the current dependency pin is the c1 PNR retry candidate l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r2, but this proposal does not claim that r2 has passed; later retries are resolved dynamically by the task generator once merged/materialized. The integrated-service r1 JSON and the selected c1 composed-service metrics row must still be materialized before dispatch even though the shared-score multivalue cluster-equivalence JSON path is already the same repo path used by related audits."
     }
   ],
   "baseline_refs": [


### PR DESCRIPTION
Makes c1/c2 composed-service activity-power jobs resolve the latest explicitly supplied PNR retry dependency instead of hard-coding the base item. Updates the c1 request to gate on today’s r2 retry without claiming it has passed.\n\nValidation: 5 focused L2 task-generator tests passed; scripts/validate_runs.py --skip_eval_queue passed.