### PR TITLE
synth: make repaired tie nets routable

### DIFF
--- a/npu/synth/run_block_sweep.py
+++ b/npu/synth/run_block_sweep.py
@@ -858,7 +858,9 @@ def build_post_floorplan_tie_root_fix_tcl() -> str:
 # Repair residual floating POWER/GROUND roots that remain after floorplan tie
 # fanout repair and timing repair. This deliberately skips special nets and
 # named VDD/VSS rails, and only inserts one tie cell when a non-special
-# POWER/GROUND net has sinks but no output driver.
+# POWER/GROUND net has sinks but no output driver. Repaired nets are converted
+# back to ordinary SIGNAL nets so downstream routing does not keep treating
+# them as floating POWER/GROUND roots.
 
 proc rtlgen_parse_tie_cell_and_port {env_var} {
   if {![info exists ::env($env_var)]} {
@@ -966,6 +968,7 @@ proc rtlgen_insert_residual_tie_roots_for_sigtype {block sig_type env_var prefix
     puts "Residual tie-root fix: inserting $lib_name/$cell_name/$port_name on $sig_type net '$net_name' with $sink_count sinks and no output driver"
     make_instance $inst_name $lib_name/$cell_name
     connect_pin $net_name $inst_name/$port_name
+    $net setSigType SIGNAL
     incr inserted
   }
   return $inserted

--- a/tests/test_run_block_sweep_mode_compare.py
+++ b/tests/test_run_block_sweep_mode_compare.py
@@ -130,6 +130,7 @@ class ModeCompareRegressionTest(unittest.TestCase):
         self.assertIn('} elseif {$io_type eq "INOUT" || $io_type eq "FEEDTHRU"} {\n      incr sink_count\n      incr output_driver_count', text)
         self.assertIn("make_instance $inst_name $lib_name/$cell_name", text)
         self.assertIn("connect_pin $net_name $inst_name/$port_name", text)
+        self.assertIn("$net setSigType SIGNAL", text)
         self.assertIn("rtlgen_unique_tie_instance_name", text)
         self.assertIn("rtlgen_auto_tielo", text)
         self.assertIn("rtlgen_auto_tiehi", text)
@@ -174,6 +175,7 @@ class ModeCompareRegressionTest(unittest.TestCase):
             hook_text = hook_path.read_text(encoding="utf-8")
             self.assertIn("Residual tie-root fix complete", hook_text)
             self.assertIn("only inserts one tie cell when a non-special", hook_text)
+            self.assertIn("converted\n# back to ordinary SIGNAL nets", hook_text)
 
     def test_parse_mode_compare_custom_modes(self):
         raw = {


### PR DESCRIPTION
## Summary
- convert repaired residual POWER/GROUND nets to ordinary SIGNAL nets after inserting tie drivers
- cover the generated post-floorplan Tcl behavior

## Evidence
The c1 service PNR r2 retained a LOGIC0_X1 driver on zero_, but global routing still failed DRT-0305 because zero_ remained typed GROUND. Direct OpenROAD verification on the failed 4_cts.odb confirms setSigType SIGNAL changes GROUND to SIGNAL.

## Validation
- focused post-floorplan tests: 2 passed
- scripts/validate_runs.py --skip_eval_queue: passed