### PR TITLE
eval: add conditional c1 3.6mm route recovery

### DIFF
--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -4770,6 +4770,58 @@ def test_multivalue_service_pnr_proposal_keeps_c2_gated_on_c1_dependency() -> No
     assert c1_item_id in (proposal_dir / "design_brief.md").read_text(encoding="utf-8")
 
 
+def test_multivalue_service_pnr_proposal_adds_explicit_c1_route_recovery_retry() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    proposal_dir = (
+        repo_root
+        / "docs"
+        / "proposals"
+        / "prop_l1_decoder_attention_decode_score_multivalue_service_pnr_v1"
+    )
+    proposal = json.loads((proposal_dir / "proposal.json").read_text(encoding="utf-8"))
+    evaluation_requests = json.loads((proposal_dir / "evaluation_requests.json").read_text(encoding="utf-8"))
+    design_brief = (proposal_dir / "design_brief.md").read_text(encoding="utf-8")
+
+    base_item_id = "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1"
+    retry_item_id = "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r4"
+    retry_sweep = (
+        "runs/campaigns/npu/decode_score_multivalue_service_v1/sweeps/"
+        "nangate45_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3600.json"
+    )
+    base_sweep = (
+        "runs/campaigns/npu/decode_score_multivalue_service_v1/sweeps/"
+        "nangate45_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000.json"
+    )
+
+    proposal_by_id = {entry["item_id"]: entry for entry in proposal["required_evaluations"]}
+    request_by_id = {entry["item_id"]: entry for entry in evaluation_requests["requested_items"]}
+    base_proposal = proposal_by_id[base_item_id]
+    retry_proposal = proposal_by_id[retry_item_id]
+    base_request = request_by_id[base_item_id]
+    retry_request = request_by_id[retry_item_id]
+
+    assert base_proposal["sweep_path"] == base_sweep
+    assert base_request["sweep_path"] == base_sweep
+    assert retry_proposal["sweep_path"] == retry_sweep
+    assert retry_request["sweep_path"] == retry_sweep
+    assert retry_proposal["prior_item_ids"] == [base_item_id + "_r3"]
+    assert retry_request["prior_item_ids"] == [base_item_id + "_r3"]
+    assert "does not claim a new area frontier" in retry_proposal["expected_result"]["reason"]
+    assert "does not claim a new area frontier" in retry_request["expected_result"]["reason"]
+    assert "only eligible if r3 fails to produce acceptable routed evidence" in retry_proposal["expected_result"]["reason"]
+    assert "only eligible if r3 fails to produce acceptable routed evidence" in retry_request["expected_result"]["reason"]
+    assert "route_recovery_sensitivity" in retry_proposal["comparison_role"]
+    assert retry_proposal["status"] == "conditional_follow_on"
+    assert retry_request["status"] == "conditional_follow_on"
+    assert "3.6 mm" in design_brief
+    assert "3.5 mm" in design_brief
+    assert "not an area-frontier replacement" in design_brief
+    assert "r2" in design_brief
+    assert "r3" in design_brief
+    assert "r4" in design_brief
+    assert "acceptable routed evidence" in design_brief
+
+
 def test_exact_root_finalizer_lane_ppa_proposal_is_pending_merge_with_all_lane_configs() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     proposal_dir = (

--- a/docs/proposals/prop_l1_decoder_attention_decode_score_multivalue_service_pnr_v1/design_brief.md
+++ b/docs/proposals/prop_l1_decoder_attention_decode_score_multivalue_service_pnr_v1/design_brief.md
@@ -19,12 +19,21 @@ enough to make the composed service physically dispatchable without dragging
 the same physical contract is proven cleanly on the current monolithic wrapper,
 and its requested item now depends explicitly on
 `l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1`.
+The original `3.0 mm` c1 point remains the conservative baseline request, while
+an explicit `r4` retry at `3.6 mm` die / `3.5 mm` core exists only as
+conditional congestion-recovery sensitivity and must not be read as a
+replacement area frontier. Retry lineage is explicit: `r2` added the tie
+driver but still left the net typed as `GROUND`, `r3` is the corrected `3.0 mm`
+`SIGNAL`-net retry currently under evaluation, and `r4` is eligible only if
+`r3` cannot produce acceptable routed evidence.
 
 ## Scope
 - include:
   - L1 generator wiring for `gen_attention_decode_score_multivalue_service.py`
   - strict pre-PPA guard and post-sweep checker
   - checked-in c1/c2 configs and Nangate45 sweeps
+  - one explicit c1 retry sweep at `3.6 mm` die / `3.5 mm` core that preserves
+    the same exact macro-backed config, `10 ns`, and `PLACE_DENSITY=0.4`
   - exact `4 bank x 16 lane x 64 row fakeram45_64x32` physical value-memory
     contract for `max_blocks=16`, while keeping behavioral mode for functional
     simulation and macro/backend equivalence testing
@@ -41,6 +50,12 @@ and its requested item now depends explicitly on
   deterministic post-floorplan residual tie-root hook, because this fix is
   intended to eliminate the observed non-special floating `zero_`/`one_`
   structural condition before detailed routing.
+- Recovery sensitivity note:
+  the explicit `l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r4`
+  request keeps the same exact config and backend contract but widens the
+  envelope to `3.6 mm` die / `3.5 mm` core only to test congestion recovery
+  after the `3.0 mm` point if `r3` cannot produce acceptable routed evidence.
+  It is not an area-frontier replacement.
 - `c2` remains conditional on the corrected c1 macro-backed implementation and
   evidence remaining clean after merge, with an explicit dependency on
   `l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1`.

--- a/docs/proposals/prop_l1_decoder_attention_decode_score_multivalue_service_pnr_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_decode_score_multivalue_service_pnr_v1/evaluation_requests.json
@@ -1,6 +1,6 @@
 {
   "proposal_id": "prop_l1_decoder_attention_decode_score_multivalue_service_pnr_v1",
-  "source_commit_note": "Replace with the merge commit that contains this corrected c1-first physical-prep patch before dispatch. Retry c1 only after the deterministic post-floorplan residual tie-root hook is present in generated design configs.",
+  "source_commit_note": "Replace with the merge commit that contains this corrected c1-first physical-prep patch before dispatch. Keep the original 3.0 mm c1 point as the conservative baseline request. Distinguish the retry lineage explicitly: r2 was the tie-driver retry that still left the net typed as GROUND, r3 is the corrected 3.0 mm SIGNAL-net retry currently under evaluation as of August 5, 2026, and the 3.6 mm / 3.5 mm envelope below is r4, a conditional congestion-recovery follow-on only if r3 does not produce acceptable routed evidence.",
   "requested_items": [
     {
       "item_id": "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1",
@@ -24,6 +24,33 @@
         "reason": "Record total composed PPA as the authoritative metric while using the single-cluster baseline only as implementation-context sensitivity, not intrinsic additive fabric PPA. This retry is specifically to verify that the deterministic post-floorplan residual tie-root hook removes the floating zero_/one_ structural condition before global routing."
       },
       "status": "pending_implementation_merge"
+    },
+    {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r4",
+      "task_type": "l1_sweep",
+      "objective": "Conditionally retry the composed multivalue service c1 route at the same exact macro-backed p128/b4/q4/rl2/round_robin configuration using a 3.6 mm die / 3.5 mm core envelope only if the corrected 3.0 mm SIGNAL-net r3 point cannot produce acceptable routed evidence.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_service",
+      "comparison_role": "composed_service_c1_route_recovery_sensitivity",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_v1",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_service_v1/sweeps/nangate45_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3600.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_composed_multivalue_service_c1_route_recovery",
+        "reason": "Preserve the 3.0 mm c1 request as the conservative baseline while adding one explicit 3.6 mm / 3.5 mm recovery sensitivity retry that keeps the same 10 ns hierarchical macro-backed implementation contract, does not claim a new area frontier, and is only eligible if r3 fails to produce acceptable routed evidence."
+      },
+      "status": "conditional_follow_on",
+      "prior_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r3"
+      ],
+      "notes": "This retry exists only to check congestion-recovery sensitivity after the 3.0 mm c1 point if r3 does not yield acceptable routed evidence. Retry lineage: r2 added the tie driver but still left the net typed as GROUND, r3 is the corrected 3.0 mm SIGNAL-net retry now under evaluation, and r4 keeps CLOCK_PERIOD=10, PLACE_DENSITY=0.4, SYNTH_HIERARCHICAL=1, the same exact config, and the same macro-backed memory contract while widening only the die/core envelope."
     },
     {
       "item_id": "l1_decoder_attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_pnr_v1",
@@ -52,6 +79,7 @@
   ],
   "follow_on_notes": [
     "c2 is intentionally kept conditional behind accepted c1 macro-backed evidence and now depends explicitly on l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1.",
+    "The explicit c1 r4 item is a 3.6 mm / 3.5 mm congestion-recovery sensitivity retry after the 3.0 mm point and is not an area-frontier replacement; it is conditional only if r3 cannot produce acceptable routed evidence.",
     "c8 is intentionally deferred from this first patch and remains a later-gated follow-up after c1/c2 feasibility is materialized.",
     "c16 and c32 remain later-gated follow-ups after c8 runtime and physical feasibility are proven."
   ]

--- a/docs/proposals/prop_l1_decoder_attention_decode_score_multivalue_service_pnr_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_decode_score_multivalue_service_pnr_v1/proposal.json
@@ -6,7 +6,7 @@
   "kind": "physical_prep",
   "title": "First physical prep for multivalue composed service",
   "abstraction_layer": "decoder_attention_decode_score_multivalue_service",
-  "hypothesis": "After the compact integrated-service r1 probe is merged and materialized, c1 can become a dispatchable physical-prep point, with c2 held as a conditional follow-on, if the actual composed service generator emits exact macro evidence for both score banks and a shared 4-bank x 16-lane x 64-row fakeram45_64x32 value store, and if the sweeps respect macro/pin-derived die bounds.",
+  "hypothesis": "After the compact integrated-service r1 probe is merged and materialized, c1 can become a dispatchable physical-prep point, with c2 held as a conditional follow-on, if the actual composed service generator emits exact macro evidence for both score banks and a shared 4-bank x 16-lane x 64-row fakeram45_64x32 value store, and if the sweeps respect macro/pin-derived die bounds. The original 3.0 mm c1 point remains the conservative baseline request. Retry lineage is explicit: r2 was the tie-driver retry that still left the net typed as GROUND, r3 is the corrected 3.0 mm SIGNAL-net retry currently under evaluation as of August 5, 2026, and a later 3.6 mm / 3.5 mm c1 retry can be used only as conditional congestion-recovery sensitivity if r3 cannot produce acceptable routed evidence, not as an area-frontier replacement.",
   "direct_comparison": {
     "primary_question": "Can the actual composed multivalue service be hardened as c1/c2 physical-prep points without silently substituting registers for value memory or under-sizing the die for macro and perimeter demand?",
     "include": [
@@ -14,12 +14,14 @@
       "exact 4-bank x 16-lane fakeram45_64x32 value-memory physical contract for max_blocks=16",
       "behavioral generator mode retained for functional simulation only",
       "strict c1/c2 guard plus post-sweep checker",
-      "dependency on l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1"
+      "dependency on l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1",
+      "one explicit c1 route-recovery sensitivity retry at 3.6 mm die / 3.5 mm core after the 3.0 mm point, conditional only if r3 cannot produce acceptable routed evidence"
     ],
     "exclude": [
       "no c4/c8/activity implementation in this patch",
       "no c16/c32 dispatch in this patch",
-      "no OpenROAD execution in this patch"
+      "no OpenROAD execution in this patch",
+      "no claim that the 3.6 mm retry replaces the conservative 3.0 mm c1 baseline or defines a new area frontier"
     ]
   },
   "required_evaluations": [
@@ -47,6 +49,33 @@
       "status": "pending_implementation_merge"
     },
     {
+      "item_id": "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r4",
+      "task_type": "l1_sweep",
+      "objective": "Conditionally retry the composed multivalue service c1 route at the same exact macro-backed p128/b4/q4/rl2/round_robin configuration using a 3.6 mm die / 3.5 mm core envelope only if the corrected 3.0 mm SIGNAL-net r3 point cannot produce acceptable routed evidence.",
+      "evaluation_mode": "frontier_followup",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_service",
+      "comparison_role": "composed_service_c1_route_recovery_sensitivity",
+      "paired_baseline_item_id": "l1_decoder_attention_decode_score_multivalue_cluster_pnr_v1",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/decode_score_multivalue_service_v1/sweeps/nangate45_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3600.json",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1_r1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_composed_multivalue_service_c1_route_recovery",
+        "reason": "Preserve the 3.0 mm c1 request as the conservative baseline while adding one explicit 3.6 mm / 3.5 mm recovery sensitivity retry that keeps the same 10 ns hierarchical macro-backed implementation contract, does not claim a new area frontier, and is only eligible if r3 fails to produce acceptable routed evidence."
+      },
+      "status": "conditional_follow_on",
+      "prior_item_ids": [
+        "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r3"
+      ],
+      "notes": "This retry exists only to check congestion-recovery sensitivity after the 3.0 mm c1 point if r3 does not yield acceptable routed evidence. Retry lineage: r2 added the tie driver but still left the net typed as GROUND, r3 is the corrected 3.0 mm SIGNAL-net retry now under evaluation, and r4 keeps CLOCK_PERIOD=10, PLACE_DENSITY=0.4, SYNTH_HIERARCHICAL=1, the same exact config, and the same macro-backed memory contract while widening only the die/core envelope."
+    },
+    {
       "item_id": "l1_decoder_attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr_pnr_v1",
       "task_type": "l1_sweep",
       "objective": "Conditionally measure the composed multivalue service at c2 using the exact 4-bank x 16-lane fakeram45_64x32 value-memory macro contract and a 3.7 mm hierarchy comparison sweep only after the corrected c1 physical path is accepted.",
@@ -72,6 +101,7 @@
   ],
   "follow_on_gates": [
     "c2 remains conditional until the corrected c1 macro-backed implementation and evidence scope are accepted, and the requested item now depends explicitly on l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1.",
+    "The explicit c1 r4 item is a 3.6 mm / 3.5 mm congestion-recovery sensitivity retry after the 3.0 mm point and is not an area-frontier replacement; it is conditional only if r3 cannot produce acceptable routed evidence.",
     "c8 remains a later-gated follow-up after c1/c2 runtime and physical feasibility are materialized.",
     "c16 and c32 remain later-gated follow-ups after c8 proves both runtime practicality and physical feasibility."
   ]

--- a/runs/campaigns/npu/decode_score_multivalue_service_v1/sweeps/nangate45_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3600.json
+++ b/runs/campaigns/npu/decode_score_multivalue_service_v1/sweeps/nangate45_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3600.json
@@ -1,0 +1,35 @@
+{
+  "tag_prefix": "decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3600_v1",
+  "flow_params": {
+    "TAG": [
+      "decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3600_v1"
+    ],
+    "FLOW_VARIANT": [
+      "decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3600_v1"
+    ],
+    "CLOCK_PERIOD": [
+      10
+    ],
+    "PLACE_DENSITY": [
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ],
+    "SYNTH_MEMORY_MAX_BITS": [
+      65536
+    ]
+  },
+  "mode_compare": {
+    "modes": [
+      {
+        "name": "macro_route_recovery_c1_die_3600_core_3500",
+        "use_macro": true,
+        "param_overrides": {
+          "DIE_AREA": "0 0 3600 3600",
+          "CORE_AREA": "50 50 3550 3550"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add a 3.6 mm die / 3.5 mm core c1 composed-service sweep with the same exact macro-backed config and 10 ns target
- retain the 3.0 mm point as the conservative baseline
- document r4 as conditional congestion recovery only if corrected 3.0 mm r3 cannot produce acceptable routed evidence

## Motivation
The corrected r3 run crosses the former tie-net failure, but 3.0 mm placement reports minimum weighted congestion above 1.0 and global routing entered bounded hard-benchmark overflow recovery. This patch prepares a separate recovery envelope without redefining the area frontier.

## Validation
- focused L1 proposal tests: 2 passed
- scripts/validate_runs.py --skip_eval_queue: passed