### PR TITLE
npu: select accepted c1 service route in activity audit

### DIFF
--- a/npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py
@@ -79,7 +79,10 @@ _SERVICE_CASES = {
         case_id="c1_p128_b4_rr",
         cluster_count=1,
         design="attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr",
-        flow_variant="decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1",
+        flow_variant=(
+            "decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1_"
+            "macro_conservative_c1_die_3000"
+        ),
         macro_counts={"fakeram45_2048x39": 56, "fakeram45_64x32": 64},
         dependency_key="integrated_service_c1",
         authoritative_ppa_key="authoritative_composed_c1_total_ppa",

--- a/tests/test_attention_decode_score_multivalue_service_activity_power.py
+++ b/tests/test_attention_decode_score_multivalue_service_activity_power.py
@@ -100,6 +100,23 @@ def _ok_metric(
     }
 
 
+def test_repo_c1_metric_contract_selects_merged_r3_row() -> None:
+    metrics = (
+        REPO_ROOT
+        / "runs/designs/npu_blocks/"
+        "attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr/metrics.csv"
+    )
+
+    row = audit._select_c1_metric(metrics, clock_period_ns=10.0)
+
+    assert row["param_hash"] == "696d01b6"
+    assert row["tag"] == (
+        "decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1_"
+        "macro_conservative_c1_die_3000"
+    )
+    assert float(row["critical_path_ns"]) == 6.7148
+
+
 def _cluster_equivalence(path: Path, *, passed: bool = True) -> None:
     path.write_text(
         json.dumps(


### PR DESCRIPTION
## Summary
- select the exact immutable flow variant accepted by PR 1548
- add a regression against the merged canonical metrics row
- preserve the failed base activity item and retry under a new item ID after merge

## Verification
- 12 activity-audit tests passed
- scripts/validate_runs.py --skip_eval_queue passed