### PR TITLE
npu: add persistent llama7b architecture closure matrix

### DIFF
--- a/npu/docs/generated/llama7b_architecture_closure.md
+++ b/npu/docs/generated/llama7b_architecture_closure.md
@@ -1,0 +1,345 @@
+# Llama7B Architecture Closure Matrix
+
+- source JSON: `npu/docs/llama7b_architecture_closure.json`
+- generated Markdown: `npu/docs/generated/llama7b_architecture_closure.md`
+- as_of: `2026-08-06`
+
+## Headline
+
+- closure counts: `closed=0`, `routed_with_caveat=1`, `measured_component=6`, `rtl_unmeasured=1`, `abstract_external=1`, `open=3`
+- provisional recommendation: `INT8 dense compute` + `score32 + exp-LUT`, `hierarchical c1/c2 service islands`, `dual producer/reducer clocks`
+- provisional because: The accepted c1 multivalue-service route is exploratory only: it is timing-clean but still carries 142 max-cap violations with worst slack -17.81 fF.
+- provisional because: Producer-service-reducer composition is only bounded by partial equivalence and cadence audits, not by a full end-to-end measured composed implementation.
+- provisional because: NoC, SRAM, and scheduler evidence are still mixed between measured primitives and analytic composition, so the final Llama7B recost is not yet a fully embodied chip closure.
+- provisional because: External DRAM controller and PHY remain an intentional abstract boundary, so full-system signoff is outside the current on-chip closure claim.
+
+## Component Status
+
+| Component | Status | Confidence | RTL | Equivalence | Routed PPA | Activity | Composition | Scale |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Precision | measured_component | medium | closed | measured_component | measured_component | measured_component | measured_component | measured_component |
+| Dense Compute | measured_component | medium | closed | closed | measured_component | open | measured_component | measured_component |
+| Norm | open | low | rtl_unmeasured | open | open | open | open | open |
+| Score/Softmax | measured_component | medium | closed | measured_component | measured_component | measured_component | measured_component | measured_component |
+| Multivalue Service | routed_with_caveat | medium | closed | closed | routed_with_caveat | open | measured_component | rtl_unmeasured |
+| Reducer | measured_component | medium | closed | closed | measured_component | open | measured_component | rtl_unmeasured |
+| Producer-Service-Reducer Composition | rtl_unmeasured | low | closed | measured_component | open | open | rtl_unmeasured | open |
+| NoC | open | low | measured_component | open | measured_component | measured_component | open | open |
+| SRAM | measured_component | medium | measured_component | measured_component | open | measured_component | measured_component | measured_component |
+| Scheduler/CDC | open | low | closed | open | measured_component | measured_component | rtl_unmeasured | open |
+| External Memory Boundary | abstract_external | high | abstract_external | abstract_external | abstract_external | abstract_external | abstract_external | abstract_external |
+| Full Llama7B Recost | measured_component | medium | open | open | measured_component | measured_component | measured_component | measured_component |
+
+## Precision
+
+- status: `measured_component`
+- confidence: `medium`
+- summary: The current quality-backed path is INT8 compute with score32 plus exp-LUT softmax. Exact-div and q16 reciprocal variants were measured and rejected on generation quality, so the precision recommendation is bounded but still not exhaustively closed across mixed-format recovery options.
+- next gate: Add any future BF16/FP quantization branch only after it passes the same Llama7B generation-quality gate and can be recosted with measured wrapper metrics.
+
+| Dimension | Status | Summary |
+| --- | --- | --- |
+| `rtl` | `closed` | Score32 exp-LUT, exact-div, reciprocal-LUT, and replacement softmax paths all exist as RTL-backed candidate branches. |
+| `equivalence` | `measured_component` | Behavior is bounded by generation-quality and replacement checks against the software reference, but not by a single full-hierarchy hash-equivalence proof. |
+| `routed_ppa` | `measured_component` | Precision-sensitive wrapper cost is backed by measured composed-wrapper and schedule-wrapper rows rather than pure heuristics. |
+| `activity` | `measured_component` | The promoted score32 schedule-wrapper activity audit provides a measured active-duty correction for the selected precision path. |
+| `composition` | `measured_component` | The score32 exp-LUT service closure and integrated frontier ranking consume the measured wrapper path as the current precision-safe branch. |
+| `scale_validation` | `measured_component` | The Llama7B ranking has been recosted around the selected score32 branch, but future FP formats and recovery flows can still move the frontier. |
+
+Caveats:
+- The precision claim is quality-backed for score32 exp-LUT, not for future FP quantization or QAT-assisted recovery paths.
+- Equivalence evidence is still mixed between RTL/reference functional comparison and composed wrapper recost rather than one full-system tensor-hash proof.
+
+Evidence:
+- `docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1/analysis_report.md` (proposal_analysis; `rtl`, `equivalence`, `composition`): Records the passing score32 exp-LUT generation-quality branch used as the current precision recommendation.
+- `docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1/analysis_report.md` (proposal_analysis; `equivalence`, `scale_validation`): Shows that the q16 reciprocal-LUT branch fails the Llama7B quality gate and cannot be promoted.
+- `docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1/analysis_report.md` (proposal_analysis; `equivalence`, `scale_validation`): Shows that exact-div shares the same quality failure mode as the reciprocal-LUT branch.
+- `docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1/analysis_report.md` (proposal_analysis; `activity`, `routed_ppa`, `composition`): Captures the promoted activity-aware ranking used in the current precision-safe Llama7B frontier.
+
+## Dense Compute
+
+- status: `measured_component`
+- confidence: `medium`
+- summary: Dense GEMM capacity is backed by measured tile PPA and by the measured-compute Llama7B closure, which already invalidated the earlier abstract MAC/cycle frontier. The primitive is measured, but density recovery above the current floor is still open engineering work.
+- next gate: Measure denser exact dense tiles or structurally different compute fabrics before promoting a compute-bound architecture conclusion.
+
+| Dimension | Status | Summary |
+| --- | --- | --- |
+| `rtl` | `closed` | The dense GEMM tile family and clustered schedule consumers are implemented in RTL. |
+| `equivalence` | `closed` | Primitive-level compute behavior is already gated by the existing RTL/perf-sim contract checks used for the measured GEMM path. |
+| `routed_ppa` | `measured_component` | Measured tile rows and stability sweeps exist for the dense compute primitive family. |
+| `activity` | `open` | The dense compute primitive has measured power, but a dedicated activity-backed closure for the final clustered array is not yet the controlling frontier input. |
+| `composition` | `measured_component` | The measured-compute closure already replaces the old abstract MAC/cycle point in the Llama7B recost. |
+| `scale_validation` | `measured_component` | Measured-compute and clustered-schedule closures bound the current density, but denser exact tiles remain unexplored. |
+
+Caveats:
+- The current measured floor is useful to falsify unrealistic throughput points, but it does not yet prove the best achievable dense-tile density.
+- A future denser primitive can still move the compute/memory balance.
+
+Evidence:
+- `docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/analysis_report.md` (proposal_analysis; `rtl`, `routed_ppa`, `scale_validation`): Anchors the measured dense tile endpoint data used by the clustered schedule model.
+- `docs/proposals/prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1/analysis_report.md` (proposal_analysis; `routed_ppa`, `composition`, `scale_validation`): Documents the measured dense GEMM v3 closure used to replace abstract compute density in the Llama7B model.
+- `docs/proposals/prop_l2_decoder_attention_measured_compute_energy_closure_llama7b_v1/analysis_report.md` (proposal_analysis; `equivalence`, `composition`, `scale_validation`): Shows that the abstract 524288 MAC/cycle frontier is physically implausible at the measured exact dense-tile density.
+
+## Norm
+
+- status: `open`
+- confidence: `low`
+- summary: Normalization remains the weakest embodied datapath block. There are proposal tracks for arithmetic calibration and reciprocal datapaths, but the current Llama7B frontier still carries this area/energy contribution as an incompletely measured term.
+- next gate: Promote one norm datapath with RTL equivalence, routed PPA, and direct integration into the Llama7B recost.
+
+| Dimension | Status | Summary |
+| --- | --- | --- |
+| `rtl` | `rtl_unmeasured` | Reciprocal and normalization datapath proposals exist, but they are not yet promoted as the measured norm block used by the frontier. |
+| `equivalence` | `open` | No full promoted norm equivalence record closes the behavior against the final frontier contract. |
+| `routed_ppa` | `open` | The frontier still lacks an accepted routed normalization primitive replacing the remaining cost heuristics. |
+| `activity` | `open` | No promoted activity-backed norm measurement is feeding the Llama7B recost. |
+| `composition` | `open` | The norm path is not yet composed into the selected architecture with the same strength as score, reducer, or service. |
+| `scale_validation` | `open` | There is no scale sweep proving that the chosen normalization structure remains valid across the intended architecture range. |
+
+Caveats:
+- Current norm accounting is not yet on the same measurement footing as dense compute, service, or the selected score32 softmax branch.
+- BF16 and fixed-point norm options are both still unresolved.
+
+Evidence:
+- `docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/quality_gate.md` (proposal_gate; `rtl`): Shows that normalization calibration work exists, but is not yet promoted as a closed measured component.
+- `docs/proposals/prop_l1_decoder_bf16_recip_norm_datapath_v1/quality_gate.md` (proposal_gate; `rtl`): Tracks the BF16 reciprocal norm path that remains future work rather than a merged closure result.
+- `docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/quality_gate.md` (proposal_gate; `rtl`): Shows that a fixed-point reciprocal norm path was explored but not promoted into the final frontier.
+- `docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/quality_gate.md` (proposal_gate; `rtl`): Provides a second unresolved norm proposal branch, reinforcing that this block remains open.
+
+## Score/Softmax
+
+- status: `measured_component`
+- confidence: `medium`
+- summary: The selected score path is the score32 exp-LUT branch. It is quality-backed, has measured composed-wrapper and schedule-wrapper anchors, and has already been recosted into the Llama7B frontier, but it is still not a full-signoff hierarchy closure.
+- next gate: Extend the exact hierarchy proof across the full group rotation before treating the score hierarchy as fully closed.
+
+| Dimension | Status | Summary |
+| --- | --- | --- |
+| `rtl` | `closed` | The promoted score32 exp-LUT dual-stream datapath exists in RTL and is the current selected branch. |
+| `equivalence` | `measured_component` | The branch is bounded by functional replacement and generation-quality checks, not by a single monolithic full-hierarchy tensor-hash equivalence gate. |
+| `routed_ppa` | `measured_component` | Measured composed-wrapper and schedule-wrapper rows replace the old heuristic cost for the selected score path. |
+| `activity` | `measured_component` | Activity-aware recost exists for the selected score32 schedule-wrapper family. |
+| `composition` | `measured_component` | The score32 path has service closure, SRAM-envelope closure, HBM-service closure, and integrated frontier ranking consumers. |
+| `scale_validation` | `measured_component` | The score32 path has been replicated into the Llama7B ranking, but full hierarchy rotation and final system signoff are still pending. |
+
+Caveats:
+- The chosen score path is still bounded by wrapper-level measurements rather than by a single final routed hierarchy.
+- The one-group exact hierarchy proof is not enough to treat the full score hierarchy as completely closed.
+
+Evidence:
+- `docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_v1/analysis_report.md` (proposal_analysis; `rtl`, `routed_ppa`): Captures the promoted L1 score32 exp-LUT composed datapath row.
+- `docs/proposals/prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/analysis_report.md` (proposal_analysis; `routed_ppa`, `composition`, `scale_validation`): Records that the selected L2 row is backed by the measured dual-stream wrapper metrics.
+- `docs/proposals/prop_l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1/analysis_report.md` (proposal_analysis; `equivalence`, `composition`): Defines the promoted service-closure record for the selected score32 branch.
+- `docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1/analysis_report.md` (proposal_analysis; `activity`, `composition`, `scale_validation`): Provides the activity-aware integrated ranking for the selected score32 schedule-wrapper family.
+
+## Multivalue Service
+
+- status: `routed_with_caveat`
+- confidence: `medium`
+- summary: The c1 multivalue-service island now has an accepted routed result and exact integrated-service consumer, so this block has crossed from pure modeling into measured silicon-facing evidence. It remains exploratory routed PPA, not signoff, because the accepted row still carries max-cap violations.
+- next gate: Measure the dedicated c1 activity-power job and then clean the electrical max-cap issue before generalizing the service-island PPA.
+- accepted c1 routed result:
+  - tag: `decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1_macro_conservative_c1_die_3000`
+  - critical path: `6.7148 ns`
+  - die/core: `9.0 mm2` / `8.41 mm2`
+  - instance/stdcell: `2.92145 mm2` / `0.295235 mm2`, `225327 cells`
+  - utilization/vectorless power: `34.73781212841855%` / `0.26 mW`
+  - route health: `DRC/setup/hold/slew clean`, but `142` max-cap violations, worst `-17.81 fF`
+
+| Dimension | Status | Summary |
+| --- | --- | --- |
+| `rtl` | `closed` | The multivalue service island exists as the exact integrated-service RTL path used by the current frontier work. |
+| `equivalence` | `closed` | The c1 route is anchored to the merged exact integrated-service proof consumed by the Llama7B service model. |
+| `routed_ppa` | `routed_with_caveat` | PR1548 accepted the c1 route as exploratory routed PPA: timing and route health are clean except for max-cap violations. |
+| `activity` | `open` | A dedicated post-route activity-power closure for the accepted c1 service row is not yet merged. |
+| `composition` | `measured_component` | The exact integrated-service L2 consumer already uses this service family as a real measured island instead of a free service placeholder. |
+| `scale_validation` | `rtl_unmeasured` | Only the c1 island is accepted at this routed level; wider service-island scaling and electrical cleanup remain open. |
+
+Caveats:
+- Treat the c1 result as exploratory routed PPA only. It is not a signoff-clean macro.
+- The accepted row is timing-feasible and route-clean for DRC/setup/hold/slew, but the remaining max-cap violations can still move buffer count, power, or timing once fixed.
+
+Evidence:
+- `control_plane/shadow_exports/l1_promotions/l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r3.json` (promotion_record; `equivalence`, `routed_ppa`): Promotion record for the accepted c1 routed row from merged PR1548.
+- `runs/designs/npu_blocks/attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr/metrics.csv` (metrics_csv; `routed_ppa`): Contains the accepted c1 metrics row with 6.7148 ns critical path and 0.26 mW vectorless power.
+- `runs/designs/npu_blocks/attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr/physical_signoff.json` (physical_signoff; `routed_ppa`): Canonical routed electrical review record: DRC/setup/hold/slew clean with 142 max-cap violations and worst slack -17.81 fF.
+- `docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/analysis_report.md` (proposal_analysis; `rtl`, `composition`): Documents the exact integrated-service consumer that makes the c1 service island meaningful in the Llama7B model.
+
+## Reducer
+
+- status: `measured_component`
+- confidence: `medium`
+- summary: The reducer has moved well past heuristic cost: there are functional reducer branches, physical harness measurements, and Llama7B recost consumers. It is still a bounded component closure rather than a complete full-hierarchy proof across every cluster/wave combination.
+- next gate: Promote the rotated full-group hierarchy proof before claiming the reducer is closed at the final clustered scale.
+
+| Dimension | Status | Summary |
+| --- | --- | --- |
+| `rtl` | `closed` | Local temporal reducer and folded reducer branches exist in RTL. |
+| `equivalence` | `closed` | Reducer functionality is already represented in the exact local-tree and local-reducer equivalence work. |
+| `routed_ppa` | `measured_component` | Physical harness rows exist for the promoted score32 local temporal reducer family. |
+| `activity` | `open` | There is no separate reducer-only promoted activity-power closure at the same level as the selected wrapper activity run. |
+| `composition` | `measured_component` | The local reducer is already consumed in the score32 hierarchy and Llama7B local-reducer recost work. |
+| `scale_validation` | `rtl_unmeasured` | The reducer is validated on bounded local structures, not yet on the full rotated hierarchy as a standalone scale closure. |
+
+Caveats:
+- The reducer is measured through promoted local and harness evidence, but not yet closed as a full-array standalone hierarchy proof.
+- The final activity share is still mixed into larger composed wrappers.
+
+Evidence:
+- `docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/analysis_report.md` (proposal_analysis; `rtl`, `equivalence`): Documents the promoted score32 local temporal reducer branch and its physical-boundary diagnostics.
+- `control_plane/shadow_exports/l1_promotions/l1_decoder_attention_score32_local_temporal_reducer_gqa8_ppa_v1_r3.json` (promotion_record; `routed_ppa`): Promotion record for the accepted local temporal reducer physical harness row.
+- `docs/proposals/prop_l2_decoder_attention_score32_local_reducer_measured_recost_llama7b_v1/analysis_report.md` (proposal_analysis; `composition`, `scale_validation`): Records the Llama7B consumer that recosts the measured local reducer into the architecture model.
+
+## Producer-Service-Reducer Composition
+
+- status: `rtl_unmeasured`
+- confidence: `low`
+- summary: There is meaningful composition evidence now: exact integrated service, bounded local-tree equivalence, and corrected producer cadence audits. But the full producer-service-reducer path is still only partially composed and has not yet been promoted as one measured end-to-end block.
+- next gate: Close the rotated exact hierarchy and then materialize a representative composed block with measured buffering/control overhead.
+
+| Dimension | Status | Summary |
+| --- | --- | --- |
+| `rtl` | `closed` | Producer, service, and reducer sub-blocks all exist in RTL and have bounded composition wrappers. |
+| `equivalence` | `measured_component` | One-group and bounded-wave equivalence gates exist, but they do not yet close the full rotated hierarchy. |
+| `routed_ppa` | `open` | No accepted single routed macro composes producer, service, and reducer together at the selected clustered scale. |
+| `activity` | `open` | The full producer-service-reducer activity pattern is still inferred from sub-block evidence and cadence audits. |
+| `composition` | `rtl_unmeasured` | Composition exists in bounded RTL proofs, but the exact hierarchy still has an explicit unresolved gap at the local persistent-state and rotated-wave boundary. |
+| `scale_validation` | `open` | The current hierarchy cadence audit explicitly warns against promoting the full architecture from one-group proof alone. |
+
+Caveats:
+- Do not promote the producer-only arithmetic cadence as a final throughput claim.
+- The current exact hierarchy proof is intentionally bounded and does not yet cover the full rotated four-group path.
+
+Evidence:
+- `docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/analysis_report.md` (proposal_analysis; `rtl`, `equivalence`): Anchors the exact integrated service portion of the producer-service-reducer stack.
+- `docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/analysis_report.md` (proposal_analysis; `equivalence`, `composition`): Closes the one-group producer-to-SRAM-to-finalized-tree path, but only for the bounded head-base case.
+- `npu/docs/generated/attention_score32_exact_partial_gqa8_dual_stream_producer_llama_wave_worst4_group_major.md` (generated_audit; `equivalence`, `composition`): Captures the worst-loaded producer cadence and command-distribution proof used by the current hierarchy analysis.
+- `npu/docs/generated/llama7b_score32_exact_hierarchy_cadence_audit_v3.md` (generated_audit; `composition`, `scale_validation`): States explicitly that the corrected producer mapping still leaves an exact hierarchy gap before throughput revision is valid.
+
+## NoC
+
+- status: `open`
+- confidence: `low`
+- summary: The repo has moved beyond a free NoC: there are profile measurements, endpoint-router PPA anchors, and topology/scheduler studies. What is still missing is a stable, physically grounded topology/scheduler pair that the final Llama7B claim can rely on without qualification.
+- next gate: Fix the final topology/scheduler pair under measured endpoint costs and then rerun the clustered frontier with that pair frozen.
+
+| Dimension | Status | Summary |
+| --- | --- | --- |
+| `rtl` | `measured_component` | Endpoint-router primitives and candidate NoC structures are represented in RTL-backed proposal work. |
+| `equivalence` | `open` | No single promoted equivalence gate closes the final selected NoC behavior against the end-to-end attention contract. |
+| `routed_ppa` | `measured_component` | Endpoint router PPA anchors exist for the segmented and wide router families. |
+| `activity` | `measured_component` | Dedicated NoC traffic profiling exists and already informs the attention model. |
+| `composition` | `open` | The final topology/scheduler composition at Llama7B scale is still under study rather than promoted as fixed. |
+| `scale_validation` | `open` | Topology/scheduler pair studies exist, but a final selected pair is not yet closed as the architecture-level standard. |
+
+Caveats:
+- NoC costs are no longer free, but the final architecture still depends on a partially analytic topology/scheduler choice.
+- The current frontier can still move if the selected pair changes under stricter physical constraints.
+
+Evidence:
+- `docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/analysis_report.md` (proposal_analysis; `rtl`, `routed_ppa`): Provides a routed PPA anchor for one endpoint-router NoC primitive family.
+- `docs/proposals/prop_l2_decoder_attention_noc_profile_v1/analysis_report.md` (proposal_analysis; `activity`): Captures the traffic profile already used to remove the old free-NoC assumption.
+- `docs/proposals/prop_l2_decoder_attention_kv_noc_scheduler_selected_v1/analysis_report.md` (proposal_analysis; `composition`, `scale_validation`): Documents a selected scheduler branch, but not yet a final physically closed architecture commitment.
+- `docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1/analysis_report.md` (proposal_analysis; `scale_validation`): Shows that topology/scheduler pairing work exists at Llama7B scale, but the pair space is not yet closed.
+
+## SRAM
+
+- status: `measured_component`
+- confidence: `medium`
+- summary: SRAM is on firmer ground than NoC: there are profile measurements, hierarchy-envelope studies, and bounded cluster-SRAM equivalence work. It is still a measured component, not a final memory-macro signoff across the full architecture.
+- next gate: Freeze SRAM together with the final NoC/scheduler pair and then rerun the frontier under the chosen clustered hierarchy.
+
+| Dimension | Status | Summary |
+| --- | --- | --- |
+| `rtl` | `measured_component` | Cluster-SRAM and local-SRAM structures are represented in the promoted attention hierarchy work. |
+| `equivalence` | `measured_component` | Cluster-SRAM composition is bounded by the local16/global-tree GQA8 equivalence gate. |
+| `routed_ppa` | `open` | The SRAM contribution is still primarily consumed through measured profile/envelope data rather than a final routed memory hierarchy. |
+| `activity` | `measured_component` | Dedicated SRAM profiling already feeds the current architecture model. |
+| `composition` | `measured_component` | The score32 SRAM hierarchy envelope and cluster-SRAM equivalence gates are already consumed by the selected frontier. |
+| `scale_validation` | `measured_component` | The SRAM hierarchy envelope indicates that conservative placement alone does not rerank the score32 frontier. |
+
+Caveats:
+- The SRAM model is materially better than a free-memory assumption, but it is still not a final top-level macro-floorplan closure.
+- The final clustered memory hierarchy can still change with the chosen NoC/scheduler pair.
+
+Evidence:
+- `docs/proposals/prop_l2_decoder_attention_sram_profile_v1/analysis_report.md` (proposal_analysis; `activity`): Provides the promoted local SRAM profile evidence used by the attention model.
+- `docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/analysis_report.md` (proposal_analysis; `rtl`, `equivalence`, `composition`): Anchors the bounded cluster-SRAM exact composition gate for the score32 hierarchy.
+- `docs/proposals/prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/analysis_report.md` (proposal_analysis; `composition`, `scale_validation`): Shows that the SRAM placement envelope does not materially rerank the selected score32 branch.
+
+## Scheduler/CDC
+
+- status: `open`
+- confidence: `low`
+- summary: Control and schedule overhead now has measured wrapper anchors, but the architecture still does not have a fully closed scheduler/CDC story for the final producer and reducer clock domains. This is the main reason the recommendation remains explicitly provisional.
+- next gate: Promote one representative dual-clock composed scheduler path with explicit CDC buffering and consume it in the Llama7B frontier.
+
+| Dimension | Status | Summary |
+| --- | --- | --- |
+| `rtl` | `closed` | Schedule-wrapper and command-control RTL exist for the promoted score32 branch. |
+| `equivalence` | `open` | No promoted gate closes the final dual-clock scheduler and CDC behavior end to end. |
+| `routed_ppa` | `measured_component` | Measured schedule-wrapper rows exist for bounded c2/c4 wrappers. |
+| `activity` | `measured_component` | The schedule-wrapper activity ranking already adjusts the current score32 frontier. |
+| `composition` | `rtl_unmeasured` | The dual producer/reducer clock plan is architecturally selected, but the final CDC/buffer composition is not yet promoted as one measured implementation. |
+| `scale_validation` | `open` | The final scheduler remains sensitive to array hierarchy and memory service assumptions, so the larger-scale validity is still open. |
+
+Caveats:
+- The selected dual producer/reducer clock recommendation is architectural, not yet a complete promoted CDC closure.
+- The scheduler result is still entangled with unresolved NoC and external-memory service assumptions.
+
+Evidence:
+- `docs/proposals/prop_l1_decoder_attention_dual_stream_schedule_wrapper_score32_exp_lut_v1/analysis_report.md` (proposal_analysis; `rtl`, `routed_ppa`): Provides the bounded schedule-wrapper PPA anchor for the selected score32 branch.
+- `docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_measured_command_control_llama7b_v1/analysis_report.md` (proposal_analysis; `routed_ppa`, `composition`): Documents the command-control recost consumed by the Llama7B score32 branch.
+- `docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1/analysis_report.md` (proposal_analysis; `activity`, `scale_validation`): Shows that measured schedule-wrapper activity already changes the integrated frontier numbers.
+- `docs/proposals/prop_l2_decoder_attention_kv_onchip_service_schedule_llama7b_v1/analysis_report.md` (proposal_analysis; `composition`, `scale_validation`): Captures the still-open on-chip service scheduling problem at Llama7B scale.
+
+## External Memory Boundary
+
+- status: `abstract_external`
+- confidence: `high`
+- summary: External DRAM controller and PHY are intentionally left abstract. This is not an untracked gap in on-chip work; it is the explicit project boundary for the current architecture-closure effort.
+- next gate: No immediate on-chip gate. Keep using source-backed boundary sensitivity until the project scope expands to full-chip memory controllers.
+
+| Dimension | Status | Summary |
+| --- | --- | --- |
+| `rtl` | `abstract_external` | Off-chip controller/PHY RTL is intentionally outside the current RTLGen closure scope. |
+| `equivalence` | `abstract_external` | There is no off-chip controller equivalence claim because this boundary is intentionally abstract. |
+| `routed_ppa` | `abstract_external` | No routed controller/PHY macro is required for the current on-chip closure claim. |
+| `activity` | `abstract_external` | External memory energy/service terms are model-based boundary conditions, not embodied on-chip activity closures. |
+| `composition` | `abstract_external` | The frontier consumes an external-service model at this boundary by design. |
+| `scale_validation` | `abstract_external` | Boundary sensitivity is studied analytically rather than by controller/PHY implementation. |
+
+Caveats:
+- This boundary is intentionally abstract; it should not be counted as missing on-chip closure work.
+- Any future full-chip tapeout study would need a separate controller/PHY program.
+
+Evidence:
+- `docs/proposals/prop_l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1/analysis_report.md` (proposal_analysis; `rtl`, `equivalence`, `routed_ppa`, `activity`, `composition`, `scale_validation`): States that the remaining abstractions are cycle-accurate HBM controller RTL and vendor HBM current signoff.
+- `docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_integrated_frontier_ranking_llama7b_v1/analysis_report.md` (proposal_analysis; `composition`, `scale_validation`): Shows that controller replay work exists as a boundary study rather than as a merged signoff controller implementation.
+
+## Full Llama7B Recost
+
+- status: `measured_component`
+- confidence: `medium`
+- summary: The full Llama7B frontier is no longer heuristic-only. It is recosted from measured compute, score/wrapper, service, SRAM, and activity anchors. The result is still a provisional architecture-level conclusion because several subsystem closures remain partial and external memory stays abstract.
+- next gate: After the remaining on-chip component gates close, rerun the integrated ranking one more time and freeze the provisional best architecture as the project conclusion.
+
+| Dimension | Status | Summary |
+| --- | --- | --- |
+| `rtl` | `open` | The full Llama7B architecture is still a recosted composition, not a single full-chip RTL/PnR closure. |
+| `equivalence` | `open` | There is no whole-system tensor-hash equivalence proof for the full recosted architecture. |
+| `routed_ppa` | `measured_component` | The recost consumes multiple measured routed or wrapper-level PPA anchors instead of using a free abstract core. |
+| `activity` | `measured_component` | The score32 schedule-wrapper activity run is already folded into the integrated frontier. |
+| `composition` | `measured_component` | Integrated ranking combines measured compute, selected score32 service closure, SRAM envelope, and HBM service models. |
+| `scale_validation` | `measured_component` | The frontier has been reranked repeatedly under measured-component substitutions, but some key subsystem closures remain provisional. |
+
+Caveats:
+- This is an architecture-level recost, not a full-chip physical implementation.
+- The result remains provisional until producer-service-reducer composition, scheduler/CDC, and the c1 service electrical caveat are tightened further.
+
+Evidence:
+- `docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/analysis_report.md` (proposal_analysis; `composition`, `scale_validation`): Records the conservative quality-backed HBM service frontier used as one baseline for the Llama7B recost.
+- `docs/proposals/prop_l2_decoder_attention_measured_compute_energy_closure_llama7b_v1/analysis_report.md` (proposal_analysis; `routed_ppa`, `composition`, `scale_validation`): Replaces the abstract compute density with measured dense-tile data in the Llama7B architecture ranking.
+- `docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1/analysis_report.md` (proposal_analysis; `activity`, `composition`, `scale_validation`): Provides the current activity-aware integrated ranking for the selected score32 branch.
+- `docs/proposals/prop_l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1/analysis_report.md` (proposal_analysis; `routed_ppa`, `composition`, `scale_validation`): Summarizes the integrated score32 ranking that now replaces the older heuristic-heavy frontier.

--- a/npu/docs/llama7b_architecture_closure.json
+++ b/npu/docs/llama7b_architecture_closure.json
@@ -1,0 +1,945 @@
+{
+  "schema_version": 1,
+  "title": "Llama7B Architecture Closure Matrix",
+  "model": "llama7b",
+  "scope": "Decoder-attention architecture exploration with persistent closure tracking",
+  "as_of": "2026-08-06",
+  "source_commit_floor": "6a5696448276c6c079dcfe13910c0a170f5f7663",
+  "generated_markdown": "npu/docs/generated/llama7b_architecture_closure.md",
+  "component_order": [
+    "precision",
+    "dense_compute",
+    "norm",
+    "score_softmax",
+    "multivalue_service",
+    "reducer",
+    "producer_service_reducer_composition",
+    "noc",
+    "sram",
+    "scheduler_cdc",
+    "external_memory_boundary",
+    "full_llama7b_recost"
+  ],
+  "dimension_order": [
+    "rtl",
+    "equivalence",
+    "routed_ppa",
+    "activity",
+    "composition",
+    "scale_validation"
+  ],
+  "status_vocabulary": [
+    "abstract_external",
+    "closed",
+    "measured_component",
+    "open",
+    "routed_with_caveat",
+    "rtl_unmeasured"
+  ],
+  "confidence_vocabulary": [
+    "high",
+    "low",
+    "medium"
+  ],
+  "recommended_architecture": {
+    "status": "provisional",
+    "compute": "INT8 dense compute",
+    "score_path": "score32 + exp-LUT",
+    "service_topology": "hierarchical c1/c2 service islands",
+    "clocking": "dual producer/reducer clocks",
+    "why_provisional": [
+      "The accepted c1 multivalue-service route is exploratory only: it is timing-clean but still carries 142 max-cap violations with worst slack -17.81 fF.",
+      "Producer-service-reducer composition is only bounded by partial equivalence and cadence audits, not by a full end-to-end measured composed implementation.",
+      "NoC, SRAM, and scheduler evidence are still mixed between measured primitives and analytic composition, so the final Llama7B recost is not yet a fully embodied chip closure.",
+      "External DRAM controller and PHY remain an intentional abstract boundary, so full-system signoff is outside the current on-chip closure claim."
+    ]
+  },
+  "components": [
+    {
+      "id": "precision",
+      "label": "Precision",
+      "status": "measured_component",
+      "confidence": "medium",
+      "summary": "The current quality-backed path is INT8 compute with score32 plus exp-LUT softmax. Exact-div and q16 reciprocal variants were measured and rejected on generation quality, so the precision recommendation is bounded but still not exhaustively closed across mixed-format recovery options.",
+      "dimensions": {
+        "rtl": {
+          "status": "closed",
+          "summary": "Score32 exp-LUT, exact-div, reciprocal-LUT, and replacement softmax paths all exist as RTL-backed candidate branches."
+        },
+        "equivalence": {
+          "status": "measured_component",
+          "summary": "Behavior is bounded by generation-quality and replacement checks against the software reference, but not by a single full-hierarchy hash-equivalence proof."
+        },
+        "routed_ppa": {
+          "status": "measured_component",
+          "summary": "Precision-sensitive wrapper cost is backed by measured composed-wrapper and schedule-wrapper rows rather than pure heuristics."
+        },
+        "activity": {
+          "status": "measured_component",
+          "summary": "The promoted score32 schedule-wrapper activity audit provides a measured active-duty correction for the selected precision path."
+        },
+        "composition": {
+          "status": "measured_component",
+          "summary": "The score32 exp-LUT service closure and integrated frontier ranking consume the measured wrapper path as the current precision-safe branch."
+        },
+        "scale_validation": {
+          "status": "measured_component",
+          "summary": "The Llama7B ranking has been recosted around the selected score32 branch, but future FP formats and recovery flows can still move the frontier."
+        }
+      },
+      "evidence": [
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "rtl",
+            "equivalence",
+            "composition"
+          ],
+          "note": "Records the passing score32 exp-LUT generation-quality branch used as the current precision recommendation."
+        },
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "equivalence",
+            "scale_validation"
+          ],
+          "note": "Shows that the q16 reciprocal-LUT branch fails the Llama7B quality gate and cannot be promoted."
+        },
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "equivalence",
+            "scale_validation"
+          ],
+          "note": "Shows that exact-div shares the same quality failure mode as the reciprocal-LUT branch."
+        },
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "activity",
+            "routed_ppa",
+            "composition"
+          ],
+          "note": "Captures the promoted activity-aware ranking used in the current precision-safe Llama7B frontier."
+        }
+      ],
+      "caveats": [
+        "The precision claim is quality-backed for score32 exp-LUT, not for future FP quantization or QAT-assisted recovery paths.",
+        "Equivalence evidence is still mixed between RTL/reference functional comparison and composed wrapper recost rather than one full-system tensor-hash proof."
+      ],
+      "next_gate": "Add any future BF16/FP quantization branch only after it passes the same Llama7B generation-quality gate and can be recosted with measured wrapper metrics."
+    },
+    {
+      "id": "dense_compute",
+      "label": "Dense Compute",
+      "status": "measured_component",
+      "confidence": "medium",
+      "summary": "Dense GEMM capacity is backed by measured tile PPA and by the measured-compute Llama7B closure, which already invalidated the earlier abstract MAC/cycle frontier. The primitive is measured, but density recovery above the current floor is still open engineering work.",
+      "dimensions": {
+        "rtl": {
+          "status": "closed",
+          "summary": "The dense GEMM tile family and clustered schedule consumers are implemented in RTL."
+        },
+        "equivalence": {
+          "status": "closed",
+          "summary": "Primitive-level compute behavior is already gated by the existing RTL/perf-sim contract checks used for the measured GEMM path."
+        },
+        "routed_ppa": {
+          "status": "measured_component",
+          "summary": "Measured tile rows and stability sweeps exist for the dense compute primitive family."
+        },
+        "activity": {
+          "status": "open",
+          "summary": "The dense compute primitive has measured power, but a dedicated activity-backed closure for the final clustered array is not yet the controlling frontier input."
+        },
+        "composition": {
+          "status": "measured_component",
+          "summary": "The measured-compute closure already replaces the old abstract MAC/cycle point in the Llama7B recost."
+        },
+        "scale_validation": {
+          "status": "measured_component",
+          "summary": "Measured-compute and clustered-schedule closures bound the current density, but denser exact tiles remain unexplored."
+        }
+      },
+      "evidence": [
+        {
+          "path": "docs/proposals/npu/prop_l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "rtl",
+            "routed_ppa",
+            "scale_validation"
+          ],
+          "note": "Anchors the measured dense tile endpoint data used by the clustered schedule model."
+        },
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "routed_ppa",
+            "composition",
+            "scale_validation"
+          ],
+          "note": "Documents the measured dense GEMM v3 closure used to replace abstract compute density in the Llama7B model."
+        },
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_measured_compute_energy_closure_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "equivalence",
+            "composition",
+            "scale_validation"
+          ],
+          "note": "Shows that the abstract 524288 MAC/cycle frontier is physically implausible at the measured exact dense-tile density."
+        }
+      ],
+      "caveats": [
+        "The current measured floor is useful to falsify unrealistic throughput points, but it does not yet prove the best achievable dense-tile density.",
+        "A future denser primitive can still move the compute/memory balance."
+      ],
+      "next_gate": "Measure denser exact dense tiles or structurally different compute fabrics before promoting a compute-bound architecture conclusion."
+    },
+    {
+      "id": "norm",
+      "label": "Norm",
+      "status": "open",
+      "confidence": "low",
+      "summary": "Normalization remains the weakest embodied datapath block. There are proposal tracks for arithmetic calibration and reciprocal datapaths, but the current Llama7B frontier still carries this area/energy contribution as an incompletely measured term.",
+      "dimensions": {
+        "rtl": {
+          "status": "rtl_unmeasured",
+          "summary": "Reciprocal and normalization datapath proposals exist, but they are not yet promoted as the measured norm block used by the frontier."
+        },
+        "equivalence": {
+          "status": "open",
+          "summary": "No full promoted norm equivalence record closes the behavior against the final frontier contract."
+        },
+        "routed_ppa": {
+          "status": "open",
+          "summary": "The frontier still lacks an accepted routed normalization primitive replacing the remaining cost heuristics."
+        },
+        "activity": {
+          "status": "open",
+          "summary": "No promoted activity-backed norm measurement is feeding the Llama7B recost."
+        },
+        "composition": {
+          "status": "open",
+          "summary": "The norm path is not yet composed into the selected architecture with the same strength as score, reducer, or service."
+        },
+        "scale_validation": {
+          "status": "open",
+          "summary": "There is no scale sweep proving that the chosen normalization structure remains valid across the intended architecture range."
+        }
+      },
+      "evidence": [
+        {
+          "path": "docs/proposals/prop_l1_decoder_normalization_arithmetic_calibration_v1/quality_gate.md",
+          "kind": "proposal_gate",
+          "dimensions": [
+            "rtl"
+          ],
+          "note": "Shows that normalization calibration work exists, but is not yet promoted as a closed measured component."
+        },
+        {
+          "path": "docs/proposals/prop_l1_decoder_bf16_recip_norm_datapath_v1/quality_gate.md",
+          "kind": "proposal_gate",
+          "dimensions": [
+            "rtl"
+          ],
+          "note": "Tracks the BF16 reciprocal norm path that remains future work rather than a merged closure result."
+        },
+        {
+          "path": "docs/proposals/prop_l1_decoder_q12_pwl_recip_norm_datapath_v1/quality_gate.md",
+          "kind": "proposal_gate",
+          "dimensions": [
+            "rtl"
+          ],
+          "note": "Shows that a fixed-point reciprocal norm path was explored but not promoted into the final frontier."
+        },
+        {
+          "path": "docs/proposals/prop_l1_decoder_q8_recip_norm_datapath_v1/quality_gate.md",
+          "kind": "proposal_gate",
+          "dimensions": [
+            "rtl"
+          ],
+          "note": "Provides a second unresolved norm proposal branch, reinforcing that this block remains open."
+        }
+      ],
+      "caveats": [
+        "Current norm accounting is not yet on the same measurement footing as dense compute, service, or the selected score32 softmax branch.",
+        "BF16 and fixed-point norm options are both still unresolved."
+      ],
+      "next_gate": "Promote one norm datapath with RTL equivalence, routed PPA, and direct integration into the Llama7B recost."
+    },
+    {
+      "id": "score_softmax",
+      "label": "Score/Softmax",
+      "status": "measured_component",
+      "confidence": "medium",
+      "summary": "The selected score path is the score32 exp-LUT branch. It is quality-backed, has measured composed-wrapper and schedule-wrapper anchors, and has already been recosted into the Llama7B frontier, but it is still not a full-signoff hierarchy closure.",
+      "dimensions": {
+        "rtl": {
+          "status": "closed",
+          "summary": "The promoted score32 exp-LUT dual-stream datapath exists in RTL and is the current selected branch."
+        },
+        "equivalence": {
+          "status": "measured_component",
+          "summary": "The branch is bounded by functional replacement and generation-quality checks, not by a single monolithic full-hierarchy tensor-hash equivalence gate."
+        },
+        "routed_ppa": {
+          "status": "measured_component",
+          "summary": "Measured composed-wrapper and schedule-wrapper rows replace the old heuristic cost for the selected score path."
+        },
+        "activity": {
+          "status": "measured_component",
+          "summary": "Activity-aware recost exists for the selected score32 schedule-wrapper family."
+        },
+        "composition": {
+          "status": "measured_component",
+          "summary": "The score32 path has service closure, SRAM-envelope closure, HBM-service closure, and integrated frontier ranking consumers."
+        },
+        "scale_validation": {
+          "status": "measured_component",
+          "summary": "The score32 path has been replicated into the Llama7B ranking, but full hierarchy rotation and final system signoff are still pending."
+        }
+      },
+      "evidence": [
+        {
+          "path": "docs/proposals/prop_l1_decoder_attention_dual_stream_composed_score32_exp_lut_div_b20_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "rtl",
+            "routed_ppa"
+          ],
+          "note": "Captures the promoted L1 score32 exp-LUT composed datapath row."
+        },
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "routed_ppa",
+            "composition",
+            "scale_validation"
+          ],
+          "note": "Records that the selected L2 row is backed by the measured dual-stream wrapper metrics."
+        },
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "equivalence",
+            "composition"
+          ],
+          "note": "Defines the promoted service-closure record for the selected score32 branch."
+        },
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "activity",
+            "composition",
+            "scale_validation"
+          ],
+          "note": "Provides the activity-aware integrated ranking for the selected score32 schedule-wrapper family."
+        }
+      ],
+      "caveats": [
+        "The chosen score path is still bounded by wrapper-level measurements rather than by a single final routed hierarchy.",
+        "The one-group exact hierarchy proof is not enough to treat the full score hierarchy as completely closed."
+      ],
+      "next_gate": "Extend the exact hierarchy proof across the full group rotation before treating the score hierarchy as fully closed."
+    },
+    {
+      "id": "multivalue_service",
+      "label": "Multivalue Service",
+      "status": "routed_with_caveat",
+      "confidence": "medium",
+      "summary": "The c1 multivalue-service island now has an accepted routed result and exact integrated-service consumer, so this block has crossed from pure modeling into measured silicon-facing evidence. It remains exploratory routed PPA, not signoff, because the accepted row still carries max-cap violations.",
+      "dimensions": {
+        "rtl": {
+          "status": "closed",
+          "summary": "The multivalue service island exists as the exact integrated-service RTL path used by the current frontier work."
+        },
+        "equivalence": {
+          "status": "closed",
+          "summary": "The c1 route is anchored to the merged exact integrated-service proof consumed by the Llama7B service model."
+        },
+        "routed_ppa": {
+          "status": "routed_with_caveat",
+          "summary": "PR1548 accepted the c1 route as exploratory routed PPA: timing and route health are clean except for max-cap violations."
+        },
+        "activity": {
+          "status": "open",
+          "summary": "A dedicated post-route activity-power closure for the accepted c1 service row is not yet merged."
+        },
+        "composition": {
+          "status": "measured_component",
+          "summary": "The exact integrated-service L2 consumer already uses this service family as a real measured island instead of a free service placeholder."
+        },
+        "scale_validation": {
+          "status": "rtl_unmeasured",
+          "summary": "Only the c1 island is accepted at this routed level; wider service-island scaling and electrical cleanup remain open."
+        }
+      },
+      "accepted_routed_result": {
+        "tag": "decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_3000_v1_macro_conservative_c1_die_3000",
+        "critical_path_ns": 6.7148,
+        "die_area_mm2": 9.0,
+        "core_area_mm2": 8.41,
+        "instance_area_mm2": 2.92145,
+        "stdcell_area_mm2": 0.295235,
+        "stdcell_count": 225327,
+        "utilization_pct": 34.73781212841855,
+        "vectorless_power_mw": 0.26,
+        "route_health": "DRC/setup/hold/slew clean",
+        "max_cap_violations": 142,
+        "worst_max_cap_ff": -17.81
+      },
+      "evidence": [
+        {
+          "path": "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r3.json",
+          "kind": "promotion_record",
+          "dimensions": [
+            "equivalence",
+            "routed_ppa"
+          ],
+          "note": "Promotion record for the accepted c1 routed row from merged PR1548."
+        },
+        {
+          "path": "runs/designs/npu_blocks/attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr/metrics.csv",
+          "kind": "metrics_csv",
+          "dimensions": [
+            "routed_ppa"
+          ],
+          "note": "Contains the accepted c1 metrics row with 6.7148 ns critical path and 0.26 mW vectorless power."
+        },
+        {
+          "path": "runs/designs/npu_blocks/attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr/physical_signoff.json",
+          "kind": "physical_signoff",
+          "dimensions": [
+            "routed_ppa"
+          ],
+          "note": "Canonical routed electrical review record: DRC/setup/hold/slew clean with 142 max-cap violations and worst slack -17.81 fF."
+        },
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "rtl",
+            "composition"
+          ],
+          "note": "Documents the exact integrated-service consumer that makes the c1 service island meaningful in the Llama7B model."
+        }
+      ],
+      "caveats": [
+        "Treat the c1 result as exploratory routed PPA only. It is not a signoff-clean macro.",
+        "The accepted row is timing-feasible and route-clean for DRC/setup/hold/slew, but the remaining max-cap violations can still move buffer count, power, or timing once fixed."
+      ],
+      "next_gate": "Measure the dedicated c1 activity-power job and then clean the electrical max-cap issue before generalizing the service-island PPA."
+    },
+    {
+      "id": "reducer",
+      "label": "Reducer",
+      "status": "measured_component",
+      "confidence": "medium",
+      "summary": "The reducer has moved well past heuristic cost: there are functional reducer branches, physical harness measurements, and Llama7B recost consumers. It is still a bounded component closure rather than a complete full-hierarchy proof across every cluster/wave combination.",
+      "dimensions": {
+        "rtl": {
+          "status": "closed",
+          "summary": "Local temporal reducer and folded reducer branches exist in RTL."
+        },
+        "equivalence": {
+          "status": "closed",
+          "summary": "Reducer functionality is already represented in the exact local-tree and local-reducer equivalence work."
+        },
+        "routed_ppa": {
+          "status": "measured_component",
+          "summary": "Physical harness rows exist for the promoted score32 local temporal reducer family."
+        },
+        "activity": {
+          "status": "open",
+          "summary": "There is no separate reducer-only promoted activity-power closure at the same level as the selected wrapper activity run."
+        },
+        "composition": {
+          "status": "measured_component",
+          "summary": "The local reducer is already consumed in the score32 hierarchy and Llama7B local-reducer recost work."
+        },
+        "scale_validation": {
+          "status": "rtl_unmeasured",
+          "summary": "The reducer is validated on bounded local structures, not yet on the full rotated hierarchy as a standalone scale closure."
+        }
+      },
+      "evidence": [
+        {
+          "path": "docs/proposals/prop_l1_decoder_attention_score32_local_temporal_reducer_gqa8_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "rtl",
+            "equivalence"
+          ],
+          "note": "Documents the promoted score32 local temporal reducer branch and its physical-boundary diagnostics."
+        },
+        {
+          "path": "control_plane/shadow_exports/l1_promotions/l1_decoder_attention_score32_local_temporal_reducer_gqa8_ppa_v1_r3.json",
+          "kind": "promotion_record",
+          "dimensions": [
+            "routed_ppa"
+          ],
+          "note": "Promotion record for the accepted local temporal reducer physical harness row."
+        },
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_score32_local_reducer_measured_recost_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "composition",
+            "scale_validation"
+          ],
+          "note": "Records the Llama7B consumer that recosts the measured local reducer into the architecture model."
+        }
+      ],
+      "caveats": [
+        "The reducer is measured through promoted local and harness evidence, but not yet closed as a full-array standalone hierarchy proof.",
+        "The final activity share is still mixed into larger composed wrappers."
+      ],
+      "next_gate": "Promote the rotated full-group hierarchy proof before claiming the reducer is closed at the final clustered scale."
+    },
+    {
+      "id": "producer_service_reducer_composition",
+      "label": "Producer-Service-Reducer Composition",
+      "status": "rtl_unmeasured",
+      "confidence": "low",
+      "summary": "There is meaningful composition evidence now: exact integrated service, bounded local-tree equivalence, and corrected producer cadence audits. But the full producer-service-reducer path is still only partially composed and has not yet been promoted as one measured end-to-end block.",
+      "dimensions": {
+        "rtl": {
+          "status": "closed",
+          "summary": "Producer, service, and reducer sub-blocks all exist in RTL and have bounded composition wrappers."
+        },
+        "equivalence": {
+          "status": "measured_component",
+          "summary": "One-group and bounded-wave equivalence gates exist, but they do not yet close the full rotated hierarchy."
+        },
+        "routed_ppa": {
+          "status": "open",
+          "summary": "No accepted single routed macro composes producer, service, and reducer together at the selected clustered scale."
+        },
+        "activity": {
+          "status": "open",
+          "summary": "The full producer-service-reducer activity pattern is still inferred from sub-block evidence and cadence audits."
+        },
+        "composition": {
+          "status": "rtl_unmeasured",
+          "summary": "Composition exists in bounded RTL proofs, but the exact hierarchy still has an explicit unresolved gap at the local persistent-state and rotated-wave boundary."
+        },
+        "scale_validation": {
+          "status": "open",
+          "summary": "The current hierarchy cadence audit explicitly warns against promoting the full architecture from one-group proof alone."
+        }
+      },
+      "evidence": [
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "rtl",
+            "equivalence"
+          ],
+          "note": "Anchors the exact integrated service portion of the producer-service-reducer stack."
+        },
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "equivalence",
+            "composition"
+          ],
+          "note": "Closes the one-group producer-to-SRAM-to-finalized-tree path, but only for the bounded head-base case."
+        },
+        {
+          "path": "npu/docs/generated/attention_score32_exact_partial_gqa8_dual_stream_producer_llama_wave_worst4_group_major.md",
+          "kind": "generated_audit",
+          "dimensions": [
+            "equivalence",
+            "composition"
+          ],
+          "note": "Captures the worst-loaded producer cadence and command-distribution proof used by the current hierarchy analysis."
+        },
+        {
+          "path": "npu/docs/generated/llama7b_score32_exact_hierarchy_cadence_audit_v3.md",
+          "kind": "generated_audit",
+          "dimensions": [
+            "composition",
+            "scale_validation"
+          ],
+          "note": "States explicitly that the corrected producer mapping still leaves an exact hierarchy gap before throughput revision is valid."
+        }
+      ],
+      "caveats": [
+        "Do not promote the producer-only arithmetic cadence as a final throughput claim.",
+        "The current exact hierarchy proof is intentionally bounded and does not yet cover the full rotated four-group path."
+      ],
+      "next_gate": "Close the rotated exact hierarchy and then materialize a representative composed block with measured buffering/control overhead."
+    },
+    {
+      "id": "noc",
+      "label": "NoC",
+      "status": "open",
+      "confidence": "low",
+      "summary": "The repo has moved beyond a free NoC: there are profile measurements, endpoint-router PPA anchors, and topology/scheduler studies. What is still missing is a stable, physically grounded topology/scheduler pair that the final Llama7B claim can rely on without qualification.",
+      "dimensions": {
+        "rtl": {
+          "status": "measured_component",
+          "summary": "Endpoint-router primitives and candidate NoC structures are represented in RTL-backed proposal work."
+        },
+        "equivalence": {
+          "status": "open",
+          "summary": "No single promoted equivalence gate closes the final selected NoC behavior against the end-to-end attention contract."
+        },
+        "routed_ppa": {
+          "status": "measured_component",
+          "summary": "Endpoint router PPA anchors exist for the segmented and wide router families."
+        },
+        "activity": {
+          "status": "measured_component",
+          "summary": "Dedicated NoC traffic profiling exists and already informs the attention model."
+        },
+        "composition": {
+          "status": "open",
+          "summary": "The final topology/scheduler composition at Llama7B scale is still under study rather than promoted as fixed."
+        },
+        "scale_validation": {
+          "status": "open",
+          "summary": "Topology/scheduler pair studies exist, but a final selected pair is not yet closed as the architecture-level standard."
+        }
+      },
+      "evidence": [
+        {
+          "path": "docs/proposals/prop_l1_decoder_attention_endpoint_router_segmented_noc_ppa_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "rtl",
+            "routed_ppa"
+          ],
+          "note": "Provides a routed PPA anchor for one endpoint-router NoC primitive family."
+        },
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_noc_profile_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "activity"
+          ],
+          "note": "Captures the traffic profile already used to remove the old free-NoC assumption."
+        },
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_kv_noc_scheduler_selected_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "composition",
+            "scale_validation"
+          ],
+          "note": "Documents a selected scheduler branch, but not yet a final physically closed architecture commitment."
+        },
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "scale_validation"
+          ],
+          "note": "Shows that topology/scheduler pairing work exists at Llama7B scale, but the pair space is not yet closed."
+        }
+      ],
+      "caveats": [
+        "NoC costs are no longer free, but the final architecture still depends on a partially analytic topology/scheduler choice.",
+        "The current frontier can still move if the selected pair changes under stricter physical constraints."
+      ],
+      "next_gate": "Fix the final topology/scheduler pair under measured endpoint costs and then rerun the clustered frontier with that pair frozen."
+    },
+    {
+      "id": "sram",
+      "label": "SRAM",
+      "status": "measured_component",
+      "confidence": "medium",
+      "summary": "SRAM is on firmer ground than NoC: there are profile measurements, hierarchy-envelope studies, and bounded cluster-SRAM equivalence work. It is still a measured component, not a final memory-macro signoff across the full architecture.",
+      "dimensions": {
+        "rtl": {
+          "status": "measured_component",
+          "summary": "Cluster-SRAM and local-SRAM structures are represented in the promoted attention hierarchy work."
+        },
+        "equivalence": {
+          "status": "measured_component",
+          "summary": "Cluster-SRAM composition is bounded by the local16/global-tree GQA8 equivalence gate."
+        },
+        "routed_ppa": {
+          "status": "open",
+          "summary": "The SRAM contribution is still primarily consumed through measured profile/envelope data rather than a final routed memory hierarchy."
+        },
+        "activity": {
+          "status": "measured_component",
+          "summary": "Dedicated SRAM profiling already feeds the current architecture model."
+        },
+        "composition": {
+          "status": "measured_component",
+          "summary": "The score32 SRAM hierarchy envelope and cluster-SRAM equivalence gates are already consumed by the selected frontier."
+        },
+        "scale_validation": {
+          "status": "measured_component",
+          "summary": "The SRAM hierarchy envelope indicates that conservative placement alone does not rerank the score32 frontier."
+        }
+      },
+      "evidence": [
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_sram_profile_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "activity"
+          ],
+          "note": "Provides the promoted local SRAM profile evidence used by the attention model."
+        },
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "rtl",
+            "equivalence",
+            "composition"
+          ],
+          "note": "Anchors the bounded cluster-SRAM exact composition gate for the score32 hierarchy."
+        },
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "composition",
+            "scale_validation"
+          ],
+          "note": "Shows that the SRAM placement envelope does not materially rerank the selected score32 branch."
+        }
+      ],
+      "caveats": [
+        "The SRAM model is materially better than a free-memory assumption, but it is still not a final top-level macro-floorplan closure.",
+        "The final clustered memory hierarchy can still change with the chosen NoC/scheduler pair."
+      ],
+      "next_gate": "Freeze SRAM together with the final NoC/scheduler pair and then rerun the frontier under the chosen clustered hierarchy."
+    },
+    {
+      "id": "scheduler_cdc",
+      "label": "Scheduler/CDC",
+      "status": "open",
+      "confidence": "low",
+      "summary": "Control and schedule overhead now has measured wrapper anchors, but the architecture still does not have a fully closed scheduler/CDC story for the final producer and reducer clock domains. This is the main reason the recommendation remains explicitly provisional.",
+      "dimensions": {
+        "rtl": {
+          "status": "closed",
+          "summary": "Schedule-wrapper and command-control RTL exist for the promoted score32 branch."
+        },
+        "equivalence": {
+          "status": "open",
+          "summary": "No promoted gate closes the final dual-clock scheduler and CDC behavior end to end."
+        },
+        "routed_ppa": {
+          "status": "measured_component",
+          "summary": "Measured schedule-wrapper rows exist for bounded c2/c4 wrappers."
+        },
+        "activity": {
+          "status": "measured_component",
+          "summary": "The schedule-wrapper activity ranking already adjusts the current score32 frontier."
+        },
+        "composition": {
+          "status": "rtl_unmeasured",
+          "summary": "The dual producer/reducer clock plan is architecturally selected, but the final CDC/buffer composition is not yet promoted as one measured implementation."
+        },
+        "scale_validation": {
+          "status": "open",
+          "summary": "The final scheduler remains sensitive to array hierarchy and memory service assumptions, so the larger-scale validity is still open."
+        }
+      },
+      "evidence": [
+        {
+          "path": "docs/proposals/prop_l1_decoder_attention_dual_stream_schedule_wrapper_score32_exp_lut_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "rtl",
+            "routed_ppa"
+          ],
+          "note": "Provides the bounded schedule-wrapper PPA anchor for the selected score32 branch."
+        },
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_composed_datapath_score32_exp_lut_div_measured_command_control_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "routed_ppa",
+            "composition"
+          ],
+          "note": "Documents the command-control recost consumed by the Llama7B score32 branch."
+        },
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "activity",
+            "scale_validation"
+          ],
+          "note": "Shows that measured schedule-wrapper activity already changes the integrated frontier numbers."
+        },
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_kv_onchip_service_schedule_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "composition",
+            "scale_validation"
+          ],
+          "note": "Captures the still-open on-chip service scheduling problem at Llama7B scale."
+        }
+      ],
+      "caveats": [
+        "The selected dual producer/reducer clock recommendation is architectural, not yet a complete promoted CDC closure.",
+        "The scheduler result is still entangled with unresolved NoC and external-memory service assumptions."
+      ],
+      "next_gate": "Promote one representative dual-clock composed scheduler path with explicit CDC buffering and consume it in the Llama7B frontier."
+    },
+    {
+      "id": "external_memory_boundary",
+      "label": "External Memory Boundary",
+      "status": "abstract_external",
+      "confidence": "high",
+      "summary": "External DRAM controller and PHY are intentionally left abstract. This is not an untracked gap in on-chip work; it is the explicit project boundary for the current architecture-closure effort.",
+      "dimensions": {
+        "rtl": {
+          "status": "abstract_external",
+          "summary": "Off-chip controller/PHY RTL is intentionally outside the current RTLGen closure scope."
+        },
+        "equivalence": {
+          "status": "abstract_external",
+          "summary": "There is no off-chip controller equivalence claim because this boundary is intentionally abstract."
+        },
+        "routed_ppa": {
+          "status": "abstract_external",
+          "summary": "No routed controller/PHY macro is required for the current on-chip closure claim."
+        },
+        "activity": {
+          "status": "abstract_external",
+          "summary": "External memory energy/service terms are model-based boundary conditions, not embodied on-chip activity closures."
+        },
+        "composition": {
+          "status": "abstract_external",
+          "summary": "The frontier consumes an external-service model at this boundary by design."
+        },
+        "scale_validation": {
+          "status": "abstract_external",
+          "summary": "Boundary sensitivity is studied analytically rather than by controller/PHY implementation."
+        }
+      },
+      "evidence": [
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "rtl",
+            "equivalence",
+            "routed_ppa",
+            "activity",
+            "composition",
+            "scale_validation"
+          ],
+          "note": "States that the remaining abstractions are cycle-accurate HBM controller RTL and vendor HBM current signoff."
+        },
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_score32_hbm_controller_replay_rtl_ppa_integrated_frontier_ranking_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "composition",
+            "scale_validation"
+          ],
+          "note": "Shows that controller replay work exists as a boundary study rather than as a merged signoff controller implementation."
+        }
+      ],
+      "caveats": [
+        "This boundary is intentionally abstract; it should not be counted as missing on-chip closure work.",
+        "Any future full-chip tapeout study would need a separate controller/PHY program."
+      ],
+      "next_gate": "No immediate on-chip gate. Keep using source-backed boundary sensitivity until the project scope expands to full-chip memory controllers."
+    },
+    {
+      "id": "full_llama7b_recost",
+      "label": "Full Llama7B Recost",
+      "status": "measured_component",
+      "confidence": "medium",
+      "summary": "The full Llama7B frontier is no longer heuristic-only. It is recosted from measured compute, score/wrapper, service, SRAM, and activity anchors. The result is still a provisional architecture-level conclusion because several subsystem closures remain partial and external memory stays abstract.",
+      "dimensions": {
+        "rtl": {
+          "status": "open",
+          "summary": "The full Llama7B architecture is still a recosted composition, not a single full-chip RTL/PnR closure."
+        },
+        "equivalence": {
+          "status": "open",
+          "summary": "There is no whole-system tensor-hash equivalence proof for the full recosted architecture."
+        },
+        "routed_ppa": {
+          "status": "measured_component",
+          "summary": "The recost consumes multiple measured routed or wrapper-level PPA anchors instead of using a free abstract core."
+        },
+        "activity": {
+          "status": "measured_component",
+          "summary": "The score32 schedule-wrapper activity run is already folded into the integrated frontier."
+        },
+        "composition": {
+          "status": "measured_component",
+          "summary": "Integrated ranking combines measured compute, selected score32 service closure, SRAM envelope, and HBM service models."
+        },
+        "scale_validation": {
+          "status": "measured_component",
+          "summary": "The frontier has been reranked repeatedly under measured-component substitutions, but some key subsystem closures remain provisional."
+        }
+      },
+      "evidence": [
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_kv_physical_hbm_quality_backed_7b_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "composition",
+            "scale_validation"
+          ],
+          "note": "Records the conservative quality-backed HBM service frontier used as one baseline for the Llama7B recost."
+        },
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_measured_compute_energy_closure_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "routed_ppa",
+            "composition",
+            "scale_validation"
+          ],
+          "note": "Replaces the abstract compute density with measured dense-tile data in the Llama7B architecture ranking."
+        },
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "activity",
+            "composition",
+            "scale_validation"
+          ],
+          "note": "Provides the current activity-aware integrated ranking for the selected score32 branch."
+        },
+        {
+          "path": "docs/proposals/prop_l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1/analysis_report.md",
+          "kind": "proposal_analysis",
+          "dimensions": [
+            "routed_ppa",
+            "composition",
+            "scale_validation"
+          ],
+          "note": "Summarizes the integrated score32 ranking that now replaces the older heuristic-heavy frontier."
+        }
+      ],
+      "caveats": [
+        "This is an architecture-level recost, not a full-chip physical implementation.",
+        "The result remains provisional until producer-service-reducer composition, scheduler/CDC, and the c1 service electrical caveat are tightened further."
+      ],
+      "next_gate": "After the remaining on-chip component gates close, rerun the integrated ranking one more time and freeze the provisional best architecture as the project conclusion."
+    }
+  ]
+}

--- a/npu/eval/report_llama7b_architecture_closure.py
+++ b/npu/eval/report_llama7b_architecture_closure.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+"""Validate and render the persistent Llama7B architecture closure matrix."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_INPUT = REPO_ROOT / "npu/docs/llama7b_architecture_closure.json"
+DEFAULT_OUTPUT = REPO_ROOT / "npu/docs/generated/llama7b_architecture_closure.md"
+
+REQUIRED_COMPONENTS = [
+    "precision",
+    "dense_compute",
+    "norm",
+    "score_softmax",
+    "multivalue_service",
+    "reducer",
+    "producer_service_reducer_composition",
+    "noc",
+    "sram",
+    "scheduler_cdc",
+    "external_memory_boundary",
+    "full_llama7b_recost",
+]
+REQUIRED_DIMENSIONS = [
+    "rtl",
+    "equivalence",
+    "routed_ppa",
+    "activity",
+    "composition",
+    "scale_validation",
+]
+STATUS_VOCAB = {
+    "closed",
+    "routed_with_caveat",
+    "measured_component",
+    "rtl_unmeasured",
+    "abstract_external",
+    "open",
+}
+CONFIDENCE_VOCAB = {"high", "medium", "low"}
+PASSLIKE_STATUSES = {"closed", "routed_with_caveat", "measured_component", "abstract_external"}
+UNRESOLVED_STATUSES = {"open", "rtl_unmeasured"}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: expected top-level JSON object")
+    return payload
+
+
+def _rel_to_repo(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path.resolve())
+
+
+def _status_count(components: list[dict[str, Any]]) -> dict[str, int]:
+    counts = {status: 0 for status in STATUS_VOCAB}
+    for component in components:
+        status = str(component.get("status", "")).strip()
+        if status in counts:
+            counts[status] += 1
+    return counts
+
+
+def _dimension_summary(component: dict[str, Any], dimension: str) -> dict[str, Any]:
+    dims = component.get("dimensions")
+    if not isinstance(dims, dict):
+        return {}
+    payload = dims.get(dimension)
+    return payload if isinstance(payload, dict) else {}
+
+
+def _evidence_dimensions(component: dict[str, Any]) -> set[str]:
+    covered: set[str] = set()
+    evidence = component.get("evidence")
+    if not isinstance(evidence, list):
+        return covered
+    for entry in evidence:
+        if not isinstance(entry, dict):
+            continue
+        dims = entry.get("dimensions")
+        if not isinstance(dims, list):
+            continue
+        for dimension in dims:
+            if isinstance(dimension, str):
+                covered.add(dimension)
+    return covered
+
+
+def validate_matrix(matrix: dict[str, Any], *, repo_root: Path = REPO_ROOT) -> list[str]:
+    errors: list[str] = []
+
+    components = matrix.get("components")
+    if not isinstance(components, list):
+        return ["components: expected list"]
+
+    if matrix.get("component_order") != REQUIRED_COMPONENTS:
+        errors.append("component_order must exactly match the required Llama7B closure component order")
+    if matrix.get("dimension_order") != REQUIRED_DIMENSIONS:
+        errors.append("dimension_order must exactly match the required closure dimensions")
+
+    status_vocab = matrix.get("status_vocabulary")
+    if status_vocab != sorted(STATUS_VOCAB):
+        errors.append("status_vocabulary must match the supported closure status set")
+    confidence_vocab = matrix.get("confidence_vocabulary")
+    if confidence_vocab != sorted(CONFIDENCE_VOCAB):
+        errors.append("confidence_vocabulary must match the supported confidence set")
+
+    generated_markdown = matrix.get("generated_markdown")
+    if not isinstance(generated_markdown, str) or not generated_markdown.strip():
+        errors.append("generated_markdown must be a non-empty repo-relative path")
+
+    recommended = matrix.get("recommended_architecture")
+    if not isinstance(recommended, dict):
+        errors.append("recommended_architecture must be an object")
+    else:
+        why_provisional = recommended.get("why_provisional")
+        if not isinstance(why_provisional, list) or not why_provisional:
+            errors.append("recommended_architecture.why_provisional must be a non-empty list")
+
+    seen_ids: set[str] = set()
+    component_ids: list[str] = []
+    for component in components:
+        if not isinstance(component, dict):
+            errors.append("components entries must be objects")
+            continue
+
+        component_id = str(component.get("id", "")).strip()
+        component_ids.append(component_id)
+        if component_id in seen_ids:
+            errors.append(f"component {component_id}: duplicate id")
+        seen_ids.add(component_id)
+        if component_id not in REQUIRED_COMPONENTS:
+            errors.append(f"component {component_id}: unsupported component id")
+
+        status = str(component.get("status", "")).strip()
+        if status not in STATUS_VOCAB:
+            errors.append(f"component {component_id}: unsupported status {status!r}")
+
+        confidence = str(component.get("confidence", "")).strip()
+        if confidence not in CONFIDENCE_VOCAB:
+            errors.append(f"component {component_id}: unsupported confidence {confidence!r}")
+
+        summary = component.get("summary")
+        if not isinstance(summary, str) or not summary.strip():
+            errors.append(f"component {component_id}: summary must be a non-empty string")
+
+        next_gate = component.get("next_gate")
+        if not isinstance(next_gate, str) or not next_gate.strip():
+            errors.append(f"component {component_id}: next_gate must be a non-empty string")
+
+        caveats = component.get("caveats")
+        if not isinstance(caveats, list):
+            errors.append(f"component {component_id}: caveats must be a list")
+
+        dimensions = component.get("dimensions")
+        if not isinstance(dimensions, dict):
+            errors.append(f"component {component_id}: dimensions must be an object")
+            continue
+        if list(dimensions.keys()) != REQUIRED_DIMENSIONS:
+            errors.append(f"component {component_id}: dimensions must match the required order")
+
+        for dimension in REQUIRED_DIMENSIONS:
+            dim_payload = _dimension_summary(component, dimension)
+            if not dim_payload:
+                errors.append(f"component {component_id}: missing dimension {dimension}")
+                continue
+            dim_status = str(dim_payload.get("status", "")).strip()
+            if dim_status not in STATUS_VOCAB:
+                errors.append(f"component {component_id}.{dimension}: unsupported status {dim_status!r}")
+            dim_summary = dim_payload.get("summary")
+            if not isinstance(dim_summary, str) or not dim_summary.strip():
+                errors.append(f"component {component_id}.{dimension}: summary must be a non-empty string")
+            if dim_status == "abstract_external" and component_id != "external_memory_boundary":
+                errors.append(
+                    f"component {component_id}.{dimension}: abstract_external is reserved for external_memory_boundary"
+                )
+
+        evidence = component.get("evidence")
+        if not isinstance(evidence, list) or not evidence:
+            errors.append(f"component {component_id}: evidence must be a non-empty list")
+            continue
+        for index, entry in enumerate(evidence):
+            if not isinstance(entry, dict):
+                errors.append(f"component {component_id}: evidence[{index}] must be an object")
+                continue
+            rel_path = entry.get("path")
+            if not isinstance(rel_path, str) or not rel_path.strip():
+                errors.append(f"component {component_id}: evidence[{index}] path must be a non-empty string")
+                continue
+            full_path = repo_root / rel_path
+            if not full_path.exists():
+                errors.append(f"component {component_id}: evidence path does not exist: {rel_path}")
+            dims = entry.get("dimensions")
+            if not isinstance(dims, list) or not dims:
+                errors.append(f"component {component_id}: evidence[{index}] dimensions must be a non-empty list")
+            else:
+                for dimension in dims:
+                    if dimension not in REQUIRED_DIMENSIONS:
+                        errors.append(
+                            f"component {component_id}: evidence[{index}] references unsupported dimension {dimension!r}"
+                        )
+
+        if component_id == "external_memory_boundary":
+            if status != "abstract_external":
+                errors.append("component external_memory_boundary: status must be abstract_external")
+            for dimension in REQUIRED_DIMENSIONS:
+                if _dimension_summary(component, dimension).get("status") != "abstract_external":
+                    errors.append(
+                        f"component external_memory_boundary.{dimension}: expected abstract_external status"
+                    )
+        elif status == "abstract_external":
+            errors.append(f"component {component_id}: only external_memory_boundary may use abstract_external")
+
+        if status == "closed":
+            for dimension in REQUIRED_DIMENSIONS:
+                dim_status = _dimension_summary(component, dimension).get("status")
+                if dim_status != "closed":
+                    errors.append(
+                        f"component {component_id}: unsupported closure, overall closed but {dimension}={dim_status!r}"
+                    )
+        if status == "routed_with_caveat":
+            routed_status = _dimension_summary(component, "routed_ppa").get("status")
+            if routed_status != "routed_with_caveat":
+                errors.append(
+                    f"component {component_id}: routed_with_caveat requires routed_ppa=routed_with_caveat"
+                )
+            if not component.get("caveats"):
+                errors.append(f"component {component_id}: routed_with_caveat requires at least one caveat")
+        elif _dimension_summary(component, "routed_ppa").get("status") == "routed_with_caveat":
+            errors.append(
+                f"component {component_id}: routed_ppa=routed_with_caveat requires overall status routed_with_caveat"
+            )
+
+        coverage = _evidence_dimensions(component)
+        for dimension in REQUIRED_DIMENSIONS:
+            dim_status = str(_dimension_summary(component, dimension).get("status", "")).strip()
+            if dim_status in PASSLIKE_STATUSES and dimension not in coverage:
+                errors.append(
+                    f"component {component_id}: unsupported closure for {dimension}, no evidence entry references it"
+                )
+
+        if status == "measured_component":
+            measured_dims = {
+                "routed_ppa",
+                "activity",
+                "composition",
+                "scale_validation",
+            }
+            if not any(
+                str(_dimension_summary(component, dim).get("status", "")).strip()
+                in {"closed", "routed_with_caveat", "measured_component"}
+                for dim in measured_dims
+            ):
+                errors.append(
+                    f"component {component_id}: measured_component requires at least one measured/routed downstream dimension"
+                )
+        if status == "rtl_unmeasured":
+            if str(_dimension_summary(component, "rtl").get("status", "")).strip() not in {"closed", "rtl_unmeasured"}:
+                errors.append(f"component {component_id}: rtl_unmeasured requires an RTL implementation path")
+        if status == "open":
+            if all(
+                str(_dimension_summary(component, dim).get("status", "")).strip() in PASSLIKE_STATUSES
+                for dim in REQUIRED_DIMENSIONS
+            ):
+                errors.append(f"component {component_id}: open status is unsupported when every dimension is closed/measured")
+
+        if component_id == "multivalue_service":
+            accepted = component.get("accepted_routed_result")
+            if not isinstance(accepted, dict):
+                errors.append("component multivalue_service: accepted_routed_result is required")
+            else:
+                required_fields = {
+                    "tag",
+                    "critical_path_ns",
+                    "die_area_mm2",
+                    "core_area_mm2",
+                    "instance_area_mm2",
+                    "stdcell_area_mm2",
+                    "stdcell_count",
+                    "utilization_pct",
+                    "vectorless_power_mw",
+                    "max_cap_violations",
+                    "worst_max_cap_ff",
+                }
+                missing = sorted(field for field in required_fields if field not in accepted)
+                if missing:
+                    errors.append(
+                        "component multivalue_service: accepted_routed_result missing fields "
+                        + ", ".join(missing)
+                    )
+
+    if component_ids != REQUIRED_COMPONENTS:
+        errors.append("components must appear exactly once and in the required order")
+
+    output_path = repo_root / str(generated_markdown or DEFAULT_OUTPUT)
+    if output_path.parent != DEFAULT_OUTPUT.parent:
+        errors.append("generated_markdown must stay under npu/docs/generated")
+    return errors
+
+
+def render_markdown(matrix: dict[str, Any], *, repo_root: Path = REPO_ROOT) -> str:
+    components = matrix["components"]
+    counts = _status_count(components)
+    recommended = matrix["recommended_architecture"]
+    generated_markdown = matrix["generated_markdown"]
+
+    lines: list[str] = []
+    lines.append("# Llama7B Architecture Closure Matrix")
+    lines.append("")
+    lines.append(f"- source JSON: `{_rel_to_repo(DEFAULT_INPUT)}`")
+    lines.append(f"- generated Markdown: `{generated_markdown}`")
+    lines.append(f"- as_of: `{matrix['as_of']}`")
+    lines.append("")
+    lines.append("## Headline")
+    lines.append("")
+    lines.append(
+        "- closure counts: "
+        f"`closed={counts['closed']}`, "
+        f"`routed_with_caveat={counts['routed_with_caveat']}`, "
+        f"`measured_component={counts['measured_component']}`, "
+        f"`rtl_unmeasured={counts['rtl_unmeasured']}`, "
+        f"`abstract_external={counts['abstract_external']}`, "
+        f"`open={counts['open']}`"
+    )
+    lines.append(
+        "- provisional recommendation: "
+        f"`{recommended['compute']}` + `{recommended['score_path']}`, "
+        f"`{recommended['service_topology']}`, `{recommended['clocking']}`"
+    )
+    for reason in recommended["why_provisional"]:
+        lines.append(f"- provisional because: {reason}")
+    lines.append("")
+    lines.append("## Component Status")
+    lines.append("")
+    lines.append(
+        "| Component | Status | Confidence | RTL | Equivalence | Routed PPA | Activity | Composition | Scale |"
+    )
+    lines.append(
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- |"
+    )
+    for component in components:
+        dims = component["dimensions"]
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    component["label"],
+                    component["status"],
+                    component["confidence"],
+                    dims["rtl"]["status"],
+                    dims["equivalence"]["status"],
+                    dims["routed_ppa"]["status"],
+                    dims["activity"]["status"],
+                    dims["composition"]["status"],
+                    dims["scale_validation"]["status"],
+                ]
+            )
+            + " |"
+        )
+    lines.append("")
+    for component in components:
+        lines.append(f"## {component['label']}")
+        lines.append("")
+        lines.append(f"- status: `{component['status']}`")
+        lines.append(f"- confidence: `{component['confidence']}`")
+        lines.append(f"- summary: {component['summary']}")
+        lines.append(f"- next gate: {component['next_gate']}")
+        if component["id"] == "multivalue_service":
+            accepted = component["accepted_routed_result"]
+            lines.append("- accepted c1 routed result:")
+            lines.append(f"  - tag: `{accepted['tag']}`")
+            lines.append(f"  - critical path: `{accepted['critical_path_ns']} ns`")
+            lines.append(f"  - die/core: `{accepted['die_area_mm2']} mm2` / `{accepted['core_area_mm2']} mm2`")
+            lines.append(
+                f"  - instance/stdcell: `{accepted['instance_area_mm2']} mm2` / "
+                f"`{accepted['stdcell_area_mm2']} mm2`, `{accepted['stdcell_count']} cells`"
+            )
+            lines.append(
+                f"  - utilization/vectorless power: `{accepted['utilization_pct']}%` / "
+                f"`{accepted['vectorless_power_mw']} mW`"
+            )
+            lines.append(
+                f"  - route health: `DRC/setup/hold/slew clean`, but "
+                f"`{accepted['max_cap_violations']}` max-cap violations, worst `{accepted['worst_max_cap_ff']} fF`"
+            )
+        lines.append("")
+        lines.append("| Dimension | Status | Summary |")
+        lines.append("| --- | --- | --- |")
+        for dimension in REQUIRED_DIMENSIONS:
+            dim_payload = component["dimensions"][dimension]
+            lines.append(
+                f"| `{dimension}` | `{dim_payload['status']}` | {dim_payload['summary']} |"
+            )
+        lines.append("")
+        if component["caveats"]:
+            lines.append("Caveats:")
+            for caveat in component["caveats"]:
+                lines.append(f"- {caveat}")
+            lines.append("")
+        lines.append("Evidence:")
+        for evidence in component["evidence"]:
+            dims = ", ".join(f"`{dim}`" for dim in evidence["dimensions"])
+            lines.append(
+                f"- `{_rel_to_repo(repo_root / evidence['path'])}` ({evidence['kind']}; {dims}): {evidence['note']}"
+            )
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, default=DEFAULT_INPUT, help="Source closure JSON")
+    parser.add_argument("--output-md", type=Path, default=DEFAULT_OUTPUT, help="Rendered Markdown output")
+    parser.add_argument(
+        "--write-markdown",
+        action="store_true",
+        help="Write the rendered Markdown to --output-md after validation",
+    )
+    parser.add_argument(
+        "--check-markdown",
+        action="store_true",
+        help="Fail if --output-md does not match the rendered Markdown",
+    )
+    args = parser.parse_args(argv)
+
+    matrix = _load_json(args.input)
+    errors = validate_matrix(matrix)
+    if errors:
+        for error in errors:
+            print(f"[llama7b_closure] ERROR: {error}", file=sys.stderr)
+        return 1
+
+    rendered = render_markdown(matrix)
+    if args.write_markdown:
+        args.output_md.parent.mkdir(parents=True, exist_ok=True)
+        args.output_md.write_text(rendered, encoding="utf-8")
+    if args.check_markdown:
+        current = args.output_md.read_text(encoding="utf-8") if args.output_md.exists() else ""
+        if current != rendered:
+            print(
+                "[llama7b_closure] ERROR: rendered Markdown does not match committed output",
+                file=sys.stderr,
+            )
+            return 1
+    if not args.write_markdown and not args.check_markdown:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llama7b_architecture_closure.py
+++ b/tests/test_llama7b_architecture_closure.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Focused tests for the persistent Llama7B architecture closure matrix."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "npu/eval/report_llama7b_architecture_closure.py"
+JSON_PATH = REPO_ROOT / "npu/docs/llama7b_architecture_closure.json"
+MARKDOWN_PATH = REPO_ROOT / "npu/docs/generated/llama7b_architecture_closure.md"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("llama7b_architecture_closure", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load module from {MODULE_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class Llama7BArchitectureClosureTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.module = _load_module()
+        cls.matrix = cls.module._load_json(JSON_PATH)
+
+    def test_repo_matrix_is_valid_and_markdown_in_sync(self) -> None:
+        errors = self.module.validate_matrix(self.matrix, repo_root=REPO_ROOT)
+        self.assertEqual(errors, [])
+        rendered = self.module.render_markdown(self.matrix, repo_root=REPO_ROOT)
+        self.assertEqual(rendered, MARKDOWN_PATH.read_text(encoding="utf-8"))
+
+    def test_closed_status_rejects_unclosed_dimension(self) -> None:
+        matrix = copy.deepcopy(self.matrix)
+        matrix["components"][2]["status"] = "closed"
+        errors = self.module.validate_matrix(matrix, repo_root=REPO_ROOT)
+        joined = "\n".join(errors)
+        self.assertIn("unsupported closure", joined)
+        self.assertIn("component norm", joined)
+
+    def test_missing_evidence_path_is_rejected(self) -> None:
+        matrix = copy.deepcopy(self.matrix)
+        matrix["components"][0]["evidence"][0]["path"] = "docs/proposals/does_not_exist.md"
+        errors = self.module.validate_matrix(matrix, repo_root=REPO_ROOT)
+        joined = "\n".join(errors)
+        self.assertIn("evidence path does not exist", joined)
+        self.assertIn("does_not_exist.md", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a machine-readable 12-component closure and ambiguity matrix
- generate a human-readable report with closure counts and next gates
- validate status vocabulary, evidence paths, unsupported closure, and Markdown synchronization
- mark DRAM controller/PHY as the intentional external abstraction boundary

## Current recommendation
INT8 dense compute + score32 + exp-LUT, hierarchical c1/c2 service islands, and dual producer/reducer clocks; still provisional pending activity, composition, NoC/scheduler, norm, and scale gates.

## Verification
- 3 closure-matrix tests passed
- renderer check passed
- scripts/validate_runs.py --skip_eval_queue passed