### PR TITLE
control_plane: resolve intermediate retry against base request

### DIFF
--- a/control_plane/control_plane/services/proposal_finalizer.py
+++ b/control_plane/control_plane/services/proposal_finalizer.py
@@ -142,6 +142,15 @@ def _resolve_requested_entry(
         _rebind_requested_entry(entry, item_id=work_item.item_id)
         return entry
     if len(retry_matches) > 1:
+        base_matches = [
+            entry
+            for entry in retry_matches
+            if str(entry.get("item_id", "")).strip() == work_retry_base
+        ]
+        if len(base_matches) == 1:
+            entry = base_matches[0]
+            _rebind_requested_entry(entry, item_id=work_item.item_id)
+            return entry
         raise ProposalFinalizationError(
             f"item {work_item.item_id} has multiple retry-base matches in {evaluation_requests_path}"
         )

--- a/control_plane/control_plane/tests/test_proposal_finalizer.py
+++ b/control_plane/control_plane/tests/test_proposal_finalizer.py
@@ -1933,6 +1933,36 @@ def test_finalize_l1_retry_item_rebinds_requested_entry() -> None:
         assert current["merged_pr_number"] == 89
 
 
+def test_retry_resolution_prefers_exact_base_when_conditional_retry_also_exists() -> None:
+    requested_items = [
+        {
+            "item_id": "l1_service_pnr_v1",
+            "task_type": "l1_sweep",
+            "status": "pending",
+        },
+        {
+            "item_id": "l1_service_pnr_v1_r4",
+            "task_type": "l1_sweep",
+            "status": "conditional_follow_on",
+        },
+    ]
+    work_item = WorkItem(
+        item_id="l1_service_pnr_v1_r3",
+        task_type="l1_sweep",
+    )
+
+    selected = proposal_finalizer._resolve_requested_entry(
+        requested_items,
+        work_item=work_item,
+        evaluation_requests_path=Path("evaluation_requests.json"),
+    )
+
+    assert selected is requested_items[0]
+    assert selected["item_id"] == "l1_service_pnr_v1_r3"
+    assert selected["prior_item_ids"] == ["l1_service_pnr_v1"]
+    assert requested_items[1]["item_id"] == "l1_service_pnr_v1_r4"
+
+
 def test_finalize_after_merge_refreshes_github_link_finalization_metadata() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"


### PR DESCRIPTION
## Summary
- bind an intermediate retry to the exact base request when a later conditional retry shares the same retry base
- preserve the conditional retry entry unchanged
- unblock finalization of PR 1548 without weakening truly ambiguous retry resolution

## Verification
- 2 retry-focused proposal-finalizer tests passed
- scripts/validate_runs.py --skip_eval_queue passed