### PR TITLE
control_plane: transport multivalue service evidence

### DIFF
--- a/control_plane/control_plane/artifact_policy.py
+++ b/control_plane/control_plane/artifact_policy.py
@@ -28,6 +28,7 @@ _ALLOWED_DATASET_PREFIXES = {
     "decoder_attention_decode_score_tile_",
     "decoder_attention_decode_score_local_cluster_",
     "decoder_attention_decode_score_multivalue_cluster_",
+    "decoder_attention_decode_score_multivalue_service_",
     "decoder_attention_decode_score_multivalue_gqa_group_",
     "decoder_attention_decode_score_multivalue_gqa_folded_lane_",
     "decoder_attention_mixed_int8_",

--- a/control_plane/control_plane/tests/test_artifact_policy.py
+++ b/control_plane/control_plane/tests/test_artifact_policy.py
@@ -177,6 +177,18 @@ def test_transportable_expected_output_allows_decode_score_multivalue_cluster_eq
     assert is_transportable_expected_output(f"{base}{stem}.md")
 
 
+def test_transportable_expected_output_allows_decode_score_multivalue_service_activity() -> None:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+    stem = (
+        "decoder_attention_decode_score_multivalue_service_activity_power__"
+        "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_"
+        "llama7b_v1_r3"
+    )
+
+    assert is_transportable_expected_output(f"{base}{stem}.json")
+    assert is_transportable_expected_output(f"{base}{stem}.md")
+
+
 def test_transportable_expected_output_allows_decode_score_multivalue_gqa_group_equivalence() -> None:
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
     stem = (


### PR DESCRIPTION
## Summary
- allow inline transport of multivalue-service JSON and Markdown dataset outputs
- add the exact c1 activity-power retry path as a regression
- preserve the successful r2 measurement as a transport-blocked historical run and rerun as r3

## Verification
- 19 artifact policy/staging tests passed
- scripts/validate_runs.py --skip_eval_queue passed