### PR TITLE
npu: canonicalize routed activity hierarchy names

### DIFF
--- a/npu/synth/run_postroute_vcd_power.py
+++ b/npu/synth/run_postroute_vcd_power.py
@@ -534,6 +534,12 @@ proc rtlgen_strip_array_index_suffix {full_name} {
   return $full_name
 }
 
+proc rtlgen_canonical_activity_name {full_name} {
+  # Yosys/OpenDB prints generated hierarchy boundaries as "].", while
+  # RTL VCD scopes use "]/". Preserve dots in ordinary identifiers.
+  return [string map [list "]." "]/"] $full_name]
+}
+
 proc rtlgen_apply_macro_pin_activities {assignments} {
   set results {}
   if {[llength $assignments] == 0} {
@@ -583,6 +589,7 @@ set sequential_register_activity_scan_samples {}
 set sequential_register_activity_assignments {}
 set sequential_register_activity_updates {}
 set sequential_register_activity_assignment_rows_by_full_name {}
+set sequential_register_activity_original_name_by_canonical {}
 set sequential_register_activity_unmatched_rows_by_full_name {}
 set sequential_register_activity_unmatched_rows_by_prefix {}
 set sequential_register_activity_assignment_rows_seen {}
@@ -620,8 +627,18 @@ foreach macro_pin_transfer_structural_row $macro_pin_transfer_structural_assignm
     continue
   }
   lassign $macro_pin_transfer_structural_row macro_pin_transfer_structural_full_name macro_pin_transfer_structural_density macro_pin_transfer_structural_duty macro_pin_transfer_structural_transition_count
-  dict set macro_pin_transfer_structural_assignment_rows_by_full_name $macro_pin_transfer_structural_full_name [list $macro_pin_transfer_structural_density $macro_pin_transfer_structural_duty $macro_pin_transfer_structural_transition_count]
-  dict set macro_pin_transfer_structural_unmatched_rows_by_full_name $macro_pin_transfer_structural_full_name 1
+  set macro_pin_transfer_structural_canonical_name \
+    [rtlgen_canonical_activity_name $macro_pin_transfer_structural_full_name]
+  if {[dict exists $macro_pin_transfer_structural_assignment_rows_by_full_name \
+          $macro_pin_transfer_structural_canonical_name]} {
+    incr macro_pin_transfer_structural_query_error_count
+    continue
+  }
+  dict set macro_pin_transfer_structural_assignment_rows_by_full_name \
+    $macro_pin_transfer_structural_canonical_name \
+    [list $macro_pin_transfer_structural_density $macro_pin_transfer_structural_duty $macro_pin_transfer_structural_transition_count]
+  dict set macro_pin_transfer_structural_unmatched_rows_by_full_name \
+    $macro_pin_transfer_structural_canonical_name $macro_pin_transfer_structural_full_name
 }
 set sequential_register_activity_assignment_count [llength $sequential_register_activity_assignments]
 foreach sequential_register_activity_row $sequential_register_activity_assignments {
@@ -635,14 +652,23 @@ foreach sequential_register_activity_row $sequential_register_activity_assignmen
     sequential_register_activity_density \
     sequential_register_activity_duty \
     sequential_register_activity_transition_count
+  set sequential_register_activity_canonical_name \
+    [rtlgen_canonical_activity_name $sequential_register_activity_full_name]
+  if {[dict exists $sequential_register_activity_assignment_rows_by_full_name \
+          $sequential_register_activity_canonical_name]} {
+    incr sequential_register_activity_query_error_count
+    continue
+  }
   dict set sequential_register_activity_assignment_rows_by_full_name \
-    $sequential_register_activity_full_name \
+    $sequential_register_activity_canonical_name \
     [list \
       $sequential_register_activity_density \
       $sequential_register_activity_duty \
       $sequential_register_activity_transition_count]
+  dict set sequential_register_activity_original_name_by_canonical \
+    $sequential_register_activity_canonical_name $sequential_register_activity_full_name
   dict set sequential_register_activity_unmatched_rows_by_full_name \
-    $sequential_register_activity_full_name 1
+    $sequential_register_activity_canonical_name $sequential_register_activity_full_name
 }
 set macro_pin_transfer_structural_candidate_count $macro_pin_transfer_structural_assignment_count
 if {[catch {set all_design_pins_unsorted [get_pins -hierarchical *]}]} {
@@ -674,12 +700,15 @@ foreach sequential_register_activity_pin $all_design_pins {
           -> sequential_register_activity_register_full_name sequential_register_activity_pin_type]} {
     continue
   }
+  set sequential_register_activity_canonical_register_full_name \
+    [rtlgen_canonical_activity_name $sequential_register_activity_register_full_name]
   if {$sequential_register_activity_pin_type eq "Q"} {
     incr sequential_register_activity_candidate_q_count
   } else {
     incr sequential_register_activity_candidate_qn_count
   }
-  if {![dict exists $sequential_register_activity_assignment_rows_by_full_name $sequential_register_activity_register_full_name]} {
+  if {![dict exists $sequential_register_activity_assignment_rows_by_full_name \
+          $sequential_register_activity_canonical_register_full_name]} {
     incr sequential_register_activity_unmatched_output_count
     set sequential_register_activity_unmatched_prefix \
       [rtlgen_strip_array_index_suffix $sequential_register_activity_register_full_name]
@@ -698,7 +727,8 @@ foreach sequential_register_activity_pin $all_design_pins {
     continue
   }
   lassign \
-    [dict get $sequential_register_activity_assignment_rows_by_full_name $sequential_register_activity_register_full_name] \
+    [dict get $sequential_register_activity_assignment_rows_by_full_name \
+      $sequential_register_activity_canonical_register_full_name] \
     sequential_register_activity_density \
     sequential_register_activity_duty \
     sequential_register_activity_transition_count
@@ -716,7 +746,8 @@ foreach sequential_register_activity_pin $all_design_pins {
   dict set sequential_register_activity_pin_register_by_pin $sequential_register_activity_pin_full_name $sequential_register_activity_register_full_name
   dict set sequential_register_activity_pin_type_by_pin $sequential_register_activity_pin_full_name $sequential_register_activity_pin_type
   dict set sequential_register_activity_pin_duty_by_pin $sequential_register_activity_pin_full_name $sequential_register_activity_effective_duty
-  dict incr sequential_register_activity_assignment_rows_seen $sequential_register_activity_register_full_name
+  dict incr sequential_register_activity_assignment_rows_seen \
+    $sequential_register_activity_canonical_register_full_name
   incr sequential_register_activity_matched_count
 }
 if {[llength $sequential_register_activity_updates] > 0} {
@@ -756,11 +787,15 @@ if {[llength $sequential_register_activity_updates] > 0} {
   }
 }
 if {[dict size $sequential_register_activity_assignment_rows_by_full_name] > 0} {
-  dict for {sequential_register_activity_unused_row _} \
+  dict for {sequential_register_activity_unused_canonical_name _} \
     $sequential_register_activity_assignment_rows_by_full_name {
-    if {[dict exists $sequential_register_activity_assignment_rows_seen $sequential_register_activity_unused_row]} {
+    if {[dict exists $sequential_register_activity_assignment_rows_seen \
+            $sequential_register_activity_unused_canonical_name]} {
       continue
     }
+    set sequential_register_activity_unused_row \
+      [dict get $sequential_register_activity_original_name_by_canonical \
+        $sequential_register_activity_unused_canonical_name]
     lappend sequential_register_activity_unused_sidecar_rows $sequential_register_activity_unused_row
     incr sequential_register_activity_unused_sidecar_row_count
     set sequential_register_activity_unused_row_prefix \
@@ -862,10 +897,14 @@ foreach macro_pin $all_design_pins {
     }
     continue
   }
-  if {[dict exists $macro_pin_transfer_structural_assignment_rows_by_full_name $macro_pin_full_name]} {
+  set macro_pin_canonical_full_name [rtlgen_canonical_activity_name $macro_pin_full_name]
+  if {[dict exists $macro_pin_transfer_structural_assignment_rows_by_full_name \
+          $macro_pin_canonical_full_name]} {
     set macro_pin_transfer_structural_row \
-      [dict get $macro_pin_transfer_structural_assignment_rows_by_full_name $macro_pin_full_name]
-    dict unset macro_pin_transfer_structural_unmatched_rows_by_full_name $macro_pin_full_name
+      [dict get $macro_pin_transfer_structural_assignment_rows_by_full_name \
+        $macro_pin_canonical_full_name]
+    dict unset macro_pin_transfer_structural_unmatched_rows_by_full_name \
+      $macro_pin_canonical_full_name
     incr macro_pin_transfer_structural_matched_count
     lassign $macro_pin_transfer_structural_row macro_pin_structural_density macro_pin_structural_duty macro_pin_structural_transition_count
     lappend macro_pin_transfer_updates \
@@ -1068,7 +1107,7 @@ foreach macro_pin $all_design_pins {
 }
 set macro_pin_transfer_structural_unmatched_count [dict size $macro_pin_transfer_structural_unmatched_rows_by_full_name]
 if {$macro_pin_transfer_structural_unmatched_count > 0} {
-  dict for {macro_pin_transfer_structural_unmatched_full_name _} \
+  dict for {_ macro_pin_transfer_structural_unmatched_full_name} \
     $macro_pin_transfer_structural_unmatched_rows_by_full_name {
     lappend macro_pin_transfer_structural_unmatched_full_names $macro_pin_transfer_structural_unmatched_full_name
   }

--- a/tests/test_postroute_vcd_power.py
+++ b/tests/test_postroute_vcd_power.py
@@ -915,9 +915,17 @@ class PostrouteVcdPowerTests(unittest.TestCase):
 
             result = root / "activity_power.json"
             macro_activity_tcl = root / "macro_activity.tcl"
+            sidecar_pin = (
+                "gen_cluster[0]/u_cluster/score_bank/"
+                "u_group_7_slice_3/dq[3]"
+            )
+            routed_pin = (
+                "gen_cluster[0].u_cluster/score_bank/"
+                "u_group_7_slice_3/dq[3]"
+            )
             macro_activity_tcl.write_text(
                 "set rtlgen_macro_activity_assignments {\n"
-                "  {pin_input_u_group[7]/dq[3] 1.234 0.5 8.9}\n"
+                f"  {{{sidecar_pin} 1.234 0.5 8.9}}\n"
                 "}\n",
                 encoding="utf-8",
             )
@@ -929,7 +937,7 @@ class PostrouteVcdPowerTests(unittest.TestCase):
                 macro_activity_tcl=macro_activity_tcl,
                 macro_transfer_pin_names=(
                     "pin_other_0",
-                    "pin_input_u_group[7]/dq[3]",
+                    routed_pin,
                     "pin_nonfinite_u_group",
                 ),
             )
@@ -986,7 +994,7 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             self.assertEqual(transfer["peer_eligible_count"], 0)
             self.assertEqual(len(transfer["transferred"]), 1)
             self.assertEqual(
-                transfer["transferred"][0]["full_name"], "pin_input_u_group[7]/dq[3]"
+                transfer["transferred"][0]["full_name"], routed_pin
             )
             self.assertEqual(transfer["transferred"][0]["source"], "vcd")
             self.assertEqual(
@@ -995,7 +1003,7 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             self.assertEqual(len(transfer["scan_samples"]), 1)
             self.assertEqual(
                 transfer["scan_samples"][0]["full_name"],
-                "pin_input_u_group[7]/dq[3]",
+                routed_pin,
             )
             self.assertEqual(
                 transfer["scan_samples"][0]["driver_origin"], "structural_vcd_sidecar"
@@ -1020,13 +1028,32 @@ class PostrouteVcdPowerTests(unittest.TestCase):
             sequential_activity_tcl = self._write_sequential_activity_tcl(
                 root=root,
                 assignments=(
-                    ("reducer/result_value[116]", 500.0, 0.25, 5.0),
-                    ("reducer/numerator_accum[56][24]", 300.0, 0.60, 3.0),
+                    (
+                        "gen_cluster[0]/u_cluster/reducer/result_value[116]",
+                        500.0,
+                        0.25,
+                        5.0,
+                    ),
+                    (
+                        "gen_cluster[0]/u_cluster/reducer/numerator_accum[56][24]",
+                        300.0,
+                        0.60,
+                        3.0,
+                    ),
                 ),
             )
-            q_pin = "reducer/numerator_accum[56][24]$_DFFE_PP_/Q"
-            qn_pin = "reducer/numerator_accum[56][24]$_DFFSR_X1_/QN"
-            second_pin = "reducer/result_value[116]$_DFFX1_/Q"
+            q_pin = (
+                "gen_cluster[0].u_cluster/reducer/"
+                "numerator_accum[56][24]$_DFFE_PP_/Q"
+            )
+            qn_pin = (
+                "gen_cluster[0].u_cluster/reducer/"
+                "numerator_accum[56][24]$_DFFSR_X1_/QN"
+            )
+            second_pin = (
+                "gen_cluster[0].u_cluster/reducer/"
+                "result_value[116]$_DFFX1_/Q"
+            )
             pin_properties = {
                 pin: {
                     "full_name": pin,


### PR DESCRIPTION
Canonicalizes Yosys/OpenDB generated hierarchy separators (].) against RTL VCD separators (]/) before macro-pin and sequential-register sidecar lookup. This fixes the observed c1 r3 loss of all 9,704 structural macro assignments without weakening the existing promotion thresholds. Adds Tcl runtime regressions for both macro and DFF mapping. Tests: 65 focused activity/power tests; validate_runs --skip_eval_queue.