### PR TITLE
npu: capture complete service activity hierarchy

### DIFF
--- a/npu/eval/extract_fakeram_vcd_activity.py
+++ b/npu/eval/extract_fakeram_vcd_activity.py
@@ -129,6 +129,7 @@ def _score_scope_result(
     parts: list[str],
     *,
     cluster_count: int,
+    preserve_instance_prefix: bool,
     group_indices: tuple[int, ...],
     slice_indices: tuple[int, ...],
 ) -> tuple[str, _MacroClassSpec] | None:
@@ -147,7 +148,7 @@ def _score_scope_result(
             continue
         if index + 2 != len(parts):
             continue
-        if int(cluster_count) > 1 and index > 0:
+        if index > 0 and (preserve_instance_prefix or int(cluster_count) > 1):
             full_scope = "/".join([*parts[:index], "score_bank", group_scope])
         else:
             full_scope = f"score_bank/{group_scope}"
@@ -158,6 +159,7 @@ def _score_scope_result(
 def _value_scope_result(
     parts: list[str],
     *,
+    preserve_instance_prefix: bool,
     value_bank_indices: tuple[int, ...],
     value_lane_indices: tuple[int, ...],
 ) -> tuple[str, _MacroClassSpec] | None:
@@ -179,10 +181,10 @@ def _value_scope_result(
             continue
         if index + 4 != len(parts):
             continue
-        return (
-            f"gen_value_macro_backend/{bank_scope}/{lane_scope}/{leaf_scope}",
-            _VALUE_MACRO_SPEC,
-        )
+        macro_parts = ["gen_value_macro_backend", bank_scope, lane_scope, leaf_scope]
+        if index > 0 and preserve_instance_prefix:
+            macro_parts = [*parts[:index], *macro_parts]
+        return ("/".join(macro_parts), _VALUE_MACRO_SPEC)
     return None
 
 
@@ -191,6 +193,7 @@ def _parse_target_scope(
     *,
     root_scope: str,
     cluster_count: int,
+    preserve_instance_prefix: bool,
     group_indices: tuple[int, ...],
     slice_indices: tuple[int, ...],
     include_value_memory: bool,
@@ -208,6 +211,7 @@ def _parse_target_scope(
     score_result = _score_scope_result(
         parts,
         cluster_count=cluster_count,
+        preserve_instance_prefix=preserve_instance_prefix,
         group_indices=group_indices,
         slice_indices=slice_indices,
     )
@@ -217,6 +221,7 @@ def _parse_target_scope(
         return None
     return _value_scope_result(
         parts,
+        preserve_instance_prefix=preserve_instance_prefix,
         value_bank_indices=value_bank_indices,
         value_lane_indices=value_lane_indices,
     )
@@ -317,6 +322,7 @@ def _extract_macro_vcd_activity(
     source_vcd_sha256: str,
     scope: str,
     cluster_count: int,
+    preserve_instance_prefix: bool,
     group_indices: tuple[int, ...],
     slice_indices: tuple[int, ...],
     expected_pin_count: int | None,
@@ -386,6 +392,7 @@ def _extract_macro_vcd_activity(
             scope_path,
             root_scope=scope,
             cluster_count=cluster_count,
+            preserve_instance_prefix=preserve_instance_prefix,
             group_indices=group_indices,
             slice_indices=slice_indices,
             include_value_memory=include_value_memory,
@@ -629,6 +636,7 @@ def extract_fakeram_vcd_activity(
         source_vcd_sha256=source_vcd_sha256,
         scope=scope,
         cluster_count=1,
+        preserve_instance_prefix=False,
         group_indices=group_indices,
         slice_indices=slice_indices,
         expected_pin_count=expected_pin_count,
@@ -663,6 +671,7 @@ def extract_multivalue_service_fakeram_vcd_activity(
         source_vcd_sha256=source_vcd_sha256,
         scope=scope,
         cluster_count=cluster_count,
+        preserve_instance_prefix=True,
         group_indices=group_indices,
         slice_indices=slice_indices,
         expected_pin_count=expected_pin_count,

--- a/npu/eval/generate_attention_decode_score_multivalue_service_activity.py
+++ b/npu/eval/generate_attention_decode_score_multivalue_service_activity.py
@@ -155,6 +155,48 @@ def _scaled_expected_counts(workload_contract: JsonDict, *, cluster_count: int) 
     return expected_counts
 
 
+def _sequential_memory_dumpvars(case: JsonDict) -> list[str]:
+    cluster_count = int(case["cluster_count"])
+    banks = int(case["banks"])
+    req_queue_depth = int(case["req_queue_depth"])
+    resp_queue_depth = int(case["resp_queue_depth"])
+    bank_queue_depth = int(case["bank_queue_depth"])
+    targets: list[str] = []
+    for cluster in range(cluster_count):
+        cluster_root = f"dut.gen_cluster[{cluster}].u_cluster"
+        targets.extend(
+            f"{cluster_root}.reducer.numerator_accum[{index}]"
+            for index in range(int(probe._workload_contract()["value_dim"]))
+        )
+        targets.extend(f"{cluster_root}.reducer.block_weight[{index}]" for index in range(8))
+        targets.extend(f"{cluster_root}.score_tile.accum[{index}]" for index in range(8))
+        targets.extend(
+            f"dut.u_router.gen_req_fifo[{cluster}].u_req_fifo.mem[{index}]"
+            for index in range(req_queue_depth)
+        )
+        targets.extend(
+            f"dut.u_router.gen_resp_fifo[{cluster}].u_resp_fifo.mem[{index}]"
+            for index in range(resp_queue_depth)
+        )
+        for name in ("request_tag_q", "expected_tag_q", "expected_addr_q", "expected_slice_q", "expected_source_q"):
+            targets.append(f"dut.{name}[{cluster}]")
+    for bank in range(banks):
+        for name in (
+            "active_tag",
+            "active_addr",
+            "active_slice",
+            "active_matrix",
+            "active_fragment",
+            "bank_latency",
+        ):
+            targets.append(f"dut.u_service.{name}[{bank}]")
+        targets.extend(
+            f"dut.u_service.gen_bank_fifo[{bank}].u_bank_fifo.mem[{index}]"
+            for index in range(bank_queue_depth)
+        )
+    return targets
+
+
 def _compile_and_run(*, sources: list[Path], timeout: int = 240) -> str:
     with tempfile.TemporaryDirectory(prefix="multivalue-service-activity-run-") as tmp_text:
         simv = Path(tmp_text) / "simv"
@@ -198,7 +240,7 @@ def _run_macro_integrated(
             cluster_count=int(case["cluster_count"]),
             values=values,
             vcd_path=str((out_dir / _OUTPUT_VCD_NAME).resolve()),
-            vcd_dumpvars=["dut"],
+            vcd_dumpvars=["dut", *_sequential_memory_dumpvars(case)],
             clock_period_ns=clock_period_ns,
         )
         tb_path.write_text(tb_text, encoding="utf-8")

--- a/tests/test_extract_fakeram_vcd_activity.py
+++ b/tests/test_extract_fakeram_vcd_activity.py
@@ -369,8 +369,11 @@ def test_extract_multivalue_service_activity_tracks_both_macro_classes(tmp_path:
     assert payload["target_profile"] == "multivalue_service_c1_v1"
     assert len(payload["pins"]) == 163
     by_name = {row["full_name"]: row for row in payload["pins"]}
-    assert "score_bank/u_group_0_slice_0/we_in" in by_name
-    assert "gen_value_macro_backend/gen_value_bank[0]/gen_value_lane[0]/u_value_mem_lane/ce_in" in by_name
+    assert "wrapper/score_bank/u_group_0_slice_0/we_in" in by_name
+    assert (
+        "wrapper/gen_value_macro_backend/gen_value_bank[0]/gen_value_lane[0]/u_value_mem_lane/ce_in"
+        in by_name
+    )
     contract = payload["structural_macro_contract"]
     assert contract["total_assignment_count"] == 163
     classes = {row["macro_name"]: row for row in contract["macro_classes"]}
@@ -507,9 +510,9 @@ def test_extract_multivalue_service_activity_real_generated_vcd_sidecar(tmp_path
     assert classes["fakeram45_64x32"]["assignment_count"] == 4608
     assert payload["structural_macro_contract"]["total_assignment_count"] == 9704
     full_names = {row["full_name"] for row in payload["pins"]}
-    assert "score_bank/u_group_7_slice_6/ce_in" in full_names
+    assert "gen_cluster[0]/u_cluster/score_bank/u_group_7_slice_6/ce_in" in full_names
     assert (
-        "gen_value_macro_backend/gen_value_bank[3]/gen_value_lane[15]/u_value_mem_lane/ce_in"
+        "u_service/gen_value_macro_backend/gen_value_bank[3]/gen_value_lane[15]/u_value_mem_lane/ce_in"
         in full_names
     )
 
@@ -537,7 +540,9 @@ def test_extract_multivalue_service_activity_real_generated_c2_vcd_sidecar(tmp_p
     full_names = {row["full_name"] for row in payload["pins"]}
     score_instances = {name.rsplit("/", 1)[0] for name in full_names if "/score_bank/" in name}
     value_instances = {
-        name.rsplit("/", 1)[0] for name in full_names if name.startswith("gen_value_macro_backend/")
+        name.rsplit("/", 1)[0]
+        for name in full_names
+        if name.startswith("u_service/gen_value_macro_backend/")
     }
     assert len(score_instances) == 112
     assert len(value_instances) == 64

--- a/tests/test_generate_attention_decode_score_multivalue_service_activity.py
+++ b/tests/test_generate_attention_decode_score_multivalue_service_activity.py
@@ -18,7 +18,11 @@ from npu.eval.generate_attention_decode_score_multivalue_service_activity import
     _REQUIRED_SERVICE_FIELDS,
     _load,
     _normalize_config,
+    _sequential_memory_dumpvars,
     generate_activity,
+)
+from npu.eval.extract_sequential_register_vcd_activity import (
+    extract_sequential_register_vcd_activity,
 )
 from npu.eval.probe_attention_decode_score_multivalue_integrated_service import _workload_contract
 
@@ -77,6 +81,27 @@ def test_activity_generator_source_has_no_artificial_macro_touch() -> None:
     assert "post-completion trace touch" not in source
 
 
+def test_sequential_memory_dumpvars_cover_c1_routed_state_arrays() -> None:
+    targets = _sequential_memory_dumpvars(
+        {
+            "cluster_count": 1,
+            "banks": 4,
+            "req_queue_depth": 4,
+            "resp_queue_depth": 4,
+            "bank_queue_depth": 4,
+        }
+    )
+
+    assert len(targets) == len(set(targets))
+    assert "dut.gen_cluster[0].u_cluster.reducer.numerator_accum[127]" in targets
+    assert "dut.gen_cluster[0].u_cluster.reducer.block_weight[7]" in targets
+    assert "dut.gen_cluster[0].u_cluster.score_tile.accum[7]" in targets
+    assert "dut.u_router.gen_resp_fifo[0].u_resp_fifo.mem[3]" in targets
+    assert "dut.u_service.active_matrix[3]" in targets
+    assert "dut.u_service.gen_bank_fifo[3].u_bank_fifo.mem[3]" in targets
+    assert "dut.expected_addr_q[0]" in targets
+
+
 @pytest.mark.skipif(not _iverilog_available(), reason="iverilog/vvp unavailable")
 def test_generate_service_activity_is_deterministic(tmp_path: Path) -> None:
     config_path = tmp_path / "config.json"
@@ -126,6 +151,16 @@ def test_generate_service_activity_is_deterministic(tmp_path: Path) -> None:
     vcd_b = (out_b / _OUTPUT_VCD_NAME).read_bytes()
     assert vcd_a == vcd_b
     assert manifest_a["hashes"]["vcd_sha256"] == manifest_b["hashes"]["vcd_sha256"]
+    sequential = extract_sequential_register_vcd_activity(
+        out_a / _OUTPUT_VCD_NAME,
+        source_vcd_sha256=manifest_a["hashes"]["vcd_sha256"],
+    )
+    register_names = {row["full_name"] for row in sequential["register_bits"]}
+    assert "gen_cluster[0]/u_cluster/reducer/numerator_accum[127][40]" in register_names
+    assert "gen_cluster[0]/u_cluster/score_tile/accum[7][31]" in register_names
+    assert "u_router/gen_resp_fifo[0]/u_resp_fifo/mem[3][157]" in register_names
+    assert "u_service/active_matrix[3][511]" in register_names
+    assert "u_service/gen_bank_fifo[3]/u_bank_fifo/mem[3][26]" in register_names
 
 
 @pytest.mark.skipif(not _iverilog_available(), reason="iverilog/vvp unavailable")


### PR DESCRIPTION
Preserves full wrapper hierarchy in multivalue-service FakeRAM sidecars and explicitly dumps unpacked sequential arrays omitted by Icarus recursive dumpvars. Covers reducer accumulators, score accumulators, service active state, router/service FIFO memories, and per-cluster metadata without synthetic toggles. Keeps all existing promotion thresholds. Tests: 80 focused activity/extractor/power tests; validate_runs --skip_eval_queue.