### PR TITLE
npu: validate full service macro activity paths

### DIFF
--- a/npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py
@@ -58,7 +58,8 @@ _SCORE_ACTIVITY_RE = re.compile(
     r"(?:addr_in\[\d+\]|wd_in\[\d+\]|w_mask_in\[\d+\]|we_in|ce_in)$"
 )
 _VALUE_ACTIVITY_RE = re.compile(
-    r"^gen_value_macro_backend/gen_value_bank\[(\d+)\]/gen_value_lane\[(\d+)\]/u_value_mem_lane/"
+    r"^(?P<instance>(?:[^/]+/)*gen_value_macro_backend/"
+    r"gen_value_bank\[(\d+)\]/gen_value_lane\[(\d+)\]/u_value_mem_lane)/"
     r"(?:addr_in\[\d+\]|wd_in\[\d+\]|w_mask_in\[\d+\]|we_in|ce_in)$"
 )
 
@@ -580,12 +581,7 @@ def _validate_service_macro_activity_contract(
         value_match = _VALUE_ACTIVITY_RE.fullmatch(full_name)
         if value_match is not None:
             value_pin_count += 1
-            value_instances.add(
-                "gen_value_macro_backend/gen_value_bank[{bank}]/gen_value_lane[{lane}]/u_value_mem_lane".format(
-                    bank=value_match.group(1),
-                    lane=value_match.group(2),
-                )
-            )
+            value_instances.add(str(value_match.group("instance")))
             continue
         raise ValueError(f"service macro activity contains unsupported full_name: {full_name}")
 

--- a/tests/test_attention_decode_score_multivalue_service_activity_power.py
+++ b/tests/test_attention_decode_score_multivalue_service_activity_power.py
@@ -16,6 +16,26 @@ from npu.eval import audit_attention_decode_score_multivalue_service_activity_po
 from npu.eval.probe_attention_decode_score_multivalue_integrated_service import _workload_contract
 
 
+def test_service_macro_activity_patterns_accept_full_routed_hierarchy() -> None:
+    score = audit._SCORE_ACTIVITY_RE.fullmatch(
+        "gen_cluster[0]/u_cluster/score_bank/u_group_7_slice_6/wd_in[38]"
+    )
+    value = audit._VALUE_ACTIVITY_RE.fullmatch(
+        "u_service/gen_value_macro_backend/gen_value_bank[3]/"
+        "gen_value_lane[15]/u_value_mem_lane/w_mask_in[31]"
+    )
+
+    assert score is not None
+    assert score.group("instance") == (
+        "gen_cluster[0]/u_cluster/score_bank/u_group_7_slice_6"
+    )
+    assert value is not None
+    assert value.group("instance") == (
+        "u_service/gen_value_macro_backend/gen_value_bank[3]/"
+        "gen_value_lane[15]/u_value_mem_lane"
+    )
+
+
 def _scaled_counts(cluster_count: int) -> dict[str, int]:
     return {
         "request_count": 48 * int(cluster_count),


### PR DESCRIPTION
Updates the strict service activity validator to accept and count full wrapper-qualified value-memory instance paths emitted by the corrected extractor. The gate remains count- and identity-strict; only the canonical path contract changes. Tests: 29 focused generator/extractor/audit tests; validate_runs --skip_eval_queue.