### PR TITLE
control_plane: preserve task type across queue roundtrip

### DIFF
--- a/control_plane/control_plane/services/queue_exporter.py
+++ b/control_plane/control_plane/services/queue_exporter.py
@@ -158,6 +158,7 @@ def export_queue_item(session: Session, request: QueueExportRequest) -> QueueExp
     export_payload["title"] = work_item.task_request.title
     export_payload["layer"] = work_item.layer.value
     export_payload["flow"] = work_item.flow.value
+    export_payload["task_type"] = work_item.task_type
     export_payload["priority"] = work_item.priority
     export_payload["requested_by"] = work_item.task_request.requested_by
     export_payload["platform"] = work_item.platform

--- a/control_plane/control_plane/services/queue_importer.py
+++ b/control_plane/control_plane/services/queue_importer.py
@@ -7,6 +7,7 @@ from hashlib import sha256
 import subprocess
 import json
 from pathlib import Path
+import re
 from typing import Any
 
 from sqlalchemy.orm import Session
@@ -69,6 +70,26 @@ def _json_sha256(payload: dict[str, Any]) -> str:
     return sha256(canonical).hexdigest()
 
 
+def _resolve_task_type(payload: dict[str, Any]) -> str:
+    explicit_task_type = str(payload.get("task_type") or "").strip()
+    if explicit_task_type:
+        if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}", explicit_task_type) is None:
+            raise QueueImportError("task_type must be a portable identifier of at most 64 characters")
+        return explicit_task_type
+    task = payload.get("task") or {}
+    commands = task.get("commands") or []
+    command_names = [cmd.get("name") for cmd in commands if isinstance(cmd, dict)]
+    if payload.get("layer") == "layer1":
+        if "run_eval" in command_names:
+            return "l1_sweep"
+        return "layer1_queue_item"
+    if payload.get("layer") == "layer2":
+        if "run_campaign" in command_names:
+            return "l2_campaign"
+        return "layer2_queue_item"
+    return "queue_item"
+
+
 def _semantic_payload(payload: dict[str, Any]) -> dict[str, Any]:
     handoff = payload.get("handoff") or {}
     semantic_handoff = {
@@ -83,6 +104,7 @@ def _semantic_payload(payload: dict[str, Any]) -> dict[str, Any]:
         "title": payload.get("title"),
         "layer": payload.get("layer"),
         "flow": payload.get("flow"),
+        "task_type": _resolve_task_type(payload),
         "priority": payload.get("priority"),
         "created_utc": payload.get("created_utc"),
         "requested_by": payload.get("requested_by"),
@@ -169,21 +191,6 @@ def _merge_state(current: WorkItemState, imported: WorkItemState) -> WorkItemSta
     return imported if _STATE_RANK[imported] > _STATE_RANK[current] else current
 
 
-def _derive_task_type(payload: dict[str, Any]) -> str:
-    task = payload.get("task") or {}
-    commands = task.get("commands") or []
-    command_names = [cmd.get("name") for cmd in commands if isinstance(cmd, dict)]
-    if payload.get("layer") == "layer1":
-        if "run_eval" in command_names:
-            return "l1_sweep"
-        return "layer1_queue_item"
-    if payload.get("layer") == "layer2":
-        if "run_campaign" in command_names:
-            return "l2_campaign"
-        return "layer2_queue_item"
-    return "queue_item"
-
-
 def _record_reconciliation(
     session: Session,
     *,
@@ -252,7 +259,7 @@ def import_queue_item(session: Session, request: QueueImportRequest) -> QueueImp
             layer=LayerName(payload.get("layer")),
             flow=FlowName(payload.get("flow")),
             platform=payload.get("platform", "unknown"),
-            task_type=_derive_task_type(payload),
+            task_type=_resolve_task_type(payload),
             state=_queue_state_to_work_item_state(payload.get("state", "queued")),
             priority=int(payload.get("priority", 1)),
             source_mode=(payload.get("task") or {}).get("source_mode"),
@@ -324,6 +331,11 @@ def import_queue_item(session: Session, request: QueueImportRequest) -> QueueImp
 
     if resolved_source_commit and existing.source_commit != resolved_source_commit:
         existing.source_commit = resolved_source_commit
+        changed = True
+
+    imported_task_type = _resolve_task_type(payload)
+    if existing.task_type != imported_task_type:
+        existing.task_type = imported_task_type
         changed = True
 
     if changed:

--- a/control_plane/control_plane/tests/test_queue_exporter.py
+++ b/control_plane/control_plane/tests/test_queue_exporter.py
@@ -116,6 +116,7 @@ def test_export_queued_snapshot() -> None:
             payload = json.loads(out.read_text(encoding="utf-8"))
             assert result.target_state == "queued"
             assert payload["state"] == "queued"
+            assert payload["task_type"] == "l2_campaign"
             assert payload["result"] is None
             assert payload["item_id"] == "l2_e2e_softmax_macro_tail_v1"
             assert session.query(QueueReconciliation).count() == 2
@@ -145,6 +146,7 @@ def test_export_evaluated_snapshot() -> None:
             payload = json.loads(out.read_text(encoding="utf-8"))
             assert result.target_state == "evaluated"
             assert payload["state"] == "evaluated"
+            assert payload["task_type"] == "l2_campaign"
             assert payload["result"]["status"] == "ok"
             assert payload["result"]["queue_item_id"] == "l2_e2e_softmax_macro_tail_v1"
             assert payload["result"]["metrics_rows"][0]["tag"] == "export_smoke"

--- a/control_plane/control_plane/tests/test_queue_importer.py
+++ b/control_plane/control_plane/tests/test_queue_importer.py
@@ -15,7 +15,7 @@ from control_plane.models.task_requests import TaskRequest
 from control_plane.models.work_items import WorkItem
 from control_plane.services.queue_importer import QueueImportConflict, QueueImportError, QueueImportRequest, import_queue_item
 
-REPO_ROOT = Path("/workspaces/RTLGen")
+REPO_ROOT = Path(__file__).resolve().parents[3]
 REAL_QUEUE_ITEM = REPO_ROOT / "runs/eval_queue/openroad/queued/l2_e2e_softmax_macro_tail_v1.json"
 
 
@@ -107,6 +107,89 @@ def test_import_same_item_is_idempotent() -> None:
         assert session.query(WorkItem).count() == 1
         assert session.query(TaskRequest).count() == 1
         assert session.query(QueueReconciliation).count() == 2
+
+
+def test_import_preserves_explicit_task_type_on_export_roundtrip(tmp_path: Path) -> None:
+    repo_root, queue_file, source_commit = _make_queue_import_repo(tmp_path)
+    exported = tmp_path / "roundtrip.json"
+
+    with make_session() as session:
+        import_queue_item(
+            session,
+            QueueImportRequest(
+                repo_root=str(repo_root),
+                queue_path=str(queue_file),
+                source_commit=source_commit,
+            ),
+        )
+        from control_plane.services.queue_exporter import QueueExportRequest, export_queue_item
+
+        export_queue_item(
+            session,
+            QueueExportRequest(
+                repo_root=str(repo_root),
+                item_id="l2_e2e_softmax_macro_tail_v1",
+                target_state="queued",
+                target_path=str(exported),
+            ),
+        )
+
+    exported_payload = json.loads(exported.read_text(encoding="utf-8"))
+    assert exported_payload["task_type"] == "l2_campaign"
+
+    with make_session() as session:
+        result = import_queue_item(
+            session,
+            QueueImportRequest(
+                repo_root=str(repo_root),
+                queue_path=str(exported),
+                source_commit=source_commit,
+            ),
+        )
+        work_item = session.query(WorkItem).filter_by(item_id="l2_e2e_softmax_macro_tail_v1").one()
+        assert result.status == "applied"
+        assert work_item.task_type == "l2_campaign"
+
+
+def test_import_accepts_legacy_queue_then_explicit_task_type_without_conflict(tmp_path: Path) -> None:
+    payload = json.loads(REAL_QUEUE_ITEM.read_text(encoding="utf-8"))
+    queue_file = tmp_path / "item.json"
+    queue_file.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    with make_session() as session:
+        first = import_queue_item(
+            session,
+            QueueImportRequest(repo_root=str(tmp_path), queue_path="item.json"),
+        )
+        payload["task_type"] = "l2_campaign"
+        queue_file.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        second = import_queue_item(
+            session,
+            QueueImportRequest(repo_root=str(tmp_path), queue_path="item.json"),
+        )
+        work_item = session.query(WorkItem).filter_by(item_id="l2_e2e_softmax_macro_tail_v1").one()
+        assert first.status == "applied"
+        assert second.status == "applied"
+        assert work_item.task_type == "l2_campaign"
+        assert session.query(WorkItem).count() == 1
+
+
+def test_import_rejects_invalid_explicit_task_type(tmp_path: Path) -> None:
+    payload = json.loads(REAL_QUEUE_ITEM.read_text(encoding="utf-8"))
+    payload["task_type"] = "invalid task type"
+    queue_file = tmp_path / "item.json"
+    queue_file.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    with make_session() as session:
+        try:
+            import_queue_item(
+                session,
+                QueueImportRequest(repo_root=str(tmp_path), queue_path="item.json"),
+            )
+        except QueueImportError as exc:
+            assert "task_type must be a portable identifier" in str(exc)
+        else:
+            raise AssertionError("invalid task_type should be rejected")
 
 
 def test_import_conflict_for_semantic_change(tmp_path: Path) -> None:

--- a/runs/eval_queue/README.md
+++ b/runs/eval_queue/README.md
@@ -52,6 +52,9 @@ Rules
 - Keep one item per file.
 - `item_id` must be globally unique across queued+evaluated.
 - `state` must match parent directory (`queued` or `evaluated`).
+- `task_type` is optional for legacy files. New control-plane exports include
+  it so an `l1_sweep` or `l2_campaign` retains its completion behavior when
+  exported and re-imported.
 - `task.source_mode` is required:
   - `config`: harden raw RTLGen modules via `--config`.
   - `src_verilog`: harden existing generated RTL/wrapper modules via

--- a/runs/eval_queue/openroad/item.schema.json
+++ b/runs/eval_queue/openroad/item.schema.json
@@ -26,6 +26,10 @@
     "title": { "type": "string", "minLength": 1 },
     "layer": { "type": "string", "enum": ["layer1", "layer2"] },
     "flow": { "type": "string", "const": "openroad" },
+    "task_type": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
+    },
     "state": { "type": "string", "enum": ["queued", "evaluated"] },
     "priority": { "type": "integer", "minimum": 0, "maximum": 5 },
     "created_utc": { "type": "string", "minLength": 1 },


### PR DESCRIPTION
Exports canonical task_type and restores it on import, preventing an exported l2_campaign from degrading to generic layer2_queue_item and losing automatic completion handling. Legacy files still use command-based inference. Updates the queue schema/runbook and validates explicit identifiers. Tests: 13 queue importer/exporter tests; validate_runs --skip_eval_queue.