### PR TITLE
Fix value SRAM activity hierarchy mapping

### DIFF
--- a/npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py
@@ -58,8 +58,8 @@ _SCORE_ACTIVITY_RE = re.compile(
     r"(?:addr_in\[\d+\]|wd_in\[\d+\]|w_mask_in\[\d+\]|we_in|ce_in)$"
 )
 _VALUE_ACTIVITY_RE = re.compile(
-    r"^(?P<instance>(?:[^/]+/)*gen_value_macro_backend/"
-    r"gen_value_bank\[(\d+)\]/gen_value_lane\[(\d+)\]/u_value_mem_lane)/"
+    r"^(?P<instance>(?:[^/]+/)*gen_value_macro_backend\."
+    r"gen_value_bank\[(\d+)\]\.gen_value_lane\[(\d+)\]\.u_value_mem_lane)/"
     r"(?:addr_in\[\d+\]|wd_in\[\d+\]|w_mask_in\[\d+\]|we_in|ce_in)$"
 )
 

--- a/npu/eval/extract_fakeram_vcd_activity.py
+++ b/npu/eval/extract_fakeram_vcd_activity.py
@@ -181,7 +181,18 @@ def _value_scope_result(
             continue
         if index + 4 != len(parts):
             continue
-        macro_parts = ["gen_value_macro_backend", bank_scope, lane_scope, leaf_scope]
+        # Yosys flattens these nested generate scopes into one escaped
+        # OpenDB instance name, while retaining module boundaries as "/".
+        macro_parts = [
+            ".".join(
+                [
+                    "gen_value_macro_backend",
+                    bank_scope,
+                    lane_scope,
+                    leaf_scope,
+                ]
+            )
+        ]
         if index > 0 and preserve_instance_prefix:
             macro_parts = [*parts[:index], *macro_parts]
         return ("/".join(macro_parts), _VALUE_MACRO_SPEC)

--- a/tests/test_attention_decode_score_multivalue_service_activity_power.py
+++ b/tests/test_attention_decode_score_multivalue_service_activity_power.py
@@ -21,8 +21,8 @@ def test_service_macro_activity_patterns_accept_full_routed_hierarchy() -> None:
         "gen_cluster[0]/u_cluster/score_bank/u_group_7_slice_6/wd_in[38]"
     )
     value = audit._VALUE_ACTIVITY_RE.fullmatch(
-        "u_service/gen_value_macro_backend/gen_value_bank[3]/"
-        "gen_value_lane[15]/u_value_mem_lane/w_mask_in[31]"
+        "u_service/gen_value_macro_backend.gen_value_bank[3]."
+        "gen_value_lane[15].u_value_mem_lane/w_mask_in[31]"
     )
 
     assert score is not None
@@ -31,8 +31,8 @@ def test_service_macro_activity_patterns_accept_full_routed_hierarchy() -> None:
     )
     assert value is not None
     assert value.group("instance") == (
-        "u_service/gen_value_macro_backend/gen_value_bank[3]/"
-        "gen_value_lane[15]/u_value_mem_lane"
+        "u_service/gen_value_macro_backend.gen_value_bank[3]."
+        "gen_value_lane[15].u_value_mem_lane"
     )
 
 

--- a/tests/test_extract_fakeram_vcd_activity.py
+++ b/tests/test_extract_fakeram_vcd_activity.py
@@ -371,7 +371,7 @@ def test_extract_multivalue_service_activity_tracks_both_macro_classes(tmp_path:
     by_name = {row["full_name"]: row for row in payload["pins"]}
     assert "wrapper/score_bank/u_group_0_slice_0/we_in" in by_name
     assert (
-        "wrapper/gen_value_macro_backend/gen_value_bank[0]/gen_value_lane[0]/u_value_mem_lane/ce_in"
+        "wrapper/gen_value_macro_backend.gen_value_bank[0].gen_value_lane[0].u_value_mem_lane/ce_in"
         in by_name
     )
     contract = payload["structural_macro_contract"]
@@ -481,6 +481,10 @@ def test_extract_multivalue_service_activity_preserves_c2_cluster_identity(tmp_p
     by_name = {row["full_name"]: row for row in payload["pins"]}
     assert "gen_cluster[0]/u_cluster/score_bank/u_group_0_slice_0/we_in" in by_name
     assert "gen_cluster[1]/u_cluster/score_bank/u_group_0_slice_0/we_in" in by_name
+    assert (
+        "gen_value_macro_backend.gen_value_bank[0].gen_value_lane[0].u_value_mem_lane/ce_in"
+        in by_name
+    )
     contract = payload["structural_macro_contract"]
     classes = {row["macro_name"]: row for row in contract["macro_classes"]}
     assert classes["fakeram45_2048x39"]["instance_count"] == 2
@@ -512,7 +516,7 @@ def test_extract_multivalue_service_activity_real_generated_vcd_sidecar(tmp_path
     full_names = {row["full_name"] for row in payload["pins"]}
     assert "gen_cluster[0]/u_cluster/score_bank/u_group_7_slice_6/ce_in" in full_names
     assert (
-        "u_service/gen_value_macro_backend/gen_value_bank[3]/gen_value_lane[15]/u_value_mem_lane/ce_in"
+        "u_service/gen_value_macro_backend.gen_value_bank[3].gen_value_lane[15].u_value_mem_lane/ce_in"
         in full_names
     )
 
@@ -542,7 +546,7 @@ def test_extract_multivalue_service_activity_real_generated_c2_vcd_sidecar(tmp_p
     value_instances = {
         name.rsplit("/", 1)[0]
         for name in full_names
-        if name.startswith("u_service/gen_value_macro_backend/")
+        if name.startswith("u_service/gen_value_macro_backend.")
     }
     assert len(score_instances) == 112
     assert len(value_instances) == 64


### PR DESCRIPTION
Maps nested value-SRAM generate scopes to the exact Yosys/OpenDB dotted instance spelling while retaining strict full-name annotation. Updates c1/c2 sidecar and validator expectations. Verification: 23 focused tests; validate_runs --skip_eval_queue; generated sidecar compared with retained c1 routed netlist, 64 expected value SRAM instances, 64 actual, zero missing or extra. This addresses all 4,608 unmatched value-SRAM pin assignments in r6.