### PR TITLE
Allow postroute power report rounding

### DIFF
--- a/npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py
@@ -40,6 +40,8 @@ _ABSOLUTE_PATH_RE = re.compile(r"/[^\s\"'`<>|&(){}\[\]]+")
 _MAX_FAILURE_DETAIL_LINES = 16
 _MAX_FAILURE_DETAIL_LINE_CHARS = 400
 _MAX_FAILURE_DETAIL_BYTES = 4096
+_POWER_COMPONENT_REL_TOL = 1e-6
+_POWER_COMPONENT_ABS_TOL_W = 1e-9
 
 _MODEL = "decoder_attention_decode_score_multivalue_service_activity_power_v1"
 _SCOPE = "tb/dut"
@@ -793,7 +795,13 @@ def _strict_service_window_measurement(
     switching_w = _finite_positive(power.get("switching_w"), "switching_w")
     leakage_w = _finite_positive(power.get("leakage_w"), "leakage_w")
     total_w = _finite_positive(power.get("total_w"), "total_w")
-    if abs((internal_w + switching_w + leakage_w) - total_w) > 1e-9:
+    component_sum_w = internal_w + switching_w + leakage_w
+    if not math.isclose(
+        component_sum_w,
+        total_w,
+        rel_tol=_POWER_COMPONENT_REL_TOL,
+        abs_tol=_POWER_COMPONENT_ABS_TOL_W,
+    ):
         raise ValueError("postroute power total_w does not match internal+switching+leakage")
     service_window_s = expected_cycle_count * expected_clock_period_ns * 1e-9
     dynamic_energy_j = (internal_w + switching_w) * service_window_s

--- a/npu/eval/audit_llm_decoder_attention_score32_schedule_wrapper_postroute_activity_power.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_schedule_wrapper_postroute_activity_power.py
@@ -44,6 +44,8 @@ _EXPECTED_REDUCTION_CYCLES = 141
 _EXPECTED_KV_WRITE_CYCLES = 10
 _EXPECTED_LAYER_CYCLES = 8231
 _SCOPE = "tb/dut"
+_POWER_COMPONENT_REL_TOL = 1e-6
+_POWER_COMPONENT_ABS_TOL_W = 1e-9
 
 
 def _load(path: Path) -> JsonDict:
@@ -259,7 +261,12 @@ def _strict_service_window_measurement(
     switching_w = _require_positive(power.get("switching_w"), "switching_w")
     leakage_w = _require_positive(power.get("leakage_w"), "leakage_w")
     total_w = _require_positive(power.get("total_w"), "total_w")
-    if abs((internal_w + switching_w + leakage_w) - total_w) > 1e-9:
+    if not math.isclose(
+        internal_w + switching_w + leakage_w,
+        total_w,
+        rel_tol=_POWER_COMPONENT_REL_TOL,
+        abs_tol=_POWER_COMPONENT_ABS_TOL_W,
+    ):
         raise ValueError("postroute power total_w does not match internal+switching+leakage")
     annotation_clock_ns = _DEFAULT_CLOCK_PERIOD_NS
     promotion_clock_ns = max(annotation_clock_ns, authoritative_critical_path_ns)

--- a/tests/test_attention_decode_score_multivalue_service_activity_power.py
+++ b/tests/test_attention_decode_score_multivalue_service_activity_power.py
@@ -368,6 +368,42 @@ def _power_report(
     }
 
 
+def test_service_window_power_accepts_independent_report_rounding() -> None:
+    report = _power_report(manifest_sha256="manifest-hash", cycle_count=8719)
+    report["phases"][0]["power"] = {
+        "internal_w": 0.153530582786,
+        "switching_w": 0.0866372808814,
+        "leakage_w": 0.116741158068,
+        "total_w": 0.356909006834,
+    }
+
+    measured = audit._strict_service_window_measurement(
+        activity_power=report,
+        manifest_sha256="manifest-hash",
+        expected_vcd_sha256="vcd-hash",
+        expected_clock_period_ns=10.0,
+        expected_cycle_count=8719,
+        expected_macro_assignment_count=9704,
+    )
+
+    assert measured["power_w"]["total"] == pytest.approx(0.356909006834)
+
+
+def test_service_window_power_rejects_material_component_mismatch() -> None:
+    report = _power_report(manifest_sha256="manifest-hash")
+    report["phases"][0]["power"]["total_w"] = 0.349
+
+    with pytest.raises(ValueError, match="total_w does not match"):
+        audit._strict_service_window_measurement(
+            activity_power=report,
+            manifest_sha256="manifest-hash",
+            expected_vcd_sha256="vcd-hash",
+            expected_clock_period_ns=10.0,
+            expected_cycle_count=321,
+            expected_macro_assignment_count=9704,
+        )
+
+
 def test_select_c1_metric_rejects_ambiguity_and_flow_mismatch(tmp_path: Path) -> None:
     metrics = tmp_path / "metrics.csv"
     _write_metrics(metrics, [_ok_metric(flow_variant="wrong_variant")])

--- a/tests/test_audit_llm_decoder_attention_score32_schedule_wrapper_postroute_activity_power.py
+++ b/tests/test_audit_llm_decoder_attention_score32_schedule_wrapper_postroute_activity_power.py
@@ -180,6 +180,40 @@ def _power_report() -> dict:
     }
 
 
+def test_service_window_power_accepts_independent_report_rounding() -> None:
+    report = _power_report()
+    report["phases"][0]["power"] = {
+        "internal_w": 0.153530582786,
+        "switching_w": 0.0866372808814,
+        "leakage_w": 0.116741158068,
+        "total_w": 0.356909006834,
+    }
+
+    measured = audit._strict_service_window_measurement(
+        activity_power=report,
+        manifest_sha256="manifest-hash",
+        expected_vcd_sha256="vcd-hash",
+        expected_cycle_count=986,
+        authoritative_critical_path_ns=48.6509,
+    )
+
+    assert measured["power_w"]["total"] == pytest.approx(0.356909006834)
+
+
+def test_service_window_power_rejects_material_component_mismatch() -> None:
+    report = _power_report()
+    report["phases"][0]["power"]["total_w"] = 0.59
+
+    with pytest.raises(ValueError, match="total_w does not match"):
+        audit._strict_service_window_measurement(
+            activity_power=report,
+            manifest_sha256="manifest-hash",
+            expected_vcd_sha256="vcd-hash",
+            expected_cycle_count=986,
+            authoritative_critical_path_ns=48.6509,
+        )
+
+
 def test_build_report_rejects_accidental_4_cycle_scaling(tmp_path: Path) -> None:
     config = tmp_path / "config.json"
     metrics = tmp_path / "metrics.csv"


### PR DESCRIPTION
OpenSTA reports total and component powers with independent finite precision. Replace the absolute 1 nW identity check with math.isclose at 1 ppm relative / 1 nW absolute tolerance in both postroute activity auditors. The observed r7 discrepancy is 14.9 nW, or 0.042 ppm; material mismatches remain rejected. Adds rounding-pass and mismatch-fail tests for both auditors. Verification: 20 focused tests and validate_runs --skip_eval_queue.