### PR TITLE
Add exact-partial multivalue service result mode

### DIFF
--- a/npu/eval/check_attention_decode_score_multivalue_service_guard.py
+++ b/npu/eval/check_attention_decode_score_multivalue_service_guard.py
@@ -49,9 +49,30 @@ def _source_w(cluster_count: int) -> int:
     return max(1, (cluster_count - 1).bit_length())
 
 
-def _top_pin_bits(cluster_count: int) -> int:
+def _semantic_profile(result_mode: str) -> str:
+    if result_mode == "exact_partial":
+        return "decode_m1x8_shared_score_16x8d_value_exact_partial_onchip_service_v1"
+    return "decode_m1x8_shared_score_16x8d_value_iterdiv_onchip_service_v1"
+
+
+def _cluster_semantic_profile(result_mode: str) -> str:
+    if result_mode == "exact_partial":
+        return "decode_m1x8_shared_score_16x8d_value_exact_partial_v1"
+    return "decode_m1x8_shared_score_16x8d_value_iterdiv_v1"
+
+
+def _result_value_bits(result_mode: str) -> int:
+    return 328 if result_mode == "exact_partial" else 320
+
+
+def _top_pin_bits(cluster_count: int, *, result_mode: str, head_id_bits: int) -> int:
     source_w = _source_w(cluster_count)
-    return (1487 + source_w) + (cluster_count * (687 + source_w))
+    base_bits = 1487 + source_w
+    per_cluster_bits = 687 + source_w
+    if result_mode == "exact_partial":
+        base_bits += head_id_bits + (_result_value_bits(result_mode) - 320)
+        per_cluster_bits += (2 * head_id_bits) + (_result_value_bits(result_mode) - 320)
+    return base_bits + (cluster_count * per_cluster_bits)
 
 
 def main() -> int:
@@ -104,8 +125,19 @@ def main() -> int:
     for key, expected in expected_config.items():
         _require(body, key, expected, "service config")
     cluster_count = int(body.get("cluster_count", 0))
+    result_mode = str(body.get("result_mode", "normalized")).strip().lower()
+    head_id_bits = int(body.get("head_id_bits", 5))
     if cluster_count not in _SUPPORTED_CLUSTER_COUNTS:
         raise SystemExit("service config cluster_count must be exactly one of 1 or 2 for this first physical patch")
+    if result_mode not in {"normalized", "exact_partial"}:
+        raise SystemExit("service config result_mode must be normalized or exact_partial")
+    if head_id_bits < 1 or head_id_bits > 8:
+        raise SystemExit("service config head_id_bits must be in [1, 8]")
+    if result_mode == "exact_partial":
+        if body.get("result_mode") != "exact_partial":
+            raise SystemExit("service config must explicitly set result_mode=exact_partial")
+        if "head_id_bits" not in body:
+            raise SystemExit("service config exact_partial mode must explicitly set head_id_bits")
 
     top_name = str(config.get("top_name") or "")
     expected_suffix = f"_c{cluster_count}_p128_b4_q4_rl2_rr"
@@ -116,7 +148,7 @@ def main() -> int:
     expected_manifest = {
         "top_name": top_name,
         "generator": "npu/rtlgen/gen_attention_decode_score_multivalue_service.py",
-        "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_onchip_service_v1",
+        "semantic_profile": _semantic_profile(result_mode),
         "cluster_count": cluster_count,
         "max_blocks": 16,
         "packet_w": 128,
@@ -131,6 +163,9 @@ def main() -> int:
         "value_slices": 16,
         "score_scale_lanes_per_cycle": 1,
         "fsm_encoding": "default",
+        "result_mode": result_mode,
+        "head_id_bits": head_id_bits,
+        "result_value_bits_per_beat": _result_value_bits(result_mode),
         "value_memory_backend": "macro_banked_4x16x64x32",
         "value_memory_promotable": True,
         "score_bank_macro_count": 56 * cluster_count,
@@ -140,14 +175,28 @@ def main() -> int:
         "shared_result_egress_initiation_interval": 1,
         "shared_result_egress_stall_semantics": "stable_until_handshake",
         "response_metadata_guard": "single_outstanding_per_cluster_v1",
-        "top_pin_bits": _top_pin_bits(cluster_count),
+        "top_pin_bits": _top_pin_bits(cluster_count, result_mode=result_mode, head_id_bits=head_id_bits),
     }
     for key, expected in expected_manifest.items():
         _require(manifest, key, expected, "generated manifest")
 
     cluster_manifest = manifest.get("submodule_manifests", {}).get("multivalue_cluster", {})
-    _require(cluster_manifest, "semantic_profile", "decode_m1x8_shared_score_16x8d_value_iterdiv_v1", "embedded cluster manifest")
+    _require(
+        cluster_manifest,
+        "semantic_profile",
+        _cluster_semantic_profile(result_mode),
+        "embedded cluster manifest",
+    )
     _require(cluster_manifest, "score_bank_macro_count", 56, "embedded cluster manifest")
+    _require(cluster_manifest, "result_mode", result_mode, "embedded cluster manifest")
+    _require(
+        cluster_manifest,
+        "result_value_bits_per_beat",
+        _result_value_bits(result_mode),
+        "embedded cluster manifest",
+    )
+    if result_mode == "exact_partial":
+        _require(cluster_manifest, "head_id_bits", head_id_bits, "embedded cluster manifest")
 
     design_macro_manifest = _load_json(paths["design_macro_manifest"])
     generated_macro_manifest = _load_json(paths["generated_macro_manifest"])
@@ -185,7 +234,7 @@ def main() -> int:
 
     macro_params = design_macro_manifest.get("manifest_params", {})
     expected_macro_params = {
-        "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_onchip_service_v1",
+        "semantic_profile": _semantic_profile(result_mode),
         "cluster_count": cluster_count,
         "score_bank_macro_count": 56 * cluster_count,
         "value_memory_backend": "macro_banked_4x16x64x32",
@@ -207,10 +256,13 @@ def main() -> int:
         "arb_mode": "round_robin",
         "locality_burst_max": 2,
         "score_scale_lanes_per_cycle": 1,
+        "result_mode": result_mode,
+        "head_id_bits": head_id_bits,
+        "result_value_bits_per_beat": _result_value_bits(result_mode),
         "score_passes_per_command": 1,
         "value_slices": 16,
         "shared_result_egress": "single_ready_valid_round_robin_hold_reg_v2",
-        "top_pin_bits": _top_pin_bits(cluster_count),
+        "top_pin_bits": _top_pin_bits(cluster_count, result_mode=result_mode, head_id_bits=head_id_bits),
         "macro_eval_excludes_io_pads": True,
     }
     for key, expected in expected_macro_params.items():
@@ -243,6 +295,18 @@ def main() -> int:
     for token in required_tokens:
         if token not in rtl:
             raise SystemExit(f"service RTL missing semantic token: {token}")
+    if result_mode == "exact_partial":
+        for token in (
+            "cluster_command_head_id",
+            "cluster_result_head_id",
+            "shared_result_head_id",
+            "raw_cluster_result_head_id",
+            "shared_result_head_id_q",
+            ".command_head_id(",
+            ".result_head_id(",
+        ):
+            if token not in rtl:
+                raise SystemExit(f"service RTL missing exact_partial token: {token}")
     for forbidden in ("equivalence_hash", "result_hash", "sha256", "checksum"):
         if re.search(rf"\b{re.escape(forbidden)}\b", rtl, flags=re.IGNORECASE):
             raise SystemExit(f"service RTL contains forbidden abstraction token: {forbidden}")
@@ -255,7 +319,10 @@ def main() -> int:
                 "design": top_name,
                 "guard": "attention_decode_score_multivalue_service_v1",
                 "cluster_count": cluster_count,
-                "top_pin_bits": _top_pin_bits(cluster_count),
+                "result_mode": result_mode,
+                "top_pin_bits": _top_pin_bits(
+                    cluster_count, result_mode=result_mode, head_id_bits=head_id_bits
+                ),
                 "status": "ok",
             },
             sort_keys=True,

--- a/npu/rtlgen/gen_attention_decode_score_multivalue_service.py
+++ b/npu/rtlgen/gen_attention_decode_score_multivalue_service.py
@@ -86,6 +86,8 @@ def _validate(config: JsonDict) -> JsonDict:
     locality_burst_max = int(body.get("locality_burst_max", 2))
     score_scale_lanes_per_cycle = int(body.get("score_scale_lanes_per_cycle", 1))
     fsm_encoding = str(body.get("fsm_encoding", "default")).strip().lower()
+    result_mode = str(body.get("result_mode", "normalized")).strip().lower()
+    head_id_bits = int(body.get("head_id_bits", 5))
     value_memory_backend = str(body.get("value_memory_backend", "behavioral")).strip().lower()
 
     if cluster_count < 1 or cluster_count > 32:
@@ -108,6 +110,10 @@ def _validate(config: JsonDict) -> JsonDict:
         raise SystemExit("score_scale_lanes_per_cycle must be one of 1,2,4,8")
     if fsm_encoding not in {"default", "binary"}:
         raise SystemExit("fsm_encoding must be default or binary")
+    if result_mode not in {"normalized", "exact_partial"}:
+        raise SystemExit("result_mode must be normalized or exact_partial")
+    if head_id_bits < 1 or head_id_bits > 8:
+        raise SystemExit("head_id_bits must be in [1, 8]")
     if value_memory_backend not in {"behavioral", "macro_banked_4x16x64x32"}:
         raise SystemExit("value_memory_backend must be behavioral or macro_banked_4x16x64x32")
     if value_memory_backend == "macro_banked_4x16x64x32":
@@ -132,6 +138,8 @@ def _validate(config: JsonDict) -> JsonDict:
         "locality_burst_max": locality_burst_max,
         "score_scale_lanes_per_cycle": score_scale_lanes_per_cycle,
         "fsm_encoding": fsm_encoding,
+        "result_mode": result_mode,
+        "head_id_bits": head_id_bits,
         "value_memory_backend": value_memory_backend,
     }
 
@@ -140,10 +148,25 @@ def _source_w(cluster_count: int) -> int:
     return _clog2(cluster_count)
 
 
-def _total_top_pin_bits(cluster_count: int) -> int:
+def _result_value_bits(params: JsonDict) -> int:
+    return 328 if str(params["result_mode"]) == "exact_partial" else 320
+
+
+def _service_semantic_profile(params: JsonDict) -> str:
+    if str(params["result_mode"]) == "exact_partial":
+        return "decode_m1x8_shared_score_16x8d_value_exact_partial_onchip_service_v1"
+    return "decode_m1x8_shared_score_16x8d_value_iterdiv_onchip_service_v1"
+
+
+def _total_top_pin_bits(params: JsonDict) -> int:
+    cluster_count = int(params["cluster_count"])
     source_w = _source_w(cluster_count)
     base_bits = 1487 + source_w
     per_cluster_bits = 687 + source_w
+    if str(params["result_mode"]) == "exact_partial":
+        head_id_bits = int(params["head_id_bits"])
+        base_bits += head_id_bits + (_result_value_bits(params) - 320)
+        per_cluster_bits += (2 * head_id_bits) + (_result_value_bits(params) - 320)
     return base_bits + (cluster_count * per_cluster_bits)
 
 
@@ -164,7 +187,7 @@ def _minimum_core_side_um(params: JsonDict) -> int:
         _value_memory_macro_count(params) * _VALUE_MEM_SIZE_UM[0] * _VALUE_MEM_SIZE_UM[1]
     )
     macro_bound_um = math.sqrt((score_bank_area + value_memory_area) / 0.4)
-    pin_bound_um = (_total_top_pin_bits(int(params["cluster_count"])) * _PIN_PITCH_UM) / 4.0
+    pin_bound_um = (_total_top_pin_bits(params) * _PIN_PITCH_UM) / 4.0
     return int(math.ceil(max(macro_bound_um, pin_bound_um)))
 
 
@@ -172,6 +195,8 @@ def _generated_macro_manifest(*, top_name: str, params: JsonDict) -> JsonDict:
     value_memory_backend = str(params["value_memory_backend"])
     score_bank_macro_count = int(params["cluster_count"]) * _SCORE_BANK_MACROS_PER_CLUSTER
     value_memory_macro_count = _value_memory_macro_count(params)
+    semantic_profile = _service_semantic_profile(params)
+    result_value_bits = _result_value_bits(params)
     blackboxes = [_SCORE_BANK_BLACKBOX]
     additional_lefs = [_SCORE_BANK_LEF]
     additional_libs = [_SCORE_BANK_LIB]
@@ -199,7 +224,7 @@ def _generated_macro_manifest(*, top_name: str, params: JsonDict) -> JsonDict:
             "config": f"runs/designs/npu_blocks/{top_name}/config.json",
         },
         "manifest_params": {
-            "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_onchip_service_v1",
+            "semantic_profile": semantic_profile,
             "cluster_count": int(params["cluster_count"]),
             "score_bank_macro_count": score_bank_macro_count,
             "value_memory_backend": value_memory_backend,
@@ -225,10 +250,13 @@ def _generated_macro_manifest(*, top_name: str, params: JsonDict) -> JsonDict:
             "arb_mode": str(params["arb_mode"]),
             "locality_burst_max": int(params["locality_burst_max"]),
             "score_scale_lanes_per_cycle": int(params["score_scale_lanes_per_cycle"]),
+            "result_mode": str(params["result_mode"]),
+            "head_id_bits": int(params["head_id_bits"]),
+            "result_value_bits_per_beat": result_value_bits,
             "score_passes_per_command": 1,
             "value_slices": 16,
             "shared_result_egress": "single_ready_valid_round_robin_hold_reg_v2",
-            "top_pin_bits": _total_top_pin_bits(int(params["cluster_count"])),
+            "top_pin_bits": _total_top_pin_bits(params),
             "minimum_core_side_um": minimum_core_side_um,
             "minimum_die_side_um": minimum_core_side_um + (2 * _TOP_LEVEL_CORE_MARGIN_UM),
             "macro_eval_excludes_io_pads": True,
@@ -249,6 +277,54 @@ def _wrapper(*, top_name: str, params: JsonDict, cluster_top: str) -> str:
     memory_impl = 1 if params["value_memory_backend"] == "macro_banked_4x16x64x32" else 0
     source_w = _clog2(cluster_count)
     frag_idx_w = _clog2(512 // packet_w)
+    partial_mode = str(params["result_mode"]) == "exact_partial"
+    head_id_bits = int(params["head_id_bits"])
+    result_value_bits = _result_value_bits(params)
+    cluster_command_head_port = (
+        f"\n    input  wire [{cluster_count * head_id_bits - 1}:0] cluster_command_head_id,"
+        if partial_mode
+        else ""
+    )
+    cluster_result_head_port = (
+        f"\n    output wire [{cluster_count * head_id_bits - 1}:0] cluster_result_head_id,"
+        if partial_mode
+        else ""
+    )
+    shared_result_head_port = (
+        f"\n    output wire [{head_id_bits - 1}:0] shared_result_head_id,"
+        if partial_mode
+        else ""
+    )
+    raw_cluster_result_head_wire = (
+        f"\n  wire [CLUSTERS*{head_id_bits}-1:0] raw_cluster_result_head_id;" if partial_mode else ""
+    )
+    shared_result_head_reg = (
+        f"\n  reg  [{head_id_bits - 1}:0] shared_result_head_id_q;" if partial_mode else ""
+    )
+    assign_cluster_result_head = (
+        "\n  assign cluster_result_head_id = raw_cluster_result_head_id;" if partial_mode else ""
+    )
+    assign_shared_result_head = (
+        "\n  assign shared_result_head_id = shared_result_head_id_q;" if partial_mode else ""
+    )
+    cluster_command_head_conn = (
+        f"\n          .command_head_id(cluster_command_head_id[(gi * {head_id_bits}) +: {head_id_bits}]),"
+        if partial_mode
+        else ""
+    )
+    cluster_result_head_conn = (
+        f"\n          .result_head_id(raw_cluster_result_head_id[(gi * {head_id_bits}) +: {head_id_bits}]),"
+        if partial_mode
+        else ""
+    )
+    reset_shared_result_head = (
+        f"\n      shared_result_head_id_q <= {head_id_bits}'d0;" if partial_mode else ""
+    )
+    capture_shared_result_head = (
+        f"\n        shared_result_head_id_q <=\n          raw_cluster_result_head_id[(candidate_idx_r * {head_id_bits}) +: {head_id_bits}];"
+        if partial_mode
+        else ""
+    )
     return f"""// Auto-generated by npu/rtlgen/gen_attention_decode_score_multivalue_service.py
 module {top_name} (
     input  wire         clk,
@@ -262,6 +338,7 @@ module {top_name} (
     output wire [{cluster_count - 1}:0] cluster_command_ready,
     input  wire [{cluster_count * 16 - 1}:0] cluster_command_id,
     input  wire [{cluster_count * 15 - 1}:0] cluster_command_block_count,
+{cluster_command_head_port}
     input  wire [{cluster_count * 32 - 1}:0] cluster_command_score_multiplier,
     input  wire [{cluster_count * 6 - 1}:0] cluster_command_score_shift,
     input  wire [{cluster_count - 1}:0] cluster_input_valid,
@@ -274,18 +351,20 @@ module {top_name} (
     output wire [{cluster_count * 16 - 1}:0] cluster_result_command_id,
     output wire [{cluster_count * 32 - 1}:0] cluster_result_global_max,
     output wire [{cluster_count * 33 - 1}:0] cluster_result_exp_sum,
+{cluster_result_head_port}
     output wire [{cluster_count * 4 - 1}:0] cluster_result_slice,
     output wire [{cluster_count - 1}:0] cluster_result_last,
-    output wire [{cluster_count * 320 - 1}:0] cluster_result_value,
+    output wire [{cluster_count * result_value_bits - 1}:0] cluster_result_value,
     output wire         shared_result_valid,
     input  wire         shared_result_ready,
     output wire [{source_w - 1}:0] shared_result_cluster,
     output wire [15:0]  shared_result_command_id,
     output wire [31:0]  shared_result_global_max,
     output wire [32:0]  shared_result_exp_sum,
+{shared_result_head_port}
     output wire [3:0]   shared_result_slice,
     output wire         shared_result_last,
-    output wire [319:0] shared_result_value,
+    output wire [{result_value_bits - 1}:0] shared_result_value,
     output wire [{cluster_count * 32 - 1}:0] cluster_accepted_count,
     output wire [{cluster_count * 32 - 1}:0] cluster_completed_count,
     output wire [{cluster_count * 32 - 1}:0] cluster_cycle_count,
@@ -368,9 +447,10 @@ module {top_name} (
   wire [CLUSTERS*16-1:0] raw_cluster_result_command_id;
   wire [CLUSTERS*32-1:0] raw_cluster_result_global_max;
   wire [CLUSTERS*33-1:0] raw_cluster_result_exp_sum;
+{raw_cluster_result_head_wire}
   wire [CLUSTERS*4-1:0] raw_cluster_result_slice;
   wire [CLUSTERS-1:0] raw_cluster_result_last;
-  wire [CLUSTERS*320-1:0] raw_cluster_result_value;
+  wire [CLUSTERS*{result_value_bits}-1:0] raw_cluster_result_value;
   reg  [TAG_W-1:0] request_tag_q [0:CLUSTERS-1];
   reg  [TAG_W-1:0] expected_tag_q [0:CLUSTERS-1];
   reg  [ADDR_W-1:0] expected_addr_q [0:CLUSTERS-1];
@@ -383,9 +463,10 @@ module {top_name} (
   reg  [15:0] shared_result_command_id_q;
   reg  [31:0] shared_result_global_max_q;
   reg  [32:0] shared_result_exp_sum_q;
+{shared_result_head_reg}
   reg  [3:0] shared_result_slice_q;
   reg  shared_result_last_q;
-  reg  [319:0] shared_result_value_q;
+  reg  [{result_value_bits - 1}:0] shared_result_value_q;
   reg  [SOURCE_W-1:0] result_rr_cursor_q;
   reg  candidate_valid_r;
   reg  [SOURCE_W-1:0] candidate_idx_r;
@@ -404,6 +485,7 @@ module {top_name} (
   assign cluster_result_command_id = raw_cluster_result_command_id;
   assign cluster_result_global_max = raw_cluster_result_global_max;
   assign cluster_result_exp_sum = raw_cluster_result_exp_sum;
+{assign_cluster_result_head}
   assign cluster_result_slice = raw_cluster_result_slice;
   assign cluster_result_last = raw_cluster_result_last;
   assign cluster_result_value = raw_cluster_result_value;
@@ -412,6 +494,7 @@ module {top_name} (
   assign shared_result_command_id = shared_result_command_id_q;
   assign shared_result_global_max = shared_result_global_max_q;
   assign shared_result_exp_sum = shared_result_exp_sum_q;
+{assign_shared_result_head}
   assign shared_result_slice = shared_result_slice_q;
   assign shared_result_last = shared_result_last_q;
   assign shared_result_value = shared_result_value_q;
@@ -432,6 +515,7 @@ module {top_name} (
           .command_ready(cluster_command_ready[gi]),
           .command_id(cluster_command_id[(gi * 16) +: 16]),
           .command_block_count(cluster_command_block_count[(gi * 15) +: 15]),
+{cluster_command_head_conn}
           .command_score_multiplier(cluster_command_score_multiplier[(gi * 32) +: 32]),
           .command_score_shift(cluster_command_score_shift[(gi * 6) +: 6]),
           .input_valid(cluster_input_valid[gi]),
@@ -453,9 +537,10 @@ module {top_name} (
           .result_command_id(raw_cluster_result_command_id[(gi * 16) +: 16]),
           .result_global_max(raw_cluster_result_global_max[(gi * 32) +: 32]),
           .result_exp_sum(raw_cluster_result_exp_sum[(gi * 33) +: 33]),
+{cluster_result_head_conn}
           .result_slice(raw_cluster_result_slice[(gi * 4) +: 4]),
           .result_last(raw_cluster_result_last[gi]),
-          .result_value(raw_cluster_result_value[(gi * 320) +: 320]),
+          .result_value(raw_cluster_result_value[(gi * {result_value_bits}) +: {result_value_bits}]),
           .accepted_count(cluster_accepted_count[(gi * 32) +: 32]),
           .completed_count(cluster_completed_count[(gi * 32) +: 32]),
           .cycle_count(cluster_cycle_count[(gi * 32) +: 32]),
@@ -627,9 +712,10 @@ module {top_name} (
       shared_result_command_id_q <= 16'd0;
       shared_result_global_max_q <= 32'd0;
       shared_result_exp_sum_q <= 33'd0;
+{reset_shared_result_head}
       shared_result_slice_q <= 4'd0;
       shared_result_last_q <= 1'b0;
-      shared_result_value_q <= 320'd0;
+      shared_result_value_q <= {result_value_bits}'d0;
       result_rr_cursor_q <= {{SOURCE_W{{1'b0}}}};
       result_arbitration_contention_cycles <= 32'd0;
       result_egress_block_cycles <= 32'd0;
@@ -655,12 +741,12 @@ module {top_name} (
         shared_result_global_max_q <=
           raw_cluster_result_global_max[(candidate_idx_r * 32) +: 32];
         shared_result_exp_sum_q <=
-          raw_cluster_result_exp_sum[(candidate_idx_r * 33) +: 33];
+          raw_cluster_result_exp_sum[(candidate_idx_r * 33) +: 33];{capture_shared_result_head}
         shared_result_slice_q <=
           raw_cluster_result_slice[(candidate_idx_r * 4) +: 4];
         shared_result_last_q <= raw_cluster_result_last[candidate_idx_r];
         shared_result_value_q <=
-          raw_cluster_result_value[(candidate_idx_r * 320) +: 320];
+          raw_cluster_result_value[(candidate_idx_r * {result_value_bits}) +: {result_value_bits}];
         if (candidate_idx_r == (CLUSTERS - 1)) begin
           result_rr_cursor_q <= {{SOURCE_W{{1'b0}}}};
         end else begin
@@ -718,6 +804,8 @@ def generate(config: JsonDict, out_dir: Path) -> None:
                     "divider_impl": "iterative_restoring",
                     "score_scale_lanes_per_cycle": params["score_scale_lanes_per_cycle"],
                     "fsm_encoding": params["fsm_encoding"],
+                    "result_mode": params["result_mode"],
+                    "head_id_bits": params["head_id_bits"],
                 },
             },
             cluster_dir,
@@ -758,11 +846,12 @@ def generate(config: JsonDict, out_dir: Path) -> None:
             }
         )
     macro_manifest = _generated_macro_manifest(top_name=top_name, params=params)
+    semantic_profile = _service_semantic_profile(params)
     manifest = {
         "version": 1,
         "generator": "npu/rtlgen/gen_attention_decode_score_multivalue_service.py",
         "top_name": top_name,
-        "semantic_profile": "decode_m1x8_shared_score_16x8d_value_iterdiv_onchip_service_v1",
+        "semantic_profile": semantic_profile,
         "cluster_count": params["cluster_count"],
         "max_blocks": params["max_blocks"],
         "packet_w": params["packet_w"],
@@ -777,12 +866,15 @@ def generate(config: JsonDict, out_dir: Path) -> None:
         "value_slices": 16,
         "score_scale_lanes_per_cycle": params["score_scale_lanes_per_cycle"],
         "fsm_encoding": params["fsm_encoding"],
+        "result_mode": params["result_mode"],
+        "head_id_bits": params["head_id_bits"],
+        "result_value_bits_per_beat": _result_value_bits(params),
         "value_memory_backend": params["value_memory_backend"],
         "value_memory_promotable": bool(_value_memory_macro_count(params)),
         "score_bank_macro_count": int(params["cluster_count"]) * _SCORE_BANK_MACROS_PER_CLUSTER,
         "value_memory_macro_count": _value_memory_macro_count(params),
         "total_macro_count": int(params["cluster_count"]) * _SCORE_BANK_MACROS_PER_CLUSTER + _value_memory_macro_count(params),
-        "top_pin_bits": _total_top_pin_bits(int(params["cluster_count"])),
+        "top_pin_bits": _total_top_pin_bits(params),
         "minimum_core_side_um": _minimum_core_side_um(params),
         "minimum_die_side_um": _minimum_core_side_um(params) + (2 * _TOP_LEVEL_CORE_MARGIN_UM),
         "shared_result_egress": "single_ready_valid_round_robin_hold_reg_v2",

--- a/tests/test_attention_decode_score_multivalue_integrated_service.py
+++ b/tests/test_attention_decode_score_multivalue_integrated_service.py
@@ -1,7 +1,9 @@
 import hashlib
 import json
 from pathlib import Path
+import re
 import shutil
+import subprocess
 import sys
 
 import pytest
@@ -23,10 +25,16 @@ from npu.eval.probe_attention_decode_score_multivalue_integrated_service import 
     validate_report,
 )
 from npu.rtlgen.gen_attention_decode_score_multivalue_service import generate
+from npu.sim.perf.attention_exact_partial import pack_numerators, partial_stream_from_blocks
 
 
 def _iverilog_available() -> bool:
     return bool(shutil.which("iverilog") and shutil.which("vvp"))
+
+
+_EXACT_RESULT_RE = re.compile(
+    r"RESULT cmd=(\d+) head=(\d+) slice=(\d+) last=(\d+) max=(-?\d+) sum=(\d+) value=([0-9a-fA-F]+)"
+)
 
 
 def _case(
@@ -80,6 +88,8 @@ def test_multivalue_service_generator_manifest(tmp_path: Path) -> None:
     )
     macro_manifest = json.loads((tmp_path / "macro_manifest.json").read_text(encoding="utf-8"))
     assert manifest["semantic_profile"] == "decode_m1x8_shared_score_16x8d_value_iterdiv_onchip_service_v1"
+    assert manifest["result_mode"] == "normalized"
+    assert manifest["result_value_bits_per_beat"] == 320
     assert manifest["cluster_count"] == 4
     assert manifest["packet_w"] == 256
     assert manifest["banks"] == 8
@@ -92,6 +102,58 @@ def test_multivalue_service_generator_manifest(tmp_path: Path) -> None:
     assert macro_manifest["manifest_params"]["score_bank_macro_count"] == 224
     assert macro_manifest["manifest_params"]["value_memory_backend"] == "behavioral"
     assert macro_manifest["manifest_params"]["value_memory_promotable"] is False
+
+
+def test_multivalue_service_generator_exact_partial_manifest_and_ports(tmp_path: Path) -> None:
+    config = {
+        "top_name": "attention_decode_score_multivalue_service_exact_partial_c1",
+        "attention_decode_score_multivalue_service": {
+            "cluster_count": 1,
+            "max_blocks": 16,
+            "packet_w": 128,
+            "banks": 4,
+            "req_queue_depth": 2,
+            "resp_queue_depth": 2,
+            "bank_queue_depth": 2,
+            "read_latency": 1,
+            "arb_mode": "round_robin",
+            "locality_burst_max": 2,
+            "score_scale_lanes_per_cycle": 1,
+            "result_mode": "exact_partial",
+            "head_id_bits": 5,
+            "value_memory_backend": "behavioral",
+        },
+    }
+    generate(config, tmp_path)
+
+    manifest = json.loads(
+        (tmp_path / "attention_decode_score_multivalue_service_manifest.json").read_text(encoding="utf-8")
+    )
+    macro_manifest = json.loads((tmp_path / "macro_manifest.json").read_text(encoding="utf-8"))
+    rtl = (tmp_path / "top.v").read_text(encoding="utf-8")
+
+    assert (
+        manifest["semantic_profile"]
+        == "decode_m1x8_shared_score_16x8d_value_exact_partial_onchip_service_v1"
+    )
+    assert manifest["result_mode"] == "exact_partial"
+    assert manifest["head_id_bits"] == 5
+    assert manifest["result_value_bits_per_beat"] == 328
+    assert (
+        manifest["submodule_manifests"]["multivalue_cluster"]["semantic_profile"]
+        == "decode_m1x8_shared_score_16x8d_value_exact_partial_v1"
+    )
+    assert manifest["submodule_manifests"]["multivalue_cluster"]["result_mode"] == "exact_partial"
+    assert (
+        manifest["submodule_manifests"]["multivalue_cluster"]["result_value_bits_per_beat"] == 328
+    )
+    assert macro_manifest["manifest_params"]["result_mode"] == "exact_partial"
+    assert macro_manifest["manifest_params"]["head_id_bits"] == 5
+    assert macro_manifest["manifest_params"]["result_value_bits_per_beat"] == 328
+    assert "input  wire [4:0] cluster_command_head_id" in rtl
+    assert "output wire [4:0] cluster_result_head_id" in rtl
+    assert "output wire [4:0] shared_result_head_id" in rtl
+    assert "output wire [327:0] shared_result_value" in rtl
 
 
 def test_multivalue_service_generator_banked_4x16x64x32_macro_contract(tmp_path: Path) -> None:
@@ -130,6 +192,370 @@ def test_multivalue_service_generator_banked_4x16x64x32_macro_contract(tmp_path:
         macro_manifest["manifest_params"]["value_memory_physical_contract"]
         == "banked_4x16x64x32_exact_capacity"
     )
+
+
+def _service_exact_partial_expected() -> list[dict[str, int]]:
+    workload = _workload_contract()
+    beats = probe_module._cluster_beats(0, head_dim=int(workload["value_dim"]))
+    score_rows = [[sum(query * keys[lane] for query, keys in block) for lane in range(8)] for block in beats]
+    partials = partial_stream_from_blocks(
+        command_id=0x4A21,
+        head_id=3,
+        score_rows=score_rows,
+        value_blocks=probe_module._shared_value_matrices(),
+    )
+    return [
+        {
+            "command_id": int(beat.command_id),
+            "head_id": int(beat.head_id),
+            "slice": int(beat.slice_index),
+            "last": int(bool(beat.last)),
+            "global_max": int(beat.max_score),
+            "exp_sum": int(beat.exp_sum),
+            "value": int(pack_numerators(beat.numerators)),
+        }
+        for beat in partials
+    ]
+
+
+def _service_exact_partial_testbench() -> str:
+    workload = _workload_contract()
+    value_dim = int(workload["value_dim"])
+    blocks = probe_module._cluster_beats(0, head_dim=value_dim)
+    flat_beats = [beat for block in blocks for beat in block]
+    values = probe_module._shared_value_matrices()
+    preload_entries = []
+    for block_index, block in enumerate(values):
+        for slice_index, matrix in enumerate(block):
+            preload_entries.append(
+                (
+                    block_index,
+                    slice_index,
+                    probe_module._pack([lane for row in matrix for lane in row], 8),
+                )
+            )
+    beat_init = "\n".join(
+        f"    q_mem[{idx}] = {probe_module._signed_literal(q, 8)}; "
+        f"k_mem[{idx}] = 64'h{probe_module._pack(keys, 8):016x}; "
+        f"last_mem[{idx}] = 1'b{1 if ((idx + 1) % value_dim == 0) else 0};"
+        for idx, (q, keys) in enumerate(flat_beats)
+    )
+    preload_init = "\n".join(
+        f"    preload_addr_mem[{idx}] = 14'd{addr}; "
+        f"preload_slice_mem[{idx}] = 4'd{value_slice}; "
+        f"preload_matrix_mem[{idx}] = 512'h{matrix:0128x};"
+        for idx, (addr, value_slice, matrix) in enumerate(preload_entries)
+    )
+    return f"""
+`timescale 1ns/1ps
+module tb;
+  localparam integer TOTAL_BEATS = {len(flat_beats)};
+  localparam integer TOTAL_PRELOAD = {len(preload_entries)};
+  localparam integer TOTAL_RESULTS = 16;
+
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  always #5 clk = ~clk;
+
+  reg preload_done = 1'b0;
+  reg [7:0] preload_index = 8'd0;
+  reg command_sent = 1'b0;
+  reg [15:0] beat_index = 16'd0;
+  reg [4:0] result_seen = 5'd0;
+  reg [31:0] cycle = 32'd0;
+
+  reg signed [7:0] q_mem [0:TOTAL_BEATS-1];
+  reg [63:0] k_mem [0:TOTAL_BEATS-1];
+  reg last_mem [0:TOTAL_BEATS-1];
+  reg [13:0] preload_addr_mem [0:TOTAL_PRELOAD-1];
+  reg [3:0] preload_slice_mem [0:TOTAL_PRELOAD-1];
+  reg [511:0] preload_matrix_mem [0:TOTAL_PRELOAD-1];
+
+  reg preload_valid;
+  wire preload_ready;
+  reg [13:0] preload_addr;
+  reg [3:0] preload_value_slice;
+  reg [511:0] preload_matrix;
+
+  reg [0:0] cluster_command_valid;
+  wire [0:0] cluster_command_ready;
+  reg [15:0] cluster_command_id;
+  reg [14:0] cluster_command_block_count;
+  reg [4:0] cluster_command_head_id;
+  reg [31:0] cluster_command_score_multiplier;
+  reg [5:0] cluster_command_score_shift;
+  reg [0:0] cluster_input_valid;
+  wire [0:0] cluster_input_ready;
+  reg [0:0] cluster_input_last;
+  reg [7:0] cluster_input_a;
+  reg [63:0] cluster_input_b;
+  wire [0:0] cluster_result_valid;
+  wire [0:0] cluster_result_ready;
+  wire [15:0] cluster_result_command_id;
+  wire [31:0] cluster_result_global_max;
+  wire [32:0] cluster_result_exp_sum;
+  wire [4:0] cluster_result_head_id;
+  wire [3:0] cluster_result_slice;
+  wire [0:0] cluster_result_last;
+  wire [327:0] cluster_result_value;
+  wire shared_result_valid;
+  reg shared_result_ready = 1'b1;
+  wire [0:0] shared_result_cluster;
+  wire [15:0] shared_result_command_id;
+  wire [31:0] shared_result_global_max;
+  wire [32:0] shared_result_exp_sum;
+  wire [4:0] shared_result_head_id;
+  wire [3:0] shared_result_slice;
+  wire shared_result_last;
+  wire [327:0] shared_result_value;
+  wire [31:0] cluster_accepted_count;
+  wire [31:0] cluster_completed_count;
+  wire [31:0] cluster_cycle_count;
+  wire [0:0] cluster_protocol_error;
+  wire [7:0] transport_req_tag;
+  wire [0:0] transport_wide_source;
+  wire [7:0] transport_wide_tag;
+  wire [13:0] transport_wide_addr;
+  wire [3:0] transport_wide_value_slice;
+  wire [0:0] transport_wide_valid;
+  wire [0:0] reassembler_protocol_error;
+  wire [31:0] router_injection_stall_cycles;
+  wire [31:0] router_arbitration_contention_cycles;
+  wire [31:0] router_response_block_cycles;
+  wire [31:0] router_req_current_occupancy;
+  wire [31:0] router_req_max_occupancy;
+  wire [31:0] router_resp_current_occupancy;
+  wire [31:0] router_resp_max_occupancy;
+  wire [31:0] service_accepted_req_count;
+  wire [31:0] service_emitted_resp_count;
+  wire [31:0] service_bank_conflict_count;
+  wire [31:0] service_response_block_cycles;
+  wire [31:0] service_req_current_occupancy;
+  wire [31:0] service_req_max_occupancy;
+  wire [31:0] service_resp_current_occupancy;
+  wire [31:0] service_resp_max_occupancy;
+  wire [31:0] result_arbitration_contention_cycles;
+  wire [31:0] result_egress_block_cycles;
+  wire protocol_error;
+
+  attention_decode_score_multivalue_service_exact_partial_probe dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .preload_valid(preload_valid),
+    .preload_ready(preload_ready),
+    .preload_addr(preload_addr),
+    .preload_value_slice(preload_value_slice),
+    .preload_matrix(preload_matrix),
+    .cluster_command_valid(cluster_command_valid),
+    .cluster_command_ready(cluster_command_ready),
+    .cluster_command_id(cluster_command_id),
+    .cluster_command_block_count(cluster_command_block_count),
+    .cluster_command_head_id(cluster_command_head_id),
+    .cluster_command_score_multiplier(cluster_command_score_multiplier),
+    .cluster_command_score_shift(cluster_command_score_shift),
+    .cluster_input_valid(cluster_input_valid),
+    .cluster_input_ready(cluster_input_ready),
+    .cluster_input_last(cluster_input_last),
+    .cluster_input_a(cluster_input_a),
+    .cluster_input_b(cluster_input_b),
+    .cluster_result_valid(cluster_result_valid),
+    .cluster_result_ready(cluster_result_ready),
+    .cluster_result_command_id(cluster_result_command_id),
+    .cluster_result_global_max(cluster_result_global_max),
+    .cluster_result_exp_sum(cluster_result_exp_sum),
+    .cluster_result_head_id(cluster_result_head_id),
+    .cluster_result_slice(cluster_result_slice),
+    .cluster_result_last(cluster_result_last),
+    .cluster_result_value(cluster_result_value),
+    .shared_result_valid(shared_result_valid),
+    .shared_result_ready(shared_result_ready),
+    .shared_result_cluster(shared_result_cluster),
+    .shared_result_command_id(shared_result_command_id),
+    .shared_result_global_max(shared_result_global_max),
+    .shared_result_exp_sum(shared_result_exp_sum),
+    .shared_result_head_id(shared_result_head_id),
+    .shared_result_slice(shared_result_slice),
+    .shared_result_last(shared_result_last),
+    .shared_result_value(shared_result_value),
+    .cluster_accepted_count(cluster_accepted_count),
+    .cluster_completed_count(cluster_completed_count),
+    .cluster_cycle_count(cluster_cycle_count),
+    .cluster_protocol_error(cluster_protocol_error),
+    .transport_req_tag(transport_req_tag),
+    .transport_wide_source(transport_wide_source),
+    .transport_wide_tag(transport_wide_tag),
+    .transport_wide_addr(transport_wide_addr),
+    .transport_wide_value_slice(transport_wide_value_slice),
+    .transport_wide_valid(transport_wide_valid),
+    .reassembler_protocol_error(reassembler_protocol_error),
+    .router_injection_stall_cycles(router_injection_stall_cycles),
+    .router_arbitration_contention_cycles(router_arbitration_contention_cycles),
+    .router_response_block_cycles(router_response_block_cycles),
+    .router_req_current_occupancy(router_req_current_occupancy),
+    .router_req_max_occupancy(router_req_max_occupancy),
+    .router_resp_current_occupancy(router_resp_current_occupancy),
+    .router_resp_max_occupancy(router_resp_max_occupancy),
+    .service_accepted_req_count(service_accepted_req_count),
+    .service_emitted_resp_count(service_emitted_resp_count),
+    .service_bank_conflict_count(service_bank_conflict_count),
+    .service_response_block_cycles(service_response_block_cycles),
+    .service_req_current_occupancy(service_req_current_occupancy),
+    .service_req_max_occupancy(service_req_max_occupancy),
+    .service_resp_current_occupancy(service_resp_current_occupancy),
+    .service_resp_max_occupancy(service_resp_max_occupancy),
+    .result_arbitration_contention_cycles(result_arbitration_contention_cycles),
+    .result_egress_block_cycles(result_egress_block_cycles),
+    .protocol_error(protocol_error)
+  );
+
+  initial begin
+{beat_init}
+{preload_init}
+    repeat (4) @(posedge clk);
+    rst_n = 1'b1;
+  end
+
+  always @(*) begin
+    preload_valid = rst_n && !preload_done;
+    preload_addr = preload_done ? 14'd0 : preload_addr_mem[preload_index];
+    preload_value_slice = preload_done ? 4'd0 : preload_slice_mem[preload_index];
+    preload_matrix = preload_done ? 512'd0 : preload_matrix_mem[preload_index];
+
+    cluster_command_valid = 1'b0;
+    cluster_command_id = 16'h4A21;
+    cluster_command_block_count = 15'd3;
+    cluster_command_head_id = 5'd3;
+    cluster_command_score_multiplier = 32'd1;
+    cluster_command_score_shift = 6'd0;
+    if (rst_n && preload_done && !command_sent) begin
+      cluster_command_valid[0] = 1'b1;
+    end
+
+    cluster_input_valid = 1'b0;
+    cluster_input_last = 1'b0;
+    cluster_input_a = 8'd0;
+    cluster_input_b = 64'd0;
+    if (rst_n && command_sent && (beat_index < TOTAL_BEATS)) begin
+      cluster_input_valid[0] = 1'b1;
+      cluster_input_last[0] = last_mem[beat_index];
+      cluster_input_a = q_mem[beat_index];
+      cluster_input_b = k_mem[beat_index];
+    end
+  end
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      preload_done <= 1'b0;
+      preload_index <= 8'd0;
+      command_sent <= 1'b0;
+      beat_index <= 16'd0;
+      result_seen <= 5'd0;
+      cycle <= 32'd0;
+    end else begin
+      cycle <= cycle + 32'd1;
+      if (!preload_done && preload_valid && preload_ready) begin
+        if (preload_index + 1 == TOTAL_PRELOAD) begin
+          preload_done <= 1'b1;
+        end else begin
+          preload_index <= preload_index + 1'b1;
+        end
+      end
+      if (!command_sent && cluster_command_valid[0] && cluster_command_ready[0]) begin
+        command_sent <= 1'b1;
+      end
+      if (cluster_input_valid[0] && cluster_input_ready[0]) begin
+        beat_index <= beat_index + 1'b1;
+      end
+      if (shared_result_valid && shared_result_ready) begin
+        $display("RESULT cmd=%0d head=%0d slice=%0d last=%0d max=%0d sum=%0d value=%082x",
+          shared_result_command_id,
+          shared_result_head_id,
+          shared_result_slice,
+          shared_result_last,
+          $signed(shared_result_global_max),
+          shared_result_exp_sum,
+          shared_result_value);
+        result_seen <= result_seen + 1'b1;
+        if (result_seen + 1 == TOTAL_RESULTS) begin
+          $finish;
+        end
+      end
+      if (cycle > 32'd20000) begin
+        $display("TIMEOUT cycle=%0d", cycle);
+        $fatal(1);
+      end
+    end
+  end
+endmodule
+"""
+
+
+def test_multivalue_service_exact_partial_smoke_matches_reference(tmp_path: Path) -> None:
+    if not _iverilog_available():
+        pytest.skip("iverilog/vvp unavailable")
+
+    config = {
+        "top_name": "attention_decode_score_multivalue_service_exact_partial_probe",
+        "attention_decode_score_multivalue_service": {
+            "cluster_count": 1,
+            "max_blocks": 16,
+            "packet_w": 128,
+            "banks": 2,
+            "req_queue_depth": 2,
+            "resp_queue_depth": 2,
+            "bank_queue_depth": 2,
+            "read_latency": 1,
+            "arb_mode": "round_robin",
+            "locality_burst_max": 2,
+            "score_scale_lanes_per_cycle": 1,
+            "result_mode": "exact_partial",
+            "head_id_bits": 5,
+            "value_memory_backend": "behavioral",
+        },
+    }
+    generate(config, tmp_path)
+    (tmp_path / "fakeram45_2048x39.v").write_text(probe_module._FAKERAM_MODEL, encoding="utf-8")
+    (tmp_path / "tb.v").write_text(_service_exact_partial_testbench(), encoding="utf-8")
+
+    compile_run = subprocess.run(
+        [
+            probe_module._tool("iverilog"),
+            "-g2012",
+            "-o",
+            str(tmp_path / "simv"),
+            str(tmp_path / "tb.v"),
+            str(tmp_path / "fakeram45_2048x39.v"),
+            str(tmp_path / "top.v"),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert compile_run.returncode == 0, compile_run.stderr
+
+    sim_run = subprocess.run(
+        [probe_module._tool("vvp"), str(tmp_path / "simv")],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert sim_run.returncode == 0, sim_run.stderr
+
+    observed = [
+        {
+            "command_id": int(match.group(1)),
+            "head_id": int(match.group(2)),
+            "slice": int(match.group(3)),
+            "last": int(match.group(4)),
+            "global_max": int(match.group(5)),
+            "exp_sum": int(match.group(6)),
+            "value": int(match.group(7), 16),
+        }
+        for line in sim_run.stdout.splitlines()
+        for match in [_EXACT_RESULT_RE.fullmatch(line.strip())]
+        if match is not None
+    ]
+    assert observed == _service_exact_partial_expected(), sim_run.stdout
 
 
 def test_integrated_service_default_cases_cover_requested_surface() -> None:

--- a/tests/test_check_attention_decode_score_multivalue_service_guard.py
+++ b/tests/test_check_attention_decode_score_multivalue_service_guard.py
@@ -6,8 +6,14 @@ import sys
 from npu.rtlgen.gen_attention_decode_score_multivalue_service import generate
 
 
-def _config(top_name: str, cluster_count: int) -> dict:
-    return {
+def _config(
+    top_name: str,
+    cluster_count: int,
+    *,
+    result_mode: str = "normalized",
+    head_id_bits: int = 5,
+) -> dict:
+    config = {
         "top_name": top_name,
         "attention_decode_score_multivalue_service": {
             "cluster_count": cluster_count,
@@ -24,12 +30,46 @@ def _config(top_name: str, cluster_count: int) -> dict:
             "value_memory_backend": "macro_banked_4x16x64x32",
         },
     }
+    if result_mode != "normalized":
+        config["attention_decode_score_multivalue_service"]["result_mode"] = result_mode
+        config["attention_decode_score_multivalue_service"]["head_id_bits"] = head_id_bits
+    return config
 
 
 def test_service_guard_accepts_c2_banked_4x16x64x32_macro_contract(tmp_path: Path) -> None:
     design_dir = tmp_path / "attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr"
     design_dir.mkdir()
     config = _config("attention_decode_score_multivalue_service_c2_p128_b4_q4_rl2_rr", 2)
+    (design_dir / "config.json").write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    generate(config, design_dir / "verilog")
+    generated_macro_manifest = (design_dir / "verilog" / "macro_manifest.json").read_text(encoding="utf-8")
+    (design_dir / "macro_manifest.json").write_text(generated_macro_manifest, encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "npu/eval/check_attention_decode_score_multivalue_service_guard.py",
+            "--design-dir",
+            str(design_dir),
+            "--config",
+            str(design_dir / "config.json"),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_service_guard_accepts_exact_partial_banked_macro_contract(tmp_path: Path) -> None:
+    design_dir = tmp_path / "attention_decode_score_multivalue_service_exact_partial_c1_p128_b4_q4_rl2_rr"
+    design_dir.mkdir()
+    config = _config(
+        "attention_decode_score_multivalue_service_exact_partial_c1_p128_b4_q4_rl2_rr",
+        1,
+        result_mode="exact_partial",
+        head_id_bits=5,
+    )
     (design_dir / "config.json").write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
     generate(config, design_dir / "verilog")
     generated_macro_manifest = (design_dir / "verilog" / "macro_manifest.json").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add an explicit normalized/exact-partial result contract to the composed multivalue service
- propagate head identity and 328-bit signed exact numerator slices through cluster and shared egress interfaces
- record the result semantics in manifests and validate both modes fail-closed
- prove the exact-partial service output against the Python partial-stream reference in RTL simulation

## Why
The measured normalized 24-token service window is valid component evidence, but its outputs cannot be composed across the full Llama7B context. Exact partial numerator outputs are required before temporal reduction and full-context scaling are mathematically valid.

## Validation
- `pytest -q tests/test_attention_decode_score_multivalue_integrated_service.py tests/test_check_attention_decode_score_multivalue_service_guard.py` (17 passed)
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`