### PR TITLE
Guard measured frontier on exact-partial service semantics

### DIFF
--- a/npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_service_activity_power.py
@@ -484,6 +484,34 @@ def _validate_generated_activity_manifest(
         raise ValueError("generated activity manifest workload contract mismatch")
     if float(activity_manifest.get("clock_period_ns", 0.0)) != 10.0:
         raise ValueError("generated activity manifest clock_period_ns mismatch")
+    validated_result_semantics = None
+    result_semantics = activity_manifest.get("result_semantics")
+    if result_semantics is not None:
+        if not isinstance(result_semantics, dict):
+            raise ValueError("generated activity manifest result_semantics must be an object when present")
+        result_mode = str(result_semantics.get("result_mode") or "").strip()
+        if result_mode not in {"normalized", "exact_partial"}:
+            raise ValueError("generated activity manifest result_semantics result_mode mismatch")
+        supports_sequence_window_composition = result_semantics.get("supports_sequence_window_composition")
+        if not isinstance(supports_sequence_window_composition, bool):
+            raise ValueError(
+                "generated activity manifest result_semantics supports_sequence_window_composition missing"
+            )
+        if supports_sequence_window_composition != (result_mode == "exact_partial"):
+            raise ValueError("generated activity manifest result_semantics composition flag mismatch")
+        composition_scope = str(result_semantics.get("composition_scope") or "").strip()
+        expected_composition_scope = (
+            "exact_partial_across_sequence_windows_before_finalization"
+            if result_mode == "exact_partial"
+            else "normalized_final_output_not_sequence_window_composable"
+        )
+        if composition_scope != expected_composition_scope:
+            raise ValueError("generated activity manifest result_semantics composition_scope mismatch")
+        validated_result_semantics = {
+            "result_mode": result_mode,
+            "supports_sequence_window_composition": supports_sequence_window_composition,
+            "composition_scope": composition_scope,
+        }
     cycle_count = int(activity_manifest.get("cycle_count", 0))
     if cycle_count <= 0:
         raise ValueError("generated activity manifest cycle_count must be positive")
@@ -526,6 +554,7 @@ def _validate_generated_activity_manifest(
         "generated_manifest_hashes": dict(activity_manifest.get("hashes") or {}),
         "bank_coverage": bank_coverage,
         "workload_contract": expected_workload,
+        "result_semantics": validated_result_semantics,
     }
 
 
@@ -734,6 +763,11 @@ def _prepare_postroute_power_manifest(
         "macro_counts": macro_counts,
         "macro_activity_contract": macro_activity_contract,
         "bank_coverage": generated_meta["bank_coverage"],
+        **(
+            {"result_semantics": generated_meta["result_semantics"]}
+            if generated_meta.get("result_semantics") is not None
+            else {}
+        ),
     }
 
 
@@ -991,6 +1025,8 @@ def build_report(
         else:
             candidate["status"] = "activity_backed"
             candidate["promotion_gate_pass"] = True
+            if activity_meta.get("result_semantics") is not None:
+                service_window_energy["result_semantics"] = dict(activity_meta["result_semantics"])
             candidate["component_service_window_energy"] = service_window_energy
             authoritative_ppa = {
                 "critical_path_ns": float(metric["critical_path_ns"]),
@@ -1057,6 +1093,11 @@ def build_report(
             "clock_period_ns": clock_period_ns,
             "cycle_count": int(activity_meta["cycle_count"]),
             "workload_contract": activity_meta["workload_contract"],
+            **(
+                {"result_semantics": activity_meta["result_semantics"]}
+                if activity_meta.get("result_semantics") is not None
+                else {}
+            ),
         },
         "macro_manifest_contract": {
             "counts": activity_meta["macro_counts"],

--- a/npu/eval/audit_attention_decode_score_multivalue_service_measured_frontier.py
+++ b/npu/eval/audit_attention_decode_score_multivalue_service_measured_frontier.py
@@ -147,6 +147,32 @@ def _validated_workload_contract(payload: Any, label: str) -> JsonDict:
     return validated
 
 
+def _validated_result_semantics(payload: Any, label: str) -> JsonDict:
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must be an object")
+    result_mode = _string(payload.get("result_mode"), f"{label} result_mode")
+    if result_mode not in {"normalized", "exact_partial"}:
+        raise ValueError(f"{label} result_mode must be normalized or exact_partial")
+    supports_sequence_window_composition = payload.get("supports_sequence_window_composition")
+    if not isinstance(supports_sequence_window_composition, bool):
+        raise ValueError(f"{label} supports_sequence_window_composition must be a boolean")
+    if supports_sequence_window_composition != (result_mode == "exact_partial"):
+        raise ValueError(f"{label} supports_sequence_window_composition mismatches result_mode")
+    composition_scope = _string(payload.get("composition_scope"), f"{label} composition_scope")
+    expected_scope = (
+        "exact_partial_across_sequence_windows_before_finalization"
+        if result_mode == "exact_partial"
+        else "normalized_final_output_not_sequence_window_composable"
+    )
+    if composition_scope != expected_scope:
+        raise ValueError(f"{label} composition_scope mismatch")
+    return {
+        "result_mode": result_mode,
+        "supports_sequence_window_composition": supports_sequence_window_composition,
+        "composition_scope": composition_scope,
+    }
+
+
 def _source_schedule(frontier: JsonDict, frontier_path: Path) -> tuple[JsonDict, str]:
     visited = {frontier_path.resolve()}
     current_payload = frontier
@@ -523,6 +549,14 @@ def _validated_service_activity(
         raise ValueError("service report lacks activity_contract")
     if abs(_positive(activity_contract.get("clock_period_ns"), "service activity_contract clock_period_ns") - _EXPECTED_SERVICE_CLOCK_NS) > 1e-9:
         raise ValueError("service activity clock_period_ns mismatch")
+    if "result_semantics" not in activity_contract:
+        raise ValueError(
+            "service activity_contract result_semantics missing; legacy or normalized-only evidence cannot anchor measured-frontier scaling"
+        )
+    activity_result_semantics = _validated_result_semantics(
+        activity_contract.get("result_semantics"),
+        "service activity_contract result_semantics",
+    )
     workload_contract = _validated_workload_contract(
         activity_contract.get("workload_contract"),
         "service activity_contract workload_contract",
@@ -544,6 +578,20 @@ def _validated_service_activity(
         raise ValueError("service component_service_window_energy label mismatch")
     if service_window.get("is_total_token_energy") is not False:
         raise ValueError("service component_service_window_energy must not be total-token energy")
+    if "result_semantics" not in service_window:
+        raise ValueError(
+            "service component_service_window_energy result_semantics missing; legacy or normalized-only evidence cannot anchor measured-frontier scaling"
+        )
+    service_window_result_semantics = _validated_result_semantics(
+        service_window.get("result_semantics"),
+        "service component_service_window_energy result_semantics",
+    )
+    if service_window_result_semantics != activity_result_semantics:
+        raise ValueError("service result_semantics mismatch between activity_contract and component_service_window_energy")
+    if activity_result_semantics["result_mode"] != "exact_partial":
+        raise ValueError(
+            "service measured-frontier promotion requires explicit exact_partial/composable result_semantics; normalized output evidence remains component-only"
+        )
     service_cycle_count = _positive_int(service_window.get("cycle_count"), "service window cycle_count")
     if service_cycle_count != _positive_int(activity_contract.get("cycle_count"), "service activity cycle_count"):
         raise ValueError("service window cycle_count does not match activity_contract cycle_count")
@@ -640,6 +688,7 @@ def _validated_service_activity(
         "integrated_hashes": integrated_hashes,
         "flow_variant": case_contract["flow_variant"],
         "design": case_contract["design"],
+        "result_semantics": activity_result_semantics,
     }
     return row
 

--- a/npu/eval/generate_attention_decode_score_multivalue_service_activity.py
+++ b/npu/eval/generate_attention_decode_score_multivalue_service_activity.py
@@ -55,6 +55,18 @@ _REQUIRED_SERVICE_FIELDS = {
 }
 
 
+def _result_semantics_for_mode(result_mode: str) -> JsonDict:
+    return {
+        "result_mode": result_mode,
+        "supports_sequence_window_composition": result_mode == "exact_partial",
+        "composition_scope": (
+            "exact_partial_across_sequence_windows_before_finalization"
+            if result_mode == "exact_partial"
+            else "normalized_final_output_not_sequence_window_composable"
+        ),
+    }
+
+
 def _required_service_fields(case: JsonDict) -> JsonDict:
     return {
         "cluster_count": int(case["cluster_count"]),
@@ -140,6 +152,10 @@ def _normalize_config_with_case(
         if value != expected:
             raise ValueError(f"attention_decode_score_multivalue_service.{key} must be {expected!r}")
         normalized_body[key] = expected
+    result_mode = str(body.get("result_mode", "normalized")).strip().lower()
+    if result_mode not in {"normalized", "exact_partial"}:
+        raise ValueError("attention_decode_score_multivalue_service.result_mode must be normalized or exact_partial")
+    normalized_body["result_mode"] = result_mode
     return {"top_name": top_name, "attention_decode_score_multivalue_service": normalized_body}, case
 
 
@@ -451,6 +467,19 @@ def generate_activity(
             "shared": dict(macro["shared"]),
             "per_cluster": dict(macro["counter_rows"]),
         },
+        "result_semantics": dict(
+            macro["manifest"].get(
+                "result_semantics",
+                _result_semantics_for_mode(
+                    str(
+                        normalized_config["attention_decode_score_multivalue_service"].get(
+                            "result_mode",
+                            "normalized",
+                        )
+                    )
+                ),
+            )
+        ),
         "shared_result_egress": {
             "architecture": macro["manifest"]["shared_result_egress"],
             "documented_initiation_interval": macro["manifest"]["shared_result_egress_initiation_interval"],

--- a/tests/test_attention_decode_score_multivalue_service_activity_power.py
+++ b/tests/test_attention_decode_score_multivalue_service_activity_power.py
@@ -234,9 +234,10 @@ def _generated_activity_manifest(
     final_hash: str = "final-hash",
     request_hash: str = "request-hash",
     wide_hash: str = "wide-hash",
+    result_mode: str | None = "normalized",
 ) -> dict:
     counts = _scaled_counts(cluster_count)
-    return {
+    payload = {
         "model": "attention_decode_score_multivalue_service_activity_v1",
         "case_id": case_id,
         "workload_contract": _workload_contract(),
@@ -261,6 +262,17 @@ def _generated_activity_manifest(
             "wide_response_matrix_hash": wide_hash,
         },
     }
+    if result_mode is not None:
+        payload["result_semantics"] = {
+            "result_mode": result_mode,
+            "supports_sequence_window_composition": result_mode == "exact_partial",
+            "composition_scope": (
+                "exact_partial_across_sequence_windows_before_finalization"
+                if result_mode == "exact_partial"
+                else "normalized_final_output_not_sequence_window_composable"
+            ),
+        }
+    return payload
 
 
 def _adapted_manifest(
@@ -308,6 +320,11 @@ def _adapted_manifest(
             "wide_response_matrix_hash": wide_hash,
         },
         "workload_contract": _workload_contract(),
+        "result_semantics": {
+            "result_mode": "normalized",
+            "supports_sequence_window_composition": False,
+            "composition_scope": "normalized_final_output_not_sequence_window_composable",
+        },
         "macro_counts": dict(macro_counts),
         "macro_activity_contract": {
             "profile": "multivalue_service_c1_v1",
@@ -480,6 +497,11 @@ def test_prepare_postroute_manifest_preserves_generated_contract(tmp_path: Path)
         "generated_manifest_hashes": generated_hashes,
         "bank_coverage": {"inactive_banks": [3]},
         "workload_contract": _workload_contract(),
+        "result_semantics": {
+            "result_mode": "normalized",
+            "supports_sequence_window_composition": False,
+            "composition_scope": "normalized_final_output_not_sequence_window_composable",
+        },
     }
 
     with mock.patch.object(
@@ -507,6 +529,7 @@ def test_prepare_postroute_manifest_preserves_generated_contract(tmp_path: Path)
 
     assert activity_meta["generated_manifest_hashes"] == generated_hashes
     assert activity_meta["workload_contract"] == _workload_contract()
+    assert activity_meta["result_semantics"]["result_mode"] == "normalized"
 
 
 def test_build_report_success_keeps_paths_portable_and_writes_markdown(tmp_path: Path) -> None:
@@ -579,6 +602,11 @@ def test_build_report_success_keeps_paths_portable_and_writes_markdown(tmp_path:
     assert payload["bank3_dynamic_inactivity"]["inactive_banks"] == [3]
     assert payload["dependency_contract"]["integrated_service_c1"]["config"]["cluster_count"] == 1
     assert payload["activity_contract"]["workload_contract"] == _workload_contract()
+    assert payload["activity_contract"]["result_semantics"]["result_mode"] == "normalized"
+    assert (
+        payload["best"]["component_service_window_energy"]["result_semantics"]["composition_scope"]
+        == "normalized_final_output_not_sequence_window_composable"
+    )
     assert payload["physical_signoff"]["status"] == "routed_with_electrical_caveat"
     assert payload["physical_signoff"]["route_checks"]["max_cap_violations"] == 142
     assert payload["physical_signoff"]["route_checks"]["worst_max_cap_slack_ff"] == -17.81
@@ -677,6 +705,18 @@ def test_validate_generated_activity_manifest_rejects_128_as_active_context(tmp_
 
     with pytest.raises(ValueError, match="workload contract mismatch"):
         audit._validate_generated_activity_manifest(payload, tmp_path)
+
+
+def test_validate_generated_activity_manifest_accepts_legacy_missing_result_semantics(tmp_path: Path) -> None:
+    payload = _generated_activity_manifest(result_mode=None)
+    (tmp_path / audit._OUTPUT_MANIFEST_NAME).write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    validated = audit._validate_generated_activity_manifest(payload, tmp_path)
+
+    assert validated["result_semantics"] is None
 
 
 def test_build_report_rejects_generated_activity_hash_mismatch(tmp_path: Path) -> None:

--- a/tests/test_attention_decode_score_multivalue_service_measured_frontier.py
+++ b/tests/test_attention_decode_score_multivalue_service_measured_frontier.py
@@ -55,6 +55,18 @@ def _workload_contract() -> dict:
     }
 
 
+def _result_semantics(result_mode: str) -> dict:
+    return {
+        "result_mode": result_mode,
+        "supports_sequence_window_composition": result_mode == "exact_partial",
+        "composition_scope": (
+            "exact_partial_across_sequence_windows_before_finalization"
+            if result_mode == "exact_partial"
+            else "normalized_final_output_not_sequence_window_composable"
+        ),
+    }
+
+
 def _prior_frontier(tmp_path: Path, *, sequence_length: int = 131072) -> Path:
     source = _source_schedule(tmp_path, sequence_length=sequence_length)
     linked_prior = _write(
@@ -185,7 +197,7 @@ def _prior_frontier(tmp_path: Path, *, sequence_length: int = 131072) -> Path:
     )
 
 
-def _service_activity_power(tmp_path: Path) -> Path:
+def _service_activity_power(tmp_path: Path, *, result_mode: str | None = "exact_partial") -> Path:
     return _write(
         tmp_path / "service_activity_power.json",
         {
@@ -232,6 +244,7 @@ def _service_activity_power(tmp_path: Path) -> Path:
                         "leakage": 8.0e-8,
                         "dynamic_plus_leakage": 5.6e-7,
                     },
+                    **({"result_semantics": _result_semantics(result_mode)} if result_mode is not None else {}),
                 },
                 "authoritative_composed_c1_total_ppa": {
                     "critical_path_ns": 9.2,
@@ -284,6 +297,7 @@ def _service_activity_power(tmp_path: Path) -> Path:
                 "clock_period_ns": 10.0,
                 "cycle_count": 160,
                 "workload_contract": _workload_contract(),
+                **({"result_semantics": _result_semantics(result_mode)} if result_mode is not None else {}),
             },
             "macro_manifest_contract": {
                 "counts": {"fakeram45_2048x39": 56, "fakeram45_64x32": 64},
@@ -317,7 +331,7 @@ def _service_activity_power(tmp_path: Path) -> Path:
     )
 
 
-def _service_activity_power_c2(tmp_path: Path) -> Path:
+def _service_activity_power_c2(tmp_path: Path, *, result_mode: str | None = "exact_partial") -> Path:
     return _write(
         tmp_path / "service_activity_power_c2.json",
         {
@@ -364,6 +378,7 @@ def _service_activity_power_c2(tmp_path: Path) -> Path:
                         "leakage": 2.0e-7,
                         "dynamic_plus_leakage": 1.2e-6,
                     },
+                    **({"result_semantics": _result_semantics(result_mode)} if result_mode is not None else {}),
                 },
                 "authoritative_composed_c2_total_ppa": {
                     "critical_path_ns": 9.7,
@@ -416,6 +431,7 @@ def _service_activity_power_c2(tmp_path: Path) -> Path:
                 "clock_period_ns": 10.0,
                 "cycle_count": 8863,
                 "workload_contract": _workload_contract(),
+                **({"result_semantics": _result_semantics(result_mode)} if result_mode is not None else {}),
             },
             "macro_manifest_contract": {
                 "counts": {"fakeram45_2048x39": 112, "fakeram45_64x32": 64},
@@ -595,6 +611,32 @@ def test_build_report_accepts_distinct_integrated_hash_domain(tmp_path: Path) ->
         payload["selected_service_activity_candidate"]["integrated_service_hashes"]["final_hash"]
         == "integrated-c1-final-hash"
     )
+
+
+def test_build_report_rejects_normalized_service_result_semantics_for_frontier_scaling(tmp_path: Path) -> None:
+    prior = _prior_frontier(tmp_path)
+    service = _service_activity_power(tmp_path, result_mode="normalized")
+    online_exact = _online_exact_measured_reducer(tmp_path)
+
+    with pytest.raises(ValueError, match="explicit exact_partial/composable result_semantics"):
+        build_report(
+            prior_cluster_frontier_json=prior,
+            online_exact_measured_reducer_json=online_exact,
+            service_activity_power_json=service,
+        )
+
+
+def test_build_report_rejects_legacy_missing_service_result_semantics_for_frontier_scaling(tmp_path: Path) -> None:
+    prior = _prior_frontier(tmp_path)
+    service = _service_activity_power(tmp_path, result_mode=None)
+    online_exact = _online_exact_measured_reducer(tmp_path)
+
+    with pytest.raises(ValueError, match="result_semantics missing"):
+        build_report(
+            prior_cluster_frontier_json=prior,
+            online_exact_measured_reducer_json=online_exact,
+            service_activity_power_json=service,
+        )
 
 
 def test_build_report_rejects_cycle_mismatch(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- preserve explicit normalized or exact-partial result semantics in generated activity and power evidence
- keep legacy activity reports valid as component-only measurements
- fail closed when measured-frontier scaling sees missing or normalized service semantics
- require exact-partial, sequence-window-composable outputs before full-context promotion

## Why
A normalized 24-token service result cannot be combined across the 131072-token Llama7B context. The prior frontier audit could silently scale its energy and latency despite that semantic mismatch.

## Validation
- 49 focused service contract, activity, power, and frontier tests passed
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`