### PR TITLE
Package exact-partial service equivalence job

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -7707,6 +7707,63 @@ def _decoder_attention_decode_score_multivalue_integrated_service_evidence(
     }
 
 
+def _decoder_attention_decode_score_multivalue_service_exact_partial_equivalence_evidence(
+    *,
+    item_id: str,
+    proposal_id: str | None = None,
+    proposal_path: str | None = None,
+) -> dict[str, Any]:
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    dependency_item = "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+    equivalence = (
+        f"{base}/decoder_attention_decode_score_multivalue_cluster_equivalence__"
+        f"{dependency_item}.json"
+    )
+    out = (
+        f"{base}/decoder_attention_decode_score_multivalue_service_exact_partial_equivalence__"
+        f"{item_id}.json"
+    )
+    report = (
+        f"{base}/decoder_attention_decode_score_multivalue_service_exact_partial_equivalence__"
+        f"{item_id}.md"
+    )
+    proposal_args: list[str] = []
+    proposal_id_text = str(proposal_id or "").strip()
+    proposal_path_text = str(proposal_path or "").strip()
+    if proposal_id_text:
+        proposal_args.extend(["--proposal-id", proposal_id_text])
+    if proposal_path_text:
+        proposal_args.extend(["--proposal-path", proposal_path_text])
+    proposal_arg_text = " ".join(shlex.quote(arg) for arg in proposal_args)
+    return {
+        "inputs": {
+            "decode_score_multivalue_service_exact_partial_equivalence_source": equivalence,
+            "decode_score_multivalue_service_exact_partial_equivalence_out": out,
+            "decode_score_multivalue_service_exact_partial_equivalence_report": report,
+            "decode_score_multivalue_service_exact_partial_equivalence_scope": (
+                "Prove exact global_max, exp_sum, head_id, slice/last, and 8xS41 numerator lanes "
+                "through the shared service in exact_partial result mode. Keep this evidence disjoint "
+                "from normalized integrated-service evidence. This does not claim full-context temporal "
+                "composition, physical PPA, activity power, HBM closure, or NoC closure."
+            ),
+        },
+        "commands": [
+            {
+                "name": "probe_decode_score_multivalue_service_exact_partial_equivalence",
+                "run": (
+                    "python3 npu/eval/probe_attention_decode_score_multivalue_integrated_service.py "
+                    "--result-mode exact_partial "
+                    f"--out {out} --out-md {report} "
+                    f"--depends-on-item-id {dependency_item} "
+                    f"{proposal_arg_text}".strip()
+                ),
+            }
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+    }
+
+
 def _decoder_attention_decode_score_multivalue_service_activity_power_evidence(
     *, item_id: str, depends_on_item_ids: list[str] | None = None
 ) -> dict[str, Any]:
@@ -11810,6 +11867,7 @@ def _build_payload(
         "decoder_attention_decode_score_multivalue_gqa_array_equivalence",
         "decoder_attention_decode_score_multivalue_cluster_activity_power",
         "decoder_attention_decode_score_multivalue_integrated_service",
+        "decoder_attention_decode_score_multivalue_service_exact_partial_equivalence",
         "decoder_attention_decode_score_multivalue_service_activity_power",
         "decoder_attention_decode_score_multivalue_service_measured_frontier",
         "decoder_attention_decode_score_multivalue_gqa_group_activity_power",
@@ -12083,6 +12141,17 @@ def _build_payload(
                 item_id=item_id,
                 proposal_id=proposal_id,
                 proposal_path=proposal_path,
+            )
+        elif (
+            abstraction_layer_name
+            == "decoder_attention_decode_score_multivalue_service_exact_partial_equivalence"
+        ):
+            decoder_evidence = (
+                _decoder_attention_decode_score_multivalue_service_exact_partial_equivalence_evidence(
+                    item_id=item_id,
+                    proposal_id=proposal_id,
+                    proposal_path=proposal_path,
+                )
             )
         elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_service_activity_power":
             decoder_evidence = _decoder_attention_decode_score_multivalue_service_activity_power_evidence(

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -9644,6 +9644,100 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_integrated_servi
             )
 
 
+def test_generate_l2_campaign_task_adds_exact_partial_integrated_service_equivalence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        item_id = (
+            "l2_decoder_attention_decode_score_multivalue_service_"
+            "exact_partial_equivalence_llama7b_v1"
+        )
+        proposal_id = (
+            "prop_l2_decoder_attention_decode_score_multivalue_service_"
+            "exact_partial_equivalence_llama7b_v1"
+        )
+        proposal_path = f"docs/proposals/{proposal_id}/proposal.json"
+        dependency_item = (
+            "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+        )
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=item_id,
+                    proposal_id=proposal_id,
+                    proposal_path=proposal_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer=(
+                        "decoder_attention_decode_score_multivalue_service_"
+                        "exact_partial_equivalence"
+                    ),
+                    evaluation_mode="equivalence",
+                    depends_on_item_ids=[dependency_item],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            payload = work_item.task_request.request_payload
+            commands = payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands] == [
+                "probe_decode_score_multivalue_service_exact_partial_equivalence",
+                "validate_runs",
+            ]
+            assert "probe_attention_decode_score_multivalue_integrated_service.py" in run
+            assert "--result-mode exact_partial" in run
+            assert f"--depends-on-item-id {dependency_item}" in run
+            assert f"--proposal-id {proposal_id}" in run
+            assert f"--proposal-path {proposal_path}" in run
+            assert decoder_inputs[
+                "decode_score_multivalue_service_exact_partial_equivalence_source"
+            ].endswith(
+                "decoder_attention_decode_score_multivalue_cluster_equivalence__"
+                f"{dependency_item}.json"
+            )
+            assert "global_max, exp_sum, head_id, slice/last" in decoder_inputs[
+                "decode_score_multivalue_service_exact_partial_equivalence_scope"
+            ]
+            assert "8xS41 numerator lanes" in decoder_inputs[
+                "decode_score_multivalue_service_exact_partial_equivalence_scope"
+            ]
+            assert "full-context temporal composition" in decoder_inputs[
+                "decode_score_multivalue_service_exact_partial_equivalence_scope"
+            ]
+            assert decoder_inputs[
+                "decode_score_multivalue_service_exact_partial_equivalence_out"
+            ].endswith(f"__{item_id}.json")
+            assert payload["task"]["expected_outputs"] == [
+                decoder_inputs["decode_score_multivalue_service_exact_partial_equivalence_out"],
+                decoder_inputs["decode_score_multivalue_service_exact_partial_equivalence_report"],
+            ]
+            assert payload["developer_loop"]["proposal_id"] == proposal_id
+            assert payload["developer_loop"]["proposal_path"] == proposal_path
+            assert payload["developer_loop"]["dependencies"] == {
+                "item_ids": [dependency_item],
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": True,
+            }
+            assert payload["source_requirement"]["required_sha"] == source_commit
+            assert payload["source_requirement"]["required_ref"] == "origin/master"
+            assert payload["source_requirement"]["requires_daemon_restart"] is True
+            assert work_item.state == WorkItemState.BLOCKED
+
+
 def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_activity_power() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_equivalence_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_equivalence_llama7b_v1/evaluation_requests.json
@@ -1,0 +1,26 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_equivalence_llama7b_v1",
+  "source_commit_note": "Do not dispatch from this development branch. At queue time, generate the task from merged origin/master so source_requirement.required_sha is automatically pinned to the merge commit containing both this disjoint task wiring and the exact-partial probe CLI, with evaluator daemon refresh required.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_service_exact_partial_equivalence_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the integrated shared-score multivalue service probe in exact_partial mode and prove exact global_max, exp_sum, head_id, slice/last, and 8xS41 numerator lanes.",
+      "evaluation_mode": "equivalence",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_service_exact_partial_equivalence",
+      "comparison_role": "exact_partial_functional_validation",
+      "paired_baseline_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_exact_partial_shared_service_equivalence",
+        "reason": "Require exact global_max, exp_sum, head_id, slice/last, and all 8xS41 numerator lanes through the shared service while keeping normalized integrated-service evidence disjoint and making no full-context temporal-composition, PPA, activity, HBM, or NoC claim."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "The merged/materialized shared-score cluster-equivalence artifact is mandatory. Generate this item only after the exact-partial probe CLI and this task wiring merge; task generation must auto-pin source_requirement.required_sha to that origin/master merge and require evaluator daemon refresh."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_equivalence_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_equivalence_llama7b_v1/proposal.json
@@ -1,0 +1,78 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_equivalence_llama7b_v1",
+  "created_utc": "2026-08-06T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Llama7B exact-partial shared multivalue service equivalence",
+  "abstraction_layer": "decoder_attention_decode_score_multivalue_service_exact_partial_equivalence",
+  "hypothesis": "After the shared-score multivalue cluster equivalence input is merged and materialized, the integrated shared service can preserve exact partial reduction state and all eight numerator lanes without reusing normalized integrated-service evidence.",
+  "direct_comparison": {
+    "primary_question": "Does the shared multivalue service preserve exact global_max, exp_sum, head_id, slice/last, and all 8xS41 numerator lanes in exact_partial result mode?",
+    "include": [
+      "depend on l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1 as a merged and materialized input",
+      "invoke the integrated-service probe with --result-mode exact_partial",
+      "preserve exact global_max and exp_sum",
+      "preserve exact head_id and slice/last protocol state",
+      "preserve all 8xS41 numerator lanes through the shared service",
+      "emit uniquely named repo-portable JSON and Markdown evidence",
+      "preserve proposal-id, proposal-path, dependency, and source-requirement linkage"
+    ],
+    "exclude": [
+      "do not overwrite or reinterpret normalized integrated-service evidence",
+      "do not claim full-context temporal composition",
+      "do not claim physical PPA",
+      "do not claim activity or energy closure",
+      "do not claim HBM closure",
+      "do not claim NoC closure"
+    ]
+  },
+  "expected_benefit": [
+    "establishes a disjoint exact-partial equivalence artifact suitable for later composability gates",
+    "keeps normalized service evidence valid for its original bounded service purpose",
+    "prevents exact-partial state-vector proof from being inferred from normalized outputs"
+  ],
+  "risks": [
+    "the exact-partial probe CLI may not be available until its source change merges",
+    "passing bounded exact-partial equivalence does not prove temporal composition across the full Llama7B context",
+    "this functional proof provides no PPA, activity, HBM, or NoC closure"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_service_exact_partial_equivalence_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the integrated shared-score multivalue service probe in exact_partial mode and prove exact global_max, exp_sum, head_id, slice/last, and 8xS41 numerator lanes.",
+      "evaluation_mode": "equivalence",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_service_exact_partial_equivalence",
+      "comparison_role": "exact_partial_functional_validation",
+      "paired_baseline_item_id": "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "record_exact_partial_shared_service_equivalence",
+        "reason": "Require exact global_max, exp_sum, head_id, slice/last, and all 8xS41 numerator lanes through the shared service while keeping normalized integrated-service evidence disjoint and making no full-context temporal-composition, PPA, activity, HBM, or NoC claim."
+      },
+      "status": "pending_implementation_merge",
+      "notes": "Generate only after this proposal/task wiring and the exact-partial probe CLI are merged to origin/master. Queue-time task generation must auto-pin source_requirement.required_sha to that merged commit and require evaluator daemon refresh."
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_cluster_equivalence__l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1.json",
+    "docs/proposals/prop_decoder_attention_decode_score_multivalue_cluster_llama7b_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1/proposal.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/probe_attention_decode_score_multivalue_integrated_service.py",
+    "control_plane/control_plane/services/l2_task_generator.py",
+    "control_plane/control_plane/tests/test_l2_task_generator.py"
+  ],
+  "remaining_abstractions_after_this_step": [
+    "Full-context temporal composition of exact partials remains unproven.",
+    "Physical PPA remains unmeasured.",
+    "Activity and energy remain unmeasured.",
+    "HBM and NoC closure remain outside this proof."
+  ]
+}


### PR DESCRIPTION
## Summary
- add a distinct L2 exact-partial shared-service equivalence abstraction
- dispatch the integrated-service probe with `--result-mode exact_partial`
- emit uniquely named JSON and Markdown without reinterpreting normalized evidence
- add proposal/dependency/source-refresh contracts for remote evaluator execution

## Scope
The job proves global max, exponential sum, head identity, slice framing, and all eight signed S41 numerator lanes through the shared service. Full-context temporal composition, PPA, activity, HBM, and wider NoC closure remain explicitly excluded.

## Validation
- focused L2 task-generator tests: 3 passed
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`