### PR TITLE
npu: finalize full-context exact-partial service output

### DIFF
--- a/npu/eval/probe_attention_decode_score_multivalue_service_finalized_cdc.py
+++ b/npu/eval/probe_attention_decode_score_multivalue_service_finalized_cdc.py
@@ -1,0 +1,667 @@
+#!/usr/bin/env python3
+"""Probe real c1 dual-clock exact-partial service through final normalization."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import replace
+import json
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval import probe_attention_decode_score_multivalue_integrated_service as service_probe
+from npu.eval import probe_attention_decode_score_multivalue_service_temporal as temporal_probe
+from npu.rtlgen.gen_attention_decode_score_multivalue_service_finalized_cdc import (
+    generate,
+)
+from npu.sim.perf.attention_exact_partial import (
+    ExactPartialWindowRecord,
+    finalize_partial_beats,
+    merge_ordered_exact_partial_temporal_stream,
+    pack_final_values,
+    partial_stream_from_blocks,
+)
+from npu.sim.perf.attention_online import requantize_score_row
+
+JsonDict = dict[str, Any]
+
+_MANIFEST = "attention_decode_score_multivalue_service_finalized_cdc_manifest.json"
+_OUT_RE = re.compile(
+    r"OUT sequence=(\d+) count=(\d+) command=(\d+) head=(\d+) "
+    r"slice=(\d+) last=(\d+) value=([0-9a-fA-F]+)"
+)
+_SUMMARY_RE = re.compile(
+    r"SUMMARY service_cycles=(\d+) temporal_cycles=(\d+) commands=(\d+) "
+    r"second_refused=(\d+) first_terminal=(-?\d+) second_accept=(-?\d+) "
+    r"outputs=(\d+) stable=(\d+) cdc_accepted=(\d+) cdc_emitted=(\d+) "
+    r"overflow=(\d+) underflow=(\d+) cdc_wr_error=(\d+) cdc_rd_error=(\d+) "
+    r"metadata_error=(\d+) cdc_wrapper_error=(\d+) service_error=(\d+) "
+    r"temporal_error=(\d+) finalizer_error=(\d+) protocol_error=(\d+) "
+    r"service_accepted=(\d+) service_completed=(\d+) service_req=(\d+) "
+    r"service_resp=(\d+) temporal_inputs=(\d+) temporal_merges=(\d+) "
+    r"temporal_emitted=(\d+) temporal_heads=(\d+) finalizer_accepted=(\d+) "
+    r"finalizer_completed=(\d+) finalizer_cycles=(\d+)"
+)
+
+
+def _tool(name: str) -> str:
+    path = shutil.which(name)
+    if path:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    if fallback.exists():
+        return str(fallback)
+    raise RuntimeError(f"required tool unavailable: {name}")
+
+
+def _config(top_name: str, *, divider_lanes: int) -> JsonDict:
+    workload = service_probe._workload_contract()
+    return {
+        "top_name": top_name,
+        "attention_decode_score_multivalue_service_finalized_cdc": {
+            "cdc_fifo_depth": 4,
+            "divider_lanes": divider_lanes,
+            "service": {
+                "cluster_count": 1,
+                "max_blocks": int(workload["max_blocks"]),
+                "packet_w": 128,
+                "banks": 2,
+                "req_queue_depth": 2,
+                "resp_queue_depth": 2,
+                "bank_queue_depth": 2,
+                "read_latency": 1,
+                "arb_mode": "round_robin",
+                "locality_burst_max": 2,
+                "score_scale_lanes_per_cycle": 1,
+                "result_mode": "exact_partial",
+                "head_id_bits": 5,
+                "value_memory_backend": "behavioral",
+            },
+            "temporal_stream": {
+                "fifo_depth": 4,
+                "exp_scale_impl": "factored_h33_l64_mul_exact",
+                "keep_hierarchy": True,
+            },
+        },
+    }
+
+
+def _expected_rows() -> list[JsonDict]:
+    values = service_probe._shared_value_matrices()
+    records: list[ExactPartialWindowRecord] = []
+    for window_index, physical_command_id in enumerate(
+        temporal_probe.PHYSICAL_COMMAND_IDS
+    ):
+        score_rows = [
+            list(
+                requantize_score_row(
+                    service_probe._raw_scores(block),
+                    multiplier=1,
+                    shift=0,
+                )
+            )
+            for block in service_probe._cluster_beats(window_index)
+        ]
+        physical_beats = partial_stream_from_blocks(
+            command_id=physical_command_id,
+            head_id=temporal_probe.HEAD_ID,
+            score_rows=score_rows,
+            value_blocks=values,
+        )
+        records.append(
+            ExactPartialWindowRecord(
+                sequence_id=temporal_probe.SEQUENCE_ID,
+                head_id=temporal_probe.HEAD_ID,
+                window_index=window_index,
+                window_count=2,
+                beats=tuple(
+                    replace(beat, command_id=temporal_probe.LOGICAL_COMMAND_ID)
+                    for beat in physical_beats
+                ),
+            )
+        )
+
+    rows: list[JsonDict] = []
+    for merged in merge_ordered_exact_partial_temporal_stream(records):
+        for beat in finalize_partial_beats(merged.beats):
+            rows.append(
+                {
+                    "sequence_id": merged.sequence_id,
+                    "window_count": merged.window_count,
+                    "command_id": beat.command_id,
+                    "head_id": beat.head_id,
+                    "slice": beat.slice_index,
+                    "last": int(beat.last),
+                    "value": pack_final_values(beat.values),
+                }
+            )
+    return rows
+
+
+def _testbench(
+    *,
+    top_name: str,
+    service_period_ns: float,
+    temporal_period_ns: float,
+) -> str:
+    values = service_probe._shared_value_matrices()
+    entries = service_probe._preload_entries(values)
+    workload = service_probe._workload_contract()
+    beats_per_window = int(
+        service_probe._workload_expected_counts(workload)["input_beat_count"]
+    )
+    all_beats = [
+        beat
+        for window_index in range(2)
+        for block in service_probe._cluster_beats(window_index)
+        for beat in block
+    ]
+    preload_init = "\n".join(
+        "    preload_addr_mem[{0}] = 14'd{1}; preload_slice_mem[{0}] = 4'd{2}; "
+        "preload_matrix_mem[{0}] = 512'h{3};".format(
+            index, entry["addr"], entry["slice"], entry["matrix_hex"]
+        )
+        for index, entry in enumerate(entries)
+    )
+    input_init = "\n".join(
+        "    q_mem[{0}] = {1}; k_mem[{0}] = 64'h{2:016x};".format(
+            index,
+            service_probe._signed_literal(query, 8),
+            service_probe._pack(keys, 8),
+        )
+        for index, (query, keys) in enumerate(all_beats)
+    )
+    return f"""`timescale 1ns/1ps
+{service_probe._FAKERAM_MODEL}
+module tb;
+  localparam integer PRELOAD_COUNT = {len(entries)};
+  localparam integer BEATS_PER_WINDOW = {beats_per_window};
+  localparam integer TOTAL_INPUT_BEATS = {len(all_beats)};
+
+  reg service_clk = 1'b0;
+  reg temporal_clk = 1'b0;
+  reg service_rst_n = 1'b0;
+  reg temporal_rst_n = 1'b0;
+  always #{service_period_ns / 2.0:g} service_clk = ~service_clk;
+  always #{temporal_period_ns / 2.0:g} temporal_clk = ~temporal_clk;
+
+  reg preload_valid;
+  wire preload_ready;
+  reg [13:0] preload_addr;
+  reg [3:0] preload_value_slice;
+  reg [511:0] preload_matrix;
+  reg [13:0] preload_addr_mem [0:PRELOAD_COUNT-1];
+  reg [3:0] preload_slice_mem [0:PRELOAD_COUNT-1];
+  reg [511:0] preload_matrix_mem [0:PRELOAD_COUNT-1];
+  reg signed [7:0] q_mem [0:TOTAL_INPUT_BEATS-1];
+  reg [63:0] k_mem [0:TOTAL_INPUT_BEATS-1];
+
+  reg cluster_command_valid;
+  wire cluster_command_ready;
+  reg [15:0] cluster_command_id;
+  reg [15:0] cluster_logical_sequence_id;
+  reg [15:0] cluster_logical_command_id;
+  reg [13:0] cluster_window_index;
+  reg [14:0] cluster_window_count;
+  reg [14:0] cluster_command_block_count;
+  reg [4:0] cluster_command_head_id;
+  reg [31:0] cluster_command_score_multiplier;
+  reg [5:0] cluster_command_score_shift;
+  reg cluster_input_valid;
+  wire cluster_input_ready;
+  reg cluster_input_last;
+  reg [7:0] cluster_input_a;
+  reg [63:0] cluster_input_b;
+
+  wire out_valid;
+  wire out_ready;
+  wire [15:0] out_sequence_id;
+  wire [14:0] out_window_count;
+  wire [15:0] out_command_id;
+  wire [4:0] out_head_id;
+  wire [3:0] out_slice;
+  wire out_last;
+  wire [319:0] out_value;
+  wire cluster_metadata_busy;
+  wire service_shared_result_valid;
+  wire service_shared_result_ready;
+  wire service_shared_result_last;
+  wire [31:0] service_cluster_accepted_count;
+  wire [31:0] service_cluster_completed_count;
+  wire [31:0] service_accepted_req_count;
+  wire [31:0] service_emitted_resp_count;
+  wire [31:0] temporal_input_accepted_count;
+  wire [31:0] temporal_merge_completed_count;
+  wire [31:0] temporal_emitted_beat_count;
+  wire [31:0] temporal_completed_head_count;
+  wire [31:0] cdc_accepted_count;
+  wire [31:0] cdc_emitted_count;
+  wire cdc_overflow_error;
+  wire cdc_underflow_error;
+  wire cdc_write_protocol_error;
+  wire cdc_read_protocol_error;
+  wire [31:0] finalizer_accepted_count;
+  wire [31:0] finalizer_completed_count;
+  wire [31:0] finalizer_cycle_count;
+  wire metadata_protocol_error;
+  wire cdc_wrapper_protocol_error;
+  wire service_protocol_error;
+  wire temporal_protocol_error;
+  wire finalizer_protocol_error;
+  wire protocol_error;
+
+  integer service_cycle;
+  integer temporal_cycle;
+  integer preload_index;
+  integer command_count;
+  integer active_window;
+  integer input_index;
+  integer second_refused_cycles;
+  integer first_terminal_cycle;
+  integer second_accept_cycle;
+  integer output_count;
+  reg preload_done;
+  reg input_active;
+  reg blocked_output_valid;
+  reg stable_output_seen;
+  reg summary_done;
+  reg [376:0] blocked_output;
+
+  assign out_ready = temporal_rst_n &&
+      (((temporal_cycle % 13) != 2) && ((temporal_cycle % 13) != 3) &&
+       ((temporal_cycle % 13) != 4) && ((temporal_cycle % 13) != 9));
+
+  {top_name} dut (
+      .service_clk(service_clk),
+      .service_rst_n(service_rst_n),
+      .temporal_clk(temporal_clk),
+      .temporal_rst_n(temporal_rst_n),
+      .preload_valid(preload_valid),
+      .preload_ready(preload_ready),
+      .preload_addr(preload_addr),
+      .preload_value_slice(preload_value_slice),
+      .preload_matrix(preload_matrix),
+      .cluster_command_valid(cluster_command_valid),
+      .cluster_command_ready(cluster_command_ready),
+      .cluster_command_id(cluster_command_id),
+      .cluster_logical_sequence_id(cluster_logical_sequence_id),
+      .cluster_logical_command_id(cluster_logical_command_id),
+      .cluster_window_index(cluster_window_index),
+      .cluster_window_count(cluster_window_count),
+      .cluster_command_block_count(cluster_command_block_count),
+      .cluster_command_head_id(cluster_command_head_id),
+      .cluster_command_score_multiplier(cluster_command_score_multiplier),
+      .cluster_command_score_shift(cluster_command_score_shift),
+      .cluster_input_valid(cluster_input_valid),
+      .cluster_input_ready(cluster_input_ready),
+      .cluster_input_last(cluster_input_last),
+      .cluster_input_a(cluster_input_a),
+      .cluster_input_b(cluster_input_b),
+      .out_valid(out_valid),
+      .out_ready(out_ready),
+      .out_sequence_id(out_sequence_id),
+      .out_window_count(out_window_count),
+      .out_command_id(out_command_id),
+      .out_head_id(out_head_id),
+      .out_slice(out_slice),
+      .out_last(out_last),
+      .out_value(out_value),
+      .cluster_metadata_busy(cluster_metadata_busy),
+      .service_shared_result_valid(service_shared_result_valid),
+      .service_shared_result_ready(service_shared_result_ready),
+      .service_shared_result_last(service_shared_result_last),
+      .service_cluster_accepted_count(service_cluster_accepted_count),
+      .service_cluster_completed_count(service_cluster_completed_count),
+      .service_accepted_req_count(service_accepted_req_count),
+      .service_emitted_resp_count(service_emitted_resp_count),
+      .temporal_input_accepted_count(temporal_input_accepted_count),
+      .temporal_merge_completed_count(temporal_merge_completed_count),
+      .temporal_emitted_beat_count(temporal_emitted_beat_count),
+      .temporal_completed_head_count(temporal_completed_head_count),
+      .cdc_accepted_count(cdc_accepted_count),
+      .cdc_emitted_count(cdc_emitted_count),
+      .cdc_overflow_error(cdc_overflow_error),
+      .cdc_underflow_error(cdc_underflow_error),
+      .cdc_write_protocol_error(cdc_write_protocol_error),
+      .cdc_read_protocol_error(cdc_read_protocol_error),
+      .finalizer_accepted_count(finalizer_accepted_count),
+      .finalizer_completed_count(finalizer_completed_count),
+      .finalizer_cycle_count(finalizer_cycle_count),
+      .metadata_protocol_error(metadata_protocol_error),
+      .cdc_wrapper_protocol_error(cdc_wrapper_protocol_error),
+      .service_protocol_error(service_protocol_error),
+      .temporal_protocol_error(temporal_protocol_error),
+      .finalizer_protocol_error(finalizer_protocol_error),
+      .protocol_error(protocol_error)
+  );
+
+  always @* begin
+    preload_valid = service_rst_n && !preload_done;
+    preload_addr = preload_done ? 14'd0 : preload_addr_mem[preload_index];
+    preload_value_slice = preload_done ? 4'd0 : preload_slice_mem[preload_index];
+    preload_matrix = preload_done ? 512'd0 : preload_matrix_mem[preload_index];
+    cluster_command_valid =
+        service_rst_n && preload_done && (command_count < 2);
+    cluster_command_id = (command_count == 0)
+        ? 16'h{temporal_probe.PHYSICAL_COMMAND_IDS[0]:04x}
+        : 16'h{temporal_probe.PHYSICAL_COMMAND_IDS[1]:04x};
+    cluster_logical_sequence_id = 16'h{temporal_probe.SEQUENCE_ID:04x};
+    cluster_logical_command_id = 16'h{temporal_probe.LOGICAL_COMMAND_ID:04x};
+    cluster_window_index = command_count[13:0];
+    cluster_window_count = 15'd2;
+    cluster_command_block_count = 15'd{int(workload["command_block_count"])};
+    cluster_command_head_id = 5'd{temporal_probe.HEAD_ID};
+    cluster_command_score_multiplier = 32'd1;
+    cluster_command_score_shift = 6'd0;
+    cluster_input_valid = service_rst_n && input_active;
+    cluster_input_a = input_active
+        ? q_mem[(active_window * BEATS_PER_WINDOW) + input_index] : 8'd0;
+    cluster_input_b = input_active
+        ? k_mem[(active_window * BEATS_PER_WINDOW) + input_index] : 64'd0;
+    cluster_input_last =
+        input_active && (((input_index + 1) % 128) == 0);
+  end
+
+  always @(posedge service_clk or negedge service_rst_n) begin
+    if (!service_rst_n) begin
+      service_cycle <= 0;
+      preload_index <= 0;
+      preload_done <= 1'b0;
+      command_count <= 0;
+      active_window <= 0;
+      input_index <= 0;
+      input_active <= 1'b0;
+      second_refused_cycles <= 0;
+      first_terminal_cycle <= -1;
+      second_accept_cycle <= -1;
+    end else begin
+      service_cycle <= service_cycle + 1;
+      if (!preload_done && preload_valid && preload_ready) begin
+        if (preload_index == PRELOAD_COUNT - 1)
+          preload_done <= 1'b1;
+        else
+          preload_index <= preload_index + 1;
+      end
+      if (cluster_command_valid && cluster_command_ready) begin
+        if (command_count == 1) second_accept_cycle <= service_cycle;
+        active_window <= command_count;
+        input_index <= 0;
+        input_active <= 1'b1;
+        command_count <= command_count + 1;
+      end
+      if ((command_count == 1) && cluster_command_valid &&
+          !cluster_command_ready && cluster_metadata_busy)
+        second_refused_cycles <= second_refused_cycles + 1;
+      if (cluster_input_valid && cluster_input_ready) begin
+        if (input_index == BEATS_PER_WINDOW - 1)
+          input_active <= 1'b0;
+        else
+          input_index <= input_index + 1;
+      end
+      if ((first_terminal_cycle < 0) && service_shared_result_valid &&
+          service_shared_result_ready && service_shared_result_last)
+        first_terminal_cycle <= service_cycle;
+      if (service_cycle > 180000) $fatal(1, "service-side timeout");
+    end
+  end
+
+  always @(posedge temporal_clk or negedge temporal_rst_n) begin
+    if (!temporal_rst_n) begin
+      temporal_cycle <= 0;
+      output_count <= 0;
+      blocked_output_valid <= 1'b0;
+      stable_output_seen <= 1'b0;
+      blocked_output <= 377'd0;
+      summary_done <= 1'b0;
+    end else begin
+      temporal_cycle <= temporal_cycle + 1;
+      if (out_valid && !out_ready) begin
+        if (!blocked_output_valid) begin
+          blocked_output_valid <= 1'b1;
+          blocked_output <= {{
+              out_sequence_id, out_window_count, out_command_id, out_head_id,
+              out_slice, out_last, out_value
+          }};
+        end else begin
+          if ({{out_sequence_id, out_window_count, out_command_id, out_head_id,
+                out_slice, out_last, out_value}} !== blocked_output)
+            $fatal(1, "finalized output changed under backpressure");
+          stable_output_seen <= 1'b1;
+        end
+      end else begin
+        blocked_output_valid <= 1'b0;
+      end
+      if (out_valid && out_ready) begin
+        $display("OUT sequence=%0d count=%0d command=%0d head=%0d slice=%0d last=%0d value=%080x",
+                 out_sequence_id, out_window_count, out_command_id, out_head_id,
+                 out_slice, out_last, out_value);
+        output_count <= output_count + 1;
+      end
+      if (!summary_done && output_count == 16) begin
+        summary_done <= 1'b1;
+        $display("SUMMARY service_cycles=%0d temporal_cycles=%0d commands=%0d second_refused=%0d first_terminal=%0d second_accept=%0d outputs=%0d stable=%0d cdc_accepted=%0d cdc_emitted=%0d overflow=%0d underflow=%0d cdc_wr_error=%0d cdc_rd_error=%0d metadata_error=%0d cdc_wrapper_error=%0d service_error=%0d temporal_error=%0d finalizer_error=%0d protocol_error=%0d service_accepted=%0d service_completed=%0d service_req=%0d service_resp=%0d temporal_inputs=%0d temporal_merges=%0d temporal_emitted=%0d temporal_heads=%0d finalizer_accepted=%0d finalizer_completed=%0d finalizer_cycles=%0d",
+                 service_cycle, temporal_cycle, command_count,
+                 second_refused_cycles, first_terminal_cycle,
+                 second_accept_cycle, output_count, stable_output_seen,
+                 cdc_accepted_count, cdc_emitted_count, cdc_overflow_error,
+                 cdc_underflow_error, cdc_write_protocol_error,
+                 cdc_read_protocol_error, metadata_protocol_error,
+                 cdc_wrapper_protocol_error, service_protocol_error,
+                 temporal_protocol_error, finalizer_protocol_error,
+                 protocol_error, service_cluster_accepted_count,
+                 service_cluster_completed_count, service_accepted_req_count,
+                 service_emitted_resp_count, temporal_input_accepted_count,
+                 temporal_merge_completed_count, temporal_emitted_beat_count,
+                 temporal_completed_head_count, finalizer_accepted_count,
+                 finalizer_completed_count, finalizer_cycle_count);
+        $finish;
+      end
+      if (temporal_cycle > 260000) $fatal(1, "temporal-side timeout");
+    end
+  end
+
+  initial begin
+{preload_init}
+{input_init}
+    repeat (4) @(posedge service_clk);
+    @(negedge service_clk);
+    service_rst_n = 1'b1;
+    #{service_period_ns * 1.3:g};
+    temporal_rst_n = 1'b1;
+  end
+endmodule
+"""
+
+
+def _parse(stdout: str) -> tuple[list[JsonDict], JsonDict]:
+    rows: list[JsonDict] = []
+    summary: JsonDict | None = None
+    for line in stdout.splitlines():
+        if match := _OUT_RE.fullmatch(line.strip()):
+            rows.append(
+                {
+                    "sequence_id": int(match.group(1)),
+                    "window_count": int(match.group(2)),
+                    "command_id": int(match.group(3)),
+                    "head_id": int(match.group(4)),
+                    "slice": int(match.group(5)),
+                    "last": int(match.group(6)),
+                    "value": int(match.group(7), 16),
+                }
+            )
+        if match := _SUMMARY_RE.fullmatch(line.strip()):
+            keys = (
+                "service_cycles",
+                "temporal_cycles",
+                "commands",
+                "second_refused",
+                "first_terminal",
+                "second_accept",
+                "outputs",
+                "stable",
+                "cdc_accepted",
+                "cdc_emitted",
+                "overflow",
+                "underflow",
+                "cdc_wr_error",
+                "cdc_rd_error",
+                "metadata_error",
+                "cdc_wrapper_error",
+                "service_error",
+                "temporal_error",
+                "finalizer_error",
+                "protocol_error",
+                "service_accepted",
+                "service_completed",
+                "service_req",
+                "service_resp",
+                "temporal_inputs",
+                "temporal_merges",
+                "temporal_emitted",
+                "temporal_heads",
+                "finalizer_accepted",
+                "finalizer_completed",
+                "finalizer_cycles",
+            )
+            summary = {
+                key: int(value)
+                for key, value in zip(keys, match.groups(), strict=True)
+            }
+    if summary is None:
+        raise RuntimeError(f"simulation did not emit SUMMARY\n{stdout}")
+    return rows, summary
+
+
+def build_report(
+    *,
+    service_period_ns: float = 10.0,
+    temporal_period_ns: float = 7.0,
+    divider_lanes: int = 8,
+) -> JsonDict:
+    top_name = "attention_decode_score_multivalue_service_finalized_cdc_probe"
+    config = _config(top_name, divider_lanes=divider_lanes)
+    expected = _expected_rows()
+    with tempfile.TemporaryDirectory(prefix="decode-service-finalized-cdc-probe-") as name:
+        temp = Path(name)
+        rtl_dir = temp / "rtl"
+        generate(config, rtl_dir)
+        tb_path = temp / "tb.sv"
+        tb_path.write_text(
+            _testbench(
+                top_name=top_name,
+                service_period_ns=service_period_ns,
+                temporal_period_ns=temporal_period_ns,
+            ),
+            encoding="utf-8",
+        )
+        simv = temp / "simv"
+        compile_run = subprocess.run(
+            [
+                _tool("iverilog"),
+                "-g2012",
+                "-s",
+                "tb",
+                "-o",
+                str(simv),
+                str(rtl_dir / "top.v"),
+                str(tb_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=240,
+        )
+        if compile_run.returncode:
+            raise RuntimeError(f"iverilog failed:\n{compile_run.stderr}")
+        sim_run = subprocess.run(
+            [_tool("vvp"), str(simv)],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        if sim_run.returncode:
+            raise RuntimeError(
+                f"simulation failed:\n{sim_run.stdout}\n{sim_run.stderr}"
+            )
+        observed, summary = _parse(sim_run.stdout)
+        manifest = json.loads(
+            (rtl_dir / _MANIFEST).read_text(encoding="utf-8")
+        )
+
+    errors = (
+        "overflow",
+        "underflow",
+        "cdc_wr_error",
+        "cdc_rd_error",
+        "metadata_error",
+        "cdc_wrapper_error",
+        "service_error",
+        "temporal_error",
+        "finalizer_error",
+        "protocol_error",
+    )
+    passed = (
+        observed == expected
+        and len(observed) == 16
+        and summary["commands"] == 2
+        and summary["second_refused"] > 0
+        and summary["second_accept"] > summary["first_terminal"] >= 0
+        and summary["stable"] == 1
+        and summary["cdc_accepted"] == 32
+        and summary["cdc_emitted"] == 32
+        and summary["service_accepted"] == 2
+        and summary["service_completed"] == 2
+        and summary["service_req"] == 96
+        and summary["service_resp"] == 96
+        and summary["temporal_inputs"] == 32
+        and summary["temporal_merges"] == 16
+        and summary["temporal_emitted"] == 16
+        and summary["temporal_heads"] == 1
+        and summary["finalizer_accepted"] == 16
+        and summary["finalizer_completed"] == 16
+        and all(summary[key] == 0 for key in errors)
+    )
+    return {
+        "model": "attention_decode_score_multivalue_service_finalized_cdc_probe_v1",
+        "passed": passed,
+        "service_period_ns": service_period_ns,
+        "temporal_period_ns": temporal_period_ns,
+        "divider_lanes": divider_lanes,
+        "observed_rows": observed,
+        "expected_rows": expected,
+        "summary": summary,
+        "manifest": manifest,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--service-period-ns", type=float, default=10.0)
+    parser.add_argument("--temporal-period-ns", type=float, default=7.0)
+    parser.add_argument("--divider-lanes", type=int, default=8)
+    parser.add_argument("--out", type=Path)
+    args = parser.parse_args()
+    report = build_report(
+        service_period_ns=args.service_period_ns,
+        temporal_period_ns=args.temporal_period_ns,
+        divider_lanes=args.divider_lanes,
+    )
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/rtlgen/gen_attention_decode_score_multivalue_service_finalized_cdc.py
+++ b/npu/rtlgen/gen_attention_decode_score_multivalue_service_finalized_cdc.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""Generate dual-clock decode-score service through full-context finalization."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import sys
+import tempfile
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_decode_score_multivalue_service_temporal_cdc import (
+    generate as generate_service_temporal_cdc,
+)
+from npu.rtlgen.gen_attention_score32_exact_root_finalizer import (
+    generate as generate_finalizer,
+)
+from npu.sim.perf.attention_exact_partial import HEAD_ID_BITS, VALUE_SLICES
+
+JsonDict = dict[str, Any]
+
+_CONFIG_KEY = "attention_decode_score_multivalue_service_finalized_cdc"
+_GENERATOR = "npu/rtlgen/gen_attention_decode_score_multivalue_service_finalized_cdc.py"
+_MANIFEST = "attention_decode_score_multivalue_service_finalized_cdc_manifest.json"
+_CDC_MANIFEST = "attention_decode_score_multivalue_service_temporal_cdc_manifest.json"
+_FINALIZER_MANIFEST = "attention_score32_exact_root_finalizer_manifest.json"
+
+
+def _load(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit(f"config must decode to a JSON object: {path}")
+    return payload
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _validate(config: JsonDict) -> JsonDict:
+    top_name = str(config.get("top_name") or "").strip()
+    body = config.get(_CONFIG_KEY)
+    if not top_name or not isinstance(body, dict):
+        raise SystemExit(f"config requires top_name and {_CONFIG_KEY}")
+    service = body.get("service")
+    temporal = body.get("temporal_stream", {})
+    if not isinstance(service, dict) or not isinstance(temporal, dict):
+        raise SystemExit("service and temporal_stream must be JSON objects")
+    service_params = dict(service)
+    if str(service_params.get("result_mode", "")).strip().lower() != "exact_partial":
+        raise SystemExit("service.result_mode must be exact_partial")
+    if int(service_params.get("head_id_bits", HEAD_ID_BITS)) != HEAD_ID_BITS:
+        raise SystemExit(f"service.head_id_bits must remain fixed at {HEAD_ID_BITS}")
+    clusters = int(service_params.get("cluster_count", 1))
+    if not 1 <= clusters <= 32:
+        raise SystemExit("service.cluster_count must be in [1, 32]")
+    cdc_depth = int(body.get("cdc_fifo_depth", 4))
+    if cdc_depth not in {4, 8, 16}:
+        raise SystemExit("cdc_fifo_depth must be one of 4, 8, or 16")
+    divider_lanes = int(body.get("divider_lanes", 8))
+    if divider_lanes not in {1, 2, 4, 8}:
+        raise SystemExit("divider_lanes must be one of 1, 2, 4, or 8")
+    return {
+        "top_name": top_name,
+        "service": service_params,
+        "temporal": dict(temporal),
+        "clusters": clusters,
+        "source_w": max(1, (clusters - 1).bit_length()),
+        "cdc_depth": cdc_depth,
+        "divider_lanes": divider_lanes,
+    }
+
+
+def _wrapper(
+    *,
+    top_name: str,
+    cdc_top: str,
+    finalizer_top: str,
+    clusters: int,
+    source_w: int,
+) -> str:
+    return f"""module {top_name} (
+    input  wire         service_clk,
+    input  wire         service_rst_n,
+    input  wire         temporal_clk,
+    input  wire         temporal_rst_n,
+    input  wire         preload_valid,
+    output wire         preload_ready,
+    input  wire [13:0]  preload_addr,
+    input  wire [3:0]   preload_value_slice,
+    input  wire [511:0] preload_matrix,
+    input  wire [{clusters - 1}:0] cluster_command_valid,
+    output wire [{clusters - 1}:0] cluster_command_ready,
+    input  wire [{clusters * 16 - 1}:0] cluster_command_id,
+    input  wire [{clusters * 16 - 1}:0] cluster_logical_sequence_id,
+    input  wire [{clusters * 16 - 1}:0] cluster_logical_command_id,
+    input  wire [{clusters * 14 - 1}:0] cluster_window_index,
+    input  wire [{clusters * 15 - 1}:0] cluster_window_count,
+    input  wire [{clusters * 15 - 1}:0] cluster_command_block_count,
+    input  wire [{clusters * HEAD_ID_BITS - 1}:0] cluster_command_head_id,
+    input  wire [{clusters * 32 - 1}:0] cluster_command_score_multiplier,
+    input  wire [{clusters * 6 - 1}:0] cluster_command_score_shift,
+    input  wire [{clusters - 1}:0] cluster_input_valid,
+    output wire [{clusters - 1}:0] cluster_input_ready,
+    input  wire [{clusters - 1}:0] cluster_input_last,
+    input  wire [{clusters * 8 - 1}:0] cluster_input_a,
+    input  wire [{clusters * 64 - 1}:0] cluster_input_b,
+    output wire         out_valid,
+    input  wire         out_ready,
+    output wire [15:0]  out_sequence_id,
+    output wire [14:0]  out_window_count,
+    output wire [15:0]  out_command_id,
+    output wire [{HEAD_ID_BITS - 1}:0] out_head_id,
+    output wire [3:0]   out_slice,
+    output wire         out_last,
+    output wire [319:0] out_value,
+    output wire [{clusters - 1}:0] cluster_metadata_busy,
+    output wire         service_shared_result_valid,
+    output wire         service_shared_result_ready,
+    output wire [{source_w - 1}:0] service_shared_result_cluster,
+    output wire [15:0]  service_shared_result_command_id,
+    output wire         service_shared_result_last,
+    output wire [{clusters * 32 - 1}:0] service_cluster_accepted_count,
+    output wire [{clusters * 32 - 1}:0] service_cluster_completed_count,
+    output wire [31:0]  service_accepted_req_count,
+    output wire [31:0]  service_emitted_resp_count,
+    output wire [31:0]  temporal_input_accepted_count,
+    output wire [31:0]  temporal_merge_completed_count,
+    output wire [31:0]  temporal_emitted_beat_count,
+    output wire [31:0]  temporal_completed_head_count,
+    output wire [31:0]  temporal_output_stall_cycles,
+    output wire [31:0]  cdc_write_occupancy,
+    output wire [31:0]  cdc_read_occupancy,
+    output wire [31:0]  cdc_accepted_count,
+    output wire [31:0]  cdc_emitted_count,
+    output wire [31:0]  cdc_full_cycles,
+    output wire [31:0]  cdc_empty_cycles,
+    output wire         cdc_overflow_error,
+    output wire         cdc_underflow_error,
+    output wire         cdc_write_protocol_error,
+    output wire         cdc_read_protocol_error,
+    output wire [31:0]  finalizer_accepted_count,
+    output wire [31:0]  finalizer_completed_count,
+    output wire [31:0]  finalizer_cycle_count,
+    output wire         metadata_protocol_error,
+    output wire         cdc_wrapper_protocol_error,
+    output wire         service_protocol_error,
+    output wire         temporal_protocol_error,
+    output wire         finalizer_protocol_error,
+    output wire         protocol_error
+);
+  localparam integer HEAD_ID_BITS = {HEAD_ID_BITS};
+
+  wire temporal_out_valid_w;
+  wire temporal_out_ready_w;
+  wire [15:0] temporal_out_sequence_id_w;
+  wire [HEAD_ID_BITS-1:0] temporal_out_head_id_w;
+  wire [14:0] temporal_out_window_count_w;
+  wire [15:0] temporal_out_command_id_w;
+  wire [31:0] temporal_out_global_max_w;
+  wire [32:0] temporal_out_exp_sum_w;
+  wire [3:0] temporal_out_slice_w;
+  wire temporal_out_last_w;
+  wire [327:0] temporal_out_value_w;
+
+  wire finalizer_in_ready_w;
+  wire finalizer_out_valid_w;
+  wire finalizer_out_ready_w;
+  wire [15:0] finalizer_out_command_id_w;
+  wire [HEAD_ID_BITS-1:0] finalizer_out_head_id_w;
+  wire [3:0] finalizer_out_slice_w;
+  wire finalizer_out_last_w;
+  wire [319:0] finalizer_out_value_w;
+
+  reg metadata_valid_q;
+  reg [15:0] metadata_sequence_id_q;
+  reg [14:0] metadata_window_count_q;
+  reg [15:0] metadata_command_id_q;
+  reg [HEAD_ID_BITS-1:0] metadata_head_id_q;
+  reg [3:0] metadata_slice_q;
+  reg metadata_last_q;
+  reg metadata_protocol_error_q;
+
+  wire temporal_domain_error_w;
+  wire metadata_open_w = !metadata_valid_q && !temporal_domain_error_w;
+  wire finalizer_input_fire_w =
+      temporal_out_valid_w && temporal_out_ready_w;
+  wire finalizer_output_metadata_error_w =
+      finalizer_out_valid_w
+      && (!metadata_valid_q
+          || finalizer_out_command_id_w != metadata_command_id_q
+          || finalizer_out_head_id_w != metadata_head_id_q
+          || finalizer_out_slice_w != metadata_slice_q
+          || finalizer_out_last_w != metadata_last_q);
+  assign temporal_domain_error_w =
+      metadata_protocol_error_q || finalizer_output_metadata_error_w
+      || cdc_wrapper_protocol_error || temporal_protocol_error
+      || finalizer_protocol_error;
+  wire finalizer_output_fire_w =
+      finalizer_out_valid_w && finalizer_out_ready_w;
+
+  assign temporal_out_ready_w =
+      finalizer_in_ready_w && metadata_open_w;
+  assign finalizer_out_ready_w =
+      out_ready && metadata_valid_q
+      && !finalizer_output_metadata_error_w && !temporal_domain_error_w;
+  assign out_valid =
+      finalizer_out_valid_w && metadata_valid_q
+      && !finalizer_output_metadata_error_w && !temporal_domain_error_w;
+  assign out_sequence_id = metadata_sequence_id_q;
+  assign out_window_count = metadata_window_count_q;
+  assign out_command_id = finalizer_out_command_id_w;
+  assign out_head_id = finalizer_out_head_id_w;
+  assign out_slice = finalizer_out_slice_w;
+  assign out_last = finalizer_out_last_w;
+  assign out_value = finalizer_out_value_w;
+  assign metadata_protocol_error =
+      metadata_protocol_error_q || finalizer_output_metadata_error_w;
+  assign protocol_error =
+      metadata_protocol_error || cdc_wrapper_protocol_error
+      || service_protocol_error || temporal_protocol_error
+      || finalizer_protocol_error || cdc_overflow_error
+      || cdc_underflow_error || cdc_write_protocol_error
+      || cdc_read_protocol_error;
+
+  always @(posedge temporal_clk or negedge temporal_rst_n) begin
+    if (!temporal_rst_n) begin
+      metadata_valid_q <= 1'b0;
+      metadata_sequence_id_q <= 16'd0;
+      metadata_window_count_q <= 15'd0;
+      metadata_command_id_q <= 16'd0;
+      metadata_head_id_q <= {{HEAD_ID_BITS{{1'b0}}}};
+      metadata_slice_q <= 4'd0;
+      metadata_last_q <= 1'b0;
+      metadata_protocol_error_q <= 1'b0;
+    end else begin
+      if (finalizer_output_metadata_error_w)
+        metadata_protocol_error_q <= 1'b1;
+      if (finalizer_input_fire_w) begin
+        metadata_valid_q <= 1'b1;
+        metadata_sequence_id_q <= temporal_out_sequence_id_w;
+        metadata_window_count_q <= temporal_out_window_count_w;
+        metadata_command_id_q <= temporal_out_command_id_w;
+        metadata_head_id_q <= temporal_out_head_id_w;
+        metadata_slice_q <= temporal_out_slice_w;
+        metadata_last_q <= temporal_out_last_w;
+      end
+      if (finalizer_output_fire_w)
+        metadata_valid_q <= 1'b0;
+    end
+  end
+
+  {cdc_top} u_service_temporal_cdc (
+      .service_clk(service_clk),
+      .service_rst_n(service_rst_n),
+      .temporal_clk(temporal_clk),
+      .temporal_rst_n(temporal_rst_n),
+      .preload_valid(preload_valid),
+      .preload_ready(preload_ready),
+      .preload_addr(preload_addr),
+      .preload_value_slice(preload_value_slice),
+      .preload_matrix(preload_matrix),
+      .cluster_command_valid(cluster_command_valid),
+      .cluster_command_ready(cluster_command_ready),
+      .cluster_command_id(cluster_command_id),
+      .cluster_logical_sequence_id(cluster_logical_sequence_id),
+      .cluster_logical_command_id(cluster_logical_command_id),
+      .cluster_window_index(cluster_window_index),
+      .cluster_window_count(cluster_window_count),
+      .cluster_command_block_count(cluster_command_block_count),
+      .cluster_command_head_id(cluster_command_head_id),
+      .cluster_command_score_multiplier(cluster_command_score_multiplier),
+      .cluster_command_score_shift(cluster_command_score_shift),
+      .cluster_input_valid(cluster_input_valid),
+      .cluster_input_ready(cluster_input_ready),
+      .cluster_input_last(cluster_input_last),
+      .cluster_input_a(cluster_input_a),
+      .cluster_input_b(cluster_input_b),
+      .out_valid(temporal_out_valid_w),
+      .out_ready(temporal_out_ready_w),
+      .out_sequence_id(temporal_out_sequence_id_w),
+      .out_head_id(temporal_out_head_id_w),
+      .out_window_count(temporal_out_window_count_w),
+      .out_command_id(temporal_out_command_id_w),
+      .out_global_max(temporal_out_global_max_w),
+      .out_exp_sum(temporal_out_exp_sum_w),
+      .out_slice(temporal_out_slice_w),
+      .out_last(temporal_out_last_w),
+      .out_value(temporal_out_value_w),
+      .cluster_metadata_busy(cluster_metadata_busy),
+      .service_shared_result_valid(service_shared_result_valid),
+      .service_shared_result_ready(service_shared_result_ready),
+      .service_shared_result_cluster(service_shared_result_cluster),
+      .service_shared_result_command_id(service_shared_result_command_id),
+      .service_shared_result_last(service_shared_result_last),
+      .service_cluster_accepted_count(service_cluster_accepted_count),
+      .service_cluster_completed_count(service_cluster_completed_count),
+      .service_accepted_req_count(service_accepted_req_count),
+      .service_emitted_resp_count(service_emitted_resp_count),
+      .temporal_input_accepted_count(temporal_input_accepted_count),
+      .temporal_merge_completed_count(temporal_merge_completed_count),
+      .temporal_emitted_beat_count(temporal_emitted_beat_count),
+      .temporal_completed_head_count(temporal_completed_head_count),
+      .temporal_output_stall_cycles(temporal_output_stall_cycles),
+      .cdc_write_occupancy(cdc_write_occupancy),
+      .cdc_read_occupancy(cdc_read_occupancy),
+      .cdc_accepted_count(cdc_accepted_count),
+      .cdc_emitted_count(cdc_emitted_count),
+      .cdc_full_cycles(cdc_full_cycles),
+      .cdc_empty_cycles(cdc_empty_cycles),
+      .cdc_overflow_error(cdc_overflow_error),
+      .cdc_underflow_error(cdc_underflow_error),
+      .cdc_write_protocol_error(cdc_write_protocol_error),
+      .cdc_read_protocol_error(cdc_read_protocol_error),
+      .wrapper_protocol_error(cdc_wrapper_protocol_error),
+      .service_protocol_error(service_protocol_error),
+      .temporal_protocol_error(temporal_protocol_error)
+  );
+
+  {finalizer_top} u_finalizer (
+      .clk(temporal_clk),
+      .rst_n(temporal_rst_n),
+      .in_valid(temporal_out_valid_w && metadata_open_w),
+      .in_ready(finalizer_in_ready_w),
+      .in_command_id(temporal_out_command_id_w),
+      .in_head_id(temporal_out_head_id_w),
+      .in_exp_sum(temporal_out_exp_sum_w),
+      .in_slice(temporal_out_slice_w),
+      .in_last(temporal_out_last_w),
+      .in_value(temporal_out_value_w),
+      .out_valid(finalizer_out_valid_w),
+      .out_ready(finalizer_out_ready_w),
+      .out_command_id(finalizer_out_command_id_w),
+      .out_head_id(finalizer_out_head_id_w),
+      .out_slice(finalizer_out_slice_w),
+      .out_last(finalizer_out_last_w),
+      .out_value(finalizer_out_value_w),
+      .accepted_count(finalizer_accepted_count),
+      .completed_count(finalizer_completed_count),
+      .cycle_count(finalizer_cycle_count),
+      .protocol_error(finalizer_protocol_error)
+  );
+endmodule
+"""
+
+
+def generate(config: JsonDict, out_dir: Path) -> None:
+    params = _validate(json.loads(json.dumps(config)))
+    top_name = str(params["top_name"])
+    cdc_top = f"{top_name}__service_temporal_cdc"
+    finalizer_top = f"{top_name}__finalizer"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    cdc_config = {
+        "top_name": cdc_top,
+        "attention_decode_score_multivalue_service_temporal_cdc": {
+            "service": params["service"],
+            "temporal_stream": params["temporal"],
+            "cdc_fifo_depth": int(params["cdc_depth"]),
+        },
+    }
+    finalizer_config = {
+        "top_name": finalizer_top,
+        "attention_score32_exact_root_finalizer": {
+            "value_slices": VALUE_SLICES,
+            "head_id_bits": HEAD_ID_BITS,
+            "divider_lanes": int(params["divider_lanes"]),
+        },
+    }
+    with tempfile.TemporaryDirectory(prefix="decode-service-finalized-cdc-gen-") as name:
+        temp = Path(name)
+        cdc_dir = temp / "cdc"
+        finalizer_dir = temp / "finalizer"
+        generate_service_temporal_cdc(cdc_config, cdc_dir)
+        generate_finalizer(finalizer_config, finalizer_dir)
+        cdc_rtl = (cdc_dir / "top.v").read_text(encoding="utf-8")
+        finalizer_rtl = (finalizer_dir / "top.v").read_text(encoding="utf-8")
+        cdc_manifest = json.loads(
+            (cdc_dir / _CDC_MANIFEST).read_text(encoding="utf-8")
+        )
+        finalizer_manifest = json.loads(
+            (finalizer_dir / _FINALIZER_MANIFEST).read_text(encoding="utf-8")
+        )
+
+    wrapper_rtl = _wrapper(
+        top_name=top_name,
+        cdc_top=cdc_top,
+        finalizer_top=finalizer_top,
+        clusters=int(params["clusters"]),
+        source_w=int(params["source_w"]),
+    )
+    top_text = "\n\n".join((cdc_rtl, finalizer_rtl, wrapper_rtl)) + "\n"
+    (out_dir / "top.v").write_text(top_text, encoding="utf-8")
+    (out_dir / "config.json").write_text(
+        json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    manifest = {
+        "version": 1,
+        "top_name": top_name,
+        "generator": _GENERATOR,
+        "semantic_profile": "decode_score_multivalue_service_finalized_cdc_v1",
+        "result_mode": "exact_partial_to_exact_finalized",
+        "cluster_count": int(params["clusters"]),
+        "divider_lanes": int(params["divider_lanes"]),
+        "full_context_normalization_embodied": True,
+        "output_interface": {
+            "kind": "ready_valid_exact_finalized_slice_stream",
+            "value_bits": 320,
+            "beats_per_head": VALUE_SLICES,
+            "metadata": [
+                "logical_sequence_id",
+                "window_count",
+                "logical_command_id",
+                "head_id",
+                "slice",
+                "last",
+            ],
+        },
+        "finalizer_metadata_hold": {
+            "capture": "exactly_on_finalizer_input_handshake",
+            "release": "matching_finalizer_output_handshake",
+            "consistency_checked": [
+                "logical_command_id",
+                "head_id",
+                "slice",
+                "last",
+            ],
+            "single_inflight": True,
+        },
+        "remaining_abstractions": [
+            "persistent_state_sram_physical_mapping",
+            "synchronizer_metastability_mtbf_and_library_cells",
+            "external_hbm_dram",
+            "physical_ppa",
+        ],
+        "submodule_manifests": {
+            "service_temporal_cdc": cdc_manifest,
+            "root_finalizer": finalizer_manifest,
+        },
+        "dependency_sources": [
+            {"path": _GENERATOR, "sha256": _sha256_file(Path(__file__))},
+            {
+                "path": "npu/rtlgen/gen_attention_decode_score_multivalue_service_temporal_cdc.py",
+                "sha256": _sha256_file(
+                    REPO_ROOT
+                    / "npu/rtlgen/gen_attention_decode_score_multivalue_service_temporal_cdc.py"
+                ),
+            },
+            {
+                "path": "npu/rtlgen/gen_attention_score32_exact_root_finalizer.py",
+                "sha256": _sha256_file(
+                    REPO_ROOT
+                    / "npu/rtlgen/gen_attention_score32_exact_root_finalizer.py"
+                ),
+            },
+        ],
+        "generated_top_sha256": _sha256_text(top_text),
+    }
+    (out_dir / _MANIFEST).write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    generate(_load(args.config), args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_attention_decode_score_multivalue_service_finalized_cdc.py
+++ b/tests/test_attention_decode_score_multivalue_service_finalized_cdc.py
@@ -1,0 +1,119 @@
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+from npu.rtlgen.gen_attention_decode_score_multivalue_service_finalized_cdc import (
+    generate,
+)
+
+
+def _tool(name: str) -> str:
+    path = shutil.which(name)
+    if path:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    if fallback.exists():
+        return str(fallback)
+    pytest.skip(f"{name} unavailable")
+
+
+def _config(*, divider_lanes: int = 8, result_mode: str = "exact_partial") -> dict:
+    return {
+        "top_name": "attention_decode_score_multivalue_service_finalized_cdc_c1",
+        "attention_decode_score_multivalue_service_finalized_cdc": {
+            "cdc_fifo_depth": 4,
+            "divider_lanes": divider_lanes,
+            "service": {
+                "cluster_count": 1,
+                "max_blocks": 16,
+                "packet_w": 128,
+                "banks": 2,
+                "req_queue_depth": 2,
+                "resp_queue_depth": 2,
+                "bank_queue_depth": 2,
+                "read_latency": 1,
+                "arb_mode": "round_robin",
+                "locality_burst_max": 2,
+                "score_scale_lanes_per_cycle": 1,
+                "result_mode": result_mode,
+                "head_id_bits": 5,
+                "value_memory_backend": "behavioral",
+            },
+            "temporal_stream": {
+                "fifo_depth": 4,
+                "exp_scale_impl": "factored_h33_l64_mul_exact",
+                "keep_hierarchy": True,
+            },
+        },
+    }
+
+
+@pytest.mark.parametrize("divider_lanes", [1, 2, 4, 8])
+def test_generator_manifest_latency_and_lint(
+    divider_lanes: int,
+    tmp_path: Path,
+) -> None:
+    config = _config(divider_lanes=divider_lanes)
+    generate(config, tmp_path)
+    manifest = json.loads(
+        (
+            tmp_path
+            / "attention_decode_score_multivalue_service_finalized_cdc_manifest.json"
+        ).read_text(encoding="utf-8")
+    )
+    rtl = (tmp_path / "top.v").read_text(encoding="utf-8")
+    finalizer = manifest["submodule_manifests"]["root_finalizer"]
+
+    assert manifest["divider_lanes"] == divider_lanes
+    assert manifest["full_context_normalization_embodied"] is True
+    assert manifest["output_interface"]["value_bits"] == 320
+    assert manifest["finalizer_metadata_hold"]["capture"] == (
+        "exactly_on_finalizer_input_handshake"
+    )
+    assert manifest["remaining_abstractions"] == [
+        "persistent_state_sram_physical_mapping",
+        "synchronizer_metastability_mtbf_and_library_cells",
+        "external_hbm_dram",
+        "physical_ppa",
+    ]
+    assert finalizer["divider_cycles_per_beat"] == (8 // divider_lanes) * 57
+    assert finalizer["accept_interval_cycles_per_beat"] == (
+        (8 // divider_lanes) * 57
+    ) + 2
+    assert "if (finalizer_input_fire_w)" in rtl
+    assert "if (finalizer_output_fire_w)" in rtl
+    assert "finalizer_out_slice_w != metadata_slice_q" in rtl
+
+    lint = subprocess.run(
+        [
+            _tool("verilator"),
+            "--lint-only",
+            "-Wno-WIDTHEXPAND",
+            "-Wno-WIDTHTRUNC",
+            "-Wno-UNUSEDSIGNAL",
+            "-Wno-UNDRIVEN",
+            "-Wno-TIMESCALEMOD",
+            "-Wno-SIDEEFFECT",
+            "-Wno-LATCH",
+            "-Wno-UNOPTFLAT",
+            "-Wno-PINMISSING",
+            "--top-module",
+            str(config["top_name"]),
+            str(tmp_path / "top.v"),
+            str(Path("npu/rtl/fakeram45_2048x39_blackbox.v")),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=240,
+    )
+    assert lint.returncode == 0, lint.stderr
+
+
+def test_invalid_result_mode_and_divider_lanes_are_rejected(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit, match="exact_partial"):
+        generate(_config(result_mode="normalized"), tmp_path)
+    with pytest.raises(SystemExit, match="divider_lanes"):
+        generate(_config(divider_lanes=3), tmp_path)

--- a/tests/test_probe_attention_decode_score_multivalue_service_finalized_cdc.py
+++ b/tests/test_probe_attention_decode_score_multivalue_service_finalized_cdc.py
@@ -1,0 +1,29 @@
+import shutil
+
+import pytest
+
+from npu.eval.probe_attention_decode_score_multivalue_service_finalized_cdc import (
+    build_report,
+)
+
+
+def test_real_c1_two_window_full_context_finalization() -> None:
+    if not (shutil.which("iverilog") and shutil.which("vvp")):
+        pytest.skip("iverilog/vvp unavailable")
+
+    report = build_report(
+        service_period_ns=10.0,
+        temporal_period_ns=7.0,
+        divider_lanes=8,
+    )
+
+    assert report["passed"] is True
+    assert report["observed_rows"] == report["expected_rows"]
+    assert len(report["observed_rows"]) == 16
+    assert report["summary"]["stable"] == 1
+    assert report["summary"]["cdc_accepted"] == 32
+    assert report["summary"]["cdc_emitted"] == 32
+    assert report["summary"]["temporal_emitted"] == 16
+    assert report["summary"]["finalizer_accepted"] == 16
+    assert report["summary"]["finalizer_completed"] == 16
+    assert report["summary"]["protocol_error"] == 0


### PR DESCRIPTION
## Summary
- append the embodied exact root finalizer to the dual-clock service/temporal composition
- preserve sequence and window metadata across the single-inflight restoring divider
- fail closed on finalizer command/head/slice/last mismatches
- expose complete CDC, temporal, finalizer, and aggregate protocol evidence

## Functional evidence
- real c1 service over two physical context windows
- 10ns service clock, 7ns temporal/finalizer clock, skewed reset release
- 32 exact-partial CDC records, 16 temporally merged slices, 16 finalized outputs
- all metadata and every 320-bit normalized output match independent temporal merge + finalization reference
- output stable under backpressure; all protocol/error gates clear
- divider lanes 1/2/4/8 lint; expected accept intervals 458/230/116/59 cycles

## Remaining abstractions
- persistent-state SRAM physical mapping
- synchronizer MTBF/library-cell implementation
- external HBM/DRAM interface
- physical PPA

## Verification
`PYTHONPATH=. pytest -q tests/test_attention_decode_score_multivalue_service_finalized_cdc.py tests/test_probe_attention_decode_score_multivalue_service_finalized_cdc.py tests/test_attention_decode_score_multivalue_service_temporal_cdc.py tests/test_probe_attention_decode_score_multivalue_service_temporal_cdc.py tests/test_attention_score32_exact_partial_temporal_stream.py` (18 passed)
