### PR TITLE
npu: compose finalized service with SRAM temporal state

### DIFF
--- a/npu/eval/probe_attention_decode_score_multivalue_service_finalized_cdc.py
+++ b/npu/eval/probe_attention_decode_score_multivalue_service_finalized_cdc.py
@@ -49,7 +49,9 @@ _SUMMARY_RE = re.compile(
     r"service_accepted=(\d+) service_completed=(\d+) service_req=(\d+) "
     r"service_resp=(\d+) temporal_inputs=(\d+) temporal_merges=(\d+) "
     r"temporal_emitted=(\d+) temporal_heads=(\d+) finalizer_accepted=(\d+) "
-    r"finalizer_completed=(\d+) finalizer_cycles=(\d+)"
+    r"finalizer_completed=(\d+) finalizer_cycles=(\d+) state_requests=(\d+) "
+    r"state_reads=(\d+) state_responses=(\d+) state_writes=(\d+) "
+    r"state_req_stalls=(\d+) state_resp_stalls=(\d+) state_error=(\d+)"
 )
 
 
@@ -63,28 +65,36 @@ def _tool(name: str) -> str:
     raise RuntimeError(f"required tool unavailable: {name}")
 
 
-def _config(top_name: str, *, divider_lanes: int) -> JsonDict:
+def _config(
+    top_name: str,
+    *,
+    divider_lanes: int,
+    temporal_state_backend: str = "behavioral",
+    service_value_memory_backend: str = "behavioral",
+) -> JsonDict:
     workload = service_probe._workload_contract()
+    macro_value = service_value_memory_backend == "macro_banked_4x16x64x32"
     return {
         "top_name": top_name,
         "attention_decode_score_multivalue_service_finalized_cdc": {
             "cdc_fifo_depth": 4,
             "divider_lanes": divider_lanes,
+            "temporal_state_backend": temporal_state_backend,
             "service": {
                 "cluster_count": 1,
                 "max_blocks": int(workload["max_blocks"]),
                 "packet_w": 128,
-                "banks": 2,
+                "banks": 4 if macro_value else 2,
                 "req_queue_depth": 2,
                 "resp_queue_depth": 2,
                 "bank_queue_depth": 2,
-                "read_latency": 1,
+                "read_latency": 2 if macro_value else 1,
                 "arb_mode": "round_robin",
                 "locality_burst_max": 2,
                 "score_scale_lanes_per_cycle": 1,
                 "result_mode": "exact_partial",
                 "head_id_bits": 5,
-                "value_memory_backend": "behavioral",
+                "value_memory_backend": service_value_memory_backend,
             },
             "temporal_stream": {
                 "fifo_depth": 4,
@@ -243,6 +253,13 @@ module tb;
   wire [31:0] temporal_merge_completed_count;
   wire [31:0] temporal_emitted_beat_count;
   wire [31:0] temporal_completed_head_count;
+  wire [31:0] temporal_state_memory_request_count;
+  wire [31:0] temporal_state_memory_read_request_count;
+  wire [31:0] temporal_state_memory_read_response_count;
+  wire [31:0] temporal_state_memory_write_count;
+  wire [31:0] temporal_state_memory_request_stall_cycles;
+  wire [31:0] temporal_state_memory_response_stall_cycles;
+  wire temporal_state_memory_protocol_error;
   wire [31:0] cdc_accepted_count;
   wire [31:0] cdc_emitted_count;
   wire cdc_overflow_error;
@@ -327,6 +344,13 @@ module tb;
       .temporal_merge_completed_count(temporal_merge_completed_count),
       .temporal_emitted_beat_count(temporal_emitted_beat_count),
       .temporal_completed_head_count(temporal_completed_head_count),
+      .temporal_state_memory_request_count(temporal_state_memory_request_count),
+      .temporal_state_memory_read_request_count(temporal_state_memory_read_request_count),
+      .temporal_state_memory_read_response_count(temporal_state_memory_read_response_count),
+      .temporal_state_memory_write_count(temporal_state_memory_write_count),
+      .temporal_state_memory_request_stall_cycles(temporal_state_memory_request_stall_cycles),
+      .temporal_state_memory_response_stall_cycles(temporal_state_memory_response_stall_cycles),
+      .temporal_state_memory_protocol_error(temporal_state_memory_protocol_error),
       .cdc_accepted_count(cdc_accepted_count),
       .cdc_emitted_count(cdc_emitted_count),
       .cdc_overflow_error(cdc_overflow_error),
@@ -448,7 +472,7 @@ module tb;
       end
       if (!summary_done && output_count == 16) begin
         summary_done <= 1'b1;
-        $display("SUMMARY service_cycles=%0d temporal_cycles=%0d commands=%0d second_refused=%0d first_terminal=%0d second_accept=%0d outputs=%0d stable=%0d cdc_accepted=%0d cdc_emitted=%0d overflow=%0d underflow=%0d cdc_wr_error=%0d cdc_rd_error=%0d metadata_error=%0d cdc_wrapper_error=%0d service_error=%0d temporal_error=%0d finalizer_error=%0d protocol_error=%0d service_accepted=%0d service_completed=%0d service_req=%0d service_resp=%0d temporal_inputs=%0d temporal_merges=%0d temporal_emitted=%0d temporal_heads=%0d finalizer_accepted=%0d finalizer_completed=%0d finalizer_cycles=%0d",
+        $display("SUMMARY service_cycles=%0d temporal_cycles=%0d commands=%0d second_refused=%0d first_terminal=%0d second_accept=%0d outputs=%0d stable=%0d cdc_accepted=%0d cdc_emitted=%0d overflow=%0d underflow=%0d cdc_wr_error=%0d cdc_rd_error=%0d metadata_error=%0d cdc_wrapper_error=%0d service_error=%0d temporal_error=%0d finalizer_error=%0d protocol_error=%0d service_accepted=%0d service_completed=%0d service_req=%0d service_resp=%0d temporal_inputs=%0d temporal_merges=%0d temporal_emitted=%0d temporal_heads=%0d finalizer_accepted=%0d finalizer_completed=%0d finalizer_cycles=%0d state_requests=%0d state_reads=%0d state_responses=%0d state_writes=%0d state_req_stalls=%0d state_resp_stalls=%0d state_error=%0d",
                  service_cycle, temporal_cycle, command_count,
                  second_refused_cycles, first_terminal_cycle,
                  second_accept_cycle, output_count, stable_output_seen,
@@ -462,7 +486,14 @@ module tb;
                  service_emitted_resp_count, temporal_input_accepted_count,
                  temporal_merge_completed_count, temporal_emitted_beat_count,
                  temporal_completed_head_count, finalizer_accepted_count,
-                 finalizer_completed_count, finalizer_cycle_count);
+                 finalizer_completed_count, finalizer_cycle_count,
+                 temporal_state_memory_request_count,
+                 temporal_state_memory_read_request_count,
+                 temporal_state_memory_read_response_count,
+                 temporal_state_memory_write_count,
+                 temporal_state_memory_request_stall_cycles,
+                 temporal_state_memory_response_stall_cycles,
+                 temporal_state_memory_protocol_error);
         $finish;
       end
       if (temporal_cycle > 260000) $fatal(1, "temporal-side timeout");
@@ -531,6 +562,13 @@ def _parse(stdout: str) -> tuple[list[JsonDict], JsonDict]:
                 "finalizer_accepted",
                 "finalizer_completed",
                 "finalizer_cycles",
+                "state_requests",
+                "state_reads",
+                "state_responses",
+                "state_writes",
+                "state_req_stalls",
+                "state_resp_stalls",
+                "state_error",
             )
             summary = {
                 key: int(value)
@@ -546,9 +584,16 @@ def build_report(
     service_period_ns: float = 10.0,
     temporal_period_ns: float = 7.0,
     divider_lanes: int = 8,
+    temporal_state_backend: str = "behavioral",
+    service_value_memory_backend: str = "behavioral",
 ) -> JsonDict:
     top_name = "attention_decode_score_multivalue_service_finalized_cdc_probe"
-    config = _config(top_name, divider_lanes=divider_lanes)
+    config = _config(
+        top_name,
+        divider_lanes=divider_lanes,
+        temporal_state_backend=temporal_state_backend,
+        service_value_memory_backend=service_value_memory_backend,
+    )
     expected = _expected_rows()
     with tempfile.TemporaryDirectory(prefix="decode-service-finalized-cdc-probe-") as name:
         temp = Path(name)
@@ -573,6 +618,15 @@ def build_report(
                 "-o",
                 str(simv),
                 str(rtl_dir / "top.v"),
+                *(
+                    [str(REPO_ROOT / "npu/sim/rtl/fakeram45_64x32_model.sv")]
+                    if (
+                        temporal_state_backend == "sram"
+                        or service_value_memory_backend
+                        == "macro_banked_4x16x64x32"
+                    )
+                    else []
+                ),
                 str(tb_path),
             ],
             capture_output=True,
@@ -595,6 +649,9 @@ def build_report(
         manifest = json.loads(
             (rtl_dir / _MANIFEST).read_text(encoding="utf-8")
         )
+        macro_manifest = json.loads(
+            (rtl_dir / "macro_manifest.json").read_text(encoding="utf-8")
+        )
 
     errors = (
         "overflow",
@@ -607,6 +664,7 @@ def build_report(
         "temporal_error",
         "finalizer_error",
         "protocol_error",
+        "state_error",
     )
     passed = (
         observed == expected
@@ -627,6 +685,16 @@ def build_report(
         and summary["temporal_heads"] == 1
         and summary["finalizer_accepted"] == 16
         and summary["finalizer_completed"] == 16
+        and (
+            (
+                summary["state_requests"] == 64
+                and summary["state_reads"] == 32
+                and summary["state_responses"] == 32
+                and summary["state_writes"] == 32
+            )
+            if temporal_state_backend == "sram"
+            else summary["state_requests"] == 0
+        )
         and all(summary[key] == 0 for key in errors)
     )
     return {
@@ -635,10 +703,13 @@ def build_report(
         "service_period_ns": service_period_ns,
         "temporal_period_ns": temporal_period_ns,
         "divider_lanes": divider_lanes,
+        "temporal_state_backend": temporal_state_backend,
+        "service_value_memory_backend": service_value_memory_backend,
         "observed_rows": observed,
         "expected_rows": expected,
         "summary": summary,
         "manifest": manifest,
+        "macro_manifest": macro_manifest,
     }
 
 
@@ -647,12 +718,24 @@ def main() -> int:
     parser.add_argument("--service-period-ns", type=float, default=10.0)
     parser.add_argument("--temporal-period-ns", type=float, default=7.0)
     parser.add_argument("--divider-lanes", type=int, default=8)
+    parser.add_argument(
+        "--temporal-state-backend",
+        choices=("behavioral", "sram"),
+        default="behavioral",
+    )
+    parser.add_argument(
+        "--service-value-memory-backend",
+        choices=("behavioral", "macro_banked_4x16x64x32"),
+        default="behavioral",
+    )
     parser.add_argument("--out", type=Path)
     args = parser.parse_args()
     report = build_report(
         service_period_ns=args.service_period_ns,
         temporal_period_ns=args.temporal_period_ns,
         divider_lanes=args.divider_lanes,
+        temporal_state_backend=args.temporal_state_backend,
+        service_value_memory_backend=args.service_value_memory_backend,
     )
     rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
     if args.out:

--- a/npu/rtlgen/gen_attention_decode_score_multivalue_service_finalized_cdc.py
+++ b/npu/rtlgen/gen_attention_decode_score_multivalue_service_finalized_cdc.py
@@ -70,6 +70,11 @@ def _validate(config: JsonDict) -> JsonDict:
     divider_lanes = int(body.get("divider_lanes", 8))
     if divider_lanes not in {1, 2, 4, 8}:
         raise SystemExit("divider_lanes must be one of 1, 2, 4, or 8")
+    temporal_state_backend = str(
+        body.get("temporal_state_backend", "behavioral")
+    ).strip().lower()
+    if temporal_state_backend not in {"behavioral", "sram"}:
+        raise SystemExit("temporal_state_backend must be behavioral or sram")
     return {
         "top_name": top_name,
         "service": service_params,
@@ -78,6 +83,7 @@ def _validate(config: JsonDict) -> JsonDict:
         "source_w": max(1, (clusters - 1).bit_length()),
         "cdc_depth": cdc_depth,
         "divider_lanes": divider_lanes,
+        "temporal_state_backend": temporal_state_backend,
     }
 
 
@@ -139,6 +145,13 @@ def _wrapper(
     output wire [31:0]  temporal_emitted_beat_count,
     output wire [31:0]  temporal_completed_head_count,
     output wire [31:0]  temporal_output_stall_cycles,
+    output wire [31:0]  temporal_state_memory_request_count,
+    output wire [31:0]  temporal_state_memory_read_request_count,
+    output wire [31:0]  temporal_state_memory_read_response_count,
+    output wire [31:0]  temporal_state_memory_write_count,
+    output wire [31:0]  temporal_state_memory_request_stall_cycles,
+    output wire [31:0]  temporal_state_memory_response_stall_cycles,
+    output wire         temporal_state_memory_protocol_error,
     output wire [31:0]  cdc_write_occupancy,
     output wire [31:0]  cdc_read_occupancy,
     output wire [31:0]  cdc_accepted_count,
@@ -312,6 +325,13 @@ def _wrapper(
       .temporal_emitted_beat_count(temporal_emitted_beat_count),
       .temporal_completed_head_count(temporal_completed_head_count),
       .temporal_output_stall_cycles(temporal_output_stall_cycles),
+      .temporal_state_memory_request_count(temporal_state_memory_request_count),
+      .temporal_state_memory_read_request_count(temporal_state_memory_read_request_count),
+      .temporal_state_memory_read_response_count(temporal_state_memory_read_response_count),
+      .temporal_state_memory_write_count(temporal_state_memory_write_count),
+      .temporal_state_memory_request_stall_cycles(temporal_state_memory_request_stall_cycles),
+      .temporal_state_memory_response_stall_cycles(temporal_state_memory_response_stall_cycles),
+      .temporal_state_memory_protocol_error(temporal_state_memory_protocol_error),
       .cdc_write_occupancy(cdc_write_occupancy),
       .cdc_read_occupancy(cdc_read_occupancy),
       .cdc_accepted_count(cdc_accepted_count),
@@ -367,6 +387,7 @@ def generate(config: JsonDict, out_dir: Path) -> None:
             "service": params["service"],
             "temporal_stream": params["temporal"],
             "cdc_fifo_depth": int(params["cdc_depth"]),
+            "temporal_state_backend": str(params["temporal_state_backend"]),
         },
     }
     finalizer_config = {
@@ -388,6 +409,9 @@ def generate(config: JsonDict, out_dir: Path) -> None:
         cdc_manifest = json.loads(
             (cdc_dir / _CDC_MANIFEST).read_text(encoding="utf-8")
         )
+        cdc_macro_manifest = json.loads(
+            (cdc_dir / "macro_manifest.json").read_text(encoding="utf-8")
+        )
         finalizer_manifest = json.loads(
             (finalizer_dir / _FINALIZER_MANIFEST).read_text(encoding="utf-8")
         )
@@ -404,6 +428,14 @@ def generate(config: JsonDict, out_dir: Path) -> None:
     (out_dir / "config.json").write_text(
         json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )
+    macro_manifest = dict(cdc_macro_manifest)
+    macro_manifest["design_id"] = top_name
+    macro_manifest["module"] = top_name
+    macro_manifest["flow_variant"] = "decode_service_finalized_cdc_composed_v1"
+    macro_manifest["source"] = {
+        "mode": "generated_decode_service_finalized_cdc",
+        "generator": _GENERATOR,
+    }
     manifest = {
         "version": 1,
         "top_name": top_name,
@@ -412,6 +444,7 @@ def generate(config: JsonDict, out_dir: Path) -> None:
         "result_mode": "exact_partial_to_exact_finalized",
         "cluster_count": int(params["clusters"]),
         "divider_lanes": int(params["divider_lanes"]),
+        "temporal_state_backend": str(params["temporal_state_backend"]),
         "full_context_normalization_embodied": True,
         "output_interface": {
             "kind": "ready_valid_exact_finalized_slice_stream",
@@ -438,11 +471,25 @@ def generate(config: JsonDict, out_dir: Path) -> None:
             "single_inflight": True,
         },
         "remaining_abstractions": [
-            "persistent_state_sram_physical_mapping",
+            *(
+                ["persistent_state_sram_physical_mapping"]
+                if params["temporal_state_backend"] == "behavioral"
+                else []
+            ),
             "synchronizer_metastability_mtbf_and_library_cells",
             "external_hbm_dram",
             "physical_ppa",
         ],
+        "temporal_state_memory_monitors": {
+            "request_count": "temporal_state_memory_request_count",
+            "read_request_count": "temporal_state_memory_read_request_count",
+            "read_response_count": "temporal_state_memory_read_response_count",
+            "write_count": "temporal_state_memory_write_count",
+            "request_stall_cycles": "temporal_state_memory_request_stall_cycles",
+            "response_stall_cycles": "temporal_state_memory_response_stall_cycles",
+            "protocol_error": "temporal_state_memory_protocol_error",
+        },
+        "macro_counts": macro_manifest["manifest_params"],
         "submodule_manifests": {
             "service_temporal_cdc": cdc_manifest,
             "root_finalizer": finalizer_manifest,
@@ -468,6 +515,10 @@ def generate(config: JsonDict, out_dir: Path) -> None:
     }
     (out_dir / _MANIFEST).write_text(
         json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    (out_dir / "macro_manifest.json").write_text(
+        json.dumps(macro_manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
     )
 
 

--- a/npu/rtlgen/gen_attention_decode_score_multivalue_service_temporal_cdc.py
+++ b/npu/rtlgen/gen_attention_decode_score_multivalue_service_temporal_cdc.py
@@ -22,6 +22,9 @@ from npu.rtlgen.gen_attention_decode_score_multivalue_service import (
 from npu.rtlgen.gen_attention_score32_exact_partial_temporal_stream import (
     generate as generate_temporal,
 )
+from npu.rtlgen.gen_attention_score32_exact_partial_temporal_stream_sram import (
+    generate as generate_temporal_sram,
+)
 from npu.sim.perf.attention_exact_partial import HEAD_ID_BITS, VALUE_SLICES
 
 JsonDict = dict[str, Any]
@@ -31,6 +34,9 @@ _GENERATOR = "npu/rtlgen/gen_attention_decode_score_multivalue_service_temporal_
 _MANIFEST = "attention_decode_score_multivalue_service_temporal_cdc_manifest.json"
 _SERVICE_MANIFEST = "attention_decode_score_multivalue_service_manifest.json"
 _TEMPORAL_MANIFEST = "attention_score32_exact_partial_temporal_stream_manifest.json"
+_TEMPORAL_SRAM_MANIFEST = (
+    "attention_score32_exact_partial_temporal_stream_sram_manifest.json"
+)
 _PAYLOAD_BITS = 464
 
 
@@ -51,6 +57,56 @@ def _sha256_text(text: str) -> str:
 
 def _clog2(value: int) -> int:
     return max(1, math.ceil(math.log2(max(2, value))))
+
+
+def _merge_macro_manifests(
+    *,
+    top_name: str,
+    service: JsonDict,
+    temporal: JsonDict | None,
+) -> JsonDict:
+    components = [service, *([temporal] if temporal is not None else [])]
+
+    def unique(key: str) -> list[str]:
+        return list(
+            dict.fromkeys(
+                str(item)
+                for component in components
+                for item in component.get(key, [])
+            )
+        )
+
+    service_count = int(service.get("manifest_params", {}).get("total_macro_count", 0))
+    temporal_count = (
+        int(temporal.get("manifest_params", {}).get("macro_count", 0))
+        if temporal is not None
+        else 0
+    )
+    return {
+        "version": "0.1",
+        "design_id": top_name,
+        "module": top_name,
+        "platform": "nangate45",
+        "flow_variant": "decode_service_temporal_cdc_composed_v1",
+        "blackboxes": unique("blackboxes"),
+        "additional_lefs": unique("additional_lefs"),
+        "additional_libs": unique("additional_libs"),
+        "additional_gds": unique("additional_gds"),
+        "blackbox_verilog": unique("blackbox_verilog"),
+        "source": {
+            "mode": "generated_decode_service_temporal_cdc",
+            "generator": _GENERATOR,
+        },
+        "manifest_params": {
+            "service_macro_count": service_count,
+            "temporal_state_macro_count": temporal_count,
+            "total_macro_count": service_count + temporal_count,
+            "component_macro_manifests": {
+                "service": service,
+                "temporal_state": temporal,
+            },
+        },
+    }
 
 
 def _validate(config: JsonDict) -> JsonDict:
@@ -78,6 +134,11 @@ def _validate(config: JsonDict) -> JsonDict:
     temporal_depth = int(temporal.get("fifo_depth", 4))
     if temporal_depth < 2 or temporal_depth > 16 or temporal_depth & (temporal_depth - 1):
         raise SystemExit("temporal_stream.fifo_depth must be a power of two in [2, 16]")
+    temporal_state_backend = str(
+        body.get("temporal_state_backend", "behavioral")
+    ).strip().lower()
+    if temporal_state_backend not in {"behavioral", "sram"}:
+        raise SystemExit("temporal_state_backend must be behavioral or sram")
     return {
         "top_name": top_name,
         "service": service_params,
@@ -89,6 +150,7 @@ def _validate(config: JsonDict) -> JsonDict:
             temporal.get("exp_scale_impl", "factored_h33_l64_mul_exact")
         ).strip(),
         "keep_hierarchy": bool(temporal.get("keep_hierarchy", True)),
+        "temporal_state_backend": temporal_state_backend,
     }
 
 
@@ -249,8 +311,29 @@ def _wrapper(
     clusters: int,
     source_w: int,
     temporal_depth: int,
+    temporal_state_backend: str,
 ) -> str:
     fifo_level_w = _clog2(temporal_depth) + 1
+    if temporal_state_backend == "sram":
+        temporal_memory_connections = """      .state_memory_request_count(temporal_state_memory_request_count),
+      .state_memory_read_request_count(temporal_state_memory_read_request_count),
+      .state_memory_read_response_count(temporal_state_memory_read_response_count),
+      .state_memory_write_count(temporal_state_memory_write_count),
+      .state_memory_request_stall_cycles(temporal_state_memory_request_stall_cycles),
+      .state_memory_response_stall_cycles(temporal_state_memory_response_stall_cycles),
+      .state_memory_protocol_error(temporal_state_memory_protocol_error),
+"""
+        temporal_memory_tieoffs = ""
+    else:
+        temporal_memory_connections = ""
+        temporal_memory_tieoffs = """  assign temporal_state_memory_request_count = 32'd0;
+  assign temporal_state_memory_read_request_count = 32'd0;
+  assign temporal_state_memory_read_response_count = 32'd0;
+  assign temporal_state_memory_write_count = 32'd0;
+  assign temporal_state_memory_request_stall_cycles = 32'd0;
+  assign temporal_state_memory_response_stall_cycles = 32'd0;
+  assign temporal_state_memory_protocol_error = 1'b0;
+"""
     return f"""module {top_name} (
     input  wire         service_clk,
     input  wire         service_rst_n,
@@ -307,6 +390,13 @@ def _wrapper(
     output wire [31:0]  temporal_completed_head_count,
     output wire [31:0]  temporal_output_stall_cycles,
     output wire [{fifo_level_w - 1}:0] temporal_fifo_level,
+    output wire [31:0]  temporal_state_memory_request_count,
+    output wire [31:0]  temporal_state_memory_read_request_count,
+    output wire [31:0]  temporal_state_memory_read_response_count,
+    output wire [31:0]  temporal_state_memory_write_count,
+    output wire [31:0]  temporal_state_memory_request_stall_cycles,
+    output wire [31:0]  temporal_state_memory_response_stall_cycles,
+    output wire         temporal_state_memory_protocol_error,
     output wire [31:0]  cdc_write_occupancy,
     output wire [31:0]  cdc_read_occupancy,
     output wire [31:0]  cdc_accepted_count,
@@ -428,6 +518,7 @@ def _wrapper(
       wrapper_protocol_error || service_protocol_error || temporal_protocol_error
       || cdc_overflow_error || cdc_underflow_error
       || cdc_write_protocol_error || cdc_read_protocol_error;
+{temporal_memory_tieoffs}
 
   integer metadata_i;
   always @(posedge service_clk or negedge service_rst_n) begin
@@ -555,7 +646,7 @@ def _wrapper(
       .completed_head_count(temporal_completed_head_count),
       .output_stall_cycles(temporal_output_stall_cycles),
       .fifo_level(temporal_fifo_level),
-      .protocol_error(temporal_protocol_error)
+{temporal_memory_connections}      .protocol_error(temporal_protocol_error)
   );
 endmodule
 """
@@ -572,34 +663,54 @@ def generate(config: JsonDict, out_dir: Path) -> None:
         "top_name": service_top,
         "attention_decode_score_multivalue_service": params["service"],
     }
-    temporal_config = {
-        "top_name": temporal_top,
-        "attention_score32_exact_partial_temporal_stream": {
-            "heads": 32,
-            "value_slices": VALUE_SLICES,
-            "head_id_bits": HEAD_ID_BITS,
-            "fifo_depth": int(params["temporal_depth"]),
-            "sequence_id_bits": 16,
-            "window_index_bits": 14,
-            "window_count_bits": 15,
-            "max_window_count": 16384,
-            "exp_scale_impl": str(params["exp_scale_impl"]),
-            "keep_hierarchy": bool(params["keep_hierarchy"]),
-        },
+    temporal_body = {
+        "heads": 32,
+        "value_slices": VALUE_SLICES,
+        "head_id_bits": HEAD_ID_BITS,
+        "fifo_depth": int(params["temporal_depth"]),
+        "sequence_id_bits": 16,
+        "window_index_bits": 14,
+        "window_count_bits": 15,
+        "max_window_count": 16384,
+        "exp_scale_impl": str(params["exp_scale_impl"]),
+        "keep_hierarchy": bool(params["keep_hierarchy"]),
     }
+    temporal_state_backend = str(params["temporal_state_backend"])
+    if temporal_state_backend == "sram":
+        temporal_config = {
+            "top_name": temporal_top,
+            "attention_score32_exact_partial_temporal_stream_sram": temporal_body,
+        }
+        temporal_generator = generate_temporal_sram
+        temporal_manifest_name = _TEMPORAL_SRAM_MANIFEST
+    else:
+        temporal_config = {
+            "top_name": temporal_top,
+            "attention_score32_exact_partial_temporal_stream": temporal_body,
+        }
+        temporal_generator = generate_temporal
+        temporal_manifest_name = _TEMPORAL_MANIFEST
     with tempfile.TemporaryDirectory(prefix="decode-service-temporal-cdc-gen-") as name:
         temp = Path(name)
         service_dir = temp / "service"
         temporal_dir = temp / "temporal"
         generate_service(service_config, service_dir)
-        generate_temporal(temporal_config, temporal_dir)
+        temporal_generator(temporal_config, temporal_dir)
         service_rtl = (service_dir / "top.v").read_text(encoding="utf-8")
         temporal_rtl = (temporal_dir / "top.v").read_text(encoding="utf-8")
         service_manifest = json.loads(
             (service_dir / _SERVICE_MANIFEST).read_text(encoding="utf-8")
         )
+        service_macro_manifest = json.loads(
+            (service_dir / "macro_manifest.json").read_text(encoding="utf-8")
+        )
         temporal_manifest = json.loads(
-            (temporal_dir / _TEMPORAL_MANIFEST).read_text(encoding="utf-8")
+            (temporal_dir / temporal_manifest_name).read_text(encoding="utf-8")
+        )
+        temporal_macro_manifest = (
+            json.loads((temporal_dir / "macro_manifest.json").read_text(encoding="utf-8"))
+            if temporal_state_backend == "sram"
+            else None
         )
 
     fifo_rtl = _async_fifo(module_name=fifo_top, depth=int(params["cdc_depth"]))
@@ -611,11 +722,17 @@ def generate(config: JsonDict, out_dir: Path) -> None:
         clusters=int(params["clusters"]),
         source_w=int(params["source_w"]),
         temporal_depth=int(params["temporal_depth"]),
+        temporal_state_backend=temporal_state_backend,
     )
     top_text = "\n\n".join((service_rtl, temporal_rtl, fifo_rtl, wrapper_rtl)) + "\n"
     (out_dir / "top.v").write_text(top_text, encoding="utf-8")
     (out_dir / "config.json").write_text(
         json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    macro_manifest = _merge_macro_manifests(
+        top_name=top_name,
+        service=service_macro_manifest,
+        temporal=temporal_macro_manifest,
     )
     manifest = {
         "version": 1,
@@ -624,6 +741,7 @@ def generate(config: JsonDict, out_dir: Path) -> None:
         "semantic_profile": "decode_score_multivalue_service_temporal_async_fifo_v1",
         "result_mode": "exact_partial",
         "cluster_count": int(params["clusters"]),
+        "temporal_state_backend": temporal_state_backend,
         "cdc_contract": {
             "source_domain": "service_clk/service_rst_n",
             "destination_domain": "temporal_clk/temporal_rst_n",
@@ -657,10 +775,24 @@ def generate(config: JsonDict, out_dir: Path) -> None:
         },
         "remaining_abstractions": [
             "downstream_full_context_final_normalizer",
-            "persistent_state_sram_physical_mapping",
+            *(
+                ["persistent_state_sram_physical_mapping"]
+                if temporal_state_backend == "behavioral"
+                else []
+            ),
             "metastability_mtbf_and_library_cell_implementation",
             "physical_ppa",
         ],
+        "temporal_state_memory_monitors": {
+            "request_count": "temporal_state_memory_request_count",
+            "read_request_count": "temporal_state_memory_read_request_count",
+            "read_response_count": "temporal_state_memory_read_response_count",
+            "write_count": "temporal_state_memory_write_count",
+            "request_stall_cycles": "temporal_state_memory_request_stall_cycles",
+            "response_stall_cycles": "temporal_state_memory_response_stall_cycles",
+            "protocol_error": "temporal_state_memory_protocol_error",
+        },
+        "macro_counts": macro_manifest["manifest_params"],
         "submodule_manifests": {
             "service": service_manifest,
             "temporal_stream": temporal_manifest,
@@ -675,10 +807,18 @@ def generate(config: JsonDict, out_dir: Path) -> None:
                 ),
             },
             {
-                "path": "npu/rtlgen/gen_attention_score32_exact_partial_temporal_stream.py",
+                "path": (
+                    "npu/rtlgen/gen_attention_score32_exact_partial_temporal_stream_sram.py"
+                    if temporal_state_backend == "sram"
+                    else "npu/rtlgen/gen_attention_score32_exact_partial_temporal_stream.py"
+                ),
                 "sha256": _sha256_file(
                     REPO_ROOT
-                    / "npu/rtlgen/gen_attention_score32_exact_partial_temporal_stream.py"
+                    / (
+                        "npu/rtlgen/gen_attention_score32_exact_partial_temporal_stream_sram.py"
+                        if temporal_state_backend == "sram"
+                        else "npu/rtlgen/gen_attention_score32_exact_partial_temporal_stream.py"
+                    )
                 ),
             },
         ],
@@ -686,6 +826,10 @@ def generate(config: JsonDict, out_dir: Path) -> None:
     }
     (out_dir / _MANIFEST).write_text(
         json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    (out_dir / "macro_manifest.json").write_text(
+        json.dumps(macro_manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
     )
 
 

--- a/tests/test_attention_decode_score_multivalue_service_finalized_sram_cdc.py
+++ b/tests/test_attention_decode_score_multivalue_service_finalized_sram_cdc.py
@@ -1,0 +1,120 @@
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+from npu.eval.probe_attention_decode_score_multivalue_service_finalized_cdc import (
+    _config,
+    build_report,
+)
+from npu.rtlgen.gen_attention_decode_score_multivalue_service_finalized_cdc import (
+    generate,
+)
+
+
+def _tool(name: str) -> str:
+    path = shutil.which(name)
+    if path:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    if fallback.exists():
+        return str(fallback)
+    pytest.skip(f"{name} unavailable")
+
+
+def _sram_config() -> dict:
+    return _config(
+        "attention_decode_score_multivalue_service_finalized_sram_cdc_c1",
+        divider_lanes=8,
+        temporal_state_backend="sram",
+        service_value_memory_backend="macro_banked_4x16x64x32",
+    )
+
+
+def test_sram_backend_rtl_macro_manifest_and_lint(tmp_path: Path) -> None:
+    config = _sram_config()
+    generate(config, tmp_path)
+    manifest = json.loads(
+        (
+            tmp_path
+            / "attention_decode_score_multivalue_service_finalized_cdc_manifest.json"
+        ).read_text(encoding="utf-8")
+    )
+    macros = json.loads((tmp_path / "macro_manifest.json").read_text(encoding="utf-8"))
+    rtl = (tmp_path / "top.v").read_text(encoding="utf-8")
+    counts = macros["manifest_params"]
+
+    assert config[
+        "attention_decode_score_multivalue_service_finalized_cdc"
+    ]["temporal_state_backend"] == "sram"
+    assert manifest["temporal_state_backend"] == "sram"
+    assert manifest["submodule_manifests"]["service_temporal_cdc"][
+        "temporal_state_backend"
+    ] == "sram"
+    assert counts["service_macro_count"] == 120
+    assert counts["temporal_state_macro_count"] == 104
+    assert counts["total_macro_count"] == 224
+    assert macros["blackboxes"] == ["fakeram45_2048x39", "fakeram45_64x32"]
+    assert macros["additional_lefs"] == [
+        "/orfs/flow/platforms/nangate45/lef/fakeram45_2048x39.lef",
+        "/orfs/flow/platforms/nangate45/lef/fakeram45_64x32.lef",
+    ]
+    assert macros["additional_libs"] == [
+        "/orfs/flow/platforms/nangate45/lib/fakeram45_2048x39.lib",
+        "/orfs/flow/platforms/nangate45/lib/fakeram45_64x32.lib",
+    ]
+    assert "fakeram45_64x32 u_state_mem" in rtl
+    assert "state_global_max_q [0:STATE_SLOTS-1]" not in rtl
+    assert "temporal_state_memory_request_count" in rtl
+
+    lint = subprocess.run(
+        [
+            _tool("verilator"),
+            "--lint-only",
+            "-Wno-WIDTHEXPAND",
+            "-Wno-WIDTHTRUNC",
+            "-Wno-UNUSEDSIGNAL",
+            "-Wno-UNDRIVEN",
+            "-Wno-TIMESCALEMOD",
+            "-Wno-SIDEEFFECT",
+            "-Wno-LATCH",
+            "-Wno-UNOPTFLAT",
+            "-Wno-PINMISSING",
+            "--top-module",
+            str(config["top_name"]),
+            str(tmp_path / "top.v"),
+            "npu/rtl/fakeram45_2048x39_blackbox.v",
+            "npu/rtl/fakeram45_64x32_blackbox.v",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=240,
+    )
+    assert lint.returncode == 0, lint.stderr
+
+
+def test_real_c1_sram_backend_finalized_equivalence() -> None:
+    if not (shutil.which("iverilog") and shutil.which("vvp")):
+        pytest.skip("iverilog/vvp unavailable")
+
+    report = build_report(
+        service_period_ns=10.0,
+        temporal_period_ns=7.0,
+        divider_lanes=8,
+        temporal_state_backend="sram",
+        service_value_memory_backend="macro_banked_4x16x64x32",
+    )
+
+    assert report["passed"] is True
+    assert report["observed_rows"] == report["expected_rows"]
+    assert len(report["observed_rows"]) == 16
+    assert report["summary"]["stable"] == 1
+    assert report["summary"]["state_requests"] == 64
+    assert report["summary"]["state_reads"] == 32
+    assert report["summary"]["state_responses"] == 32
+    assert report["summary"]["state_writes"] == 32
+    assert report["summary"]["state_error"] == 0
+    assert report["summary"]["protocol_error"] == 0
+    assert report["macro_manifest"]["manifest_params"]["total_macro_count"] == 224


### PR DESCRIPTION
## Summary
- add explicit behavioral/SRAM temporal-state backend selection to dual-clock service composition
- pass backend through the full-context finalized wrapper while preserving behavioral defaults
- merge service and temporal macro collateral without losing blackboxes, LEF/LIB paths, or component counts
- expose temporal-state SRAM activity and protocol monitors at the finalized top level

## Physical composition
- service score/value SRAM: 120 macros
- temporal persistent state: 104 macros
- combined: 224 macros
- generated RTL contains temporal state macros and no inferred 394-bit state array

## End-to-end evidence
- real c1, two windows, dual clocks, final divider lanes=8
- 32 partial CDC records -> 16 temporal slices -> 16 exact finalized 320-bit outputs
- all outputs match independent reference under backpressure
- temporal state: 64 requests, 32 reads/responses, 32 writes
- zero service, CDC, SRAM, temporal, finalizer, metadata, or aggregate errors

## Verification
Focused combined suite: 20 passed.
