### PR TITLE
npu: package exact-partial clock-island physical calibration

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -1715,6 +1715,92 @@ def _read_config_target(
                 },
             ],
         )
+    elif "top_name" in cfg and (
+        "attention_score32_exact_partial_temporal_finalizer_physical_harness" in cfg
+        or "attention_exact_partial_async_fifo_physical_harness" in cfg
+    ):
+        top_name = str(cfg["top_name"]).strip()
+        if not top_name:
+            raise Layer1TaskGenerationError(f"top_name must not be empty in {config_path}")
+        try:
+            design_dir = str(config_path.parent.resolve().relative_to(repo_root.resolve()))
+        except ValueError as exc:
+            raise Layer1TaskGenerationError(
+                "exact-partial physical calibration config must live under "
+                f"repo_root/runs/designs/...: {config_path}"
+            ) from exc
+        design_name = config_path.parent.name
+        is_temporal_finalizer = (
+            "attention_score32_exact_partial_temporal_finalizer_physical_harness"
+            in cfg
+        )
+        generator = (
+            "npu/rtlgen/"
+            "gen_attention_score32_exact_partial_temporal_finalizer_physical_harness.py"
+            if is_temporal_finalizer
+            else "npu/rtlgen/gen_attention_exact_partial_async_fifo_physical_harness.py"
+        )
+        command_slug = (
+            "attention_score32_exact_partial_temporal_finalizer_physical_harness"
+            if is_temporal_finalizer
+            else "attention_exact_partial_async_fifo_physical_harness"
+        )
+        macro_arg = (
+            f" --macro_manifest {design_dir}/macro_manifest.json"
+            if is_temporal_finalizer
+            else ""
+        )
+        return Layer1ConfigTarget(
+            design_kind="block",
+            design_name=design_name,
+            expected_metrics_path=block_metrics_path(design_name),
+            expected_report_paths=[f"{design_dir}/timing_debug_report.md"],
+            commands=[
+                {
+                    "name": f"generate_{command_slug}_rtl",
+                    "run": _with_oss_cad_path(
+                        (
+                            f"python3 {generator} "
+                            f"--config {config_rel} "
+                            f"--out {design_dir}/verilog"
+                        )
+                    ),
+                },
+                {
+                    "name": "check_attention_exact_partial_physical_calibration_guard",
+                    "run": (
+                        "python3 npu/eval/"
+                        "check_attention_exact_partial_physical_calibration_guard.py "
+                        f"--design-dir {design_dir}"
+                    ),
+                },
+                {
+                    "name": "run_block_sweep",
+                    "run": _with_oss_cad_path(
+                        (
+                            "python3 npu/synth/run_block_sweep.py "
+                            f"--design_dir {design_dir} "
+                            "--platform {platform} "
+                            f"--top {top_name} "
+                            f"--sweep {{sweep_path}} "
+                            f"--out_root {out_root}"
+                            f"{macro_arg} "
+                            + (f"--make_target {make_target} " if make_target else "")
+                            + "--skip_existing"
+                        )
+                    ),
+                },
+                {
+                    "name": f"extract_{command_slug}_timing_paths",
+                    "run": (
+                        "python3 npu/eval/extract_openroad_timing_summary.py "
+                        f"--design-dir {design_dir} "
+                        f"--out {design_dir}/timing_debug_report.md "
+                        "--max-paths 8"
+                    ),
+                },
+            ],
+        )
     elif "top_name" in cfg and "attention_score32_exact_local_temporal_reducer_physical_harness" in cfg:
         top_name = str(cfg["top_name"]).strip()
         if not top_name:

--- a/docs/proposals/prop_l1_decoder_attention_exact_partial_physical_calibration_v1/README.md
+++ b/docs/proposals/prop_l1_decoder_attention_exact_partial_physical_calibration_v1/README.md
@@ -1,0 +1,18 @@
+# Exact-partial physical calibration
+
+This package prepares two remote Nangate45 evaluation items and intentionally
+does not dispatch either item.
+
+The temporal/finalizer item measures one real temporal clock island with 104
+`fakeram45_64x32` state macros. Divider-lane variants are separate designs.
+The 1600 um die and 1500 um core are conservative relative to the calculated
+129,024.896 um2 raw macro area.
+
+The async-FIFO item contains source-domain and destination-domain variants.
+Each variant uses the external `clk` only for the selected timing domain and a
+protocol-safe generated helper clock for the inactive side. These are
+per-domain diagnostics, not a common-clock or CDC-signoff measurement.
+
+At queue time, use merged `origin/master` as the task source commit. The normal
+L1 task generation request must place that SHA in
+`source_requirement.required_sha`.

--- a/docs/proposals/prop_l1_decoder_attention_exact_partial_physical_calibration_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_exact_partial_physical_calibration_v1/evaluation_requests.json
@@ -1,0 +1,64 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_exact_partial_physical_calibration_v1",
+  "source_commit_note": "Do not dispatch this development branch. After merge, generate both tasks from merged origin/master so source_requirement.required_sha is pinned to the merge commit containing the harnesses, guards, configs, sweeps, proposal linkage, and task-generator support.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_exact_partial_temporal_finalizer_physical_calibration_v1",
+      "task_type": "l1_sweep",
+      "title": "Exact-partial SRAM temporal reducer plus root finalizer physical calibration",
+      "objective": "Run four separate divider-lane Nangate45 macro-mode sweeps on the single temporal clock island.",
+      "status": "pending",
+      "evaluation_mode": "physical_calibration",
+      "abstraction_layer": "decoder_attention_exact_partial_temporal_finalizer",
+      "comparison_role": "single_clock_island_physical_anchor",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l1/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l4/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_exact_partial_physical_calibration_v1/sweeps/nangate45_temporal_finalizer_macro.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l1/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l1/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l2/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l2/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l4/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l4/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l8/timing_debug_report.md"
+      ],
+      "acceptance_notes": "Use macro mode with exactly 104 fakeram45_64x32 instances, 1600um die, 1500um core, PLACE_DENSITY=0.4, SYNTH_HIERARCHICAL=1, and CLOCK_PERIOD 6/8/10/12ns. Keep divider variants as separate design points.",
+      "notes": "Queue only after merge with source_requirement.required_sha pinned to the merged origin/master commit. Do not dispatch during parent review."
+    },
+    {
+      "item_id": "l1_decoder_attention_exact_partial_async_fifo_domain_physical_calibration_v1",
+      "task_type": "l1_sweep",
+      "title": "Exact-partial depth-4 async FIFO per-domain physical diagnostics",
+      "objective": "Run separate source-domain and destination-domain Nangate45 diagnostics for the 464-bit FIFO.",
+      "status": "pending",
+      "evaluation_mode": "physical_calibration",
+      "abstraction_layer": "decoder_attention_exact_partial_async_fifo",
+      "comparison_role": "per_clock_domain_diagnostic",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": [
+        "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_source_domain_physical/config.json",
+        "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_destination_domain_physical/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_exact_partial_physical_calibration_v1/sweeps/nangate45_async_fifo_per_domain.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_source_domain_physical/metrics.csv",
+        "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_source_domain_physical/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_destination_domain_physical/metrics.csv",
+        "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_destination_domain_physical/timing_debug_report.md"
+      ],
+      "acceptance_notes": "Treat each result only as timing for the selected source or destination domain. Never report a whole dual-clock common delay, CDC MTBF, or cross-domain signoff result.",
+      "notes": "Queue only after merge with source_requirement.required_sha pinned to the merged origin/master commit. Do not dispatch during parent review."
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_exact_partial_physical_calibration_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_exact_partial_physical_calibration_v1/proposal.json
@@ -1,0 +1,88 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_exact_partial_physical_calibration_v1",
+  "created_utc": "2026-08-07T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "title": "Exact-partial temporal/finalizer and CDC clock-island physical calibration",
+  "abstraction_layer": "decoder_attention_exact_partial_physical_calibration",
+  "hypothesis": "Narrow-I/O self-traffic harnesses can measure the SRAM-backed temporal reducer plus exact root finalizer in its real temporal clock island and measure each async-FIFO clock domain diagnostically without inventing a false common-clock end-to-end path.",
+  "direct_comparison": {
+    "primary_question": "What Nangate45 timing, area, and power are physically supported by each divider-lane temporal/finalizer point and by each individual FIFO clock domain?",
+    "baselines": [
+      "attention_score32_exact_partial_temporal_stream_sram",
+      "attention_score32_exact_root_finalizer",
+      "attention_decode_score_multivalue_service_temporal_cdc"
+    ],
+    "candidate": [
+      "l1_decoder_attention_exact_partial_temporal_finalizer_physical_calibration_v1",
+      "l1_decoder_attention_exact_partial_async_fifo_domain_physical_calibration_v1"
+    ],
+    "include": [
+      "104 fakeram45_64x32 physical state macros",
+      "divider_lanes 1, 2, 4, and 8 as separate design points",
+      "protocol-valid two-head two-window self traffic",
+      "source-domain and destination-domain FIFO timing diagnostics"
+    ],
+    "exclude": [
+      "a common-clock timing claim across the async FIFO",
+      "CDC MTBF or synchronizer library-cell signoff",
+      "external HBM/DRAM and service score/value SRAM",
+      "promotion to a full service PPA point"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "stdcell_area_um2",
+      "total_power_mw",
+      "macro_count",
+      "flow_status",
+      "timed_domain"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_exact_partial_temporal_finalizer_physical_calibration_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the single-temporal-clock SRAM reducer plus exact finalizer at divider_lanes 1/2/4/8 using the 104-macro floorplan.",
+      "status": "pending",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l1/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l4/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_exact_partial_physical_calibration_v1/sweeps/nangate45_temporal_finalizer_macro.json",
+      "out_root": "runs/designs/npu_blocks",
+      "notes": "Generate only from merged origin/master and pin source_requirement.required_sha to the merge commit containing this proposal, both harness generators, guards, configs, sweeps, and L1 task-generator support."
+    },
+    {
+      "item_id": "l1_decoder_attention_exact_partial_async_fifo_domain_physical_calibration_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure source and destination clock-domain timing diagnostics for the 464-bit depth-4 async FIFO without a common-clock end-to-end claim.",
+      "status": "pending",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": [
+        "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_source_domain_physical/config.json",
+        "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_destination_domain_physical/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_exact_partial_physical_calibration_v1/sweeps/nangate45_async_fifo_per_domain.json",
+      "out_root": "runs/designs/npu_blocks",
+      "notes": "Results are selected-domain diagnostics only. Generate only from merged origin/master and pin source_requirement.required_sha to that merge commit."
+    }
+  ],
+  "remaining_abstractions": [
+    "CDC metastability MTBF and synchronizer library-cell implementation remain open.",
+    "Macro placement will be selected by OpenROAD; this request fixes only die/core bounds and macro inventory.",
+    "The service clock island and external memory system are not part of these calibration points."
+  ],
+  "source_refs": [
+    "npu/rtlgen/gen_attention_score32_exact_partial_temporal_finalizer_physical_harness.py",
+    "npu/rtlgen/gen_attention_exact_partial_async_fifo_physical_harness.py",
+    "npu/eval/check_attention_exact_partial_physical_calibration_guard.py",
+    "runs/campaigns/npu/attention_exact_partial_physical_calibration_v1/sweeps/nangate45_temporal_finalizer_macro.json",
+    "runs/campaigns/npu/attention_exact_partial_physical_calibration_v1/sweeps/nangate45_async_fifo_per_domain.json"
+  ]
+}

--- a/npu/eval/check_attention_exact_partial_physical_calibration_guard.py
+++ b/npu/eval/check_attention_exact_partial_physical_calibration_guard.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Guard checked exact-partial physical-calibration harness artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_exact_partial_async_fifo_physical_harness import (
+    generate as generate_cdc,
+)
+from npu.rtlgen.gen_attention_score32_exact_partial_temporal_finalizer_physical_harness import (
+    generate as generate_temporal_finalizer,
+)
+
+_TEMPORAL_KEY = "attention_score32_exact_partial_temporal_finalizer_physical_harness"
+_CDC_KEY = "attention_exact_partial_async_fifo_physical_harness"
+_PROPOSAL_ID = "prop_l1_decoder_attention_exact_partial_physical_calibration_v1"
+
+
+def _json(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit(f"expected JSON object: {path}")
+    return payload
+
+
+def _top_module(rtl: str, top_name: str) -> str:
+    match = re.search(
+        rf"module\s+{re.escape(top_name)}\b.*?endmodule",
+        rtl,
+        flags=re.DOTALL,
+    )
+    if match is None:
+        raise SystemExit(f"generated RTL does not contain top module {top_name}")
+    return match.group(0)
+
+
+def _require(value: object, expected: object, label: str) -> None:
+    if value != expected:
+        raise SystemExit(f"{label}: expected {expected!r}, got {value!r}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--design-dir", type=Path, required=True)
+    args = parser.parse_args(argv)
+    design_dir = args.design_dir.resolve()
+    config_path = design_dir / "config.json"
+    checked_macro_path = design_dir / "macro_manifest.json"
+    rtl_dir = design_dir / "verilog"
+    for path in (config_path, checked_macro_path, rtl_dir / "top.v", rtl_dir / "config.json"):
+        if not path.is_file():
+            raise SystemExit(f"missing calibration artifact: {path}")
+
+    config = _json(config_path)
+    generated_config = _json(rtl_dir / "config.json")
+    _require(generated_config, config, "generated config")
+    top_name = str(config.get("top_name") or "").strip()
+    if not top_name:
+        raise SystemExit("config top_name must not be empty")
+
+    if _TEMPORAL_KEY in config:
+        generator = generate_temporal_finalizer
+        manifest_name = (
+            "attention_score32_exact_partial_temporal_finalizer_"
+            "physical_harness_manifest.json"
+        )
+        kind = "temporal_finalizer"
+    elif _CDC_KEY in config:
+        generator = generate_cdc
+        manifest_name = "attention_exact_partial_async_fifo_physical_harness_manifest.json"
+        kind = "cdc"
+    else:
+        raise SystemExit("unsupported physical calibration config")
+
+    with tempfile.TemporaryDirectory(prefix="exact-partial-physical-guard-") as name:
+        regenerated = Path(name)
+        generator(config, regenerated)
+        for filename in ("top.v", "config.json", "macro_manifest.json", manifest_name):
+            if (regenerated / filename).read_text(encoding="utf-8") != (
+                rtl_dir / filename
+            ).read_text(encoding="utf-8"):
+                raise SystemExit(f"checked artifact differs from generator output: {filename}")
+
+    manifest = _json(rtl_dir / manifest_name)
+    generated_macro = _json(rtl_dir / "macro_manifest.json")
+    checked_macro = _json(checked_macro_path)
+    _require(manifest.get("linked_proposal_id"), _PROPOSAL_ID, "proposal linkage")
+    _require(manifest.get("whole_dual_clock_common_delay_claim"), False, "timing claim")
+    _require(
+        generated_macro.get("blackboxes"),
+        checked_macro.get("blackboxes"),
+        "checked macro blackboxes",
+    )
+    generated_params = generated_macro.get("manifest_params")
+    checked_params = checked_macro.get("manifest_params")
+    if not isinstance(generated_params, dict) or not isinstance(checked_params, dict):
+        raise SystemExit("macro manifests require manifest_params")
+
+    rtl = (rtl_dir / "top.v").read_text(encoding="utf-8")
+    top = _top_module(rtl, top_name)
+    port_declarations = top.split(");", 1)[0]
+    for forbidden in ("[463:0]", "[393:0]", "[327:0]", "[319:0]"):
+        if forbidden in port_declarations:
+            raise SystemExit(f"top-level narrow-I/O contract violated by {forbidden}")
+
+    if kind == "temporal_finalizer":
+        _require(manifest.get("top_pin_bits"), 388, "temporal top pin count")
+        _require(manifest.get("macro_count"), 104, "temporal macro count")
+        _require(generated_params.get("macro_count"), 104, "generated macro count")
+        _require(checked_params.get("macro_count"), 104, "checked macro count")
+        _require(manifest.get("physical_timing_claim"), "single_temporal_clock_domain", "timing claim")
+        if "fakeram45_64x32 u_state_mem" not in rtl:
+            raise SystemExit("temporal harness must instantiate fakeram45_64x32 state macros")
+        for forbidden in (
+            "state_global_max_q [0:",
+            "state_exp_sum_q [0:",
+            "state_value_q [0:",
+            "reg [393:0] state",
+        ):
+            if forbidden in rtl:
+                raise SystemExit(f"wide behavioral state array is forbidden: {forbidden}")
+    else:
+        _require(manifest.get("top_pin_bits"), 292, "CDC top pin count")
+        _require(manifest.get("macro_count"), 0, "CDC macro count")
+        _require(generated_params.get("macro_count"), 0, "generated CDC macro count")
+        _require(
+            manifest.get("cross_domain_paths_are_signoff_timing"),
+            False,
+            "CDC signoff claim",
+        )
+        if "reg [463:0] mem [0:DEPTH-1];" not in rtl:
+            raise SystemExit("CDC harness must contain the real 464-bit depth-4 FIFO")
+        if "helper_clk_q <= ~helper_clk_q;" not in top:
+            raise SystemExit("CDC inactive domain must use protocol-safe generated clock")
+
+    links = config.get("report_links")
+    if not isinstance(links, dict):
+        raise SystemExit("config requires report_links")
+    _require(links.get("proposal_id"), _PROPOSAL_ID, "config proposal linkage")
+    print(
+        json.dumps(
+            {
+                "design": top_name,
+                "kind": kind,
+                "top_pin_bits": manifest["top_pin_bits"],
+                "status": "ok",
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/rtlgen/gen_attention_exact_partial_async_fifo_physical_harness.py
+++ b/npu/rtlgen/gen_attention_exact_partial_async_fifo_physical_harness.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Generate selected-domain narrow-IO physical diagnostics for the 464-bit CDC FIFO."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_decode_score_multivalue_service_temporal_cdc import (
+    _PAYLOAD_BITS,
+    _async_fifo,
+)
+
+JsonDict = dict[str, Any]
+_CONFIG_KEY = "attention_exact_partial_async_fifo_physical_harness"
+_MANIFEST = "attention_exact_partial_async_fifo_physical_harness_manifest.json"
+_PROPOSAL_ID = "prop_l1_decoder_attention_exact_partial_physical_calibration_v1"
+_PROPOSAL_PATH = f"docs/proposals/{_PROPOSAL_ID}/proposal.json"
+_TOP_PIN_BITS = 292
+
+
+def _load(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit(f"config must decode to a JSON object: {path}")
+    return payload
+
+
+def _validate(config: JsonDict) -> JsonDict:
+    top_name = str(config.get("top_name") or "").strip()
+    body = config.get(_CONFIG_KEY)
+    if not top_name or not isinstance(body, dict):
+        raise SystemExit(f"config requires top_name and {_CONFIG_KEY}")
+    domain = str(body.get("timed_domain", "")).strip().lower()
+    if domain not in {"source", "destination"}:
+        raise SystemExit("timed_domain must be source or destination")
+    if int(body.get("depth", 4)) != 4:
+        raise SystemExit("physical calibration FIFO depth must remain 4")
+    return {"top_name": top_name, "timed_domain": domain}
+
+
+def _top(*, top_name: str, fifo_top: str, timed_domain: str) -> str:
+    source_clock = "clk" if timed_domain == "source" else "helper_clk_q"
+    destination_clock = "helper_clk_q" if timed_domain == "source" else "clk"
+    return f"""// Selected-domain CDC physical diagnostic; not a common-clock wrapper.
+(* keep_hierarchy = 1 *)
+module {top_name} (
+    input  wire        clk,
+    input  wire        rst_n,
+    input  wire        start,
+    input  wire [31:0] seed,
+    output wire        done,
+    output wire [31:0] folded_result,
+    output wire [31:0] accepted_count,
+    output wire [31:0] emitted_count,
+    output wire [31:0] full_cycles,
+    output wire [31:0] empty_cycles,
+    output wire [31:0] source_occupancy,
+    output wire [31:0] destination_occupancy,
+    output wire [31:0] protocol_error_count
+);
+  localparam integer TRANSFERS = 32;
+  localparam integer PAYLOAD_BITS = {_PAYLOAD_BITS};
+
+  reg helper_clk_q;
+  reg source_running_q;
+  reg destination_running_q;
+  reg source_done_q;
+  reg destination_done_q;
+  reg [5:0] source_index_q;
+  reg [31:0] source_lfsr_q;
+  reg [31:0] destination_fold_q;
+  reg [31:0] destination_cycle_q;
+  reg [31:0] protocol_error_count_q;
+
+  wire source_clk_w = {source_clock};
+  wire destination_clk_w = {destination_clock};
+  wire wr_valid_w = source_running_q && source_index_q < TRANSFERS;
+  wire wr_ready_w;
+  wire wr_fire_w = wr_valid_w && wr_ready_w;
+  wire [PAYLOAD_BITS-1:0] wr_data_w = {{
+      16'h5100,
+      16'h6200,
+      14'd0,
+      15'd2,
+      5'd1,
+      source_lfsr_q,
+      {{1'b0, source_lfsr_q}},
+      source_index_q[3:0],
+      source_index_q[3:0] == 4'd15,
+      {{10{{source_lfsr_q}}}},
+      source_lfsr_q[7:0]
+  }};
+  wire [31:0] source_lfsr_next_w = {{
+      source_lfsr_q[30:0],
+      source_lfsr_q[31] ^ source_lfsr_q[21]
+          ^ source_lfsr_q[1] ^ source_lfsr_q[0]
+  }};
+  wire rd_valid_w;
+  wire rd_ready_w =
+      destination_running_q && destination_cycle_q[2:0] != 3'b000;
+  wire rd_fire_w = rd_valid_w && rd_ready_w;
+  wire [PAYLOAD_BITS-1:0] rd_data_w;
+  wire overflow_error_w;
+  wire underflow_error_w;
+  wire wr_protocol_error_w;
+  wire rd_protocol_error_w;
+  wire [31:0] emitted_count_w;
+  wire [31:0] rd_fold_w =
+      rd_data_w[31:0] ^ rd_data_w[63:32] ^ rd_data_w[95:64]
+      ^ rd_data_w[127:96] ^ rd_data_w[159:128]
+      ^ rd_data_w[191:160] ^ rd_data_w[223:192]
+      ^ rd_data_w[255:224] ^ rd_data_w[287:256]
+      ^ rd_data_w[319:288] ^ rd_data_w[351:320]
+      ^ rd_data_w[383:352] ^ rd_data_w[415:384]
+      ^ rd_data_w[447:416] ^ {{16'd0, rd_data_w[463:448]}};
+
+  assign done = destination_done_q;
+  assign folded_result = destination_fold_q;
+  assign protocol_error_count = protocol_error_count_q;
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n)
+      helper_clk_q <= 1'b0;
+    else
+      helper_clk_q <= ~helper_clk_q;
+  end
+
+  always @(posedge source_clk_w or negedge rst_n) begin
+    if (!rst_n) begin
+      source_running_q <= 1'b0;
+      source_done_q <= 1'b0;
+      source_index_q <= 6'd0;
+      source_lfsr_q <= 32'h1;
+    end else begin
+      if (start && !source_running_q && !source_done_q) begin
+        source_running_q <= 1'b1;
+        source_lfsr_q <= seed == 0 ? 32'h1 : seed;
+      end
+      if (wr_fire_w) begin
+        source_index_q <= source_index_q + 1'b1;
+        source_lfsr_q <= source_lfsr_next_w;
+        if (source_index_q == TRANSFERS - 1) begin
+          source_running_q <= 1'b0;
+          source_done_q <= 1'b1;
+        end
+      end
+    end
+  end
+
+  always @(posedge destination_clk_w or negedge rst_n) begin
+    if (!rst_n) begin
+      destination_running_q <= 1'b0;
+      destination_done_q <= 1'b0;
+      destination_fold_q <= 32'd0;
+      destination_cycle_q <= 32'd0;
+      protocol_error_count_q <= 32'd0;
+    end else begin
+      if (start && !destination_running_q && !destination_done_q)
+        destination_running_q <= 1'b1;
+      if (destination_running_q)
+        destination_cycle_q <= destination_cycle_q + 1'b1;
+      if (rd_fire_w) begin
+        destination_fold_q <= destination_fold_q ^ rd_fold_w;
+        if (emitted_count_w == TRANSFERS - 1) begin
+          destination_running_q <= 1'b0;
+          destination_done_q <= 1'b1;
+        end
+      end
+      if (overflow_error_w || underflow_error_w
+          || wr_protocol_error_w || rd_protocol_error_w)
+        protocol_error_count_q <= protocol_error_count_q + 1'b1;
+    end
+  end
+
+  {fifo_top} u_async_fifo (
+      .wr_clk(source_clk_w),
+      .wr_rst_n(rst_n),
+      .wr_valid(wr_valid_w),
+      .wr_ready(wr_ready_w),
+      .wr_data(wr_data_w),
+      .rd_clk(destination_clk_w),
+      .rd_rst_n(rst_n),
+      .rd_valid(rd_valid_w),
+      .rd_ready(rd_ready_w),
+      .rd_data(rd_data_w),
+      .wr_occupancy(source_occupancy),
+      .rd_occupancy(destination_occupancy),
+      .accepted_count(accepted_count),
+      .emitted_count(emitted_count_w),
+      .full_cycles(full_cycles),
+      .empty_cycles(empty_cycles),
+      .overflow_error(overflow_error_w),
+      .underflow_error(underflow_error_w),
+      .wr_protocol_error(wr_protocol_error_w),
+      .rd_protocol_error(rd_protocol_error_w)
+  );
+  assign emitted_count = emitted_count_w;
+endmodule
+"""
+
+
+def generate(config: JsonDict, out_dir: Path) -> None:
+    params = _validate(json.loads(json.dumps(config)))
+    top_name = str(params["top_name"])
+    fifo_top = f"{top_name}__async_fifo"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    rtl = "\n\n".join(
+        (
+            _async_fifo(module_name=fifo_top, depth=4),
+            _top(
+                top_name=top_name,
+                fifo_top=fifo_top,
+                timed_domain=str(params["timed_domain"]),
+            ),
+        )
+    )
+    (out_dir / "top.v").write_text(rtl + "\n", encoding="utf-8")
+    (out_dir / "config.json").write_text(
+        json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    manifest = {
+        "version": 1,
+        "generator": (
+            "npu/rtlgen/gen_attention_exact_partial_async_fifo_physical_harness.py"
+        ),
+        "top_name": top_name,
+        "semantic_profile": "exact_partial_async_fifo_selected_domain_physical_diagnostic_v1",
+        "payload_bits": _PAYLOAD_BITS,
+        "depth": 4,
+        "timed_domain": str(params["timed_domain"]),
+        "timed_clock_port": "clk",
+        "inactive_domain_clock": "protocol_safe_divide_by_two_generated_clock",
+        "external_interface": "clk_reset_start_seed_done_folded_result_and_counters_only",
+        "top_pin_bits": _TOP_PIN_BITS,
+        "macro_count": 0,
+        "physical_timing_claim": f"{params['timed_domain']}_domain_diagnostic_only",
+        "whole_dual_clock_common_delay_claim": False,
+        "cross_domain_paths_are_signoff_timing": False,
+        "cdc_correctness_evidence": (
+            "separate non_harmonic_functional_probe_not_this_openroad_harness"
+        ),
+        "linked_proposal_id": _PROPOSAL_ID,
+        "linked_proposal_path": _PROPOSAL_PATH,
+    }
+    (out_dir / _MANIFEST).write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    macro_manifest = {
+        "version": "0.1",
+        "design_id": top_name,
+        "module": top_name,
+        "platform": "nangate45",
+        "flow_variant": "exact_partial_async_fifo_selected_domain_diagnostic_v1",
+        "blackboxes": [],
+        "additional_lefs": [],
+        "additional_libs": [],
+        "additional_gds": [],
+        "blackbox_verilog": [],
+        "source": {
+            "mode": "generated_physical_harness",
+            "generator": (
+                "npu/rtlgen/"
+                "gen_attention_exact_partial_async_fifo_physical_harness.py"
+            ),
+        },
+        "manifest_params": {"macro_count": 0},
+    }
+    (out_dir / "macro_manifest.json").write_text(
+        json.dumps(macro_manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    generate(_load(args.config), args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/rtlgen/gen_attention_score32_exact_partial_temporal_finalizer_physical_harness.py
+++ b/npu/rtlgen/gen_attention_score32_exact_partial_temporal_finalizer_physical_harness.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""Generate a narrow-IO physical harness for SRAM temporal reduction and finalization."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.rtlgen.gen_attention_score32_exact_partial_temporal_stream_sram import (
+    generate as generate_temporal,
+)
+from npu.rtlgen.gen_attention_score32_exact_root_finalizer import (
+    generate as generate_finalizer,
+)
+
+JsonDict = dict[str, Any]
+_CONFIG_KEY = "attention_score32_exact_partial_temporal_finalizer_physical_harness"
+_MANIFEST = "attention_score32_exact_partial_temporal_finalizer_physical_harness_manifest.json"
+_PROPOSAL_ID = "prop_l1_decoder_attention_exact_partial_physical_calibration_v1"
+_PROPOSAL_PATH = f"docs/proposals/{_PROPOSAL_ID}/proposal.json"
+_TOP_PIN_BITS = 388
+
+
+def _load(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit(f"config must decode to a JSON object: {path}")
+    return payload
+
+
+def _validate(config: JsonDict) -> JsonDict:
+    top_name = str(config.get("top_name") or "").strip()
+    body = config.get(_CONFIG_KEY)
+    if not top_name or not isinstance(body, dict):
+        raise SystemExit(f"config requires top_name and {_CONFIG_KEY}")
+    divider_lanes = int(body.get("divider_lanes", 8))
+    if divider_lanes not in {1, 2, 4, 8}:
+        raise SystemExit("divider_lanes must be one of 1, 2, 4, or 8")
+    if int(body.get("heads", 2)) != 2 or int(body.get("windows", 2)) != 2:
+        raise SystemExit("physical calibration traffic must remain fixed at 2 heads x 2 windows")
+    return {
+        "top_name": top_name,
+        "divider_lanes": divider_lanes,
+    }
+
+
+def _payload_expression() -> str:
+    words = [
+        f"{{9'd0, (source_lfsr_q ^ 32'h{0x10203040 * (lane + 1):08x})}}"
+        for lane in reversed(range(8))
+    ]
+    return "{\n      " + ",\n      ".join(words) + "\n  }"
+
+
+def _top(*, top_name: str, temporal_top: str, finalizer_top: str) -> str:
+    return f"""// Generated narrow-IO physical calibration harness.
+(* keep_hierarchy = 1 *)
+module {top_name} (
+    input  wire        clk,
+    input  wire        rst_n,
+    input  wire        start,
+    input  wire [31:0] seed,
+    output wire        done,
+    output wire [31:0] folded_result,
+    output wire [31:0] cycle_count,
+    output wire [31:0] source_accepted_count,
+    output wire [31:0] temporal_emitted_count,
+    output wire [31:0] finalizer_completed_count,
+    output wire [31:0] state_request_count,
+    output wire [31:0] state_read_count,
+    output wire [31:0] state_write_count,
+    output wire [31:0] state_stall_count,
+    output wire [31:0] output_stall_count,
+    output wire [31:0] protocol_error_count
+);
+  localparam integer SOURCE_BEATS = 64;
+  localparam integer FINAL_BEATS = 32;
+
+  reg running_q;
+  reg done_q;
+  reg [6:0] source_index_q;
+  reg [31:0] source_lfsr_q;
+  reg [31:0] cycle_count_q;
+  reg [31:0] folded_result_q;
+  reg [31:0] output_stall_count_q;
+  reg [31:0] protocol_error_count_q;
+
+  wire source_valid_w = running_q && source_index_q < SOURCE_BEATS;
+  wire source_ready_w;
+  wire source_fire_w = source_valid_w && source_ready_w;
+  wire [4:0] source_head_w = {{4'd0, source_index_q[5]}};
+  wire [13:0] source_window_w = {{13'd0, source_index_q[4]}};
+  wire [3:0] source_slice_w = source_index_q[3:0];
+  wire [327:0] source_value_w = {_payload_expression()};
+  wire [31:0] lfsr_next_w = {{
+      source_lfsr_q[30:0],
+      source_lfsr_q[31] ^ source_lfsr_q[21]
+          ^ source_lfsr_q[1] ^ source_lfsr_q[0]
+  }};
+
+  wire temporal_valid_w;
+  wire temporal_ready_w;
+  wire [15:0] temporal_command_w;
+  wire [4:0] temporal_head_w;
+  wire [32:0] temporal_sum_w;
+  wire [3:0] temporal_slice_w;
+  wire temporal_last_w;
+  wire [327:0] temporal_value_w;
+  wire [31:0] temporal_input_count_w;
+  wire [31:0] temporal_emitted_count_w;
+  wire [31:0] temporal_output_stalls_w;
+  wire [31:0] state_request_count_w;
+  wire [31:0] state_read_count_w;
+  wire [31:0] state_write_count_w;
+  wire [31:0] state_request_stalls_w;
+  wire [31:0] state_response_stalls_w;
+  wire temporal_state_error_w;
+  wire temporal_error_w;
+
+  wire final_valid_w;
+  wire final_ready_w =
+      running_q && (cycle_count_q[2:0] != 3'b000);
+  wire [15:0] final_command_w;
+  wire [4:0] final_head_w;
+  wire [3:0] final_slice_w;
+  wire final_last_w;
+  wire [319:0] final_value_w;
+  wire [31:0] finalizer_completed_count_w;
+  wire finalizer_error_w;
+  wire final_fire_w = final_valid_w && final_ready_w;
+  wire [31:0] final_fold_w =
+      {{16'd0, final_command_w}}
+      ^ {{27'd0, final_head_w}}
+      ^ {{28'd0, final_slice_w}}
+      ^ {{31'd0, final_last_w}}
+      ^ final_value_w[31:0]
+      ^ final_value_w[63:32]
+      ^ final_value_w[95:64]
+      ^ final_value_w[127:96]
+      ^ final_value_w[159:128]
+      ^ final_value_w[191:160]
+      ^ final_value_w[223:192]
+      ^ final_value_w[255:224]
+      ^ final_value_w[287:256]
+      ^ final_value_w[319:288];
+
+  assign done = done_q;
+  assign folded_result = folded_result_q;
+  assign cycle_count = cycle_count_q;
+  assign source_accepted_count = temporal_input_count_w;
+  assign temporal_emitted_count = temporal_emitted_count_w;
+  assign finalizer_completed_count = finalizer_completed_count_w;
+  assign state_request_count = state_request_count_w;
+  assign state_read_count = state_read_count_w;
+  assign state_write_count = state_write_count_w;
+  assign state_stall_count =
+      state_request_stalls_w + state_response_stalls_w;
+  assign output_stall_count =
+      output_stall_count_q + temporal_output_stalls_w;
+  assign protocol_error_count = protocol_error_count_q;
+
+  {temporal_top} u_temporal (
+      .clk(clk),
+      .rst_n(rst_n),
+      .in_valid(source_valid_w),
+      .in_ready(source_ready_w),
+      .in_sequence_id(16'h5100 + {{15'd0, source_index_q[5]}}),
+      .in_head_id(source_head_w),
+      .in_window_index(source_window_w),
+      .in_window_count(15'd2),
+      .in_command_id(16'h6200 + {{15'd0, source_index_q[5]}}),
+      .in_global_max(32'sd0),
+      .in_exp_sum(33'h080000000 + {{27'd0, source_index_q[5:0]}}),
+      .in_slice(source_slice_w),
+      .in_last(source_slice_w == 4'd15),
+      .in_value(source_value_w),
+      .out_valid(temporal_valid_w),
+      .out_ready(temporal_ready_w),
+      .out_sequence_id(),
+      .out_head_id(temporal_head_w),
+      .out_window_count(),
+      .out_command_id(temporal_command_w),
+      .out_global_max(),
+      .out_exp_sum(temporal_sum_w),
+      .out_slice(temporal_slice_w),
+      .out_last(temporal_last_w),
+      .out_value(temporal_value_w),
+      .cycle_count(),
+      .input_accepted_count(temporal_input_count_w),
+      .merge_completed_count(),
+      .emitted_beat_count(temporal_emitted_count_w),
+      .completed_head_count(),
+      .fifo_full_stall_cycles(),
+      .output_stall_cycles(temporal_output_stalls_w),
+      .fifo_level(),
+      .state_memory_request_count(state_request_count_w),
+      .state_memory_read_request_count(state_read_count_w),
+      .state_memory_read_response_count(),
+      .state_memory_write_count(state_write_count_w),
+      .state_memory_request_stall_cycles(state_request_stalls_w),
+      .state_memory_response_stall_cycles(state_response_stalls_w),
+      .state_memory_protocol_error(temporal_state_error_w),
+      .protocol_error(temporal_error_w)
+  );
+
+  {finalizer_top} u_finalizer (
+      .clk(clk),
+      .rst_n(rst_n),
+      .in_valid(temporal_valid_w),
+      .in_ready(temporal_ready_w),
+      .in_command_id(temporal_command_w),
+      .in_head_id(temporal_head_w),
+      .in_exp_sum(temporal_sum_w),
+      .in_slice(temporal_slice_w),
+      .in_last(temporal_last_w),
+      .in_value(temporal_value_w),
+      .out_valid(final_valid_w),
+      .out_ready(final_ready_w),
+      .out_command_id(final_command_w),
+      .out_head_id(final_head_w),
+      .out_slice(final_slice_w),
+      .out_last(final_last_w),
+      .out_value(final_value_w),
+      .accepted_count(),
+      .completed_count(finalizer_completed_count_w),
+      .cycle_count(),
+      .protocol_error(finalizer_error_w)
+  );
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      running_q <= 1'b0;
+      done_q <= 1'b0;
+      source_index_q <= 7'd0;
+      source_lfsr_q <= 32'h1;
+      cycle_count_q <= 32'd0;
+      folded_result_q <= 32'd0;
+      output_stall_count_q <= 32'd0;
+      protocol_error_count_q <= 32'd0;
+    end else begin
+      if (start && !running_q && !done_q) begin
+        running_q <= 1'b1;
+        source_lfsr_q <= seed == 0 ? 32'h1 : seed;
+      end
+      if (running_q) cycle_count_q <= cycle_count_q + 1'b1;
+      if (source_fire_w) begin
+        source_index_q <= source_index_q + 1'b1;
+        source_lfsr_q <= lfsr_next_w;
+      end
+      if (final_valid_w && !final_ready_w)
+        output_stall_count_q <= output_stall_count_q + 1'b1;
+      if (final_fire_w) begin
+        folded_result_q <= folded_result_q ^ final_fold_w;
+        if (finalizer_completed_count_w == FINAL_BEATS - 1) begin
+          running_q <= 1'b0;
+          done_q <= 1'b1;
+        end
+      end
+      if (temporal_error_w || temporal_state_error_w || finalizer_error_w)
+        protocol_error_count_q <= protocol_error_count_q + 1'b1;
+    end
+  end
+endmodule
+"""
+
+
+def generate(config: JsonDict, out_dir: Path) -> None:
+    params = _validate(json.loads(json.dumps(config)))
+    top_name = str(params["top_name"])
+    temporal_top = f"{top_name}__temporal"
+    finalizer_top = f"{top_name}__finalizer"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="exact-partial-physical-harness-") as name:
+        temp = Path(name)
+        temporal_dir = temp / "temporal"
+        finalizer_dir = temp / "finalizer"
+        generate_temporal(
+            {
+                "top_name": temporal_top,
+                "attention_score32_exact_partial_temporal_stream_sram": {
+                    "heads": 32,
+                    "value_slices": 16,
+                    "head_id_bits": 5,
+                    "fifo_depth": 4,
+                    "exp_scale_impl": "factored_h33_l64_mul_exact",
+                    "keep_hierarchy": True,
+                },
+            },
+            temporal_dir,
+        )
+        generate_finalizer(
+            {
+                "top_name": finalizer_top,
+                "attention_score32_exact_root_finalizer": {
+                    "value_slices": 16,
+                    "head_id_bits": 5,
+                    "divider_lanes": int(params["divider_lanes"]),
+                },
+            },
+            finalizer_dir,
+        )
+        temporal_rtl = (temporal_dir / "top.v").read_text(encoding="utf-8")
+        finalizer_rtl = (finalizer_dir / "top.v").read_text(encoding="utf-8")
+        temporal_manifest = json.loads(
+            (
+                temporal_dir
+                / "attention_score32_exact_partial_temporal_stream_sram_manifest.json"
+            ).read_text(encoding="utf-8")
+        )
+        finalizer_manifest = json.loads(
+            (
+                finalizer_dir / "attention_score32_exact_root_finalizer_manifest.json"
+            ).read_text(encoding="utf-8")
+        )
+        macro_manifest = json.loads(
+            (temporal_dir / "macro_manifest.json").read_text(encoding="utf-8")
+        )
+
+    rtl = "\n\n".join(
+        (
+            temporal_rtl,
+            finalizer_rtl,
+            _top(
+                top_name=top_name,
+                temporal_top=temporal_top,
+                finalizer_top=finalizer_top,
+            ),
+        )
+    )
+    (out_dir / "top.v").write_text(rtl + "\n", encoding="utf-8")
+    (out_dir / "config.json").write_text(
+        json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    macro_manifest["design_id"] = top_name
+    macro_manifest["module"] = top_name
+    macro_manifest["flow_variant"] = "exact_partial_temporal_finalizer_physical_harness_v1"
+    macro_manifest["source"] = {
+        "mode": "generated_physical_harness",
+        "generator": (
+            "npu/rtlgen/"
+            "gen_attention_score32_exact_partial_temporal_finalizer_physical_harness.py"
+        ),
+    }
+    (out_dir / "macro_manifest.json").write_text(
+        json.dumps(macro_manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    manifest = {
+        "version": 1,
+        "generator": (
+            "npu/rtlgen/"
+            "gen_attention_score32_exact_partial_temporal_finalizer_physical_harness.py"
+        ),
+        "top_name": top_name,
+        "semantic_profile": "exact_partial_temporal_sram_finalizer_physical_harness_v1",
+        "divider_lanes": int(params["divider_lanes"]),
+        "clock_domains": ["temporal_clk"],
+        "clock_port": "clk",
+        "traffic": {
+            "heads": 2,
+            "windows_per_head": 2,
+            "slices_per_window": 16,
+            "source_beats": 64,
+            "finalized_beats": 32,
+            "ready_valid_stability": "source state advances only on input handshake",
+            "output_stalls": "cycle_count[2:0] == 0",
+        },
+        "top_pin_bits": _TOP_PIN_BITS,
+        "external_interface": "clk_reset_start_seed_done_folded_result_and_counters_only",
+        "macro_count": 104,
+        "macro_area_um2": 104 * 20.14 * 61.6,
+        "persistent_state_inferred_as_flops": False,
+        "physical_timing_claim": "single_temporal_clock_domain",
+        "whole_dual_clock_common_delay_claim": False,
+        "linked_proposal_id": _PROPOSAL_ID,
+        "linked_proposal_path": _PROPOSAL_PATH,
+        "submodule_manifests": {
+            "temporal_sram": temporal_manifest,
+            "root_finalizer": finalizer_manifest,
+        },
+    }
+    (out_dir / _MANIFEST).write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    generate(_load(args.config), args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runs/campaigns/npu/attention_exact_partial_physical_calibration_v1/sweeps/nangate45_async_fifo_per_domain.json
+++ b/runs/campaigns/npu/attention_exact_partial_physical_calibration_v1/sweeps/nangate45_async_fifo_per_domain.json
@@ -1,0 +1,23 @@
+{
+  "tag_prefix": "attention_exact_partial_async_fifo_per_domain_v1",
+  "flow_params": {
+    "CLOCK_PERIOD": [
+      6.0,
+      8.0,
+      10.0,
+      12.0
+    ],
+    "DIE_AREA": [
+      "0 0 500 500"
+    ],
+    "CORE_AREA": [
+      "25 25 475 475"
+    ],
+    "PLACE_DENSITY": [
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ]
+  }
+}

--- a/runs/campaigns/npu/attention_exact_partial_physical_calibration_v1/sweeps/nangate45_temporal_finalizer_macro.json
+++ b/runs/campaigns/npu/attention_exact_partial_physical_calibration_v1/sweeps/nangate45_temporal_finalizer_macro.json
@@ -1,0 +1,23 @@
+{
+  "tag_prefix": "attention_exact_partial_temporal_finalizer_macro_v1",
+  "flow_params": {
+    "CLOCK_PERIOD": [
+      6.0,
+      8.0,
+      10.0,
+      12.0
+    ],
+    "DIE_AREA": [
+      "0 0 1600 1600"
+    ],
+    "CORE_AREA": [
+      "50 50 1550 1550"
+    ],
+    "PLACE_DENSITY": [
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ]
+  }
+}

--- a/runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_destination_domain_physical/config.json
+++ b/runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_destination_domain_physical/config.json
@@ -1,0 +1,11 @@
+{
+  "top_name": "attention_exact_partial_async_fifo_d4_destination_domain_physical",
+  "attention_exact_partial_async_fifo_physical_harness": {
+    "depth": 4,
+    "timed_domain": "destination"
+  },
+  "report_links": {
+    "proposal_id": "prop_l1_decoder_attention_exact_partial_physical_calibration_v1",
+    "proposal_path": "docs/proposals/prop_l1_decoder_attention_exact_partial_physical_calibration_v1/proposal.json"
+  }
+}

--- a/runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_destination_domain_physical/macro_manifest.json
+++ b/runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_destination_domain_physical/macro_manifest.json
@@ -1,0 +1,21 @@
+{
+  "version": "0.1",
+  "design_id": "attention_exact_partial_async_fifo_d4_destination_domain_physical",
+  "module": "attention_exact_partial_async_fifo_d4_destination_domain_physical",
+  "platform": "nangate45",
+  "flow_variant": "exact_partial_async_fifo_selected_domain_diagnostic_v1",
+  "blackboxes": [],
+  "additional_lefs": [],
+  "additional_libs": [],
+  "additional_gds": [],
+  "blackbox_verilog": [],
+  "source": {
+    "mode": "generated_physical_harness",
+    "generator": "npu/rtlgen/gen_attention_exact_partial_async_fifo_physical_harness.py"
+  },
+  "manifest_params": {
+    "macro_count": 0,
+    "timed_domain": "destination",
+    "whole_dual_clock_common_delay_claim": false
+  }
+}

--- a/runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_source_domain_physical/config.json
+++ b/runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_source_domain_physical/config.json
@@ -1,0 +1,11 @@
+{
+  "top_name": "attention_exact_partial_async_fifo_d4_source_domain_physical",
+  "attention_exact_partial_async_fifo_physical_harness": {
+    "depth": 4,
+    "timed_domain": "source"
+  },
+  "report_links": {
+    "proposal_id": "prop_l1_decoder_attention_exact_partial_physical_calibration_v1",
+    "proposal_path": "docs/proposals/prop_l1_decoder_attention_exact_partial_physical_calibration_v1/proposal.json"
+  }
+}

--- a/runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_source_domain_physical/macro_manifest.json
+++ b/runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_source_domain_physical/macro_manifest.json
@@ -1,0 +1,21 @@
+{
+  "version": "0.1",
+  "design_id": "attention_exact_partial_async_fifo_d4_source_domain_physical",
+  "module": "attention_exact_partial_async_fifo_d4_source_domain_physical",
+  "platform": "nangate45",
+  "flow_variant": "exact_partial_async_fifo_selected_domain_diagnostic_v1",
+  "blackboxes": [],
+  "additional_lefs": [],
+  "additional_libs": [],
+  "additional_gds": [],
+  "blackbox_verilog": [],
+  "source": {
+    "mode": "generated_physical_harness",
+    "generator": "npu/rtlgen/gen_attention_exact_partial_async_fifo_physical_harness.py"
+  },
+  "manifest_params": {
+    "macro_count": 0,
+    "timed_domain": "source",
+    "whole_dual_clock_common_delay_claim": false
+  }
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l1/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l1/config.json
@@ -1,0 +1,12 @@
+{
+  "top_name": "attention_score32_exact_partial_temporal_finalizer_physical_l1",
+  "attention_score32_exact_partial_temporal_finalizer_physical_harness": {
+    "divider_lanes": 1,
+    "heads": 2,
+    "windows": 2
+  },
+  "report_links": {
+    "proposal_id": "prop_l1_decoder_attention_exact_partial_physical_calibration_v1",
+    "proposal_path": "docs/proposals/prop_l1_decoder_attention_exact_partial_physical_calibration_v1/proposal.json"
+  }
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l1/macro_manifest.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l1/macro_manifest.json
@@ -1,0 +1,22 @@
+{
+  "version": "0.1",
+  "design_id": "attention_score32_exact_partial_temporal_finalizer_physical_l1",
+  "module": "attention_score32_exact_partial_temporal_finalizer_physical_l1",
+  "platform": "nangate45",
+  "flow_variant": "exact_partial_temporal_finalizer_physical_harness_v1",
+  "blackboxes": ["fakeram45_64x32"],
+  "additional_lefs": ["/orfs/flow/platforms/nangate45/lef/fakeram45_64x32.lef"],
+  "additional_libs": ["/orfs/flow/platforms/nangate45/lib/fakeram45_64x32.lib"],
+  "additional_gds": [],
+  "blackbox_verilog": ["npu/rtl/fakeram45_64x32_blackbox.v"],
+  "source": {
+    "mode": "generated_physical_harness",
+    "generator": "npu/rtlgen/gen_attention_score32_exact_partial_temporal_finalizer_physical_harness.py"
+  },
+  "manifest_params": {
+    "macro_count": 104,
+    "macro_width_um": 20.14,
+    "macro_height_um": 61.6,
+    "total_macro_area_um2": 129024.896
+  }
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l2/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l2/config.json
@@ -1,0 +1,12 @@
+{
+  "top_name": "attention_score32_exact_partial_temporal_finalizer_physical_l2",
+  "attention_score32_exact_partial_temporal_finalizer_physical_harness": {
+    "divider_lanes": 2,
+    "heads": 2,
+    "windows": 2
+  },
+  "report_links": {
+    "proposal_id": "prop_l1_decoder_attention_exact_partial_physical_calibration_v1",
+    "proposal_path": "docs/proposals/prop_l1_decoder_attention_exact_partial_physical_calibration_v1/proposal.json"
+  }
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l2/macro_manifest.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l2/macro_manifest.json
@@ -1,0 +1,22 @@
+{
+  "version": "0.1",
+  "design_id": "attention_score32_exact_partial_temporal_finalizer_physical_l2",
+  "module": "attention_score32_exact_partial_temporal_finalizer_physical_l2",
+  "platform": "nangate45",
+  "flow_variant": "exact_partial_temporal_finalizer_physical_harness_v1",
+  "blackboxes": ["fakeram45_64x32"],
+  "additional_lefs": ["/orfs/flow/platforms/nangate45/lef/fakeram45_64x32.lef"],
+  "additional_libs": ["/orfs/flow/platforms/nangate45/lib/fakeram45_64x32.lib"],
+  "additional_gds": [],
+  "blackbox_verilog": ["npu/rtl/fakeram45_64x32_blackbox.v"],
+  "source": {
+    "mode": "generated_physical_harness",
+    "generator": "npu/rtlgen/gen_attention_score32_exact_partial_temporal_finalizer_physical_harness.py"
+  },
+  "manifest_params": {
+    "macro_count": 104,
+    "macro_width_um": 20.14,
+    "macro_height_um": 61.6,
+    "total_macro_area_um2": 129024.896
+  }
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l4/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l4/config.json
@@ -1,0 +1,12 @@
+{
+  "top_name": "attention_score32_exact_partial_temporal_finalizer_physical_l4",
+  "attention_score32_exact_partial_temporal_finalizer_physical_harness": {
+    "divider_lanes": 4,
+    "heads": 2,
+    "windows": 2
+  },
+  "report_links": {
+    "proposal_id": "prop_l1_decoder_attention_exact_partial_physical_calibration_v1",
+    "proposal_path": "docs/proposals/prop_l1_decoder_attention_exact_partial_physical_calibration_v1/proposal.json"
+  }
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l4/macro_manifest.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l4/macro_manifest.json
@@ -1,0 +1,22 @@
+{
+  "version": "0.1",
+  "design_id": "attention_score32_exact_partial_temporal_finalizer_physical_l4",
+  "module": "attention_score32_exact_partial_temporal_finalizer_physical_l4",
+  "platform": "nangate45",
+  "flow_variant": "exact_partial_temporal_finalizer_physical_harness_v1",
+  "blackboxes": ["fakeram45_64x32"],
+  "additional_lefs": ["/orfs/flow/platforms/nangate45/lef/fakeram45_64x32.lef"],
+  "additional_libs": ["/orfs/flow/platforms/nangate45/lib/fakeram45_64x32.lib"],
+  "additional_gds": [],
+  "blackbox_verilog": ["npu/rtl/fakeram45_64x32_blackbox.v"],
+  "source": {
+    "mode": "generated_physical_harness",
+    "generator": "npu/rtlgen/gen_attention_score32_exact_partial_temporal_finalizer_physical_harness.py"
+  },
+  "manifest_params": {
+    "macro_count": 104,
+    "macro_width_um": 20.14,
+    "macro_height_um": 61.6,
+    "total_macro_area_um2": 129024.896
+  }
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l8/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l8/config.json
@@ -1,0 +1,12 @@
+{
+  "top_name": "attention_score32_exact_partial_temporal_finalizer_physical_l8",
+  "attention_score32_exact_partial_temporal_finalizer_physical_harness": {
+    "divider_lanes": 8,
+    "heads": 2,
+    "windows": 2
+  },
+  "report_links": {
+    "proposal_id": "prop_l1_decoder_attention_exact_partial_physical_calibration_v1",
+    "proposal_path": "docs/proposals/prop_l1_decoder_attention_exact_partial_physical_calibration_v1/proposal.json"
+  }
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l8/macro_manifest.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l8/macro_manifest.json
@@ -1,0 +1,22 @@
+{
+  "version": "0.1",
+  "design_id": "attention_score32_exact_partial_temporal_finalizer_physical_l8",
+  "module": "attention_score32_exact_partial_temporal_finalizer_physical_l8",
+  "platform": "nangate45",
+  "flow_variant": "exact_partial_temporal_finalizer_physical_harness_v1",
+  "blackboxes": ["fakeram45_64x32"],
+  "additional_lefs": ["/orfs/flow/platforms/nangate45/lef/fakeram45_64x32.lef"],
+  "additional_libs": ["/orfs/flow/platforms/nangate45/lib/fakeram45_64x32.lib"],
+  "additional_gds": [],
+  "blackbox_verilog": ["npu/rtl/fakeram45_64x32_blackbox.v"],
+  "source": {
+    "mode": "generated_physical_harness",
+    "generator": "npu/rtlgen/gen_attention_score32_exact_partial_temporal_finalizer_physical_harness.py"
+  },
+  "manifest_params": {
+    "macro_count": 104,
+    "macro_width_um": 20.14,
+    "macro_height_um": 61.6,
+    "total_macro_area_um2": 129024.896
+  }
+}

--- a/tests/test_attention_exact_partial_physical_calibration.py
+++ b/tests/test_attention_exact_partial_physical_calibration.py
@@ -195,7 +195,7 @@ def test_checked_designs_guards_sweeps_and_task_commands(tmp_path: Path) -> None
 
 def test_normal_task_mechanism_attaches_required_source_commit() -> None:
     source_commit = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
+        ["git", "rev-parse", "origin/master"],
         cwd=REPO_ROOT,
         capture_output=True,
         check=True,

--- a/tests/test_attention_exact_partial_physical_calibration.py
+++ b/tests/test_attention_exact_partial_physical_calibration.py
@@ -1,0 +1,307 @@
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from control_plane.db import create_all
+from control_plane.models.task_requests import TaskRequest
+from control_plane.models.work_items import WorkItem
+from control_plane.services.l1_task_generator import (
+    Layer1SweepGenerateRequest,
+    _read_config_target,
+    generate_l1_sweep_task,
+)
+from npu.eval.check_attention_exact_partial_physical_calibration_guard import (
+    main as guard_main,
+)
+from npu.rtlgen.gen_attention_exact_partial_async_fifo_physical_harness import (
+    generate as generate_cdc,
+)
+from npu.rtlgen.gen_attention_score32_exact_partial_temporal_finalizer_physical_harness import (
+    generate as generate_temporal_finalizer,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROPOSAL_ID = "prop_l1_decoder_attention_exact_partial_physical_calibration_v1"
+TEMPORAL_DESIGNS = [
+    f"attention_score32_exact_partial_temporal_finalizer_physical_l{lanes}"
+    for lanes in (1, 2, 4, 8)
+]
+CDC_DESIGNS = [
+    "attention_exact_partial_async_fifo_d4_source_domain_physical",
+    "attention_exact_partial_async_fifo_d4_destination_domain_physical",
+]
+
+
+def _tool(name: str) -> str:
+    path = shutil.which(name)
+    if path:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    if fallback.exists():
+        return str(fallback)
+    pytest.skip(f"{name} unavailable")
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _lint(top: str, rtl: Path, *, macros: bool) -> None:
+    command = [
+        _tool("verilator"),
+        "--lint-only",
+        "-Wno-WIDTHEXPAND",
+        "-Wno-WIDTHTRUNC",
+        "-Wno-UNUSEDSIGNAL",
+        "-Wno-UNDRIVEN",
+        "-Wno-TIMESCALEMOD",
+        "-Wno-SIDEEFFECT",
+        "-Wno-LATCH",
+        "-Wno-UNOPTFLAT",
+        "-Wno-MULTIDRIVEN",
+        "--top-module",
+        top,
+        str(rtl),
+    ]
+    if macros:
+        command.append(str(REPO_ROOT / "npu/rtl/fakeram45_64x32_blackbox.v"))
+    result = subprocess.run(command, capture_output=True, text=True, timeout=240)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize("lanes", [1, 2, 4, 8])
+def test_temporal_finalizer_generator_is_narrow_and_macro_backed(
+    tmp_path: Path, lanes: int
+) -> None:
+    top = f"calibration_l{lanes}"
+    config = {
+        "top_name": top,
+        "attention_score32_exact_partial_temporal_finalizer_physical_harness": {
+            "divider_lanes": lanes,
+            "heads": 2,
+            "windows": 2,
+        },
+    }
+    generate_temporal_finalizer(config, tmp_path)
+    rtl = (tmp_path / "top.v").read_text(encoding="utf-8")
+    manifest = _load(
+        tmp_path
+        / "attention_score32_exact_partial_temporal_finalizer_physical_harness_manifest.json"
+    )
+    macros = _load(tmp_path / "macro_manifest.json")
+
+    assert manifest["divider_lanes"] == lanes
+    assert manifest["top_pin_bits"] == 388
+    assert manifest["macro_count"] == 104
+    assert manifest["whole_dual_clock_common_delay_claim"] is False
+    assert macros["blackboxes"] == ["fakeram45_64x32"]
+    assert macros["manifest_params"]["macro_count"] == 104
+    assert "fakeram45_64x32 u_state_mem" in rtl
+    assert "state_global_max_q [0:" not in rtl
+    assert "reg [393:0] state" not in rtl
+    assert "localparam integer SOURCE_BEATS = 64;" in rtl
+    assert "localparam integer FINAL_BEATS = 32;" in rtl
+    _lint(top, tmp_path / "top.v", macros=True)
+
+
+@pytest.mark.parametrize("domain", ["source", "destination"])
+def test_cdc_generator_is_selected_domain_only(
+    tmp_path: Path, domain: str
+) -> None:
+    top = f"cdc_{domain}"
+    config = {
+        "top_name": top,
+        "attention_exact_partial_async_fifo_physical_harness": {
+            "depth": 4,
+            "timed_domain": domain,
+        },
+    }
+    generate_cdc(config, tmp_path)
+    rtl = (tmp_path / "top.v").read_text(encoding="utf-8")
+    manifest = _load(
+        tmp_path / "attention_exact_partial_async_fifo_physical_harness_manifest.json"
+    )
+
+    assert manifest["payload_bits"] == 464
+    assert manifest["depth"] == 4
+    assert manifest["timed_domain"] == domain
+    assert manifest["top_pin_bits"] == 292
+    assert manifest["whole_dual_clock_common_delay_claim"] is False
+    assert manifest["cross_domain_paths_are_signoff_timing"] is False
+    assert "reg [463:0] mem [0:DEPTH-1];" in rtl
+    assert "helper_clk_q <= ~helper_clk_q;" in rtl
+    _lint(top, tmp_path / "top.v", macros=False)
+
+
+def test_checked_designs_guards_sweeps_and_task_commands(tmp_path: Path) -> None:
+    for design in TEMPORAL_DESIGNS + CDC_DESIGNS:
+        source_dir = REPO_ROOT / "runs/designs/npu_blocks" / design
+        config = _load(source_dir / "config.json")
+        macro = _load(source_dir / "macro_manifest.json")
+        assert config["report_links"]["proposal_id"] == PROPOSAL_ID
+        assert macro["module"] == design
+
+        copied = tmp_path / "runs/designs/npu_blocks" / design
+        copied.mkdir(parents=True)
+        shutil.copy2(source_dir / "config.json", copied / "config.json")
+        shutil.copy2(source_dir / "macro_manifest.json", copied / "macro_manifest.json")
+        generator = (
+            generate_temporal_finalizer if design in TEMPORAL_DESIGNS else generate_cdc
+        )
+        generator(config, copied / "verilog")
+        assert guard_main(["--design-dir", str(copied)]) == 0
+
+        target = _read_config_target(
+            source_dir / "config.json",
+            repo_root=REPO_ROOT,
+            config_rel=str((source_dir / "config.json").relative_to(REPO_ROOT)),
+            out_root="runs/designs/npu_blocks",
+            make_target=None,
+        )
+        names = [command["name"] for command in target.commands]
+        assert names[1] == "check_attention_exact_partial_physical_calibration_guard"
+        assert "run_block_sweep" == names[2]
+        if design in TEMPORAL_DESIGNS:
+            assert "--macro_manifest" in target.commands[2]["run"]
+        else:
+            assert "--macro_manifest" not in target.commands[2]["run"]
+
+    temporal_sweep = _load(
+        REPO_ROOT
+        / "runs/campaigns/npu/attention_exact_partial_physical_calibration_v1/"
+        "sweeps/nangate45_temporal_finalizer_macro.json"
+    )["flow_params"]
+    assert temporal_sweep["CLOCK_PERIOD"] == [6.0, 8.0, 10.0, 12.0]
+    assert temporal_sweep["DIE_AREA"] == ["0 0 1600 1600"]
+    assert temporal_sweep["CORE_AREA"] == ["50 50 1550 1550"]
+    assert temporal_sweep["PLACE_DENSITY"] == [0.4]
+    assert temporal_sweep["SYNTH_HIERARCHICAL"] == [1]
+
+    request = _load(
+        REPO_ROOT
+        / f"docs/proposals/{PROPOSAL_ID}/evaluation_requests.json"
+    )
+    assert [item["item_id"] for item in request["requested_items"]] == [
+        "l1_decoder_attention_exact_partial_temporal_finalizer_physical_calibration_v1",
+        "l1_decoder_attention_exact_partial_async_fifo_domain_physical_calibration_v1",
+    ]
+    assert "source_requirement.required_sha" in request["source_commit_note"]
+
+
+def test_normal_task_mechanism_attaches_required_source_commit() -> None:
+    source_commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        check=True,
+        text=True,
+    ).stdout.strip()
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    create_all(engine)
+    config_paths = [
+        f"runs/designs/npu_blocks/{design}/config.json"
+        for design in TEMPORAL_DESIGNS
+    ]
+    with Session(engine) as session:
+        result = generate_l1_sweep_task(
+            session,
+            Layer1SweepGenerateRequest(
+                repo_root=str(REPO_ROOT),
+                sweep_path=(
+                    "runs/campaigns/npu/attention_exact_partial_physical_calibration_v1/"
+                    "sweeps/nangate45_temporal_finalizer_macro.json"
+                ),
+                config_paths=config_paths,
+                platform="nangate45",
+                out_root="runs/designs/npu_blocks",
+                requested_by="@developer",
+                source_commit=source_commit,
+                item_id=(
+                    "l1_decoder_attention_exact_partial_temporal_finalizer_"
+                    "physical_calibration_v1"
+                ),
+                proposal_id=PROPOSAL_ID,
+                update_proposal_files=False,
+            ),
+        )
+        work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+        task_request = session.query(TaskRequest).filter_by(id=work_item.task_request_id).one()
+        assert work_item.source_commit == source_commit
+        assert task_request.source_commit == source_commit
+        assert task_request.request_payload["source_requirement"]["required_sha"] == source_commit
+        assert len(work_item.command_manifest) == 18
+        assert all(
+            "--macro_manifest" in command["run"]
+            for command in work_item.command_manifest
+            if command["name"].startswith("run_block_sweep_")
+        )
+
+
+def test_temporal_finalizer_self_traffic_completes_without_protocol_error(
+    tmp_path: Path,
+) -> None:
+    if not (shutil.which("iverilog") and shutil.which("vvp")):
+        pytest.skip("iverilog/vvp unavailable")
+    config = _load(
+        REPO_ROOT
+        / "runs/designs/npu_blocks/"
+        "attention_score32_exact_partial_temporal_finalizer_physical_l8/config.json"
+    )
+    generate_temporal_finalizer(config, tmp_path)
+    tb = tmp_path / "tb.v"
+    tb.write_text(
+        """`timescale 1ns/1ps
+module tb;
+reg clk=0; always #5 clk=~clk;
+reg rst_n=0, start=0; reg [31:0] seed=32'h12345678;
+wire done; wire [31:0] protocol_error_count;
+wire [31:0] folded_result, cycle_count, source_accepted_count;
+wire [31:0] temporal_emitted_count, finalizer_completed_count;
+wire [31:0] state_request_count, state_read_count, state_write_count;
+wire [31:0] state_stall_count, output_stall_count;
+attention_score32_exact_partial_temporal_finalizer_physical_l8 dut(.*);
+initial begin
+  repeat(4) @(posedge clk); rst_n <= 1;
+  repeat(2) @(posedge clk); start <= 1;
+  @(posedge clk); start <= 0;
+  wait(done); @(posedge clk);
+  if(source_accepted_count != 64 || temporal_emitted_count != 32
+      || finalizer_completed_count != 32 || protocol_error_count != 0)
+    $fatal(1, "invalid physical-harness self traffic");
+  $finish;
+end
+initial begin #1000000; $fatal(1, "timeout"); end
+endmodule
+""",
+        encoding="utf-8",
+    )
+    simv = tmp_path / "simv"
+    compile_result = subprocess.run(
+        [
+            _tool("iverilog"),
+            "-g2012",
+            "-s",
+            "tb",
+            "-o",
+            str(simv),
+            str(tmp_path / "top.v"),
+            str(REPO_ROOT / "npu/sim/rtl/fakeram45_64x32_model.sv"),
+            str(tb),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert compile_result.returncode == 0, compile_result.stderr
+    run_result = subprocess.run(
+        [_tool("vvp"), str(simv)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert run_result.returncode == 0, run_result.stdout + run_result.stderr


### PR DESCRIPTION
## Summary
- add narrow-I/O SRAM temporal-reducer + root-finalizer physical harnesses for divider lanes 1/2/4/8
- add separate source-domain and destination-domain diagnostics for the 464-bit depth-4 async FIFO
- preserve exactly 104 fakeram45_64x32 state macros and reject inferred wide state arrays
- add Nangate45 sweeps, guards, proposal linkage, and L1 task-generator support

## Physical contract
- temporal/finalizer: one real temporal clock domain, 1600um die / 1500um core, density 0.4, periods 6/8/10/12ns
- CDC: selected-domain diagnostics only; no common-clock, MTBF, or cross-domain signoff claim
- service clock island and external HBM remain outside these points

## Task items after merge
- `l1_decoder_attention_exact_partial_temporal_finalizer_physical_calibration_v1`
- `l1_decoder_attention_exact_partial_async_fifo_domain_physical_calibration_v1`

Both must be generated from merged origin/master so `source_requirement.required_sha` pins the merge commit.

## Verification
Focused physical + SRAM suite: 16 passed. No job dispatched from this branch.
