### PR TITLE
eval: bound exact-partial temporal physical calibration

### DIFF
--- a/docs/proposals/prop_l1_decoder_attention_exact_partial_temporal_finalizer_bounded_physical_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_decoder_attention_exact_partial_temporal_finalizer_bounded_physical_v1/evaluation_requests.json
@@ -1,0 +1,38 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_exact_partial_temporal_finalizer_bounded_physical_v1",
+  "source_commit_note": "Dispatch only after this proposal is merged. Pin source_requirement.required_sha to the merge commit containing the bounded 12 ns sweep and proposal linkage.",
+  "requested_items": [
+    {
+      "item_id": "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1",
+      "task_type": "l1_sweep",
+      "title": "Exact-partial temporal/finalizer bounded 12 ns physical calibration",
+      "objective": "Run one 12 ns Nangate45 macro-mode point for divider_lanes 1, 2, 4, and 8.",
+      "status": "ready_to_queue",
+      "evaluation_mode": "physical_calibration",
+      "abstraction_layer": "decoder_attention_exact_partial_temporal_finalizer",
+      "comparison_role": "bounded_single_clock_island_physical_anchor",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l1/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l4/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_exact_partial_physical_calibration_v2/sweeps/nangate45_temporal_finalizer_12ns.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l1/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l1/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l2/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l2/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l4/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l4/timing_debug_report.md",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l8/timing_debug_report.md"
+      ],
+      "acceptance_notes": "Require exactly one status=ok row per design, CLOCK_PERIOD=12ns, critical_path_ns<=12ns, exactly 104 fakeram45_64x32 instances, no missing blackboxes, and no generic /16777215 operator. Treat total_power_mw as generic OpenROAD physical power only.",
+      "notes": "The prior lane1 6ns routed checkpoint measured critical_path_ns=9.3036, instance_area_um2=394956, total_power_mw=0.0605, and 104 macros after 3769.82 seconds. It is retained as explicit timing-infeasible boundary evidence and is not repeated."
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_decoder_attention_exact_partial_temporal_finalizer_bounded_physical_v1/proposal.json
+++ b/docs/proposals/prop_l1_decoder_attention_exact_partial_temporal_finalizer_bounded_physical_v1/proposal.json
@@ -1,0 +1,69 @@
+{
+  "proposal_id": "prop_l1_decoder_attention_exact_partial_temporal_finalizer_bounded_physical_v1",
+  "created_utc": "2026-08-07T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "title": "Bounded exact-partial temporal/finalizer physical calibration",
+  "abstraction_layer": "decoder_attention_exact_partial_temporal_finalizer",
+  "hypothesis": "A single conservative 12 ns implementation point per divider-lane variant can establish timing-feasible physical anchors without repeating the hour-scale infeasible 6 ns and likely infeasible 8 ns flows.",
+  "direct_comparison": {
+    "primary_question": "Which divider-lane temporal/finalizer variants are physically feasible at 12 ns, and what timing, area, and generic OpenROAD power do they measure?",
+    "baselines": [
+      "l1_decoder_attention_exact_partial_temporal_finalizer_physical_calibration_v1_r1 lane1 6ns routed checkpoint"
+    ],
+    "candidate": [
+      "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1"
+    ],
+    "include": [
+      "divider_lanes 1, 2, 4, and 8 as separate design points",
+      "exactly 104 fakeram45_64x32 state macros per design",
+      "bit-exact mersenne24_correction2_exact scale division",
+      "one 12 ns clock request per design"
+    ],
+    "exclude": [
+      "repeating the infeasible 6 ns lane1 point",
+      "an exhaustive 6/8/10/12 ns sweep",
+      "activity-backed temporal/finalizer token energy",
+      "a common-clock timing claim across the async FIFO"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "instance_area_um2",
+      "stdcell_area_um2",
+      "total_power_mw",
+      "macro_count",
+      "flow_status"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure one conservative 12 ns Nangate45 macro-mode point for each exact-partial temporal/finalizer divider-lane variant.",
+      "status": "pending",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": [
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l1/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l2/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l4/config.json",
+        "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l8/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_exact_partial_physical_calibration_v2/sweeps/nangate45_temporal_finalizer_12ns.json",
+      "out_root": "runs/designs/npu_blocks",
+      "notes": "Generate only after merge and pin source_requirement.required_sha to the merge commit containing this bounded request. Refine at 10 ns only for variants whose 12 ns routed critical path leaves meaningful margin."
+    }
+  ],
+  "remaining_abstractions": [
+    "Temporal/finalizer power is generic OpenROAD physical power, not workload-activity-backed token energy.",
+    "The independently measured service and async FIFO remain separate clock islands until bounded composition recost.",
+    "CDC MTBF and synchronizer library-cell signoff remain open."
+  ],
+  "source_refs": [
+    "docs/proposals/prop_l1_decoder_attention_exact_partial_physical_calibration_v1/proposal.json",
+    "npu/rtlgen/gen_attention_score32_exact_partial_temporal_finalizer_physical_harness.py",
+    "npu/eval/check_attention_exact_partial_physical_calibration_guard.py",
+    "runs/campaigns/npu/attention_exact_partial_physical_calibration_v2/sweeps/nangate45_temporal_finalizer_12ns.json"
+  ]
+}

--- a/runs/campaigns/npu/attention_exact_partial_physical_calibration_v2/sweeps/nangate45_temporal_finalizer_12ns.json
+++ b/runs/campaigns/npu/attention_exact_partial_physical_calibration_v2/sweeps/nangate45_temporal_finalizer_12ns.json
@@ -1,0 +1,20 @@
+{
+  "tag_prefix": "attention_exact_partial_temporal_finalizer_12ns_v1",
+  "flow_params": {
+    "CLOCK_PERIOD": [
+      12.0
+    ],
+    "DIE_AREA": [
+      "0 0 1600 1600"
+    ],
+    "CORE_AREA": [
+      "50 50 1550 1550"
+    ],
+    "PLACE_DENSITY": [
+      0.4
+    ],
+    "SYNTH_HIERARCHICAL": [
+      1
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- replace the hour-scale exhaustive 6/8/10/12 ns temporal/finalizer sweep with one 12 ns point per divider-lane design
- retain the completed lane1 6 ns routed row as explicit timing-infeasible boundary evidence
- require timing-feasible 12 ns rows, 104 SRAM macros, and generic-power provenance before selective 10 ns refinement

## Measured checkpoint
- lane1 at requested 6 ns: `critical_path_ns=9.3036`, `instance_area_um2=394956`, `total_power_mw=0.0605`, 104 macros, `flow_elapsed_seconds=3769.82`
- worst slack: `-2.69 ns`

## Verification
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest tests/test_attention_exact_partial_physical_calibration.py -q` (9 passed)
- `python3 scripts/validate_runs.py --skip_eval_queue`
