### PR TITLE
Add finalized CDC lane probe campaign

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -699,6 +699,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "decode_score_multivalue_service_exact_partial_equivalence_report",
     ),
     (
+        "decode_score_multivalue_service_finalized_cdc_lane_probe_out",
+        "decode_score_multivalue_service_finalized_cdc_lane_probe_report",
+    ),
+    (
         "score_bank_proxy_equivalence_out",
         "score_bank_proxy_equivalence_report",
     ),

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -7764,6 +7764,90 @@ def _decoder_attention_decode_score_multivalue_service_exact_partial_equivalence
     }
 
 
+def _decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_evidence(
+    *,
+    item_id: str,
+    proposal_id: str | None = None,
+    proposal_path: str | None = None,
+) -> dict[str, Any]:
+    expected_proposal_id = (
+        "prop_l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_v1"
+    )
+    expected_proposal_path = f"docs/proposals/{expected_proposal_id}/proposal.json"
+    if str(proposal_id or "").strip() != expected_proposal_id:
+        raise Layer2TaskGenerationError("finalized-CDC lane probe proposal_id mismatch")
+    if str(proposal_path or "").strip() != expected_proposal_path:
+        raise Layer2TaskGenerationError("finalized-CDC lane probe proposal_path mismatch")
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    campaign = (
+        "runs/campaigns/npu/"
+        "attention_decode_score_multivalue_service_finalized_cdc_lane_probe_v1/campaign.json"
+    )
+    out_root = (
+        f"{base}/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__"
+        f"{item_id}"
+    )
+    lane_outputs = [f"{out_root}/lane{lane}.json" for lane in (1, 2, 4, 8)]
+    campaign_summary = f"{out_root}/campaign_summary.json"
+    command = _bounded_launcher_command(
+        memory_high="6G",
+        memory_max="8G",
+        cpu_quota="300%",
+        tasks_max=256,
+        runtime_max_sec=2400,
+        child_command=[
+            "python3",
+            "npu/eval/run_attention_decode_score_multivalue_service_finalized_cdc_lane_campaign.py",
+            "--campaign",
+            campaign,
+            "--out-root",
+            out_root,
+        ],
+    )
+    return {
+        "inputs": {
+            "decode_score_multivalue_service_finalized_cdc_lane_probe_campaign": campaign,
+            "decode_score_multivalue_service_finalized_cdc_lane_probe_out": campaign_summary,
+            "decode_score_multivalue_service_finalized_cdc_lane_probe_lane1_json": lane_outputs[0],
+            "decode_score_multivalue_service_finalized_cdc_lane_probe_lane2_json": lane_outputs[1],
+            "decode_score_multivalue_service_finalized_cdc_lane_probe_lane4_json": lane_outputs[2],
+            "decode_score_multivalue_service_finalized_cdc_lane_probe_lane8_json": lane_outputs[3],
+            "decode_score_multivalue_service_finalized_cdc_lane_probe_scope": (
+                "Run exactly four lane-matched finalized-CDC functional probes at service_period_ns=10 "
+                "and temporal_period_ns=12 with SRAM temporal state and macro-banked service value memory. "
+                "Emit only recost-compatible per-lane summaries plus one aggregate manifest; do not emit "
+                "row histories, generated RTL manifests, physical PPA, or activity-energy claims."
+            ),
+        },
+        "commands": [
+            {
+                "name": "probe_decode_score_multivalue_service_finalized_cdc_lanes_10ns_12ns",
+                "run": command,
+            }
+        ],
+        "expected_outputs": [*lane_outputs, campaign_summary],
+        "evidence_only": True,
+        "worker_resources": {
+            "exclusive_worker": True,
+            "memory_high": "6G",
+            "memory_max": "8G",
+            "cpu_quota": "300%",
+            "tasks_max": 256,
+            "outer_timeout_seconds": 2400,
+            "stall_timeout_seconds": 600,
+        },
+        "acceptance": [
+            "Write exactly four per-lane JSON summaries and one campaign_summary.json",
+            "Require divider_lanes [1,2,4,8], service_period_ns=10, and temporal_period_ns=12",
+            "Require temporal_state_backend=sram and service_value_memory_backend=macro_banked_4x16x64x32",
+            "Require every lane passed=true with zero protocol, state, and CDC errors",
+            "Require every lane summary to be directly consumable by the exact-partial physical recost audit",
+            "Do not include observed_rows, expected_rows, generated RTL manifests, or macro manifests",
+            "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing",
+        ],
+    }
+
+
 def _decoder_attention_decode_score_multivalue_service_activity_power_evidence(
     *, item_id: str, depends_on_item_ids: list[str] | None = None
 ) -> dict[str, Any]:
@@ -11868,6 +11952,7 @@ def _build_payload(
         "decoder_attention_decode_score_multivalue_cluster_activity_power",
         "decoder_attention_decode_score_multivalue_integrated_service",
         "decoder_attention_decode_score_multivalue_service_exact_partial_equivalence",
+        "decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe",
         "decoder_attention_decode_score_multivalue_service_activity_power",
         "decoder_attention_decode_score_multivalue_service_measured_frontier",
         "decoder_attention_decode_score_multivalue_gqa_group_activity_power",
@@ -12148,6 +12233,17 @@ def _build_payload(
         ):
             decoder_evidence = (
                 _decoder_attention_decode_score_multivalue_service_exact_partial_equivalence_evidence(
+                    item_id=item_id,
+                    proposal_id=proposal_id,
+                    proposal_path=proposal_path,
+                )
+            )
+        elif (
+            abstraction_layer_name
+            == "decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe"
+        ):
+            decoder_evidence = (
+                _decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_evidence(
                     item_id=item_id,
                     proposal_id=proposal_id,
                     proposal_path=proposal_path,

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -9738,6 +9738,92 @@ def test_generate_l2_campaign_task_adds_exact_partial_integrated_service_equival
             assert work_item.state == WorkItemState.BLOCKED
 
 
+def test_generate_l2_campaign_task_adds_finalized_cdc_lane_probe_campaign() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        item_id = (
+            "l2_decoder_attention_decode_score_multivalue_service_"
+            "finalized_cdc_lane_probe_10ns_12ns_v1"
+        )
+        proposal_id = (
+            "prop_l2_decoder_attention_decode_score_multivalue_service_"
+            "finalized_cdc_lane_probe_v1"
+        )
+        proposal_path = f"docs/proposals/{proposal_id}/proposal.json"
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=item_id,
+                    proposal_id=proposal_id,
+                    proposal_path=proposal_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer=(
+                        "decoder_attention_decode_score_multivalue_service_"
+                        "finalized_cdc_lane_probe"
+                    ),
+                    evaluation_mode="equivalence",
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=False,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            payload = work_item.task_request.request_payload
+            commands = payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands] == [
+                "probe_decode_score_multivalue_service_finalized_cdc_lanes_10ns_12ns",
+                "validate_runs",
+            ]
+            assert "control_plane/scripts/run_bounded_command.py" in run
+            assert "--memory-max 8G" in run
+            assert "--runtime-max-sec 2400" in run
+            assert (
+                "run_attention_decode_score_multivalue_service_finalized_cdc_lane_campaign.py"
+                in run
+            )
+            assert "attention_decode_score_multivalue_service_finalized_cdc_lane_probe_v1/campaign.json" in run
+            assert decoder_inputs[
+                "decode_score_multivalue_service_finalized_cdc_lane_probe_out"
+            ].endswith("campaign_summary.json")
+            expected_outputs = payload["task"]["expected_outputs"]
+            assert len(expected_outputs) == 5
+            assert [Path(path).name for path in expected_outputs] == [
+                "lane1.json",
+                "lane2.json",
+                "lane4.json",
+                "lane8.json",
+                "campaign_summary.json",
+            ]
+            expected_worker_resources = {
+                "exclusive_worker": True,
+                "memory_high": "6G",
+                "memory_max": "8G",
+                "cpu_quota": "300%",
+                "tasks_max": 256,
+                "outer_timeout_seconds": 2400,
+                "stall_timeout_seconds": 600,
+            }
+            assert work_item.input_manifest["worker_resources"] == expected_worker_resources
+            assert payload["task"]["inputs"]["worker_resources"] == expected_worker_resources
+            assert payload["source_requirement"]["required_sha"] == source_commit
+            assert payload["source_requirement"]["required_ref"] == "origin/master"
+            assert payload["source_requirement"]["requires_daemon_restart"] is True
+
+
 def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_activity_power() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_v1/evaluation_requests.json
@@ -1,0 +1,30 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_v1",
+  "source_commit_note": "Do not dispatch from this development branch. After merge, generate the task from current origin/master so source_requirement.required_sha pins the merged bounded campaign and requires evaluator refresh.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1",
+      "task_type": "l2_campaign",
+      "title": "Finalized-CDC lane-matched 10 ns / 12 ns functional probes",
+      "objective": "Run divider_lanes 1, 2, 4, and 8 at service_period_ns=10 and temporal_period_ns=12 with SRAM temporal state and macro-banked service value memory.",
+      "status": "ready_to_queue_after_merge",
+      "evaluation_mode": "equivalence",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe",
+      "comparison_role": "lane_matched_functional_cycle_calibration",
+      "cost_class": "bounded_medium",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": false,
+      "run_physical": false,
+      "campaign_path": "runs/campaigns/npu/attention_decode_score_multivalue_service_finalized_cdc_lane_probe_v1/campaign.json",
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1/lane1.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1/lane2.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1/lane4.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1/lane8.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1/campaign_summary.json"
+      ],
+      "acceptance_notes": "Require exactly four passing summaries with divider_lanes [1,2,4,8], service_period_ns=10, temporal_period_ns=12, temporal_state_backend=sram, service_value_memory_backend=macro_banked_4x16x64x32, zero protocol/state/CDC errors, and no bulky observed_rows, expected_rows, generated RTL manifest, or macro manifest fields. Each lane JSON must be accepted directly by the exact-partial physical recost functional-probe validator.",
+      "notes": "The driver runs points sequentially under the control-plane bounded launcher. Queue only after merge from origin/master; do not dispatch this preparation branch."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_v1/proposal.json
@@ -1,0 +1,67 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_v1",
+  "created_utc": "2026-08-08T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Lane-matched finalized-CDC functional probes at the bounded 10 ns / 12 ns clock pair",
+  "abstraction_layer": "decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe",
+  "hypothesis": "Running the SRAM/macro-backed finalized dual-clock service at the exact selected service and temporal periods for divider_lanes 1, 2, 4, and 8 will provide cycle evidence that can be paired without clock-ratio or lane-count substitution in exact-partial physical recosting.",
+  "direct_comparison": {
+    "primary_question": "Do all four divider-lane variants preserve finalized exact-partial functional behavior at service_period_ns=10 and temporal_period_ns=12 with the physical-memory backends enabled, and what elapsed service/temporal cycle counts do they report?",
+    "include": [
+      "service_period_ns=10",
+      "temporal_period_ns=12",
+      "divider_lanes 1, 2, 4, and 8",
+      "temporal_state_backend=sram",
+      "service_value_memory_backend=macro_banked_4x16x64x32",
+      "one lightweight recost-compatible JSON summary per lane",
+      "one aggregate campaign summary with hashes and output paths"
+    ],
+    "exclude": [
+      "physical synthesis or place-and-route",
+      "OpenROAD critical-path composition across CDC",
+      "activity-backed token energy",
+      "observed/expected row histories in committed outputs",
+      "generated RTL and macro manifests in committed outputs",
+      "clock pairs or lane values outside the fixed four-point campaign"
+    ],
+    "metrics": [
+      "passed",
+      "service_cycles",
+      "temporal_cycles elapsed wall-clock",
+      "finalizer_cycles diagnostic counter",
+      "CDC accepted/emitted counts",
+      "finalizer completed count",
+      "protocol and state error counters"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the fixed four-point finalized-CDC functional probe campaign and emit lightweight lane-matched recost inputs.",
+      "evaluation_mode": "equivalence",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe",
+      "comparison_role": "lane_matched_functional_cycle_calibration",
+      "status": "pending_implementation_merge",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": false,
+      "run_physical": false,
+      "notes": "Generate and dispatch only from merged origin/master so source_requirement.required_sha includes the bounded driver, campaign contract, task wiring, and tests. This development branch must not be dispatched."
+    }
+  ],
+  "source_refs": [
+    "npu/eval/probe_attention_decode_score_multivalue_service_finalized_cdc.py",
+    "npu/eval/run_attention_decode_score_multivalue_service_finalized_cdc_lane_campaign.py",
+    "runs/campaigns/npu/attention_decode_score_multivalue_service_finalized_cdc_lane_probe_v1/campaign.json",
+    "npu/eval/audit_attention_decode_score_multivalue_service_exact_partial_physical_recost.py",
+    "docs/proposals/prop_l1_decoder_attention_exact_partial_temporal_finalizer_bounded_physical_v1/proposal.json"
+  ],
+  "remaining_abstractions_after_this_step": [
+    "The functional probe does not establish physical timing; it only supplies cycle counts for independently selected physical periods.",
+    "The finalizer counter overlaps the elapsed temporal counter and remains diagnostic rather than an added latency phase.",
+    "CDC MTBF and synchronizer library-cell signoff remain open.",
+    "Composed activity-backed token energy remains open."
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_v1/quality_gate.md
@@ -1,0 +1,8 @@
+# Quality gate
+
+- The campaign contract fixes service period 10 ns, temporal period 12 ns, divider lanes 1/2/4/8, SRAM temporal state, and macro-banked service value memory.
+- The driver rejects any other point set or backend and publishes no new output directory when a probe fails.
+- Every per-lane output remains compatible with `audit_attention_decode_score_multivalue_service_exact_partial_physical_recost.py` and omits row histories and generated manifests.
+- Focused driver and control-plane task-generation tests pass.
+- `python3 scripts/validate_runs.py --skip_eval_queue` passes.
+- Dispatch is prohibited until this proposal is merged and the task is generated from the merged `origin/master` SHA.

--- a/npu/eval/run_attention_decode_score_multivalue_service_finalized_cdc_lane_campaign.py
+++ b/npu/eval/run_attention_decode_score_multivalue_service_finalized_cdc_lane_campaign.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Run the bounded lane-matched finalized-CDC functional probe campaign."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+import sys
+import tempfile
+from typing import Any, Callable
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from npu.eval.probe_attention_decode_score_multivalue_service_finalized_cdc import (
+    build_report as build_probe_report,
+)
+
+
+JsonDict = dict[str, Any]
+ProbeRunner = Callable[..., JsonDict]
+
+_CAMPAIGN_MODEL = "attention_decode_score_multivalue_service_finalized_cdc_lane_campaign_v1"
+_PROBE_MODEL = "attention_decode_score_multivalue_service_finalized_cdc_probe_v1"
+_SERVICE_PERIOD_NS = 10.0
+_TEMPORAL_PERIOD_NS = 12.0
+_DIVIDER_LANES = (1, 2, 4, 8)
+_TEMPORAL_STATE_BACKEND = "sram"
+_SERVICE_VALUE_MEMORY_BACKEND = "macro_banked_4x16x64x32"
+_SUMMARY_MODEL = "attention_decode_score_multivalue_service_finalized_cdc_probe_v1"
+_AGGREGATE_MODEL = "attention_decode_score_multivalue_service_finalized_cdc_lane_campaign_summary_v1"
+_PROPOSAL_ID = "prop_l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_v1"
+_PROPOSAL_PATH = f"docs/proposals/{_PROPOSAL_ID}/proposal.json"
+
+
+def _load_json(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return payload
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _portable_path(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(_REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.resolve().as_posix()
+
+
+def _string(value: Any, label: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{label} must be a non-empty string")
+    return text
+
+
+def _finite_float(value: Any, label: str) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be finite") from exc
+    if not math.isfinite(result) or result <= 0.0:
+        raise ValueError(f"{label} must be positive and finite")
+    return result
+
+
+def _validate_campaign(payload: JsonDict) -> JsonDict:
+    if _string(payload.get("model"), "campaign model") != _CAMPAIGN_MODEL:
+        raise ValueError("campaign model mismatch")
+    campaign_id = _string(payload.get("campaign_id"), "campaign_id")
+    proposal_ref = payload.get("proposal_ref")
+    if not isinstance(proposal_ref, dict):
+        raise ValueError("campaign requires proposal_ref")
+    proposal_id = _string(proposal_ref.get("proposal_id"), "proposal_ref.proposal_id")
+    proposal_path = _string(proposal_ref.get("proposal_path"), "proposal_ref.proposal_path")
+    if proposal_id != _PROPOSAL_ID or proposal_path != _PROPOSAL_PATH:
+        raise ValueError("campaign proposal_ref must match the finalized-CDC lane-probe proposal")
+
+    fixed = payload.get("fixed_parameters")
+    if not isinstance(fixed, dict):
+        raise ValueError("campaign requires fixed_parameters")
+    service_period_ns = _finite_float(fixed.get("service_period_ns"), "service_period_ns")
+    temporal_period_ns = _finite_float(fixed.get("temporal_period_ns"), "temporal_period_ns")
+    if service_period_ns != _SERVICE_PERIOD_NS or temporal_period_ns != _TEMPORAL_PERIOD_NS:
+        raise ValueError("campaign periods must be exactly service=10ns and temporal=12ns")
+    if _string(fixed.get("temporal_state_backend"), "temporal_state_backend") != _TEMPORAL_STATE_BACKEND:
+        raise ValueError("campaign temporal_state_backend must be sram")
+    if (
+        _string(fixed.get("service_value_memory_backend"), "service_value_memory_backend")
+        != _SERVICE_VALUE_MEMORY_BACKEND
+    ):
+        raise ValueError("campaign service_value_memory_backend must be macro_banked_4x16x64x32")
+
+    raw_lanes = payload.get("divider_lanes")
+    if not isinstance(raw_lanes, list) or any(isinstance(value, bool) for value in raw_lanes):
+        raise ValueError("campaign divider_lanes must be a list")
+    try:
+        lanes = tuple(int(value) for value in raw_lanes)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("campaign divider_lanes must contain integers") from exc
+    if lanes != _DIVIDER_LANES:
+        raise ValueError("campaign divider_lanes must be exactly [1, 2, 4, 8]")
+
+    return {
+        "campaign_id": campaign_id,
+        "proposal_ref": {
+            "proposal_id": proposal_id,
+            "proposal_path": proposal_path,
+        },
+        "service_period_ns": service_period_ns,
+        "temporal_period_ns": temporal_period_ns,
+        "divider_lanes": lanes,
+        "temporal_state_backend": _TEMPORAL_STATE_BACKEND,
+        "service_value_memory_backend": _SERVICE_VALUE_MEMORY_BACKEND,
+    }
+
+
+def _lightweight_probe_summary(report: JsonDict, *, campaign: JsonDict, lane: int) -> JsonDict:
+    if report.get("passed") is not True:
+        raise RuntimeError(f"finalized-CDC probe failed for divider_lanes={lane}")
+    if _string(report.get("model"), "probe model") != _PROBE_MODEL:
+        raise ValueError(f"probe model mismatch for divider_lanes={lane}")
+    expected_values = {
+        "service_period_ns": campaign["service_period_ns"],
+        "temporal_period_ns": campaign["temporal_period_ns"],
+        "divider_lanes": lane,
+        "temporal_state_backend": campaign["temporal_state_backend"],
+        "service_value_memory_backend": campaign["service_value_memory_backend"],
+    }
+    for key, expected in expected_values.items():
+        if report.get(key) != expected:
+            raise ValueError(f"probe {key} mismatch for divider_lanes={lane}")
+    summary = report.get("summary")
+    if not isinstance(summary, dict) or not summary:
+        raise ValueError(f"probe summary missing for divider_lanes={lane}")
+    normalized_summary: dict[str, int] = {}
+    for key, value in summary.items():
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError(f"probe summary.{key} must be an integer for divider_lanes={lane}")
+        normalized_summary[str(key)] = value
+
+    return {
+        "model": _SUMMARY_MODEL,
+        "passed": True,
+        "service_period_ns": campaign["service_period_ns"],
+        "temporal_period_ns": campaign["temporal_period_ns"],
+        "divider_lanes": lane,
+        "temporal_state_backend": campaign["temporal_state_backend"],
+        "service_value_memory_backend": campaign["service_value_memory_backend"],
+        "summary": dict(sorted(normalized_summary.items())),
+        "campaign_provenance": {
+            "campaign_id": campaign["campaign_id"],
+            "proposal_ref": campaign["proposal_ref"],
+            "full_probe_rows_omitted": True,
+            "generated_rtl_manifests_omitted": True,
+        },
+    }
+
+
+def run_campaign(
+    *,
+    campaign_path: Path,
+    out_root: Path,
+    probe_runner: ProbeRunner = build_probe_report,
+) -> JsonDict:
+    campaign_path = campaign_path.resolve()
+    out_root = out_root.resolve()
+    campaign = _validate_campaign(_load_json(campaign_path))
+    out_root.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="finalized-cdc-lane-campaign-", dir=out_root.parent) as temp_name:
+        stage_root = Path(temp_name)
+        staged: list[tuple[Path, Path, JsonDict]] = []
+        for lane in campaign["divider_lanes"]:
+            print(f"running finalized-CDC probe divider_lanes={lane}", flush=True)
+            full_report = probe_runner(
+                service_period_ns=campaign["service_period_ns"],
+                temporal_period_ns=campaign["temporal_period_ns"],
+                divider_lanes=lane,
+                temporal_state_backend=campaign["temporal_state_backend"],
+                service_value_memory_backend=campaign["service_value_memory_backend"],
+            )
+            summary = _lightweight_probe_summary(full_report, campaign=campaign, lane=lane)
+            staged_path = stage_root / f"lane{lane}.json"
+            staged_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            staged.append((staged_path, out_root / staged_path.name, summary))
+            print(f"passed finalized-CDC probe divider_lanes={lane}", flush=True)
+
+        point_rows = [
+            {
+                "divider_lanes": summary["divider_lanes"],
+                "output": _portable_path(final_path),
+                "sha256": _sha256(staged_path),
+                "service_cycles": summary["summary"].get("service_cycles"),
+                "temporal_cycles": summary["summary"].get("temporal_cycles"),
+                "finalizer_cycles_diagnostic": summary["summary"].get("finalizer_cycles"),
+            }
+            for staged_path, final_path, summary in staged
+        ]
+        aggregate = {
+            "model": _AGGREGATE_MODEL,
+            "campaign_id": campaign["campaign_id"],
+            "passed": True,
+            "proposal_ref": campaign["proposal_ref"],
+            "campaign_path": _portable_path(campaign_path),
+            "campaign_sha256": _sha256(campaign_path),
+            "fixed_parameters": {
+                "service_period_ns": campaign["service_period_ns"],
+                "temporal_period_ns": campaign["temporal_period_ns"],
+                "temporal_state_backend": campaign["temporal_state_backend"],
+                "service_value_memory_backend": campaign["service_value_memory_backend"],
+            },
+            "divider_lanes": list(campaign["divider_lanes"]),
+            "point_count": len(point_rows),
+            "points": point_rows,
+            "artifact_contract": {
+                "per_lane_outputs_are_direct_recost_functional_probe_inputs": True,
+                "observed_and_expected_rows_omitted": True,
+                "generated_rtl_manifests_omitted": True,
+            },
+        }
+        aggregate_stage = stage_root / "campaign_summary.json"
+        aggregate_stage.write_text(json.dumps(aggregate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+        out_root.mkdir(parents=True, exist_ok=True)
+        for staged_path, final_path, _summary in staged:
+            staged_path.replace(final_path)
+        aggregate_stage.replace(out_root / "campaign_summary.json")
+    return aggregate
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--campaign", type=Path, required=True)
+    parser.add_argument("--out-root", type=Path, required=True)
+    args = parser.parse_args(argv)
+    run_campaign(campaign_path=args.campaign, out_root=args.out_root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runs/campaigns/npu/attention_decode_score_multivalue_service_finalized_cdc_lane_probe_v1/campaign.json
+++ b/runs/campaigns/npu/attention_decode_score_multivalue_service_finalized_cdc_lane_probe_v1/campaign.json
@@ -1,0 +1,20 @@
+{
+  "model": "attention_decode_score_multivalue_service_finalized_cdc_lane_campaign_v1",
+  "campaign_id": "attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1",
+  "proposal_ref": {
+    "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_v1",
+    "proposal_path": "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_v1/proposal.json"
+  },
+  "fixed_parameters": {
+    "service_period_ns": 10.0,
+    "temporal_period_ns": 12.0,
+    "temporal_state_backend": "sram",
+    "service_value_memory_backend": "macro_banked_4x16x64x32"
+  },
+  "divider_lanes": [
+    1,
+    2,
+    4,
+    8
+  ]
+}

--- a/tests/test_run_attention_decode_score_multivalue_service_finalized_cdc_lane_campaign.py
+++ b/tests/test_run_attention_decode_score_multivalue_service_finalized_cdc_lane_campaign.py
@@ -1,0 +1,148 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from npu.eval.audit_attention_decode_score_multivalue_service_exact_partial_physical_recost import (
+    _validate_functional_probe,
+)
+from npu.eval.run_attention_decode_score_multivalue_service_finalized_cdc_lane_campaign import (
+    _lightweight_probe_summary,
+    _validate_campaign,
+    run_campaign,
+)
+
+
+PROPOSAL_ID = "prop_l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_v1"
+
+
+def _campaign() -> dict:
+    return {
+        "model": "attention_decode_score_multivalue_service_finalized_cdc_lane_campaign_v1",
+        "campaign_id": "attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1",
+        "proposal_ref": {
+            "proposal_id": PROPOSAL_ID,
+            "proposal_path": f"docs/proposals/{PROPOSAL_ID}/proposal.json",
+        },
+        "fixed_parameters": {
+            "service_period_ns": 10.0,
+            "temporal_period_ns": 12.0,
+            "temporal_state_backend": "sram",
+            "service_value_memory_backend": "macro_banked_4x16x64x32",
+        },
+        "divider_lanes": [1, 2, 4, 8],
+    }
+
+
+def _probe_report(lane: int, *, passed: bool = True) -> dict:
+    return {
+        "model": "attention_decode_score_multivalue_service_finalized_cdc_probe_v1",
+        "passed": passed,
+        "service_period_ns": 10.0,
+        "temporal_period_ns": 12.0,
+        "divider_lanes": lane,
+        "temporal_state_backend": "sram",
+        "service_value_memory_backend": "macro_banked_4x16x64x32",
+        "observed_rows": [[lane, 1, 2, 3]],
+        "expected_rows": [[lane, 1, 2, 3]],
+        "manifest": {"large": "omitted"},
+        "macro_manifest": {"large": "omitted"},
+        "summary": {
+            "service_cycles": 120,
+            "temporal_cycles": 36 + lane,
+            "finalizer_cycles": 20 - lane,
+            "cdc_accepted": 32,
+            "cdc_emitted": 32,
+            "finalizer_completed": 16,
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("mutation", "error"),
+    [
+        (lambda payload: payload["fixed_parameters"].update(service_period_ns=9.0), "periods must be exactly"),
+        (lambda payload: payload["fixed_parameters"].update(temporal_state_backend="behavioral"), "must be sram"),
+        (
+            lambda payload: payload["fixed_parameters"].update(service_value_memory_backend="behavioral"),
+            "must be macro_banked_4x16x64x32",
+        ),
+        (lambda payload: payload.update(divider_lanes=[1, 2, 8]), r"exactly \[1, 2, 4, 8\]"),
+        (lambda payload: payload["proposal_ref"].update(proposal_id="prop_wrong"), "proposal_ref must match"),
+    ],
+)
+def test_validate_campaign_rejects_unbounded_contract(mutation, error: str) -> None:
+    payload = _campaign()
+    mutation(payload)
+    with pytest.raises(ValueError, match=error):
+        _validate_campaign(payload)
+
+
+def test_lightweight_summary_is_direct_recost_input() -> None:
+    campaign = _validate_campaign(_campaign())
+    summary = _lightweight_probe_summary(_probe_report(4), campaign=campaign, lane=4)
+
+    assert summary["model"] == "attention_decode_score_multivalue_service_finalized_cdc_probe_v1"
+    assert summary["divider_lanes"] == 4
+    assert summary["service_period_ns"] == 10.0
+    assert summary["temporal_period_ns"] == 12.0
+    assert summary["temporal_state_backend"] == "sram"
+    assert summary["service_value_memory_backend"] == "macro_banked_4x16x64x32"
+    assert "observed_rows" not in summary
+    assert "expected_rows" not in summary
+    assert "manifest" not in summary
+    assert "macro_manifest" not in summary
+    assert _validate_functional_probe(summary)["divider_lanes"] == 4
+
+
+def test_run_campaign_writes_four_atomic_lightweight_outputs(tmp_path: Path) -> None:
+    campaign_path = tmp_path / "campaign.json"
+    campaign_path.write_text(json.dumps(_campaign()), encoding="utf-8")
+    calls: list[dict] = []
+
+    def probe_runner(**kwargs):
+        calls.append(kwargs)
+        return _probe_report(kwargs["divider_lanes"])
+
+    out_root = tmp_path / "outputs"
+    aggregate = run_campaign(
+        campaign_path=campaign_path,
+        out_root=out_root,
+        probe_runner=probe_runner,
+    )
+
+    assert [call["divider_lanes"] for call in calls] == [1, 2, 4, 8]
+    assert all(call["service_period_ns"] == 10.0 for call in calls)
+    assert all(call["temporal_period_ns"] == 12.0 for call in calls)
+    assert all(call["temporal_state_backend"] == "sram" for call in calls)
+    assert all(call["service_value_memory_backend"] == "macro_banked_4x16x64x32" for call in calls)
+    assert aggregate["passed"] is True
+    assert aggregate["point_count"] == 4
+    assert sorted(path.name for path in out_root.iterdir()) == [
+        "campaign_summary.json",
+        "lane1.json",
+        "lane2.json",
+        "lane4.json",
+        "lane8.json",
+    ]
+    for lane in (1, 2, 4, 8):
+        payload = json.loads((out_root / f"lane{lane}.json").read_text(encoding="utf-8"))
+        assert payload["divider_lanes"] == lane
+        assert _validate_functional_probe(payload)["temporal_period_ns"] == 12.0
+
+
+def test_run_campaign_publishes_nothing_when_a_probe_fails(tmp_path: Path) -> None:
+    campaign_path = tmp_path / "campaign.json"
+    campaign_path.write_text(json.dumps(_campaign()), encoding="utf-8")
+    out_root = tmp_path / "outputs"
+
+    def probe_runner(**kwargs):
+        return _probe_report(kwargs["divider_lanes"], passed=kwargs["divider_lanes"] != 4)
+
+    with pytest.raises(RuntimeError, match="divider_lanes=4"):
+        run_campaign(
+            campaign_path=campaign_path,
+            out_root=out_root,
+            probe_runner=probe_runner,
+        )
+    assert not out_root.exists()


### PR DESCRIPTION
## Summary
- add a fixed 10 ns service / 12 ns temporal finalized-CDC probe campaign for divider lanes 1, 2, 4, and 8
- use SRAM temporal state and macro-banked service value memory, while retaining only lightweight recost-compatible outputs
- wire a bounded exclusive remote L2 task and artifact consumer contract

## Validation
- focused campaign/probe tests: 11 passed
- focused control-plane task-generator test: passed
- direct evaluator-style CLI campaign: passed
- `python3 scripts/validate_runs.py --skip_eval_queue`: passed
- full task-generator suite: 246 passed; one unrelated pre-existing origin/master manifest/test mismatch for service-activity `_r3`