### PR TITLE
Add exact-partial composed physical recost campaign

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -703,6 +703,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "decode_score_multivalue_service_finalized_cdc_lane_probe_report",
     ),
     (
+        "decode_score_multivalue_service_exact_partial_physical_recost_out",
+        "decode_score_multivalue_service_exact_partial_physical_recost_report",
+    ),
+    (
         "score_bank_proxy_equivalence_out",
         "score_bank_proxy_equivalence_report",
     ),

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -7848,6 +7848,108 @@ def _decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_
     }
 
 
+def _decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_evidence(
+    *,
+    item_id: str,
+    depends_on_item_ids: list[str] | None = None,
+    proposal_id: str | None = None,
+    proposal_path: str | None = None,
+) -> dict[str, Any]:
+    expected_proposal_id = (
+        "prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1"
+    )
+    expected_proposal_path = f"docs/proposals/{expected_proposal_id}/proposal.json"
+    if str(proposal_id or "").strip() != expected_proposal_id:
+        raise Layer2TaskGenerationError("exact-partial physical recost proposal_id mismatch")
+    if str(proposal_path or "").strip() != expected_proposal_path:
+        raise Layer2TaskGenerationError("exact-partial physical recost proposal_path mismatch")
+    required_dependencies = [
+        "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
+        (
+            "l2_decoder_attention_decode_score_multivalue_service_"
+            "finalized_cdc_lane_probe_10ns_12ns_v1"
+        ),
+    ]
+    normalized_dependencies = [
+        str(dependency).strip()
+        for dependency in (depends_on_item_ids or [])
+        if str(dependency).strip()
+    ]
+    if normalized_dependencies != required_dependencies:
+        raise Layer2TaskGenerationError(
+            "exact-partial physical recost requires the exact physical and functional dependency items"
+        )
+
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    campaign = (
+        "runs/campaigns/npu/"
+        "attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/campaign.json"
+    )
+    output_prefix = (
+        f"{base}/decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost__"
+        f"{item_id}"
+    )
+    out = f"{output_prefix}.json"
+    csv_out = f"{output_prefix}.csv"
+    command = _bounded_launcher_command(
+        memory_high="2G",
+        memory_max="4G",
+        cpu_quota="200%",
+        tasks_max=128,
+        runtime_max_sec=300,
+        child_command=[
+            "python3",
+            "npu/eval/run_attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign.py",
+            "--campaign",
+            campaign,
+            "--out",
+            out,
+            "--csv-out",
+            csv_out,
+        ],
+    )
+    return {
+        "inputs": {
+            "decode_score_multivalue_service_exact_partial_physical_recost_campaign": campaign,
+            "decode_score_multivalue_service_exact_partial_physical_recost_service_anchor": (
+                f"{base}/decoder_attention_decode_score_multivalue_service_activity_power__"
+                "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1_r8.json"
+            ),
+            "decode_score_multivalue_service_exact_partial_physical_recost_physical_dependency_item_id": (
+                required_dependencies[0]
+            ),
+            "decode_score_multivalue_service_exact_partial_physical_recost_functional_dependency_item_id": (
+                required_dependencies[1]
+            ),
+            "decode_score_multivalue_service_exact_partial_physical_recost_out": out,
+            "decode_score_multivalue_service_exact_partial_physical_recost_csv_out": csv_out,
+            "decode_score_multivalue_service_exact_partial_physical_recost_scope": (
+                "Compose divider_lanes 1, 2, 4, and 8 from the promoted c1 r8 activity anchor, "
+                "lane-matched 12 ns temporal/finalizer rows, 10 ns source and 12 ns destination FIFO "
+                "views, and hashed finalized-CDC summaries. Preserve overlap/serial timing bounds and "
+                "provisional energy provenance; emit one aggregate JSON and one four-row CSV only."
+            ),
+        },
+        "commands": [
+            {
+                "name": "audit_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns",
+                "run": command,
+            }
+        ],
+        "expected_outputs": [out, csv_out],
+        "evidence_only": True,
+        "acceptance": [
+            "Require both exact dependency items to be merged and materialized",
+            "Require four lane-matched rows ordered [1,2,4,8]",
+            "Preserve overlap lower bounds and serial upper bounds from functional elapsed cycles",
+            "Preserve bounded provisional energy provenance and do not claim exact token energy",
+            "Count one canonical source-domain FIFO while validating both FIFO domain views",
+            "Write exactly one aggregate JSON report and one four-row CSV",
+            "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing",
+        ],
+    }
+
+
 def _decoder_attention_decode_score_multivalue_service_activity_power_evidence(
     *, item_id: str, depends_on_item_ids: list[str] | None = None
 ) -> dict[str, Any]:
@@ -11953,6 +12055,7 @@ def _build_payload(
         "decoder_attention_decode_score_multivalue_integrated_service",
         "decoder_attention_decode_score_multivalue_service_exact_partial_equivalence",
         "decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe",
+        "decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost",
         "decoder_attention_decode_score_multivalue_service_activity_power",
         "decoder_attention_decode_score_multivalue_service_measured_frontier",
         "decoder_attention_decode_score_multivalue_gqa_group_activity_power",
@@ -12245,6 +12348,18 @@ def _build_payload(
             decoder_evidence = (
                 _decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_evidence(
                     item_id=item_id,
+                    proposal_id=proposal_id,
+                    proposal_path=proposal_path,
+                )
+            )
+        elif (
+            abstraction_layer_name
+            == "decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost"
+        ):
+            decoder_evidence = (
+                _decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_evidence(
+                    item_id=item_id,
+                    depends_on_item_ids=depends_on_item_ids,
                     proposal_id=proposal_id,
                     proposal_path=proposal_path,
                 )

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -327,6 +327,33 @@ def test_decoder_evidence_paths_recognizes_decode_score_multivalue_service_activ
     }
 
 
+def test_decoder_evidence_paths_recognizes_exact_partial_physical_recost(
+    tmp_path: Path,
+) -> None:
+    evidence_rel = "runs/datasets/demo/exact_partial_physical_recost.json"
+    _write(tmp_path / evidence_rel, "{}\n")
+    work_item = SimpleNamespace(
+        input_manifest={
+            "decoder_contract": {
+                "decode_score_multivalue_service_exact_partial_physical_recost_out": (
+                    evidence_rel
+                )
+            }
+        }
+    )
+
+    evidence_ref, source_refs = _decoder_evidence_paths(
+        repo_root=tmp_path, work_item=work_item
+    )
+
+    assert evidence_ref == evidence_rel
+    assert source_refs == {
+        "decoder_decode_score_multivalue_service_exact_partial_physical_recost_out": (
+            evidence_rel
+        )
+    }
+
+
 @pytest.mark.parametrize(
     "prefix",
     [

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -8,6 +8,7 @@ import subprocess
 import tempfile
 from unittest.mock import patch
 
+import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
@@ -78,6 +79,21 @@ def _write_committed_finalized_cdc_lane_campaign(repo_root: Path) -> str:
     relative_path = Path(
         "runs/campaigns/npu/"
         "attention_decode_score_multivalue_service_finalized_cdc_lane_probe_v1/"
+        "campaign.json"
+    )
+    source_path = Path(__file__).resolve().parents[3] / relative_path
+    destination_path = repo_root / relative_path
+    destination_path.parent.mkdir(parents=True, exist_ok=True)
+    destination_path.write_text(
+        source_path.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    return relative_path.as_posix()
+
+
+def _write_committed_exact_partial_physical_recost_campaign(repo_root: Path) -> str:
+    relative_path = Path(
+        "runs/campaigns/npu/"
+        "attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/"
         "campaign.json"
     )
     source_path = Path(__file__).resolve().parents[3] / relative_path
@@ -9837,6 +9853,131 @@ def test_generate_l2_campaign_task_adds_finalized_cdc_lane_probe_campaign() -> N
             assert payload["source_requirement"]["required_sha"] == source_commit
             assert payload["source_requirement"]["required_ref"] == "origin/master"
             assert payload["source_requirement"]["requires_daemon_restart"] is True
+
+
+def test_generate_l2_campaign_task_adds_exact_partial_physical_recost_consumer() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_committed_exact_partial_physical_recost_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        item_id = (
+            "l2_decoder_attention_decode_score_multivalue_service_"
+            "exact_partial_physical_recost_10ns_12ns_v1"
+        )
+        proposal_id = (
+            "prop_l2_decoder_attention_decode_score_multivalue_service_"
+            "exact_partial_physical_recost_v1"
+        )
+        proposal_path = f"docs/proposals/{proposal_id}/proposal.json"
+        dependencies = [
+            "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
+            (
+                "l2_decoder_attention_decode_score_multivalue_service_"
+                "finalized_cdc_lane_probe_10ns_12ns_v1"
+            ),
+        ]
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=item_id,
+                    proposal_id=proposal_id,
+                    proposal_path=proposal_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer=(
+                        "decoder_attention_decode_score_multivalue_service_"
+                        "exact_partial_physical_recost"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    depends_on_item_ids=dependencies,
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            payload = work_item.task_request.request_payload
+            commands = payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands] == [
+                "audit_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns",
+                "validate_runs",
+            ]
+            assert "control_plane/scripts/run_bounded_command.py" in run
+            assert "--memory-max 4G" in run
+            assert "--runtime-max-sec 300" in run
+            assert (
+                "run_attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign.py"
+                in run
+            )
+            assert "--csv-out" in run
+            assert payload["task"]["expected_outputs"] == [
+                decoder_inputs["decode_score_multivalue_service_exact_partial_physical_recost_out"],
+                decoder_inputs["decode_score_multivalue_service_exact_partial_physical_recost_csv_out"],
+            ]
+            assert payload["developer_loop"]["dependencies"] == {
+                "item_ids": dependencies,
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": True,
+            }
+            assert payload["source_requirement"]["required_sha"] == source_commit
+            assert payload["source_requirement"]["required_ref"] == "origin/master"
+            assert work_item.state == WorkItemState.BLOCKED
+
+
+def test_exact_partial_physical_recost_consumer_rejects_missing_dependency() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_committed_exact_partial_physical_recost_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session, pytest.raises(
+            Layer2TaskGenerationError, match="requires the exact physical and functional dependency"
+        ):
+            generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=(
+                        "l2_decoder_attention_decode_score_multivalue_service_"
+                        "exact_partial_physical_recost_10ns_12ns_v1"
+                    ),
+                    proposal_id=(
+                        "prop_l2_decoder_attention_decode_score_multivalue_service_"
+                        "exact_partial_physical_recost_v1"
+                    ),
+                    proposal_path=(
+                        "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_"
+                        "exact_partial_physical_recost_v1/proposal.json"
+                    ),
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer=(
+                        "decoder_attention_decode_score_multivalue_service_"
+                        "exact_partial_physical_recost"
+                    ),
+                    depends_on_item_ids=[
+                        "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1"
+                    ],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
 
 
 def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_activity_power() -> None:

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/evaluation_requests.json
@@ -1,0 +1,31 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1",
+  "source_commit_note": "After merge and after both dependency outputs are materialized, generate from current origin/master so source_requirement.required_sha pins the merged aggregate driver and consumer wiring. Do not dispatch this preparation branch.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1",
+      "task_type": "l2_campaign",
+      "title": "Exact-partial composed-service 10 ns / 12 ns physical recost",
+      "objective": "Record one fail-closed aggregate report and four-row CSV for divider_lanes 1, 2, 4, and 8.",
+      "status": "ready_to_queue_after_merge_and_dependencies",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost",
+      "comparison_role": "lane_matched_composed_physical_recost",
+      "cost_class": "lightweight",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
+        "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "campaign_path": "runs/campaigns/npu/attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/campaign.json",
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost__l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost__l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1.csv"
+      ],
+      "acceptance_notes": "Fail closed unless both exact dependency items are satisfied and all four lane-matched 12 ns temporal bundles plus hashed finalized-CDC probe summaries are materialized. Require four rows ordered [1,2,4,8], source-domain single-FIFO accounting from the 10 ns row, the 12 ns destination diagnostic row, preserved overlap/serial timing bounds, and bounded provisional energy provenance. Emit no per-lane recost files.",
+      "notes": "Queue only from merged origin/master after dependency materialization. This preparation request must not be dispatched."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/proposal.json
@@ -1,0 +1,74 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1",
+  "created_utc": "2026-08-08T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Lane-matched exact-partial composed-service physical recost",
+  "abstraction_layer": "decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost",
+  "hypothesis": "Composing the promoted c1 activity anchor with lane-matched 12 ns temporal/finalizer rows, the measured 10 ns source and 12 ns destination FIFO views, and finalized-CDC cycle probes will establish conservative overlap/serial timing bounds and additive physical cost for divider lanes 1, 2, 4, and 8 without overstating token energy.",
+  "direct_comparison": {
+    "primary_question": "What four-point physical recost is obtained when every divider lane uses its matching temporal measurement and finalized-CDC probe at the selected 10 ns / 12 ns domain periods?",
+    "include": [
+      "promoted c1 service activity anchor r8",
+      "divider_lanes 1, 2, 4, and 8",
+      "one timing-feasible 12 ns temporal/finalizer physical row plus config and macro manifest per lane",
+      "the 10 ns source-domain and 12 ns destination-domain async FIFO rows plus configs and manifests",
+      "one matching lightweight finalized-CDC functional probe per lane",
+      "one aggregate JSON report and one four-row CSV"
+    ],
+    "exclude": [
+      "dispatch from the preparation branch",
+      "a routed whole-top dual-clock signoff claim",
+      "adding both FIFO domain views to composed area or power",
+      "using OpenROAD critical paths as CDC latency",
+      "claiming exact composed token energy",
+      "bulky per-lane report artifacts"
+    ],
+    "metrics": [
+      "overlap_lower_bound_ns",
+      "serial_upper_bound_ns",
+      "throughput bounds",
+      "composed_instance_area_um2",
+      "generic_composed_total_power_mw",
+      "provisional energy provenance"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1",
+      "task_type": "l2_campaign",
+      "objective": "Record the fail-closed four-lane exact-partial composed-service physical recost at the selected 10 ns / 12 ns domain pair.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost",
+      "comparison_role": "lane_matched_composed_physical_recost",
+      "depends_on_item_ids": [
+        "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
+        "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "status": "pending_implementation_merge",
+      "expected_result": {
+        "direction": "record_bounded_exact_partial_composed_service_physical_recost",
+        "reason": "Preserve lane-matched functional cycle counts, overlap and serial timing bounds, single-FIFO accounting, additive standalone physical measurements, and bounded provisional energy provenance across all four divider-lane points."
+      },
+      "notes": "Generate only after this implementation and both dependency outputs are merged/materialized on current origin/master. Do not dispatch, open a PR, or queue from this preparation branch."
+    }
+  ],
+  "source_refs": [
+    "npu/eval/audit_attention_decode_score_multivalue_service_exact_partial_physical_recost.py",
+    "npu/eval/run_attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign.py",
+    "runs/campaigns/npu/attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/campaign.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_activity_power__l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1_r8.json",
+    "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_source_domain_physical/metrics.csv",
+    "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_destination_domain_physical/metrics.csv"
+  ],
+  "remaining_abstractions_after_this_step": [
+    "The composed physical result is an additive normalization of independently routed clock islands, not whole-top route signoff.",
+    "CDC latency remains bounded from functional elapsed cycles and selected domain periods; CDC MTBF and synchronizer-cell signoff remain open.",
+    "Temporal/finalizer and FIFO power remain generic OpenROAD estimates, so composed activity-backed token energy remains open.",
+    "The service activity-window cycle count remains distinct from the finalized-CDC functional service-cycle count."
+  ]
+}

--- a/npu/eval/run_attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign.py
+++ b/npu/eval/run_attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Compose the four lane-matched exact-partial physical recost points."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from pathlib import Path
+import sys
+import tempfile
+from typing import Any, Callable
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from npu.eval.audit_attention_decode_score_multivalue_service_exact_partial_physical_recost import (
+    build_report as build_recost_report,
+)
+
+
+JsonDict = dict[str, Any]
+AuditRunner = Callable[..., JsonDict]
+
+_CAMPAIGN_MODEL = "attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign_v1"
+_SUMMARY_MODEL = "attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign_summary_v1"
+_AUDIT_MODEL = "decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1"
+_CAMPAIGN_ID = "attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1"
+_PROPOSAL_ID = "prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1"
+_PROPOSAL_PATH = f"docs/proposals/{_PROPOSAL_ID}/proposal.json"
+_PHYSICAL_DEPENDENCY = "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1"
+_FUNCTIONAL_DEPENDENCY = (
+    "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1"
+)
+_DEPENDENCIES = (_PHYSICAL_DEPENDENCY, _FUNCTIONAL_DEPENDENCY)
+_LANES = (1, 2, 4, 8)
+_SERVICE_PERIOD_NS = 10.0
+_TEMPORAL_PERIOD_NS = 12.0
+_SERVICE_ANCHOR = (
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+    "decoder_attention_decode_score_multivalue_service_activity_power__"
+    "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1_r8.json"
+)
+_FUNCTIONAL_ROOT = (
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+    "decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__"
+    f"{_FUNCTIONAL_DEPENDENCY}"
+)
+_FUNCTIONAL_SUMMARY_MODEL = (
+    "attention_decode_score_multivalue_service_finalized_cdc_lane_campaign_summary_v1"
+)
+_FUNCTIONAL_CAMPAIGN_ID = (
+    "attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1"
+)
+
+
+def _load_json(path: Path) -> JsonDict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return payload
+
+
+def _string(value: Any, label: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{label} must be a non-empty string")
+    return text
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _repo_path(repo_root: Path, value: Any, label: str) -> Path:
+    relative = Path(_string(value, label))
+    if relative.is_absolute():
+        raise ValueError(f"{label} must be repository-relative")
+    resolved = (repo_root / relative).resolve()
+    try:
+        resolved.relative_to(repo_root.resolve())
+    except ValueError as exc:
+        raise ValueError(f"{label} escapes the repository") from exc
+    return resolved
+
+
+def _require_file(path: Path, label: str) -> Path:
+    if not path.is_file():
+        raise ValueError(f"{label} is not materialized: {path}")
+    return path
+
+
+def _validate_campaign(payload: JsonDict) -> JsonDict:
+    if _string(payload.get("model"), "campaign model") != _CAMPAIGN_MODEL:
+        raise ValueError("campaign model mismatch")
+    if _string(payload.get("campaign_id"), "campaign_id") != _CAMPAIGN_ID:
+        raise ValueError("campaign_id mismatch")
+    proposal_ref = payload.get("proposal_ref")
+    if not isinstance(proposal_ref, dict) or proposal_ref != {
+        "proposal_id": _PROPOSAL_ID,
+        "proposal_path": _PROPOSAL_PATH,
+    }:
+        raise ValueError("campaign proposal_ref mismatch")
+    dependencies = payload.get("depends_on_item_ids")
+    if dependencies != list(_DEPENDENCIES):
+        raise ValueError("campaign must require exactly the physical and functional dependency items")
+
+    fixed = payload.get("fixed_inputs")
+    if not isinstance(fixed, dict):
+        raise ValueError("campaign requires fixed_inputs")
+    if fixed.get("service_activity_power_json") != _SERVICE_ANCHOR:
+        raise ValueError("campaign must use the promoted c1 service activity anchor r8")
+    if fixed.get("service_period_ns") != _SERVICE_PERIOD_NS:
+        raise ValueError("campaign service_period_ns must be 10")
+    if fixed.get("temporal_period_ns") != _TEMPORAL_PERIOD_NS:
+        raise ValueError("campaign temporal_period_ns must be 12")
+    if fixed.get("fifo_canonical_timed_domain") != "source":
+        raise ValueError("campaign must use source-domain canonical FIFO accounting")
+    expected_summary = f"{_FUNCTIONAL_ROOT}/campaign_summary.json"
+    if fixed.get("functional_probe_summary_json") != expected_summary:
+        raise ValueError("campaign functional probe summary must come from the required functional item")
+
+    for domain in ("source", "destination"):
+        fifo = fixed.get(f"async_fifo_{domain}")
+        expected_design = f"attention_exact_partial_async_fifo_d4_{domain}_domain_physical"
+        expected_root = f"runs/designs/npu_blocks/{expected_design}"
+        if not isinstance(fifo, dict) or fifo != {
+            "design": expected_design,
+            "metrics_csv": f"{expected_root}/metrics.csv",
+            "config_json": f"{expected_root}/config.json",
+            "macro_manifest_json": f"{expected_root}/macro_manifest.json",
+        }:
+            raise ValueError(f"campaign async_fifo_{domain} bundle mismatch")
+
+    points = payload.get("points")
+    if not isinstance(points, list) or len(points) != len(_LANES):
+        raise ValueError("campaign requires exactly four points")
+    for point, lane in zip(points, _LANES, strict=True):
+        design = f"attention_score32_exact_partial_temporal_finalizer_physical_l{lane}"
+        design_root = f"runs/designs/npu_blocks/{design}"
+        expected = {
+            "divider_lanes": lane,
+            "temporal_design": design,
+            "temporal_metrics_csv": f"{design_root}/metrics.csv",
+            "temporal_config_json": f"{design_root}/config.json",
+            "temporal_macro_manifest_json": f"{design_root}/macro_manifest.json",
+            "functional_probe_json": f"{_FUNCTIONAL_ROOT}/lane{lane}.json",
+        }
+        if point != expected:
+            raise ValueError(f"campaign point mismatch for divider_lanes={lane}")
+    return payload
+
+
+def _validate_functional_summary(
+    *, summary_path: Path, campaign: JsonDict, repo_root: Path
+) -> None:
+    summary = _load_json(summary_path)
+    if summary.get("model") != _FUNCTIONAL_SUMMARY_MODEL or summary.get("passed") is not True:
+        raise ValueError("functional dependency campaign summary must be passing")
+    if summary.get("campaign_id") != _FUNCTIONAL_CAMPAIGN_ID:
+        raise ValueError("functional dependency campaign summary campaign_id mismatch")
+    fixed = summary.get("fixed_parameters")
+    if not isinstance(fixed, dict) or fixed.get("service_period_ns") != _SERVICE_PERIOD_NS:
+        raise ValueError("functional dependency campaign summary service period mismatch")
+    if fixed.get("temporal_period_ns") != _TEMPORAL_PERIOD_NS:
+        raise ValueError("functional dependency campaign summary temporal period mismatch")
+    if summary.get("divider_lanes") != list(_LANES) or summary.get("point_count") != len(_LANES):
+        raise ValueError("functional dependency campaign summary lane set mismatch")
+    points = summary.get("points")
+    if not isinstance(points, list) or len(points) != len(_LANES):
+        raise ValueError("functional dependency campaign summary points mismatch")
+    for point, campaign_point, lane in zip(points, campaign["points"], _LANES, strict=True):
+        if not isinstance(point, dict) or point.get("divider_lanes") != lane:
+            raise ValueError(f"functional dependency summary lane mismatch for divider_lanes={lane}")
+        probe_path = _require_file(
+            _repo_path(repo_root, campaign_point["functional_probe_json"], "functional_probe_json"),
+            f"functional probe lane {lane}",
+        )
+        if point.get("output") != campaign_point["functional_probe_json"]:
+            raise ValueError(f"functional dependency output path mismatch for divider_lanes={lane}")
+        if point.get("sha256") != _sha256(probe_path):
+            raise ValueError(f"functional dependency hash mismatch for divider_lanes={lane}")
+
+
+def _audit_kwargs(*, campaign: JsonDict, point: JsonDict, repo_root: Path) -> JsonDict:
+    fixed = campaign["fixed_inputs"]
+    source = fixed["async_fifo_source"]
+    destination = fixed["async_fifo_destination"]
+    raw_paths = {
+        "service_activity_power_json": fixed["service_activity_power_json"],
+        "temporal_metrics_csv": point["temporal_metrics_csv"],
+        "temporal_config_json": point["temporal_config_json"],
+        "temporal_macro_manifest_json": point["temporal_macro_manifest_json"],
+        "async_fifo_source_metrics_csv": source["metrics_csv"],
+        "async_fifo_source_config_json": source["config_json"],
+        "async_fifo_source_macro_manifest_json": source["macro_manifest_json"],
+        "async_fifo_destination_metrics_csv": destination["metrics_csv"],
+        "async_fifo_destination_config_json": destination["config_json"],
+        "async_fifo_destination_macro_manifest_json": destination["macro_manifest_json"],
+        "functional_probe_json": point["functional_probe_json"],
+    }
+    paths = {
+        key: _require_file(_repo_path(repo_root, value, key), key)
+        for key, value in raw_paths.items()
+    }
+    return {
+        **paths,
+        "temporal_design": point["temporal_design"],
+        "temporal_clock_period_ns": fixed["temporal_period_ns"],
+        "async_fifo_source_design": source["design"],
+        "async_fifo_source_clock_period_ns": fixed["service_period_ns"],
+        "async_fifo_destination_design": destination["design"],
+        "async_fifo_destination_clock_period_ns": fixed["temporal_period_ns"],
+        "fifo_canonical_timed_domain": fixed["fifo_canonical_timed_domain"],
+        "csv_out": None,
+    }
+
+
+def _lightweight_point(report: JsonDict, *, lane: int) -> JsonDict:
+    rows = report.get("rows")
+    if report.get("model") != _AUDIT_MODEL or not isinstance(rows, list) or len(rows) != 1:
+        raise ValueError(f"recost audit returned an invalid report for divider_lanes={lane}")
+    row = rows[0]
+    if not isinstance(row, dict) or row.get("divider_lanes") != lane:
+        raise ValueError(f"recost audit returned the wrong lane for divider_lanes={lane}")
+    timing_bounds = report.get("timing_bounds")
+    if not isinstance(timing_bounds, dict):
+        raise ValueError(f"recost audit omitted timing bounds for divider_lanes={lane}")
+    composed = report.get("composed_physical")
+    if not isinstance(composed, dict) or not isinstance(composed.get("power_provenance"), dict):
+        raise ValueError(f"recost audit omitted physical power provenance for divider_lanes={lane}")
+    if not isinstance(composed.get("composition_contract"), dict):
+        raise ValueError(f"recost audit omitted composition contract for divider_lanes={lane}")
+    energy = report.get("energy_contract")
+    if not isinstance(energy, dict) or energy.get("exact_token_energy_claimed") is not False:
+        raise ValueError(f"recost audit overstated energy status for divider_lanes={lane}")
+    return {
+        "divider_lanes": lane,
+        "candidate_id": report.get("candidate_id"),
+        "inputs": report.get("inputs"),
+        "input_hashes": report.get("input_hashes"),
+        "timing_bounds": timing_bounds,
+        "composed_physical": {
+            key: composed.get(key)
+            for key in (
+                "instance_area_um2",
+                "instance_area_mm2",
+                "generic_composed_total_power_mw",
+                "service_activity_window_power_mw",
+                "service_activity_window_energy_j",
+                "power_provenance",
+                "composition_contract",
+            )
+        },
+        "energy_contract": energy,
+        "functional_contract": report.get("functional_contract"),
+    }
+
+
+def run_campaign(
+    *,
+    campaign_path: Path,
+    out: Path,
+    csv_out: Path,
+    repo_root: Path = _REPO_ROOT,
+    audit_runner: AuditRunner = build_recost_report,
+) -> JsonDict:
+    repo_root = repo_root.resolve()
+    campaign_path = campaign_path.resolve()
+    campaign = _validate_campaign(_load_json(campaign_path))
+    summary_path = _require_file(
+        _repo_path(
+            repo_root,
+            campaign["fixed_inputs"]["functional_probe_summary_json"],
+            "functional_probe_summary_json",
+        ),
+        "functional dependency campaign summary",
+    )
+    _validate_functional_summary(summary_path=summary_path, campaign=campaign, repo_root=repo_root)
+
+    rows: list[JsonDict] = []
+    point_summaries: list[JsonDict] = []
+    for point in campaign["points"]:
+        lane = point["divider_lanes"]
+        print(f"recosting exact-partial composed service divider_lanes={lane}", flush=True)
+        report = audit_runner(**_audit_kwargs(campaign=campaign, point=point, repo_root=repo_root))
+        point_summary = _lightweight_point(report, lane=lane)
+        rows.append(report["rows"][0])
+        point_summaries.append(point_summary)
+
+    fieldnames = list(rows[0])
+    if any(list(row) != fieldnames for row in rows):
+        raise ValueError("recost audit CSV row schemas differ across lanes")
+    summary = {
+        "model": _SUMMARY_MODEL,
+        "decision": "exact_partial_composed_service_physical_recost_campaign_recorded",
+        "campaign_id": _CAMPAIGN_ID,
+        "passed": True,
+        "proposal_ref": campaign["proposal_ref"],
+        "dependency_contract": {
+            "depends_on_item_ids": list(_DEPENDENCIES),
+            "both_dependencies_required": True,
+            "both_dependencies_materialized": True,
+        },
+        "campaign_path": campaign_path.relative_to(repo_root).as_posix(),
+        "campaign_sha256": _sha256(campaign_path),
+        "functional_dependency_summary_sha256": _sha256(summary_path),
+        "divider_lanes": list(_LANES),
+        "point_count": len(rows),
+        "points": point_summaries,
+        "rows": rows,
+        "artifact_contract": {
+            "one_aggregate_json": True,
+            "one_four_row_csv": True,
+            "per_lane_recost_reports_omitted": True,
+            "overlap_and_serial_bounds_preserved": True,
+            "provisional_energy_provenance_preserved": True,
+        },
+    }
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    csv_out.parent.mkdir(parents=True, exist_ok=True)
+    if out.parent.resolve() != csv_out.parent.resolve():
+        raise ValueError("aggregate JSON and CSV outputs must share a directory")
+    with tempfile.TemporaryDirectory(prefix="exact-partial-physical-recost-", dir=out.parent) as temp_name:
+        stage_root = Path(temp_name)
+        staged_json = stage_root / out.name
+        staged_csv = stage_root / csv_out.name
+        staged_json.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        with staged_csv.open("w", encoding="utf-8", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(rows)
+        staged_json.replace(out)
+        staged_csv.replace(csv_out)
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--campaign", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--csv-out", type=Path, required=True)
+    args = parser.parse_args(argv)
+    run_campaign(campaign_path=args.campaign, out=args.out, csv_out=args.csv_out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runs/campaigns/npu/attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/campaign.json
+++ b/runs/campaigns/npu/attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/campaign.json
@@ -1,0 +1,72 @@
+{
+  "model": "attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign_v1",
+  "campaign_id": "attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1",
+  "proposal_ref": {
+    "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1",
+    "proposal_path": "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/proposal.json"
+  },
+  "depends_on_item_ids": [
+    "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
+    "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1"
+  ],
+  "fixed_inputs": {
+    "service_activity_power_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_activity_power__l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1_r8.json",
+    "service_period_ns": 10.0,
+    "temporal_period_ns": 12.0,
+    "fifo_canonical_timed_domain": "source",
+    "async_fifo_source": {
+      "design": "attention_exact_partial_async_fifo_d4_source_domain_physical",
+      "metrics_csv": "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_source_domain_physical/metrics.csv",
+      "config_json": "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_source_domain_physical/config.json",
+      "macro_manifest_json": "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_source_domain_physical/macro_manifest.json"
+    },
+    "async_fifo_destination": {
+      "design": "attention_exact_partial_async_fifo_d4_destination_domain_physical",
+      "metrics_csv": "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_destination_domain_physical/metrics.csv",
+      "config_json": "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_destination_domain_physical/config.json",
+      "macro_manifest_json": "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_destination_domain_physical/macro_manifest.json"
+    },
+    "functional_probe_summary_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1/campaign_summary.json"
+  },
+  "points": [
+    {
+      "divider_lanes": 1,
+      "temporal_design": "attention_score32_exact_partial_temporal_finalizer_physical_l1",
+      "temporal_metrics_csv": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l1/metrics.csv",
+      "temporal_config_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l1/config.json",
+      "temporal_macro_manifest_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l1/macro_manifest.json",
+      "functional_probe_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1/lane1.json"
+    },
+    {
+      "divider_lanes": 2,
+      "temporal_design": "attention_score32_exact_partial_temporal_finalizer_physical_l2",
+      "temporal_metrics_csv": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l2/metrics.csv",
+      "temporal_config_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l2/config.json",
+      "temporal_macro_manifest_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l2/macro_manifest.json",
+      "functional_probe_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1/lane2.json"
+    },
+    {
+      "divider_lanes": 4,
+      "temporal_design": "attention_score32_exact_partial_temporal_finalizer_physical_l4",
+      "temporal_metrics_csv": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l4/metrics.csv",
+      "temporal_config_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l4/config.json",
+      "temporal_macro_manifest_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l4/macro_manifest.json",
+      "functional_probe_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1/lane4.json"
+    },
+    {
+      "divider_lanes": 8,
+      "temporal_design": "attention_score32_exact_partial_temporal_finalizer_physical_l8",
+      "temporal_metrics_csv": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l8/metrics.csv",
+      "temporal_config_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l8/config.json",
+      "temporal_macro_manifest_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l8/macro_manifest.json",
+      "functional_probe_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1/lane8.json"
+    }
+  ],
+  "outputs": {
+    "campaign_dir": "runs/campaigns/npu/attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/results",
+    "results_csv": "runs/campaigns/npu/attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/results/results.csv",
+    "report_md": "runs/campaigns/npu/attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/results/report.md",
+    "report_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost__l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1.json",
+    "rows_csv": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost__l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1.csv"
+  }
+}

--- a/tests/test_run_attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign.py
+++ b/tests/test_run_attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign.py
@@ -1,0 +1,189 @@
+import csv
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from npu.eval.run_attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign import (
+    _validate_campaign,
+    run_campaign,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CAMPAIGN_REL = Path(
+    "runs/campaigns/npu/"
+    "attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/campaign.json"
+)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _materialize_committed_campaign(tmp_path: Path) -> tuple[Path, dict]:
+    repo_root = tmp_path / "repo"
+    campaign_path = repo_root / CAMPAIGN_REL
+    campaign_path.parent.mkdir(parents=True)
+    campaign_path.write_text((REPO_ROOT / CAMPAIGN_REL).read_text(encoding="utf-8"), encoding="utf-8")
+    campaign = json.loads(campaign_path.read_text(encoding="utf-8"))
+    fixed = campaign["fixed_inputs"]
+
+    input_paths = [fixed["service_activity_power_json"]]
+    for domain in ("source", "destination"):
+        bundle = fixed[f"async_fifo_{domain}"]
+        input_paths.extend(
+            [bundle["metrics_csv"], bundle["config_json"], bundle["macro_manifest_json"]]
+        )
+    for point in campaign["points"]:
+        input_paths.extend(
+            [
+                point["temporal_metrics_csv"],
+                point["temporal_config_json"],
+                point["temporal_macro_manifest_json"],
+                point["functional_probe_json"],
+            ]
+        )
+    for relative in input_paths:
+        path = repo_root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"fixture for {relative}\n", encoding="utf-8")
+
+    summary_path = repo_root / fixed["functional_probe_summary_json"]
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary = {
+        "model": "attention_decode_score_multivalue_service_finalized_cdc_lane_campaign_summary_v1",
+        "campaign_id": "attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1",
+        "passed": True,
+        "fixed_parameters": {"service_period_ns": 10.0, "temporal_period_ns": 12.0},
+        "divider_lanes": [1, 2, 4, 8],
+        "point_count": 4,
+        "points": [
+            {
+                "divider_lanes": point["divider_lanes"],
+                "output": point["functional_probe_json"],
+                "sha256": _sha256(repo_root / point["functional_probe_json"]),
+            }
+            for point in campaign["points"]
+        ],
+    }
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+    return repo_root, campaign
+
+
+def _fake_audit(**kwargs) -> dict:
+    lane = int(str(kwargs["temporal_design"]).rsplit("_l", 1)[1])
+    assert kwargs["temporal_clock_period_ns"] == 12.0
+    assert kwargs["async_fifo_source_clock_period_ns"] == 10.0
+    assert kwargs["async_fifo_destination_clock_period_ns"] == 12.0
+    row = {
+        "divider_lanes": lane,
+        "candidate_id": f"candidate_l{lane}",
+        "overlap_lower_bound_ns": 1200.0 + lane,
+        "serial_upper_bound_ns": 1600.0 + lane,
+        "energy_status": "bounded_provisional_activity_plus_openroad_physical_power_not_exact_token_energy",
+    }
+    return {
+        "model": "decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1",
+        "candidate_id": row["candidate_id"],
+        "inputs": {"functional_probe_json": str(kwargs["functional_probe_json"])},
+        "input_hashes": {"functional_probe_json": {"file_sha256": _sha256(kwargs["functional_probe_json"])}},
+        "timing_bounds": {
+            "overlap_lower_bound_ns": row["overlap_lower_bound_ns"],
+            "serial_upper_bound_ns": row["serial_upper_bound_ns"],
+        },
+        "composed_physical": {
+            "instance_area_um2": 3_000_000.0 + lane,
+            "power_provenance": {
+                "generic_composed_total_power_mw": "homogeneous_generic_openroad_power_sum_only"
+            },
+            "composition_contract": {"fifo_instance_area_added_once": True},
+        },
+        "energy_contract": {
+            "status": row["energy_status"],
+            "exact_token_energy_claimed": False,
+        },
+        "functional_contract": {"divider_lanes": lane},
+        "rows": [row],
+    }
+
+
+def test_committed_campaign_contract_requires_exact_dependencies() -> None:
+    campaign = json.loads((REPO_ROOT / CAMPAIGN_REL).read_text(encoding="utf-8"))
+    validated = _validate_campaign(campaign)
+
+    assert [point["divider_lanes"] for point in validated["points"]] == [1, 2, 4, 8]
+    assert validated["depends_on_item_ids"] == [
+        "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
+        "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1",
+    ]
+
+    campaign["depends_on_item_ids"].pop()
+    with pytest.raises(ValueError, match="must require exactly"):
+        _validate_campaign(campaign)
+
+
+def test_run_campaign_writes_one_lightweight_report_and_four_row_csv(tmp_path: Path) -> None:
+    repo_root, _campaign = _materialize_committed_campaign(tmp_path)
+    out = repo_root / "outputs" / "recost.json"
+    csv_out = repo_root / "outputs" / "recost.csv"
+
+    summary = run_campaign(
+        campaign_path=repo_root / CAMPAIGN_REL,
+        out=out,
+        csv_out=csv_out,
+        repo_root=repo_root,
+        audit_runner=_fake_audit,
+    )
+
+    assert summary["passed"] is True
+    assert summary["divider_lanes"] == [1, 2, 4, 8]
+    assert summary["point_count"] == 4
+    assert summary["dependency_contract"]["both_dependencies_materialized"] is True
+    assert summary["artifact_contract"]["per_lane_recost_reports_omitted"] is True
+    assert summary["artifact_contract"]["overlap_and_serial_bounds_preserved"] is True
+    assert summary["artifact_contract"]["provisional_energy_provenance_preserved"] is True
+    assert all(point["energy_contract"]["exact_token_energy_claimed"] is False for point in summary["points"])
+    with csv_out.open("r", encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    assert [int(row["divider_lanes"]) for row in rows] == [1, 2, 4, 8]
+    assert sorted(path.name for path in out.parent.iterdir()) == ["recost.csv", "recost.json"]
+
+
+def test_run_campaign_fails_closed_on_missing_physical_lane(tmp_path: Path) -> None:
+    repo_root, campaign = _materialize_committed_campaign(tmp_path)
+    missing = repo_root / campaign["points"][2]["temporal_metrics_csv"]
+    missing.unlink()
+    out = repo_root / "outputs" / "recost.json"
+    csv_out = repo_root / "outputs" / "recost.csv"
+
+    with pytest.raises(ValueError, match="not materialized"):
+        run_campaign(
+            campaign_path=repo_root / CAMPAIGN_REL,
+            out=out,
+            csv_out=csv_out,
+            repo_root=repo_root,
+            audit_runner=_fake_audit,
+        )
+    assert not out.exists()
+    assert not csv_out.exists()
+
+
+def test_run_campaign_fails_closed_on_functional_probe_hash_mismatch(tmp_path: Path) -> None:
+    repo_root, campaign = _materialize_committed_campaign(tmp_path)
+    probe = repo_root / campaign["points"][0]["functional_probe_json"]
+    probe.write_text("changed after producer summary\n", encoding="utf-8")
+    out = repo_root / "outputs" / "recost.json"
+    csv_out = repo_root / "outputs" / "recost.csv"
+
+    with pytest.raises(ValueError, match="hash mismatch"):
+        run_campaign(
+            campaign_path=repo_root / CAMPAIGN_REL,
+            out=out,
+            csv_out=csv_out,
+            repo_root=repo_root,
+            audit_runner=_fake_audit,
+        )
+    assert not out.exists()
+    assert not csv_out.exists()


### PR DESCRIPTION
## Summary
- add a fail-closed four-lane composed physical recost campaign using measured service, temporal/finalizer, and both FIFO-domain inputs
- require the exact physical and finalized-CDC dependency items and verify functional artifact hashes
- preserve overlap/serial timing bounds, single-FIFO accounting, and provisional energy provenance in lightweight aggregate outputs
- wire L2 task generation and result consumption

## Validation
- focused campaign/task/consumer tests: 7 passed after review fix
- preparation branch focused suite: 31 passed
- `python3 scripts/validate_runs.py --skip_eval_queue`
- full L2 generator suite: 248 passed with one unrelated pre-existing stale `_r3` expectation