### PR TITLE
Define Llama7B BF16 RMSNorm reference contract

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -7,6 +7,7 @@ Current primary references still include:
 - `docs/developer_agent_artifacts.md`
 - `docs/metadata_schema.json`
 - `docs/runs_artifact_policy.md`
+- `docs/reference/llama7b_rmsnorm_bf16_contract.md`
 
 This directory is the target canonical home for a future cleanup of those
 reference materials.

--- a/docs/reference/llama7b_rmsnorm_bf16_contract.md
+++ b/docs/reference/llama7b_rmsnorm_bf16_contract.md
@@ -1,0 +1,114 @@
+# Llama-7B BF16 RMSNorm Contract
+
+This document defines the Phase 1 numerical and eventual streaming contract for
+a Llama-7B transformer RMSNorm block. The executable reference is
+`npu/eval/llama7b_rmsnorm_reference.py`.
+
+## Scope
+
+The operation is transformer RMSNorm over one hidden row:
+
+```text
+mean_square = sum(x[i] * x[i], i=0..4095) / 4096
+inv_rms     = 1 / sqrt(mean_square + 1e-6)
+y[i]        = (x[i] * inv_rms) * gamma[i]
+```
+
+There is no mean subtraction and no softmax, exponential, row-sum reciprocal,
+or probability normalization. Hidden size is fixed at `4096`; epsilon is fixed
+at decimal `1e-6`.
+
+Phase 1 provides a contract, executable model, and tests only. It does not
+provide RTL, PPA evidence, or an approximation for reciprocal square root.
+
+## Software input contract
+
+- `row` and `gamma` each contain exactly `4096` raw unsigned BF16 words.
+- Every word is an integer in `[0x0000, 0xffff]`; Python `bool` is not accepted.
+- `lanes` is a positive integer divisor of `4096`.
+- Shape, lane, and word validation completes before arithmetic starts. A
+  malformed argument raises `ValueError` and returns no partial output.
+- A legal lane count changes only the streaming grouping. It cannot change the
+  numerical result.
+
+## BF16 classification
+
+BF16 uses one sign bit, eight exponent bits, and seven fraction bits.
+
+- Exponent `0`: signed zero when the fraction is zero, otherwise a subnormal.
+  Both are accepted and decoded exactly as FP32 values by appending 16 zero
+  fraction bits. No flush-to-zero mode is used.
+- Exponents `1..254`: accepted finite normal values.
+- Exponent `255`: infinity or NaN, regardless of sign or payload. Any such word
+  in either `row` or `gamma` makes the whole transaction a protocol error.
+
+On an exponent-255 input, the canonical result is `protocol_error=True`, all
+`4096` output words equal to canonical quiet NaN `0x7fc0`, and all exposed
+arithmetic-state fields equal to zero. No input NaN payload or sign propagates,
+and no valid prefix is emitted. This behavior is data-independent after input
+validation.
+
+## Internal arithmetic
+
+Inputs are exact BF16 values embedded in IEEE-754 binary32. Internal operations
+use binary32 round-to-nearest, ties-to-even (RNE), with gradual underflow:
+
+1. Traverse logical indices `0..4095`. For each index, round `x[i] * x[i]` to
+   FP32, then round `sum_squares + square` to FP32. The initial sum is `+0`.
+2. Multiply the completed sum by exact binary `2^-12` (`0x39800000`) and round
+   to FP32.
+3. Add epsilon. Decimal `1e-6` is represented by FP32 word `0x358637bd`; round
+   the addition to FP32.
+4. Square root, then `1.0 / root`, are each rounded to FP32 RNE.
+5. For each output, round `x[i] * inv_rms` to FP32, then round that result times
+   `gamma[i]` to FP32.
+6. Narrow FP32 to BF16 RNE once, preserving sign. A halfway value increments
+   only when the retained BF16 least-significant bit is one.
+
+The reference uses an ascending-index scalar accumulation even when `lanes > 1`.
+An RTL implementation must fold accepted lanes in lane-number order into the
+same scalar state, or prove bit equivalence to that order. Reassociation,
+fused multiply-add, wider accumulation, reciprocal-square-root approximation,
+and intermediate BF16 rounding do not conform to this Phase 1 model.
+
+Finite arithmetic overflow follows IEEE-754. It can produce infinity in exposed
+internal state or output without setting the input protocol-error flag. This is
+distinct from receiving an exponent-255 input.
+
+## Zero and subnormal behavior
+
+- Input subnormals participate without flushing. Their square may round to
+  FP32 zero according to FP32 RNE.
+- Epsilon keeps the reciprocal-square-root operand positive for an all-zero or
+  underflowed row.
+- FP32 and BF16 signed zeros are preserved. Since `inv_rms` is nonnegative, an
+  exact-zero output has sign `sign(x) XOR sign(gamma)` under IEEE multiplication.
+- BF16 output underflow is gradual and rounds to a signed zero only when required
+  by BF16 RNE.
+
+## Eventual streaming state contract
+
+The eventual RTL transaction has `4096 / LANES` accepted input beats and the
+same number of output beats. Beat `b`, lane `l` maps only to logical index
+`b * LANES + l`; lanes are contiguous and ascending.
+
+The required conceptual phases are:
+
+1. `IDLE/ACCEPT`: accept paired row and gamma lanes, classify every word, store
+   both vectors for replay, and update one FP32 `sum_squares` state in lane order.
+2. `FINALIZE`: after exactly 4096 accepted elements, compute mean square,
+   epsilon addition, square root, and reciprocal with the boundaries above.
+3. `EMIT`: replay stored row/gamma in original order and emit each BF16 result.
+4. `ERROR_EMIT`: if any accepted input had exponent 255, emit only canonical
+   `0x7fc0` words and assert the transaction protocol-error status.
+
+State advances only on ready/valid handshakes. Input data and framing must stay
+stable while stalled; output data, index, last, and error status must stay stable
+while stalled. `last` is true only on the final input/output beat. Early or
+missing input `last`, an unpaired row/gamma beat, a beat outside an active row,
+or accepting more than `4096` elements is a framing protocol error. Reset or a
+fully accepted final output beat clears row-local arithmetic, index, and sticky
+error state before another row can be accepted.
+
+No normal output may be exposed before classification of the complete input row,
+which ensures a late exponent-255 input still canonicalizes the entire output.

--- a/docs/reference/llama7b_rmsnorm_bf16_contract.md
+++ b/docs/reference/llama7b_rmsnorm_bf16_contract.md
@@ -18,8 +18,10 @@ There is no mean subtraction and no softmax, exponential, row-sum reciprocal,
 or probability normalization. Hidden size is fixed at `4096`; epsilon is fixed
 at decimal `1e-6`.
 
-Phase 1 provides a contract, executable model, and tests only. It does not
-provide RTL, PPA evidence, or an approximation for reciprocal square root.
+Phase 1 freezes a bit-exact block-floating sum-of-squares contract. Reciprocal
+square root, output multiplication, and output rounding remain provisional
+software semantics. Phase 1 does not provide RTL, PPA evidence, or a bit-exact
+claim for the complete RMSNorm operation.
 
 ## Software input contract
 
@@ -28,63 +30,118 @@ provide RTL, PPA evidence, or an approximation for reciprocal square root.
 - `lanes` is a positive integer divisor of `4096`.
 - Shape, lane, and word validation completes before arithmetic starts. A
   malformed argument raises `ValueError` and returns no partial output.
-- A legal lane count changes only the streaming grouping. It cannot change the
-  numerical result.
+- A legal lane count changes only streaming grouping. It cannot change
+  accumulation state or provisional output.
 
 ## BF16 classification
 
 BF16 uses one sign bit, eight exponent bits, and seven fraction bits.
 
 - Exponent `0`: signed zero when the fraction is zero, otherwise a subnormal.
-  Both are accepted and decoded exactly as FP32 values by appending 16 zero
-  fraction bits. No flush-to-zero mode is used.
+  Both are accepted without flush-to-zero.
 - Exponents `1..254`: accepted finite normal values.
 - Exponent `255`: infinity or NaN, regardless of sign or payload. Any such word
   in either `row` or `gamma` makes the whole transaction a protocol error.
 
 On an exponent-255 input, the canonical result is `protocol_error=True`, all
-`4096` output words equal to canonical quiet NaN `0x7fc0`, and all exposed
-arithmetic-state fields equal to zero. No input NaN payload or sign propagates,
-and no valid prefix is emitted. This behavior is data-independent after input
-validation.
+`4096` output words equal to canonical quiet NaN `0x7fc0`, integer accumulation
+state equal to zero, and provisional inverse RMS equal to `0.0`. No input NaN
+payload or sign propagates, and no valid prefix is emitted.
 
-## Internal arithmetic
+## Exact BF16 square decomposition
 
-Inputs are exact BF16 values embedded in IEEE-754 binary32. Internal operations
-use binary32 round-to-nearest, ties-to-even (RNE), with gradual underflow:
+Each finite BF16 magnitude is represented as an unsigned integer significand
+times a power of two:
 
-1. Traverse logical indices `0..4095`. For each index, round `x[i] * x[i]` to
-   FP32, then round `sum_squares + square` to FP32. The initial sum is `+0`.
-2. Multiply the completed sum by exact binary `2^-12` (`0x39800000`) and round
-   to FP32.
-3. Add epsilon. Decimal `1e-6` is represented by FP32 word `0x358637bd`; round
-   the addition to FP32.
-4. Square root, then `1.0 / root`, are each rounded to FP32 RNE.
-5. For each output, round `x[i] * inv_rms` to FP32, then round that result times
-   `gamma[i]` to FP32.
-6. Narrow FP32 to BF16 RNE once, preserving sign. A halfway value increments
-   only when the retained BF16 least-significant bit is one.
+```text
+exponent field E = 0:       x = fraction       * 2^-133
+exponent field E = 1..254:  x = (128+fraction) * 2^(E-134)
+```
 
-The reference uses an ascending-index scalar accumulation even when `lanes > 1`.
-An RTL implementation must fold accepted lanes in lane-number order into the
-same scalar state, or prove bit equivalence to that order. Reassociation,
-fused multiply-add, wider accumulation, reciprocal-square-root approximation,
-and intermediate BF16 rounding do not conform to this Phase 1 model.
+The sign is irrelevant to the square. Each square is formed exactly as
+`coefficient * 2^term_exponent`, where `coefficient` is the at-most-16-bit
+integer significand square and `term_exponent` is twice the value exponent.
 
-Finite arithmetic overflow follows IEEE-754. It can produce infinity in exposed
-internal state or output without setting the input protocol-error flag. This is
-distinct from receiving an exponent-255 input.
+## Bit-exact 48-bit accumulation
+
+The row uses a shared block-floating scale selected before accumulation:
+
+1. For every nonzero exact square, compute
+   `square_exponent = floor(log2(coefficient)) + term_exponent`.
+2. Let `max_square_exponent` be the maximum of those values.
+3. Set `accumulator_lsb_exponent = max_square_exponent - 34`.
+4. Align every exact square to that LSB exponent. Right shifts use unsigned
+   round-to-nearest, ties-to-even. Left shifts are exact.
+5. Sum the aligned nonnegative integers without reassociation-dependent
+   rounding into `accumulator_mantissa_48`.
+
+An all-zero row has mantissa, LSB exponent, and maximum square exponent all zero.
+For a nonzero finite row, `max_square_exponent` is in `[-266, 255]` and
+`accumulator_lsb_exponent` is in `[-300, 221]`; each therefore fits a signed
+10-bit field. The represented sum is:
+
+```text
+sum_squares_bfp = accumulator_mantissa_48 * 2^accumulator_lsb_exponent
+```
+
+The largest aligned term has its leading one at bit 34 and is less than `2^35`
+before alignment rounding. RNE can produce at most `2^35` per term. With exactly
+`4096 = 2^12` terms, the conservative sum bound is `2^47`, which fits an unsigned
+48-bit accumulator. Therefore every combination of 4096 finite BF16 inputs is
+covered without accumulator overflow. This bound is independent of input order
+and lane count.
+
+The alignment quantization window retains 34 bits below the largest square's
+leading bit. A term below half of the shared LSB rounds to zero. This bounded
+loss is intentional Phase 1 behavior and is checked against a separate robust
+scaled FP64 oracle.
+
+## Provisional finalization
+
+The following behavior produces useful quality vectors but is not a bit-exact
+RTL contract:
+
+1. Convert the block-floating sum exactly to binary64 and divide by 4096 with a
+   power-of-two exponent adjustment.
+2. Compute `1 / sqrt(mean_square + 1e-6)` with the host binary64 square root and
+   division operations.
+3. Multiply each exact BF16 input by that inverse RMS and its exact BF16 gamma in
+   binary64.
+4. Round binary64 directly to BF16 with round-to-nearest, ties-to-even, preserving
+   signed zero and gradual BF16 underflow.
+
+These operations are correctly scaled for the full finite BF16 input range: an
+all-maximum-finite row with `gamma=1` produces approximately `+1` (`0x3f80`), not
+zero, and does not set `protocol_error`.
+
+Phase 2 must select the reciprocal-square-root implementation, including LUT
+addressing and contents, seed precision, Newton iteration count, intermediate
+widths, normalization shifts, and rounding/saturation after every operation.
+It must also freeze output multiply and BF16 narrowing boundaries. Only then may
+the complete RMSNorm path claim bit-exact RTL equivalence. The Phase 1
+`provisional_inv_rms` field is diagnostic and must not be used as an RTL golden
+bit pattern.
 
 ## Zero and subnormal behavior
 
-- Input subnormals participate without flushing. Their square may round to
-  FP32 zero according to FP32 RNE.
-- Epsilon keeps the reciprocal-square-root operand positive for an all-zero or
-  underflowed row.
-- FP32 and BF16 signed zeros are preserved. Since `inv_rms` is nonnegative, an
-  exact-zero output has sign `sign(x) XOR sign(gamma)` under IEEE multiplication.
-- BF16 output underflow is gradual and rounds to a signed zero only when required
-  by BF16 RNE.
+- Input subnormals participate in exact square decomposition without flushing.
+  Their aligned square may round to zero under the documented block scale.
+- Epsilon keeps the provisional reciprocal-square-root operand positive for an
+  all-zero or quantized-zero sum.
+- Signed-zero inputs and gamma values are preserved. Since provisional
+  `inv_rms` is positive, an exact-zero output has sign
+  `sign(x) XOR sign(gamma)`.
+- Provisional BF16 output underflow is gradual and rounds to signed zero only
+  when required by BF16 RNE.
+
+## Exposed result fields
+
+- `output`: 4096 provisional BF16 words.
+- `protocol_error`: canonical row-level input classification error.
+- `accumulator_mantissa_48`: bit-exact unsigned 48-bit accumulation mantissa.
+- `accumulator_lsb_exponent`: signed power-of-two weight of accumulator bit 0.
+- `max_square_exponent`: selected row maximum used to derive the block scale.
+- `provisional_inv_rms`: binary64 software value, diagnostic only.
 
 ## Eventual streaming state contract
 
@@ -94,21 +151,25 @@ same number of output beats. Beat `b`, lane `l` maps only to logical index
 
 The required conceptual phases are:
 
-1. `IDLE/ACCEPT`: accept paired row and gamma lanes, classify every word, store
-   both vectors for replay, and update one FP32 `sum_squares` state in lane order.
-2. `FINALIZE`: after exactly 4096 accepted elements, compute mean square,
-   epsilon addition, square root, and reciprocal with the boundaries above.
-3. `EMIT`: replay stored row/gamma in original order and emit each BF16 result.
-4. `ERROR_EMIT`: if any accepted input had exponent 255, emit only canonical
-   `0x7fc0` words and assert the transaction protocol-error status.
+1. `IDLE/ACCEPT_MAX`: accept paired row and gamma lanes, classify every word,
+   store both vectors, and determine `max_square_exponent` over the complete row.
+2. `ACCUMULATE_REPLAY`: replay stored row values, align exact squares to the
+   selected shared exponent, and update the 48-bit integer sum. Lane-local terms
+   are integer-added; no intermediate narrowing or order-dependent rounding is
+   allowed.
+3. `FINALIZE`: apply the Phase-2-frozen mean, epsilon, reciprocal-square-root,
+   and output-scale contract. Until Phase 2, software uses provisional semantics.
+4. `EMIT`: replay stored row/gamma in original order and emit BF16 results.
+5. `ERROR_EMIT`: if any accepted input had exponent 255, emit only canonical
+   `0x7fc0` words and assert transaction protocol-error status.
 
 State advances only on ready/valid handshakes. Input data and framing must stay
 stable while stalled; output data, index, last, and error status must stay stable
 while stalled. `last` is true only on the final input/output beat. Early or
 missing input `last`, an unpaired row/gamma beat, a beat outside an active row,
 or accepting more than `4096` elements is a framing protocol error. Reset or a
-fully accepted final output beat clears row-local arithmetic, index, and sticky
-error state before another row can be accepted.
+fully accepted final output beat clears row-local state before another row can
+be accepted.
 
 No normal output may be exposed before classification of the complete input row,
-which ensures a late exponent-255 input still canonicalizes the entire output.
+which ensures a late exponent-255 input canonicalizes the entire output.

--- a/npu/eval/llama7b_rmsnorm_reference.py
+++ b/npu/eval/llama7b_rmsnorm_reference.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Bit-exact BF16-boundary reference for Llama-7B transformer RMSNorm."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+import struct
+from typing import Sequence
+
+
+HIDDEN_SIZE = 4096
+EPSILON = 1.0e-6
+CANONICAL_PROTOCOL_ERROR_BF16 = 0x7FC0
+
+_BF16_EXPONENT_MASK = 0x7F80
+_FP32_ONE_BITS = 0x3F800000
+_FP32_EPSILON_BITS = 0x358637BD
+
+
+@dataclass(frozen=True)
+class RMSNormResult:
+    """One completed row and the arithmetic state exposed for RTL checking."""
+
+    output: tuple[int, ...]
+    protocol_error: bool
+    sum_squares_fp32_bits: int
+    mean_square_fp32_bits: int
+    inv_rms_fp32_bits: int
+
+
+def _bits_to_fp32(bits: int) -> float:
+    return struct.unpack(">f", struct.pack(">I", bits))[0]
+
+
+def _fp32_to_bits(value: float) -> int:
+    try:
+        return struct.unpack(">I", struct.pack(">f", value))[0]
+    except OverflowError:
+        return 0xFF800000 if math.copysign(1.0, value) < 0.0 else 0x7F800000
+
+
+def _round_fp32(value: float) -> float:
+    return _bits_to_fp32(_fp32_to_bits(value))
+
+
+def _add_fp32(lhs: float, rhs: float) -> float:
+    return _round_fp32(lhs + rhs)
+
+
+def _mul_fp32(lhs: float, rhs: float) -> float:
+    return _round_fp32(lhs * rhs)
+
+
+def _div_fp32(lhs: float, rhs: float) -> float:
+    return _round_fp32(lhs / rhs)
+
+
+def _sqrt_fp32(value: float) -> float:
+    return _round_fp32(math.sqrt(value))
+
+
+def bf16_to_fp32(word: int) -> float:
+    """Decode one validated BF16 bit pattern exactly into an FP32 value."""
+
+    _validate_word(word, name="BF16 word", index=None)
+    return _bits_to_fp32(word << 16)
+
+
+def fp32_to_bf16(value: float) -> int:
+    """Round an FP32 value to BF16 using round-to-nearest, ties-to-even."""
+
+    bits = _fp32_to_bits(value)
+    exponent = (bits >> 23) & 0xFF
+    fraction = bits & 0x7FFFFF
+    if exponent == 0xFF:
+        if fraction:
+            return CANONICAL_PROTOCOL_ERROR_BF16
+        return bits >> 16
+
+    upper = bits >> 16
+    discarded = bits & 0xFFFF
+    if discarded > 0x8000 or (discarded == 0x8000 and (upper & 1)):
+        upper += 1
+    return upper & 0xFFFF
+
+
+def _validate_word(word: int, *, name: str, index: int | None) -> None:
+    location = "" if index is None else f"[{index}]"
+    if isinstance(word, bool) or not isinstance(word, int) or not 0 <= word <= 0xFFFF:
+        raise ValueError(f"{name}{location} must be an integer BF16 word in [0, 0xffff]")
+
+
+def _validate_inputs(row: Sequence[int], gamma: Sequence[int], lanes: int) -> None:
+    if len(row) != HIDDEN_SIZE:
+        raise ValueError(f"row must contain exactly {HIDDEN_SIZE} BF16 words")
+    if len(gamma) != HIDDEN_SIZE:
+        raise ValueError(f"gamma must contain exactly {HIDDEN_SIZE} BF16 words")
+    if isinstance(lanes, bool) or not isinstance(lanes, int) or lanes <= 0:
+        raise ValueError("lanes must be a positive integer")
+    if HIDDEN_SIZE % lanes:
+        raise ValueError(f"lanes must divide hidden size {HIDDEN_SIZE}")
+    for index, word in enumerate(row):
+        _validate_word(word, name="row", index=index)
+    for index, word in enumerate(gamma):
+        _validate_word(word, name="gamma", index=index)
+
+
+def _has_exponent_255(words: Sequence[int]) -> bool:
+    return any((word & _BF16_EXPONENT_MASK) == _BF16_EXPONENT_MASK for word in words)
+
+
+def rmsnorm_bf16(
+    row: Sequence[int],
+    gamma: Sequence[int],
+    *,
+    lanes: int,
+) -> RMSNormResult:
+    """Evaluate one fixed-size transformer RMSNorm row.
+
+    ``lanes`` defines streaming beat width. Arithmetic always follows ascending
+    logical element order, making the result invariant across legal lane counts.
+    Inputs and outputs are raw BF16 words; all internal primitives are FP32 RNE.
+    """
+
+    _validate_inputs(row, gamma, lanes)
+    if _has_exponent_255(row) or _has_exponent_255(gamma):
+        return RMSNormResult(
+            output=(CANONICAL_PROTOCOL_ERROR_BF16,) * HIDDEN_SIZE,
+            protocol_error=True,
+            sum_squares_fp32_bits=0,
+            mean_square_fp32_bits=0,
+            inv_rms_fp32_bits=0,
+        )
+
+    row_fp32 = tuple(_bits_to_fp32(word << 16) for word in row)
+    gamma_fp32 = tuple(_bits_to_fp32(word << 16) for word in gamma)
+
+    sum_squares = 0.0
+    for beat_base in range(0, HIDDEN_SIZE, lanes):
+        for lane in range(lanes):
+            value = row_fp32[beat_base + lane]
+            square = _mul_fp32(value, value)
+            sum_squares = _add_fp32(sum_squares, square)
+
+    # Division by 4096 is exact in binary before the explicit FP32 boundary.
+    mean_square = _mul_fp32(sum_squares, _bits_to_fp32(0x39800000))
+    variance_with_epsilon = _add_fp32(mean_square, _bits_to_fp32(_FP32_EPSILON_BITS))
+    inv_rms = _div_fp32(_bits_to_fp32(_FP32_ONE_BITS), _sqrt_fp32(variance_with_epsilon))
+
+    output = []
+    for value, weight in zip(row_fp32, gamma_fp32):
+        normalized = _mul_fp32(value, inv_rms)
+        output.append(fp32_to_bf16(_mul_fp32(normalized, weight)))
+
+    return RMSNormResult(
+        output=tuple(output),
+        protocol_error=False,
+        sum_squares_fp32_bits=_fp32_to_bits(sum_squares),
+        mean_square_fp32_bits=_fp32_to_bits(mean_square),
+        inv_rms_fp32_bits=_fp32_to_bits(inv_rms),
+    )

--- a/npu/eval/llama7b_rmsnorm_reference.py
+++ b/npu/eval/llama7b_rmsnorm_reference.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Bit-exact BF16-boundary reference for Llama-7B transformer RMSNorm."""
+"""Phase-1 BF16-boundary reference for Llama-7B transformer RMSNorm."""
 
 from __future__ import annotations
 
@@ -11,22 +11,23 @@ from typing import Sequence
 
 HIDDEN_SIZE = 4096
 EPSILON = 1.0e-6
+ACCUMULATOR_WIDTH = 48
+ACCUMULATOR_TERM_MSB = 34
 CANONICAL_PROTOCOL_ERROR_BF16 = 0x7FC0
 
 _BF16_EXPONENT_MASK = 0x7F80
-_FP32_ONE_BITS = 0x3F800000
-_FP32_EPSILON_BITS = 0x358637BD
 
 
 @dataclass(frozen=True)
 class RMSNormResult:
-    """One completed row and the arithmetic state exposed for RTL checking."""
+    """Completed row, bit-exact accumulation state, and provisional finalization."""
 
     output: tuple[int, ...]
     protocol_error: bool
-    sum_squares_fp32_bits: int
-    mean_square_fp32_bits: int
-    inv_rms_fp32_bits: int
+    accumulator_mantissa_48: int
+    accumulator_lsb_exponent: int
+    max_square_exponent: int
+    provisional_inv_rms: float
 
 
 def _bits_to_fp32(bits: int) -> float:
@@ -40,26 +41,6 @@ def _fp32_to_bits(value: float) -> int:
         return 0xFF800000 if math.copysign(1.0, value) < 0.0 else 0x7F800000
 
 
-def _round_fp32(value: float) -> float:
-    return _bits_to_fp32(_fp32_to_bits(value))
-
-
-def _add_fp32(lhs: float, rhs: float) -> float:
-    return _round_fp32(lhs + rhs)
-
-
-def _mul_fp32(lhs: float, rhs: float) -> float:
-    return _round_fp32(lhs * rhs)
-
-
-def _div_fp32(lhs: float, rhs: float) -> float:
-    return _round_fp32(lhs / rhs)
-
-
-def _sqrt_fp32(value: float) -> float:
-    return _round_fp32(math.sqrt(value))
-
-
 def bf16_to_fp32(word: int) -> float:
     """Decode one validated BF16 bit pattern exactly into an FP32 value."""
 
@@ -67,22 +48,57 @@ def bf16_to_fp32(word: int) -> float:
     return _bits_to_fp32(word << 16)
 
 
+def _round_ratio_pow2(numerator: int, denominator: int, shift: int) -> int:
+    if shift >= 0:
+        numerator <<= shift
+    else:
+        denominator <<= -shift
+    quotient, remainder = divmod(numerator, denominator)
+    twice_remainder = remainder << 1
+    if twice_remainder > denominator or (twice_remainder == denominator and (quotient & 1)):
+        quotient += 1
+    return quotient
+
+
+def _float64_to_bf16(value: float) -> int:
+    """Round binary64 directly to BF16 RNE without an FP32 double-round."""
+
+    sign = 0x8000 if math.copysign(1.0, value) < 0.0 else 0
+    magnitude = abs(value)
+    if math.isnan(magnitude):
+        return CANONICAL_PROTOCOL_ERROR_BF16
+    if math.isinf(magnitude):
+        return sign | 0x7F80
+    if magnitude == 0.0:
+        return sign
+
+    numerator, denominator = magnitude.as_integer_ratio()
+    exponent = numerator.bit_length() - denominator.bit_length()
+    if exponent >= 0:
+        if numerator < (denominator << exponent):
+            exponent -= 1
+    elif (numerator << -exponent) < denominator:
+        exponent -= 1
+
+    if exponent < -126:
+        significand = _round_ratio_pow2(numerator, denominator, 133)
+        if significand < 128:
+            return sign | significand
+        return sign | 0x0080
+
+    significand = _round_ratio_pow2(numerator, denominator, 7 - exponent)
+    if significand == 256:
+        significand = 128
+        exponent += 1
+    if exponent > 127:
+        return sign | 0x7F80
+    return sign | ((exponent + 127) << 7) | (significand - 128)
+
+
 def fp32_to_bf16(value: float) -> int:
-    """Round an FP32 value to BF16 using round-to-nearest, ties-to-even."""
+    """Round an FP32 value to BF16 RNE, canonicalizing an FP32 NaN."""
 
-    bits = _fp32_to_bits(value)
-    exponent = (bits >> 23) & 0xFF
-    fraction = bits & 0x7FFFFF
-    if exponent == 0xFF:
-        if fraction:
-            return CANONICAL_PROTOCOL_ERROR_BF16
-        return bits >> 16
-
-    upper = bits >> 16
-    discarded = bits & 0xFFFF
-    if discarded > 0x8000 or (discarded == 0x8000 and (upper & 1)):
-        upper += 1
-    return upper & 0xFFFF
+    return _float64_to_bf16(_bits_to_fp32(_fp32_to_bits(value)))
 
 
 def _validate_word(word: int, *, name: str, index: int | None) -> None:
@@ -110,6 +126,48 @@ def _has_exponent_255(words: Sequence[int]) -> bool:
     return any((word & _BF16_EXPONENT_MASK) == _BF16_EXPONENT_MASK for word in words)
 
 
+def _square_components(word: int) -> tuple[int, int]:
+    """Return exact square as ``coefficient * 2**exponent``."""
+
+    exponent_field = (word >> 7) & 0xFF
+    fraction = word & 0x7F
+    if exponent_field == 0:
+        significand = fraction
+        value_exponent = -133
+    else:
+        significand = 128 + fraction
+        value_exponent = exponent_field - 134
+    return significand * significand, 2 * value_exponent
+
+
+def _round_shift_right(value: int, shift: int) -> int:
+    if shift <= 0:
+        return value << -shift
+    quotient = value >> shift
+    remainder = value - (quotient << shift)
+    halfway = 1 << (shift - 1)
+    if remainder > halfway or (remainder == halfway and (quotient & 1)):
+        quotient += 1
+    return quotient
+
+
+def _accumulate_squares(row: Sequence[int]) -> tuple[int, int, int]:
+    terms = [_square_components(word) for word in row]
+    nonzero_terms = [(coefficient, exponent) for coefficient, exponent in terms if coefficient]
+    if not nonzero_terms:
+        return 0, 0, 0
+
+    max_square_exponent = max(coefficient.bit_length() - 1 + exponent for coefficient, exponent in nonzero_terms)
+    accumulator_lsb_exponent = max_square_exponent - ACCUMULATOR_TERM_MSB
+    accumulator = 0
+    for coefficient, exponent in terms:
+        accumulator += _round_shift_right(coefficient, accumulator_lsb_exponent - exponent)
+
+    if accumulator >= (1 << ACCUMULATOR_WIDTH):
+        raise AssertionError("48-bit RMSNorm accumulator bound violated")
+    return accumulator, accumulator_lsb_exponent, max_square_exponent
+
+
 def rmsnorm_bf16(
     row: Sequence[int],
     gamma: Sequence[int],
@@ -118,9 +176,9 @@ def rmsnorm_bf16(
 ) -> RMSNormResult:
     """Evaluate one fixed-size transformer RMSNorm row.
 
-    ``lanes`` defines streaming beat width. Arithmetic always follows ascending
-    logical element order, making the result invariant across legal lane counts.
-    Inputs and outputs are raw BF16 words; all internal primitives are FP32 RNE.
+    The block-floating accumulation fields are bit-exact Phase-1 contract state.
+    Reciprocal square root, multiplication, and BF16 output are provisional
+    correctly-scaled software semantics pending a Phase-2 approximation freeze.
     """
 
     _validate_inputs(row, gamma, lanes)
@@ -128,35 +186,25 @@ def rmsnorm_bf16(
         return RMSNormResult(
             output=(CANONICAL_PROTOCOL_ERROR_BF16,) * HIDDEN_SIZE,
             protocol_error=True,
-            sum_squares_fp32_bits=0,
-            mean_square_fp32_bits=0,
-            inv_rms_fp32_bits=0,
+            accumulator_mantissa_48=0,
+            accumulator_lsb_exponent=0,
+            max_square_exponent=0,
+            provisional_inv_rms=0.0,
         )
 
-    row_fp32 = tuple(_bits_to_fp32(word << 16) for word in row)
-    gamma_fp32 = tuple(_bits_to_fp32(word << 16) for word in gamma)
+    accumulator, lsb_exponent, max_square_exponent = _accumulate_squares(row)
+    mean_square = math.ldexp(float(accumulator), lsb_exponent - 12)
+    provisional_inv_rms = 1.0 / math.sqrt(mean_square + EPSILON)
 
-    sum_squares = 0.0
-    for beat_base in range(0, HIDDEN_SIZE, lanes):
-        for lane in range(lanes):
-            value = row_fp32[beat_base + lane]
-            square = _mul_fp32(value, value)
-            sum_squares = _add_fp32(sum_squares, square)
-
-    # Division by 4096 is exact in binary before the explicit FP32 boundary.
-    mean_square = _mul_fp32(sum_squares, _bits_to_fp32(0x39800000))
-    variance_with_epsilon = _add_fp32(mean_square, _bits_to_fp32(_FP32_EPSILON_BITS))
-    inv_rms = _div_fp32(_bits_to_fp32(_FP32_ONE_BITS), _sqrt_fp32(variance_with_epsilon))
-
-    output = []
-    for value, weight in zip(row_fp32, gamma_fp32):
-        normalized = _mul_fp32(value, inv_rms)
-        output.append(fp32_to_bf16(_mul_fp32(normalized, weight)))
-
+    output = tuple(
+        _float64_to_bf16(bf16_to_fp32(value) * provisional_inv_rms * bf16_to_fp32(weight))
+        for value, weight in zip(row, gamma)
+    )
     return RMSNormResult(
-        output=tuple(output),
+        output=output,
         protocol_error=False,
-        sum_squares_fp32_bits=_fp32_to_bits(sum_squares),
-        mean_square_fp32_bits=_fp32_to_bits(mean_square),
-        inv_rms_fp32_bits=_fp32_to_bits(inv_rms),
+        accumulator_mantissa_48=accumulator,
+        accumulator_lsb_exponent=lsb_exponent,
+        max_square_exponent=max_square_exponent,
+        provisional_inv_rms=provisional_inv_rms,
     )

--- a/tests/test_llama7b_rmsnorm_reference.py
+++ b/tests/test_llama7b_rmsnorm_reference.py
@@ -1,0 +1,167 @@
+import math
+import struct
+
+import numpy as np
+import pytest
+
+from npu.eval.llama7b_rmsnorm_reference import (
+    CANONICAL_PROTOCOL_ERROR_BF16,
+    HIDDEN_SIZE,
+    bf16_to_fp32,
+    fp32_to_bf16,
+    rmsnorm_bf16,
+)
+
+
+def _bf16(value: float) -> int:
+    bits = struct.unpack(">I", struct.pack(">f", value))[0]
+    upper, lower = bits >> 16, bits & 0xFFFF
+    return (upper + (lower > 0x8000 or (lower == 0x8000 and (upper & 1)))) & 0xFFFF
+
+
+def _decode(words: list[int] | tuple[int, ...]) -> np.ndarray:
+    bits = np.asarray(words, dtype=np.uint16).astype(np.uint32) << 16
+    return bits.view(np.float32)
+
+
+def _oracle(row: list[int], gamma: list[int]) -> np.ndarray:
+    x = _decode(row)
+    weight = _decode(gamma)
+    mean_square = np.mean(x * x, dtype=np.float32)
+    inv_rms = np.float32(1.0) / np.sqrt(mean_square + np.float32(1.0e-6), dtype=np.float32)
+    return np.asarray(x * inv_rms * weight, dtype=np.float32)
+
+
+def test_matches_independent_fp32_oracle_and_is_lane_invariant() -> None:
+    rng = np.random.default_rng(0x524D534E)
+    row_values = rng.normal(0.0, 0.75, HIDDEN_SIZE).astype(np.float32)
+    gamma_values = rng.uniform(0.5, 1.5, HIDDEN_SIZE).astype(np.float32)
+    row = [_bf16(float(value)) for value in row_values]
+    gamma = [_bf16(float(value)) for value in gamma_values]
+
+    baseline = rmsnorm_bf16(row, gamma, lanes=1)
+    assert not baseline.protocol_error
+    for lanes in (2, 8, 16, 64, 256, 4096):
+        assert rmsnorm_bf16(row, gamma, lanes=lanes) == baseline
+
+    actual = _decode(baseline.output)
+    expected = _oracle(row, gamma)
+    np.testing.assert_allclose(actual, expected, rtol=8.0e-3, atol=2.0e-4)
+
+
+def test_uniform_row_has_pinned_bit_exact_arithmetic_state() -> None:
+    result = rmsnorm_bf16(
+        [0x3F80] * HIDDEN_SIZE,
+        [0x3F80] * HIDDEN_SIZE,
+        lanes=16,
+    )
+
+    assert not result.protocol_error
+    assert result.sum_squares_fp32_bits == 0x45800000
+    assert result.mean_square_fp32_bits == 0x3F800000
+    assert result.inv_rms_fp32_bits == 0x3F7FFFF8
+    assert result.output == (0x3F80,) * HIDDEN_SIZE
+
+
+def test_adversarial_dynamic_range_tracks_fp32_oracle() -> None:
+    pattern = [
+        0x0001,
+        0x8001,
+        _bf16(2.0**-60),
+        _bf16(-(2.0**-30)),
+        _bf16(1.0),
+        _bf16(-1.0),
+        _bf16(127.5),
+        _bf16(-255.0),
+    ]
+    row = (pattern * (HIDDEN_SIZE // len(pattern)))[:HIDDEN_SIZE]
+    gamma = ([_bf16(0.5), _bf16(-0.75), _bf16(1.0), _bf16(1.5)] * 1024)[:HIDDEN_SIZE]
+
+    result = rmsnorm_bf16(row, gamma, lanes=32)
+    assert not result.protocol_error
+    np.testing.assert_allclose(
+        _decode(result.output),
+        _oracle(row, gamma),
+        rtol=8.0e-3,
+        atol=2.0e-4,
+    )
+
+
+def test_finite_fp32_overflow_is_not_an_input_protocol_error() -> None:
+    result = rmsnorm_bf16(
+        [0x7F7F] * HIDDEN_SIZE,
+        [0x3F80] * HIDDEN_SIZE,
+        lanes=64,
+    )
+
+    assert not result.protocol_error
+    assert result.sum_squares_fp32_bits == 0x7F800000
+    assert result.mean_square_fp32_bits == 0x7F800000
+    assert result.inv_rms_fp32_bits == 0x00000000
+    assert result.output == (0x0000,) * HIDDEN_SIZE
+
+
+def test_subnormals_and_signed_zero_are_not_flushed_on_input() -> None:
+    row = [0x0000] * HIDDEN_SIZE
+    gamma = [0x3F80] * HIDDEN_SIZE
+    row[:6] = [0x0000, 0x8000, 0x0001, 0x8001, 0x0002, 0x8002]
+    gamma[:6] = [0x3F80, 0x3F80, 0xBF80, 0xBF80, 0x8000, 0x0000]
+
+    result = rmsnorm_bf16(row, gamma, lanes=16)
+
+    assert result.output[0] == 0x0000
+    assert result.output[1] == 0x8000
+    assert result.output[2] != 0 and result.output[2] & 0x8000
+    assert result.output[3] != 0 and not result.output[3] & 0x8000
+    assert result.output[4] == 0x8000
+    assert result.output[5] == 0x8000
+    assert bf16_to_fp32(0x0001) == math.ldexp(1.0, -133)
+    assert math.copysign(1.0, bf16_to_fp32(0x8000)) < 0.0
+
+
+@pytest.mark.parametrize("bad_word", [0x7F80, 0xFF80, 0x7F81, 0xFFC1])
+@pytest.mark.parametrize("target", ["row", "gamma"])
+def test_exponent_255_input_has_canonical_protocol_error(bad_word: int, target: str) -> None:
+    row = [0x3F80] * HIDDEN_SIZE
+    gamma = [0x3F80] * HIDDEN_SIZE
+    (row if target == "row" else gamma)[HIDDEN_SIZE - 1] = bad_word
+
+    result = rmsnorm_bf16(row, gamma, lanes=16)
+
+    assert result.protocol_error
+    assert result.output == (CANONICAL_PROTOCOL_ERROR_BF16,) * HIDDEN_SIZE
+    assert result.sum_squares_fp32_bits == 0
+    assert result.mean_square_fp32_bits == 0
+    assert result.inv_rms_fp32_bits == 0
+
+
+@pytest.mark.parametrize(
+    ("row_size", "gamma_size", "lanes"),
+    [
+        (HIDDEN_SIZE - 1, HIDDEN_SIZE, 16),
+        (HIDDEN_SIZE + 1, HIDDEN_SIZE, 16),
+        (HIDDEN_SIZE, HIDDEN_SIZE - 1, 16),
+        (HIDDEN_SIZE, HIDDEN_SIZE + 1, 16),
+        (HIDDEN_SIZE, HIDDEN_SIZE, 0),
+        (HIDDEN_SIZE, HIDDEN_SIZE, 3),
+    ],
+)
+def test_malformed_dimensions_fail_closed(row_size: int, gamma_size: int, lanes: int) -> None:
+    with pytest.raises(ValueError):
+        rmsnorm_bf16([0] * row_size, [0x3F80] * gamma_size, lanes=lanes)
+
+
+@pytest.mark.parametrize("bad_word", [-1, 0x10000, 1.0, True])
+def test_malformed_words_fail_closed(bad_word: object) -> None:
+    row = [0] * HIDDEN_SIZE
+    row[2048] = bad_word  # type: ignore[assignment]
+    with pytest.raises(ValueError):
+        rmsnorm_bf16(row, [0x3F80] * HIDDEN_SIZE, lanes=16)
+
+
+def test_fp32_to_bf16_uses_ties_to_even_and_preserves_zero_sign() -> None:
+    even_halfway = struct.unpack(">f", struct.pack(">I", 0x3F808000))[0]
+    odd_halfway = struct.unpack(">f", struct.pack(">I", 0x3F818000))[0]
+    assert fp32_to_bf16(even_halfway) == 0x3F80
+    assert fp32_to_bf16(odd_halfway) == 0x3F82
+    assert fp32_to_bf16(-0.0) == 0x8000

--- a/tests/test_llama7b_rmsnorm_reference.py
+++ b/tests/test_llama7b_rmsnorm_reference.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from npu.eval.llama7b_rmsnorm_reference import (
+    ACCUMULATOR_WIDTH,
     CANONICAL_PROTOCOL_ERROR_BF16,
     HIDDEN_SIZE,
     bf16_to_fp32,
@@ -19,20 +20,29 @@ def _bf16(value: float) -> int:
     return (upper + (lower > 0x8000 or (lower == 0x8000 and (upper & 1)))) & 0xFFFF
 
 
+def _decode_word(word: int) -> float:
+    return float(struct.unpack(">f", struct.pack(">I", word << 16))[0])
+
+
 def _decode(words: list[int] | tuple[int, ...]) -> np.ndarray:
-    bits = np.asarray(words, dtype=np.uint16).astype(np.uint32) << 16
-    return bits.view(np.float32)
+    return np.asarray([_decode_word(word) for word in words], dtype=np.float64)
 
 
-def _oracle(row: list[int], gamma: list[int]) -> np.ndarray:
-    x = _decode(row)
-    weight = _decode(gamma)
-    mean_square = np.mean(x * x, dtype=np.float32)
-    inv_rms = np.float32(1.0) / np.sqrt(mean_square + np.float32(1.0e-6), dtype=np.float32)
-    return np.asarray(x * inv_rms * weight, dtype=np.float32)
+def _scaled_fp64_oracle(row: list[int], gamma: list[int]) -> np.ndarray:
+    """Independent overflow-safe RMSNorm oracle with no model helper reuse."""
+
+    x = [_decode_word(word) for word in row]
+    weight = [_decode_word(word) for word in gamma]
+    scale = max(abs(value) for value in x)
+    if scale == 0.0:
+        rms = math.sqrt(1.0e-6)
+    else:
+        scaled_mean_square = math.fsum((value / scale) ** 2 for value in x) / HIDDEN_SIZE
+        rms = math.hypot(scale * math.sqrt(scaled_mean_square), math.sqrt(1.0e-6))
+    return np.asarray([value / rms * gain for value, gain in zip(x, weight)], dtype=np.float64)
 
 
-def test_matches_independent_fp32_oracle_and_is_lane_invariant() -> None:
+def test_matches_independent_scaled_fp64_oracle_and_is_lane_invariant() -> None:
     rng = np.random.default_rng(0x524D534E)
     row_values = rng.normal(0.0, 0.75, HIDDEN_SIZE).astype(np.float32)
     gamma_values = rng.uniform(0.5, 1.5, HIDDEN_SIZE).astype(np.float32)
@@ -44,12 +54,15 @@ def test_matches_independent_fp32_oracle_and_is_lane_invariant() -> None:
     for lanes in (2, 8, 16, 64, 256, 4096):
         assert rmsnorm_bf16(row, gamma, lanes=lanes) == baseline
 
-    actual = _decode(baseline.output)
-    expected = _oracle(row, gamma)
-    np.testing.assert_allclose(actual, expected, rtol=8.0e-3, atol=2.0e-4)
+    np.testing.assert_allclose(
+        _decode(baseline.output),
+        _scaled_fp64_oracle(row, gamma),
+        rtol=8.0e-3,
+        atol=2.0e-4,
+    )
 
 
-def test_uniform_row_has_pinned_bit_exact_arithmetic_state() -> None:
+def test_uniform_row_has_pinned_bit_exact_accumulator_state() -> None:
     result = rmsnorm_bf16(
         [0x3F80] * HIDDEN_SIZE,
         [0x3F80] * HIDDEN_SIZE,
@@ -57,48 +70,78 @@ def test_uniform_row_has_pinned_bit_exact_arithmetic_state() -> None:
     )
 
     assert not result.protocol_error
-    assert result.sum_squares_fp32_bits == 0x45800000
-    assert result.mean_square_fp32_bits == 0x3F800000
-    assert result.inv_rms_fp32_bits == 0x3F7FFFF8
+    assert result.accumulator_mantissa_48 == 1 << 46
+    assert result.accumulator_lsb_exponent == -34
+    assert result.max_square_exponent == 0
     assert result.output == (0x3F80,) * HIDDEN_SIZE
 
 
-def test_adversarial_dynamic_range_tracks_fp32_oracle() -> None:
-    pattern = [
-        0x0001,
-        0x8001,
-        _bf16(2.0**-60),
-        _bf16(-(2.0**-30)),
-        _bf16(1.0),
-        _bf16(-1.0),
-        _bf16(127.5),
-        _bf16(-255.0),
-    ]
-    row = (pattern * (HIDDEN_SIZE // len(pattern)))[:HIDDEN_SIZE]
-    gamma = ([_bf16(0.5), _bf16(-0.75), _bf16(1.0), _bf16(1.5)] * 1024)[:HIDDEN_SIZE]
+def test_all_maximum_finite_normalizes_to_one_without_overflow() -> None:
+    row = [0x7F7F] * HIDDEN_SIZE
+    gamma = [0x3F80] * HIDDEN_SIZE
 
-    result = rmsnorm_bf16(row, gamma, lanes=32)
+    result = rmsnorm_bf16(row, gamma, lanes=64)
+
     assert not result.protocol_error
+    assert 0 < result.accumulator_mantissa_48 < (1 << ACCUMULATOR_WIDTH)
+    assert result.accumulator_lsb_exponent == 221
+    assert result.max_square_exponent == 255
+    assert result.output == (0x3F80,) * HIDDEN_SIZE
     np.testing.assert_allclose(
         _decode(result.output),
-        _oracle(row, gamma),
+        _scaled_fp64_oracle(row, gamma),
         rtol=8.0e-3,
-        atol=2.0e-4,
+        atol=0.0,
     )
 
 
-def test_finite_fp32_overflow_is_not_an_input_protocol_error() -> None:
-    result = rmsnorm_bf16(
-        [0x7F7F] * HIDDEN_SIZE,
-        [0x3F80] * HIDDEN_SIZE,
-        lanes=64,
-    )
+def test_mixed_exponents_are_order_and_lane_invariant() -> None:
+    pattern = [
+        0x0001,
+        0x807F,
+        _bf16(2.0**-100),
+        _bf16(-(2.0**-40)),
+        _bf16(2.0**-10),
+        _bf16(-1.0),
+        _bf16(2.0**20),
+        _bf16(-(2.0**60)),
+        0x7F7F,
+    ]
+    row = [pattern[index % len(pattern)] for index in range(HIDDEN_SIZE)]
+    gamma = [_bf16(0.5 + (index % 5) * 0.25) for index in range(HIDDEN_SIZE)]
+    baseline = rmsnorm_bf16(row, gamma, lanes=1)
+
+    permutation = np.random.default_rng(0xB10CF10A).permutation(HIDDEN_SIZE).tolist()
+    shuffled_row = [row[index] for index in permutation]
+    shuffled_gamma = [gamma[index] for index in permutation]
+    shuffled = rmsnorm_bf16(shuffled_row, shuffled_gamma, lanes=128)
+
+    assert shuffled.accumulator_mantissa_48 == baseline.accumulator_mantissa_48
+    assert shuffled.accumulator_lsb_exponent == baseline.accumulator_lsb_exponent
+    assert shuffled.max_square_exponent == baseline.max_square_exponent
+    assert shuffled.output == tuple(baseline.output[index] for index in permutation)
+    for lanes in (4, 16, 64, 1024):
+        assert rmsnorm_bf16(row, gamma, lanes=lanes) == baseline
+
+
+def test_every_finite_exponent_class_stays_within_accumulator_bound() -> None:
+    row = []
+    for index in range(HIDDEN_SIZE):
+        exponent = index % 255
+        fraction = (index * 73) & 0x7F
+        sign = (index & 1) << 15
+        row.append(sign | (exponent << 7) | fraction)
+
+    result = rmsnorm_bf16(row, [0x3F80] * HIDDEN_SIZE, lanes=32)
 
     assert not result.protocol_error
-    assert result.sum_squares_fp32_bits == 0x7F800000
-    assert result.mean_square_fp32_bits == 0x7F800000
-    assert result.inv_rms_fp32_bits == 0x00000000
-    assert result.output == (0x0000,) * HIDDEN_SIZE
+    assert 0 < result.accumulator_mantissa_48 < (1 << ACCUMULATOR_WIDTH)
+    np.testing.assert_allclose(
+        _decode(result.output),
+        _scaled_fp64_oracle(row, [0x3F80] * HIDDEN_SIZE),
+        rtol=8.0e-3,
+        atol=1.0e-40,
+    )
 
 
 def test_subnormals_and_signed_zero_are_not_flushed_on_input() -> None:
@@ -115,6 +158,8 @@ def test_subnormals_and_signed_zero_are_not_flushed_on_input() -> None:
     assert result.output[3] != 0 and not result.output[3] & 0x8000
     assert result.output[4] == 0x8000
     assert result.output[5] == 0x8000
+    assert result.accumulator_lsb_exponent == -298
+    assert result.max_square_exponent == -264
     assert bf16_to_fp32(0x0001) == math.ldexp(1.0, -133)
     assert math.copysign(1.0, bf16_to_fp32(0x8000)) < 0.0
 
@@ -130,9 +175,10 @@ def test_exponent_255_input_has_canonical_protocol_error(bad_word: int, target: 
 
     assert result.protocol_error
     assert result.output == (CANONICAL_PROTOCOL_ERROR_BF16,) * HIDDEN_SIZE
-    assert result.sum_squares_fp32_bits == 0
-    assert result.mean_square_fp32_bits == 0
-    assert result.inv_rms_fp32_bits == 0
+    assert result.accumulator_mantissa_48 == 0
+    assert result.accumulator_lsb_exponent == 0
+    assert result.max_square_exponent == 0
+    assert result.provisional_inv_rms == 0.0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- distinguish transformer RMSNorm from the existing softmax normalization artifacts
- define the fixed 4096-element BF16 boundary and fail-closed protocol behavior
- add a deterministic, hardware-realizable 48-bit block-floating sum-of-squares contract across the full finite BF16 range
- keep rsqrt/output semantics explicitly provisional until LUT/Newton widths and rounding are frozen in phase 2

## Validation
- focused RMSNorm tests: 25 passed
- exhaustive conversion audit: all 65,280 finite BF16 encodings
- `python3 scripts/validate_runs.py --skip_eval_queue`

## Review note
The initial preparation used serial FP32 accumulation and overflowed maximum finite BF16 rows. That behavior was removed before this PR; the all-maximum row now normalizes to BF16 1.0 without protocol error.