### PR TITLE
Gate exact-partial recost on Llama7B workload proof

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -7869,6 +7869,7 @@ def _decoder_attention_decode_score_multivalue_service_exact_partial_physical_re
             "l2_decoder_attention_decode_score_multivalue_service_"
             "finalized_cdc_lane_probe_10ns_12ns_v1"
         ),
+        "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1",
     ]
     normalized_dependencies = [
         str(dependency).strip()
@@ -7877,7 +7878,7 @@ def _decoder_attention_decode_score_multivalue_service_exact_partial_physical_re
     ]
     if normalized_dependencies != required_dependencies:
         raise Layer2TaskGenerationError(
-            "exact-partial physical recost requires the exact physical and functional dependency items"
+            "exact-partial physical recost requires the exact physical, functional, and workload dependency items"
         )
 
     base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
@@ -7921,13 +7922,17 @@ def _decoder_attention_decode_score_multivalue_service_exact_partial_physical_re
             "decode_score_multivalue_service_exact_partial_physical_recost_functional_dependency_item_id": (
                 required_dependencies[1]
             ),
+            "decode_score_multivalue_service_exact_partial_physical_recost_workload_dependency_item_id": (
+                required_dependencies[2]
+            ),
             "decode_score_multivalue_service_exact_partial_physical_recost_out": out,
             "decode_score_multivalue_service_exact_partial_physical_recost_csv_out": csv_out,
             "decode_score_multivalue_service_exact_partial_physical_recost_scope": (
                 "Compose divider_lanes 1, 2, 4, and 8 from the promoted c1 r8 activity anchor, "
                 "lane-matched 12 ns temporal/finalizer rows, 10 ns source and 12 ns destination FIFO "
-                "views, and hashed finalized-CDC summaries. Preserve overlap/serial timing bounds and "
-                "provisional energy provenance; emit one aggregate JSON and one four-row CSV only."
+                "views, hashed finalized-CDC summaries, and the proven 131k Llama7B workload recurrence. "
+                "Preserve conservative workload timing bounds and provisional energy provenance; emit "
+                "one aggregate JSON and one four-row CSV only."
             ),
         },
         "commands": [
@@ -7939,9 +7944,10 @@ def _decoder_attention_decode_score_multivalue_service_exact_partial_physical_re
         "expected_outputs": [out, csv_out],
         "evidence_only": True,
         "acceptance": [
-            "Require both exact dependency items to be merged and materialized",
+            "Require all three exact dependency items to be merged and materialized",
             "Require four lane-matched rows ordered [1,2,4,8]",
             "Preserve overlap lower bounds and serial upper bounds from functional elapsed cycles",
+            "Preserve the fail-closed affine 131k Llama7B workload projection for every lane",
             "Preserve bounded provisional energy provenance and do not claim exact token energy",
             "Count one canonical source-domain FIFO while validating both FIFO domain views",
             "Write exactly one aggregate JSON report and one four-row CSV",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -9878,6 +9878,7 @@ def test_generate_l2_campaign_task_adds_exact_partial_physical_recost_consumer()
                 "l2_decoder_attention_decode_score_multivalue_service_"
                 "finalized_cdc_lane_probe_10ns_12ns_v1"
             ),
+            "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1",
         ]
 
         with Session(engine) as session:
@@ -9945,7 +9946,8 @@ def test_exact_partial_physical_recost_consumer_rejects_missing_dependency() -> 
         create_all(engine)
 
         with Session(engine) as session, pytest.raises(
-            Layer2TaskGenerationError, match="requires the exact physical and functional dependency"
+            Layer2TaskGenerationError,
+            match="requires the exact physical, functional, and workload dependency",
         ):
             generate_l2_campaign_task(
                 session,

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/evaluation_requests.json
@@ -14,7 +14,8 @@
       "cost_class": "lightweight",
       "depends_on_item_ids": [
         "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
-        "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1"
+        "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1",
+        "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -24,7 +25,7 @@
         "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost__l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1.json",
         "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost__l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1.csv"
       ],
-      "acceptance_notes": "Fail closed unless both exact dependency items are satisfied and all four lane-matched 12 ns temporal bundles plus hashed finalized-CDC probe summaries are materialized. Require four rows ordered [1,2,4,8], source-domain single-FIFO accounting from the 10 ns row, the 12 ns destination diagnostic row, preserved overlap/serial timing bounds, and bounded provisional energy provenance. Emit no per-lane recost files.",
+      "acceptance_notes": "Fail closed unless all three exact dependency items are satisfied and all four lane-matched 12 ns temporal bundles, hashed finalized-CDC probe summaries, and the passing 131k Llama7B workload-correspondence report are materialized. Require four rows ordered [1,2,4,8], source-domain single-FIFO accounting from the 10 ns row, the 12 ns destination diagnostic row, preserved overlap/serial timing bounds, conservative affine workload projections, and bounded provisional energy provenance. Emit no per-lane recost files.",
       "notes": "Queue only from merged origin/master after dependency materialization. This preparation request must not be dispatched."
     }
   ]

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/proposal.json
@@ -6,7 +6,7 @@
   "kind": "architecture",
   "title": "Lane-matched exact-partial composed-service physical recost",
   "abstraction_layer": "decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost",
-  "hypothesis": "Composing the promoted c1 activity anchor with lane-matched 12 ns temporal/finalizer rows, the measured 10 ns source and 12 ns destination FIFO views, and finalized-CDC cycle probes will establish conservative overlap/serial timing bounds and additive physical cost for divider lanes 1, 2, 4, and 8 without overstating token energy.",
+  "hypothesis": "Composing the promoted c1 activity anchor with lane-matched 12 ns temporal/finalizer rows, the measured 10 ns source and 12 ns destination FIFO views, finalized-CDC cycle probes, and the proven 131k Llama7B workload recurrence will establish conservative workload timing bounds and additive physical cost for divider lanes 1, 2, 4, and 8 without overstating token energy.",
   "direct_comparison": {
     "primary_question": "What four-point physical recost is obtained when every divider lane uses its matching temporal measurement and finalized-CDC probe at the selected 10 ns / 12 ns domain periods?",
     "include": [
@@ -15,6 +15,7 @@
       "one timing-feasible 12 ns temporal/finalizer physical row plus config and macro manifest per lane",
       "the 10 ns source-domain and 12 ns destination-domain async FIFO rows plus configs and manifests",
       "one matching lightweight finalized-CDC functional probe per lane",
+      "the passing bounded-to-131k workload-correspondence report",
       "one aggregate JSON report and one four-row CSV"
     ],
     "exclude": [
@@ -44,7 +45,8 @@
       "comparison_role": "lane_matched_composed_physical_recost",
       "depends_on_item_ids": [
         "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
-        "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1"
+        "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1",
+        "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
@@ -52,9 +54,9 @@
       "status": "pending_implementation_merge",
       "expected_result": {
         "direction": "record_bounded_exact_partial_composed_service_physical_recost",
-        "reason": "Preserve lane-matched functional cycle counts, overlap and serial timing bounds, single-FIFO accounting, additive standalone physical measurements, and bounded provisional energy provenance across all four divider-lane points."
+        "reason": "Preserve lane-matched functional cycle counts, conservative 131k Llama7B affine projections, single-FIFO accounting, additive standalone physical measurements, and bounded provisional energy provenance across all four divider-lane points."
       },
-      "notes": "Generate only after this implementation and both dependency outputs are merged/materialized on current origin/master. Do not dispatch, open a PR, or queue from this preparation branch."
+      "notes": "Generate only after this implementation and all three dependency outputs are merged/materialized on current origin/master. Do not dispatch, open a PR, or queue from this preparation branch."
     }
   ],
   "source_refs": [
@@ -63,7 +65,8 @@
     "runs/campaigns/npu/attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/campaign.json",
     "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_activity_power__l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1_r8.json",
     "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_source_domain_physical/metrics.csv",
-    "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_destination_domain_physical/metrics.csv"
+    "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_destination_domain_physical/metrics.csv",
+    "docs/proposals/prop_l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1/workload_correspondence_report.json"
   ],
   "remaining_abstractions_after_this_step": [
     "The composed physical result is an additive normalization of independently routed clock islands, not whole-top route signoff.",

--- a/npu/eval/run_attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign.py
+++ b/npu/eval/run_attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign.py
@@ -34,7 +34,10 @@ _PHYSICAL_DEPENDENCY = "l1_decoder_attention_exact_partial_temporal_finalizer_bo
 _FUNCTIONAL_DEPENDENCY = (
     "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1"
 )
-_DEPENDENCIES = (_PHYSICAL_DEPENDENCY, _FUNCTIONAL_DEPENDENCY)
+_WORKLOAD_DEPENDENCY = (
+    "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1"
+)
+_DEPENDENCIES = (_PHYSICAL_DEPENDENCY, _FUNCTIONAL_DEPENDENCY, _WORKLOAD_DEPENDENCY)
 _LANES = (1, 2, 4, 8)
 _SERVICE_PERIOD_NS = 10.0
 _TEMPORAL_PERIOD_NS = 12.0
@@ -53,6 +56,12 @@ _FUNCTIONAL_SUMMARY_MODEL = (
 )
 _FUNCTIONAL_CAMPAIGN_ID = (
     "attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1"
+)
+_WORKLOAD_MODEL = "attention_decode_score_multivalue_service_workload_correspondence_v1"
+_WORKLOAD_JSON = (
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+    "decoder_attention_exact_partial_c1_workload_correspondence__"
+    f"{_WORKLOAD_DEPENDENCY}.json"
 )
 
 
@@ -109,7 +118,9 @@ def _validate_campaign(payload: JsonDict) -> JsonDict:
         raise ValueError("campaign proposal_ref mismatch")
     dependencies = payload.get("depends_on_item_ids")
     if dependencies != list(_DEPENDENCIES):
-        raise ValueError("campaign must require exactly the physical and functional dependency items")
+        raise ValueError(
+            "campaign must require exactly the physical, functional, and workload dependency items"
+        )
 
     fixed = payload.get("fixed_inputs")
     if not isinstance(fixed, dict):
@@ -125,6 +136,10 @@ def _validate_campaign(payload: JsonDict) -> JsonDict:
     expected_summary = f"{_FUNCTIONAL_ROOT}/campaign_summary.json"
     if fixed.get("functional_probe_summary_json") != expected_summary:
         raise ValueError("campaign functional probe summary must come from the required functional item")
+    if fixed.get("workload_correspondence_json") != _WORKLOAD_JSON:
+        raise ValueError(
+            "campaign workload correspondence must come from the required workload item"
+        )
 
     for domain in ("source", "destination"):
         fifo = fixed.get(f"async_fifo_{domain}")
@@ -186,6 +201,65 @@ def _validate_functional_summary(
             raise ValueError(f"functional dependency output path mismatch for divider_lanes={lane}")
         if point.get("sha256") != _sha256(probe_path):
             raise ValueError(f"functional dependency hash mismatch for divider_lanes={lane}")
+
+
+def _validate_workload_correspondence(path: Path) -> dict[int, JsonDict]:
+    payload = _load_json(path)
+    if payload.get("model") != _WORKLOAD_MODEL or payload.get("passed") is not True:
+        raise ValueError("workload correspondence dependency must be passing")
+    workload = payload.get("workload")
+    if not isinstance(workload, dict):
+        raise ValueError("workload correspondence requires workload metadata")
+    if workload.get("sequence_length") != 131072 or workload.get("windows_per_head") != 5462:
+        raise ValueError("workload correspondence must describe the selected Llama7B 131k workload")
+    lane_reports = payload.get("lane_reports")
+    if not isinstance(lane_reports, list) or len(lane_reports) != len(_LANES):
+        raise ValueError("workload correspondence lane set mismatch")
+    by_lane: dict[int, JsonDict] = {}
+    for report, lane in zip(lane_reports, _LANES, strict=True):
+        if not isinstance(report, dict) or report.get("divider_lanes") != lane:
+            raise ValueError(f"workload correspondence lane mismatch for divider_lanes={lane}")
+        proof = report.get("affine_recurrence_proof")
+        projection = report.get("projection")
+        if not isinstance(proof, dict) or proof.get("proven") is not True:
+            raise ValueError(f"workload affine proof missing for divider_lanes={lane}")
+        if proof.get("bounded_window_counts") != [1, 2, 3, 4]:
+            raise ValueError(f"workload affine proof bounds mismatch for divider_lanes={lane}")
+        if not isinstance(projection, dict) or projection.get("windows_per_head") != 5462:
+            raise ValueError(f"workload projection missing for divider_lanes={lane}")
+        startup = proof.get("startup_cycles")
+        steady = proof.get("steady_state_cycles_per_additional_full_window")
+        measured = proof.get("measured_service_span_cycles")
+        deltas = proof.get("counter_deltas")
+        if (
+            not isinstance(startup, int)
+            or isinstance(startup, bool)
+            or startup <= 0
+            or not isinstance(steady, int)
+            or isinstance(steady, bool)
+            or steady <= 0
+        ):
+            raise ValueError(f"workload affine coefficients invalid for divider_lanes={lane}")
+        if measured != [startup + index * steady for index in range(4)]:
+            raise ValueError(f"workload affine measurements mismatch for divider_lanes={lane}")
+        if deltas != [steady, steady, steady]:
+            raise ValueError(f"workload affine deltas mismatch for divider_lanes={lane}")
+        service_cycles = projection.get("service_cycles_per_head")
+        final_drain = projection.get("temporal_final_drain_cycles_per_head")
+        expected_service_cycles = startup + (5462 - 1) * steady
+        if service_cycles != expected_service_cycles:
+            raise ValueError(f"workload service projection mismatch for divider_lanes={lane}")
+        if not isinstance(final_drain, int) or isinstance(final_drain, bool) or final_drain <= 0:
+            raise ValueError(f"workload final drain invalid for divider_lanes={lane}")
+        expected_head_ns = service_cycles * _SERVICE_PERIOD_NS + final_drain * _TEMPORAL_PERIOD_NS
+        if projection.get("head_latency_ns_serial_upper_bound") != expected_head_ns:
+            raise ValueError(f"workload head latency mismatch for divider_lanes={lane}")
+        if projection.get("layer_latency_ns_serial_upper_bound") != expected_head_ns * 32:
+            raise ValueError(f"workload layer latency mismatch for divider_lanes={lane}")
+        if report.get("tail_adjustment_used_in_projection") is not False:
+            raise ValueError(f"workload projection must conservatively omit tail saving for lane={lane}")
+        by_lane[lane] = report
+    return by_lane
 
 
 def _audit_kwargs(*, campaign: JsonDict, point: JsonDict, repo_root: Path) -> JsonDict:
@@ -283,6 +357,15 @@ def run_campaign(
         "functional dependency campaign summary",
     )
     _validate_functional_summary(summary_path=summary_path, campaign=campaign, repo_root=repo_root)
+    workload_path = _require_file(
+        _repo_path(
+            repo_root,
+            campaign["fixed_inputs"]["workload_correspondence_json"],
+            "workload_correspondence_json",
+        ),
+        "workload correspondence dependency",
+    )
+    workload_by_lane = _validate_workload_correspondence(workload_path)
 
     rows: list[JsonDict] = []
     point_summaries: list[JsonDict] = []
@@ -291,7 +374,37 @@ def run_campaign(
         print(f"recosting exact-partial composed service divider_lanes={lane}", flush=True)
         report = audit_runner(**_audit_kwargs(campaign=campaign, point=point, repo_root=repo_root))
         point_summary = _lightweight_point(report, lane=lane)
-        rows.append(report["rows"][0])
+        workload = workload_by_lane[lane]
+        proof = workload["affine_recurrence_proof"]
+        projection = workload["projection"]
+        row = dict(report["rows"][0])
+        row.update(
+            {
+                "workload_windows_per_head": projection["windows_per_head"],
+                "workload_service_startup_cycles": proof["startup_cycles"],
+                "workload_service_steady_cycles_per_window": proof[
+                    "steady_state_cycles_per_additional_full_window"
+                ],
+                "workload_service_cycles_per_head": projection["service_cycles_per_head"],
+                "workload_temporal_final_drain_cycles_per_head": projection[
+                    "temporal_final_drain_cycles_per_head"
+                ],
+                "workload_head_latency_ns_serial_upper_bound": projection[
+                    "head_latency_ns_serial_upper_bound"
+                ],
+                "workload_layer_latency_ns_serial_upper_bound": projection[
+                    "layer_latency_ns_serial_upper_bound"
+                ],
+            }
+        )
+        rows.append(row)
+        point_summary["workload_correspondence"] = {
+            "affine_recurrence_proof": proof,
+            "projection": projection,
+            "tail_adjustment_used_in_projection": workload[
+                "tail_adjustment_used_in_projection"
+            ],
+        }
         point_summaries.append(point_summary)
 
     fieldnames = list(rows[0])
@@ -305,12 +418,13 @@ def run_campaign(
         "proposal_ref": campaign["proposal_ref"],
         "dependency_contract": {
             "depends_on_item_ids": list(_DEPENDENCIES),
-            "both_dependencies_required": True,
-            "both_dependencies_materialized": True,
+            "all_dependencies_required": True,
+            "all_dependencies_materialized": True,
         },
         "campaign_path": campaign_path.relative_to(repo_root).as_posix(),
         "campaign_sha256": _sha256(campaign_path),
         "functional_dependency_summary_sha256": _sha256(summary_path),
+        "workload_correspondence_sha256": _sha256(workload_path),
         "divider_lanes": list(_LANES),
         "point_count": len(rows),
         "points": point_summaries,
@@ -321,6 +435,7 @@ def run_campaign(
             "per_lane_recost_reports_omitted": True,
             "overlap_and_serial_bounds_preserved": True,
             "provisional_energy_provenance_preserved": True,
+            "llama7b_workload_projection_preserved": True,
         },
     }
 

--- a/runs/campaigns/npu/attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/campaign.json
+++ b/runs/campaigns/npu/attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/campaign.json
@@ -7,7 +7,8 @@
   },
   "depends_on_item_ids": [
     "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
-    "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1"
+    "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1",
+    "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1"
   ],
   "fixed_inputs": {
     "service_activity_power_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_activity_power__l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1_r8.json",
@@ -26,7 +27,8 @@
       "config_json": "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_destination_domain_physical/config.json",
       "macro_manifest_json": "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_destination_domain_physical/macro_manifest.json"
     },
-    "functional_probe_summary_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1/campaign_summary.json"
+    "functional_probe_summary_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1/campaign_summary.json",
+    "workload_correspondence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_exact_partial_c1_workload_correspondence__l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1.json"
   },
   "points": [
     {

--- a/tests/test_run_attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign.py
+++ b/tests/test_run_attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign.py
@@ -50,6 +50,46 @@ def _materialize_committed_campaign(tmp_path: Path) -> tuple[Path, dict]:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(f"fixture for {relative}\n", encoding="utf-8")
 
+    workload_path = repo_root / fixed["workload_correspondence_json"]
+    workload_path.parent.mkdir(parents=True, exist_ok=True)
+    workload_path.write_text(
+        json.dumps(
+            {
+                "model": "attention_decode_score_multivalue_service_workload_correspondence_v1",
+                "passed": True,
+                "workload": {"sequence_length": 131072, "windows_per_head": 5462},
+                "lane_reports": [
+                    {
+                        "divider_lanes": lane,
+                        "affine_recurrence_proof": {
+                            "proven": True,
+                            "bounded_window_counts": [1, 2, 3, 4],
+                            "startup_cycles": 1051,
+                            "steady_state_cycles_per_additional_full_window": 1076,
+                            "measured_service_span_cycles": [1051, 2127, 3203, 4279],
+                            "counter_deltas": [1076, 1076, 1076],
+                        },
+                        "tail_adjustment_used_in_projection": False,
+                        "projection": {
+                            "windows_per_head": 5462,
+                            "service_cycles_per_head": 5_877_087,
+                            "temporal_final_drain_cycles_per_head": 16 * (57 * (8 // lane) + 2),
+                            "head_latency_ns_serial_upper_bound": (
+                                5_877_087 * 10.0 + 16 * (57 * (8 // lane) + 2) * 12.0
+                            ),
+                            "layer_latency_ns_serial_upper_bound": (
+                                (5_877_087 * 10.0 + 16 * (57 * (8 // lane) + 2) * 12.0)
+                                * 32
+                            ),
+                        },
+                    }
+                    for lane in (1, 2, 4, 8)
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
     summary_path = repo_root / fixed["functional_probe_summary_json"]
     summary_path.parent.mkdir(parents=True, exist_ok=True)
     summary = {
@@ -117,6 +157,7 @@ def test_committed_campaign_contract_requires_exact_dependencies() -> None:
     assert validated["depends_on_item_ids"] == [
         "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
         "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1",
+        "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1",
     ]
 
     campaign["depends_on_item_ids"].pop()
@@ -140,10 +181,15 @@ def test_run_campaign_writes_one_lightweight_report_and_four_row_csv(tmp_path: P
     assert summary["passed"] is True
     assert summary["divider_lanes"] == [1, 2, 4, 8]
     assert summary["point_count"] == 4
-    assert summary["dependency_contract"]["both_dependencies_materialized"] is True
+    assert summary["dependency_contract"]["all_dependencies_materialized"] is True
     assert summary["artifact_contract"]["per_lane_recost_reports_omitted"] is True
     assert summary["artifact_contract"]["overlap_and_serial_bounds_preserved"] is True
     assert summary["artifact_contract"]["provisional_energy_provenance_preserved"] is True
+    assert summary["artifact_contract"]["llama7b_workload_projection_preserved"] is True
+    assert summary["rows"][0]["workload_service_cycles_per_head"] == 5_877_087
+    assert summary["points"][3]["workload_correspondence"]["projection"][
+        "temporal_final_drain_cycles_per_head"
+    ] == 944
     assert all(point["energy_contract"]["exact_token_energy_claimed"] is False for point in summary["points"])
     with csv_out.open("r", encoding="utf-8", newline="") as handle:
         rows = list(csv.DictReader(handle))
@@ -178,6 +224,27 @@ def test_run_campaign_fails_closed_on_functional_probe_hash_mismatch(tmp_path: P
     csv_out = repo_root / "outputs" / "recost.csv"
 
     with pytest.raises(ValueError, match="hash mismatch"):
+        run_campaign(
+            campaign_path=repo_root / CAMPAIGN_REL,
+            out=out,
+            csv_out=csv_out,
+            repo_root=repo_root,
+            audit_runner=_fake_audit,
+        )
+    assert not out.exists()
+    assert not csv_out.exists()
+
+
+def test_run_campaign_fails_closed_on_invalid_workload_projection(tmp_path: Path) -> None:
+    repo_root, campaign = _materialize_committed_campaign(tmp_path)
+    workload = repo_root / campaign["fixed_inputs"]["workload_correspondence_json"]
+    payload = json.loads(workload.read_text(encoding="utf-8"))
+    payload["lane_reports"][0]["affine_recurrence_proof"]["proven"] = False
+    workload.write_text(json.dumps(payload), encoding="utf-8")
+    out = repo_root / "outputs" / "recost.json"
+    csv_out = repo_root / "outputs" / "recost.csv"
+
+    with pytest.raises(ValueError, match="affine proof missing"):
         run_campaign(
             campaign_path=repo_root / CAMPAIGN_REL,
             out=out,


### PR DESCRIPTION
## Summary
- make the merged 131k Llama7B workload-correspondence item a mandatory third recost dependency
- validate and hash its per-lane affine proof and conservative projection
- emit workload service/final-drain/latency fields in the aggregate JSON and four-row CSV
- fail closed on corrupt coefficients, measurements, deltas, or derived latency

## Verification
- `python3 -m pytest -q tests/test_run_attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign.py`
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -k exact_partial_physical_recost`
- `python3 scripts/validate_runs.py --skip_eval_queue`

The full task-generator/result-consumer test pair has one unrelated pre-existing failure in `test_service_activity_power_request_manifests_remain_dependency_gated`: the committed manifest contains `_r3` while that stale test still expects the unsuffixed item.
