### PR TITLE
Add workload correspondence task generator

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -7848,6 +7848,83 @@ def _decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_
     }
 
 
+def _decoder_attention_exact_partial_c1_workload_correspondence_evidence(
+    *,
+    item_id: str,
+    proposal_id: str | None = None,
+    proposal_path: str | None = None,
+) -> dict[str, Any]:
+    expected_proposal_id = (
+        "prop_l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1"
+    )
+    expected_proposal_path = f"docs/proposals/{expected_proposal_id}/proposal.json"
+    if str(proposal_id or "").strip() != expected_proposal_id:
+        raise Layer2TaskGenerationError("workload correspondence proposal_id mismatch")
+    if str(proposal_path or "").strip() != expected_proposal_path:
+        raise Layer2TaskGenerationError("workload correspondence proposal_path mismatch")
+    campaign = (
+        "runs/campaigns/npu/"
+        "attention_exact_partial_c1_workload_correspondence_v1/campaign.json"
+    )
+    out = (
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_exact_partial_c1_workload_correspondence__"
+        f"{item_id}.json"
+    )
+    command = _bounded_launcher_command(
+        memory_high="4G",
+        memory_max="6G",
+        cpu_quota="200%",
+        tasks_max=192,
+        runtime_max_sec=600,
+        child_command=[
+            "python3",
+            "npu/eval/probe_attention_decode_score_multivalue_service_workload_correspondence.py",
+            "--out",
+            out,
+        ],
+    )
+    return {
+        "inputs": {
+            "exact_partial_c1_workload_correspondence_campaign": campaign,
+            "exact_partial_c1_workload_correspondence_out": out,
+            "exact_partial_c1_workload_correspondence_scope": (
+                "Run the bounded finalized-CDC RTL matrix for divider lanes 1, 2, 4, and 8 over "
+                "one through four full windows, one eight-token tail, and same-slot two-head reuse. "
+                "Require exact software values and counters, then project 5,462 windows per head "
+                "only from equal measured affine deltas."
+            ),
+        },
+        "commands": [
+            {
+                "name": "probe_exact_partial_c1_workload_correspondence_llama7b_131k",
+                "run": command,
+            }
+        ],
+        "expected_outputs": [out],
+        "evidence_only": True,
+        "worker_resources": {
+            "exclusive_worker": True,
+            "memory_high": "4G",
+            "memory_max": "6G",
+            "cpu_quota": "200%",
+            "tasks_max": 192,
+            "outer_timeout_seconds": 600,
+            "stall_timeout_seconds": 300,
+        },
+        "acceptance": [
+            "Require divider_lanes [1,2,4,8] at service_period_ns=10 and temporal_period_ns=12",
+            "Require exact software/RTL outputs and every modeled counter for all bounded cases",
+            "Require equal service deltas for full-window counts 1, 2, 3, and 4",
+            "Require a real 8-token tail refill/finalization and two-head same-slot state reuse",
+            "Project 5,462 windows per head only from the proven affine recurrence",
+            "Keep the measured tail saving uncredited in the conservative projection",
+            "Write exactly one workload correspondence JSON artifact",
+            "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing",
+        ],
+    }
+
+
 def _decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_evidence(
     *,
     item_id: str,
@@ -12061,6 +12138,7 @@ def _build_payload(
         "decoder_attention_decode_score_multivalue_integrated_service",
         "decoder_attention_decode_score_multivalue_service_exact_partial_equivalence",
         "decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe",
+        "decoder_attention_exact_partial_c1_workload_correspondence",
         "decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost",
         "decoder_attention_decode_score_multivalue_service_activity_power",
         "decoder_attention_decode_score_multivalue_service_measured_frontier",
@@ -12369,6 +12447,12 @@ def _build_payload(
                     proposal_id=proposal_id,
                     proposal_path=proposal_path,
                 )
+            )
+        elif abstraction_layer_name == "decoder_attention_exact_partial_c1_workload_correspondence":
+            decoder_evidence = _decoder_attention_exact_partial_c1_workload_correspondence_evidence(
+                item_id=item_id,
+                proposal_id=proposal_id,
+                proposal_path=proposal_path,
             )
         elif abstraction_layer_name == "decoder_attention_decode_score_multivalue_service_activity_power":
             decoder_evidence = _decoder_attention_decode_score_multivalue_service_activity_power_evidence(

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -90,6 +90,20 @@ def _write_committed_finalized_cdc_lane_campaign(repo_root: Path) -> str:
     return relative_path.as_posix()
 
 
+def _write_committed_workload_correspondence_campaign(repo_root: Path) -> str:
+    relative_path = Path(
+        "runs/campaigns/npu/"
+        "attention_exact_partial_c1_workload_correspondence_v1/campaign.json"
+    )
+    source_path = Path(__file__).resolve().parents[3] / relative_path
+    destination_path = repo_root / relative_path
+    destination_path.parent.mkdir(parents=True, exist_ok=True)
+    destination_path.write_text(
+        source_path.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    return relative_path.as_posix()
+
+
 def _write_committed_exact_partial_physical_recost_campaign(repo_root: Path) -> str:
     relative_path = Path(
         "runs/campaigns/npu/"
@@ -9853,6 +9867,80 @@ def test_generate_l2_campaign_task_adds_finalized_cdc_lane_probe_campaign() -> N
             assert payload["source_requirement"]["required_sha"] == source_commit
             assert payload["source_requirement"]["required_ref"] == "origin/master"
             assert payload["source_requirement"]["requires_daemon_restart"] is True
+
+
+def test_generate_l2_campaign_task_adds_workload_correspondence_campaign() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_committed_workload_correspondence_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        item_id = "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1"
+        proposal_id = (
+            "prop_l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1"
+        )
+        proposal_path = f"docs/proposals/{proposal_id}/proposal.json"
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=item_id,
+                    proposal_id=proposal_id,
+                    proposal_path=proposal_path,
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer="decoder_attention_exact_partial_c1_workload_correspondence",
+                    evaluation_mode="equivalence",
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=False,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            payload = work_item.task_request.request_payload
+            commands = payload["task"]["commands"]
+            run = commands[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+
+            assert [command["name"] for command in commands] == [
+                "probe_exact_partial_c1_workload_correspondence_llama7b_131k",
+                "validate_runs",
+            ]
+            assert "control_plane/scripts/run_bounded_command.py" in run
+            assert "--memory-max 6G" in run
+            assert "--runtime-max-sec 600" in run
+            assert (
+                "probe_attention_decode_score_multivalue_service_workload_correspondence.py"
+                in run
+            )
+            assert payload["task"]["expected_outputs"] == [
+                decoder_inputs["exact_partial_c1_workload_correspondence_out"]
+            ]
+            assert payload["developer_loop"]["dependencies"] == {
+                "item_ids": [],
+                "requires_merged_inputs": True,
+                "requires_materialized_refs": False,
+            }
+            expected_worker_resources = {
+                "exclusive_worker": True,
+                "memory_high": "4G",
+                "memory_max": "6G",
+                "cpu_quota": "200%",
+                "tasks_max": 192,
+                "outer_timeout_seconds": 600,
+                "stall_timeout_seconds": 300,
+            }
+            assert work_item.input_manifest["worker_resources"] == expected_worker_resources
+            assert payload["source_requirement"]["required_sha"] == source_commit
+            assert payload["source_requirement"]["required_ref"] == "origin/master"
+            assert payload["source_requirement"]["requires_daemon_restart"] is True
+            assert work_item.state == WorkItemState.DISPATCH_PENDING
 
 
 def test_generate_l2_campaign_task_adds_exact_partial_physical_recost_consumer() -> None:

--- a/docs/proposals/prop_l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1/evaluation_requests.json
@@ -15,6 +15,7 @@
       "requires_merged_inputs": true,
       "requires_materialized_refs": false,
       "run_physical": false,
+      "campaign_path": "runs/campaigns/npu/attention_exact_partial_c1_workload_correspondence_v1/campaign.json",
       "command": "python3 npu/eval/probe_attention_decode_score_multivalue_service_workload_correspondence.py --out runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_exact_partial_c1_workload_correspondence__l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1.json",
       "expected_outputs": [
         "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_exact_partial_c1_workload_correspondence__l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1.json"

--- a/docs/proposals/prop_l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1/proposal.json
@@ -51,6 +51,7 @@
     }
   ],
   "source_refs": [
+    "runs/campaigns/npu/attention_exact_partial_c1_workload_correspondence_v1/campaign.json",
     "npu/eval/probe_attention_decode_score_multivalue_service_workload_correspondence.py",
     "npu/eval/probe_attention_decode_score_multivalue_service_finalized_cdc.py",
     "docs/proposals/prop_l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1/workload_correspondence_report.md",

--- a/runs/campaigns/npu/attention_exact_partial_c1_workload_correspondence_v1/campaign.json
+++ b/runs/campaigns/npu/attention_exact_partial_c1_workload_correspondence_v1/campaign.json
@@ -1,0 +1,23 @@
+{
+  "model": "attention_decode_score_multivalue_service_workload_correspondence_campaign_v1",
+  "campaign_id": "attention_exact_partial_c1_workload_correspondence_llama7b_131k_v1",
+  "proposal_ref": {
+    "proposal_id": "prop_l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1",
+    "proposal_path": "docs/proposals/prop_l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1/proposal.json"
+  },
+  "fixed_parameters": {
+    "sequence_length": 131072,
+    "tokens_per_full_window": 24,
+    "windows_per_head": 5462,
+    "service_period_ns": 10.0,
+    "temporal_period_ns": 12.0,
+    "divider_lanes": [1, 2, 4, 8],
+    "temporal_state_backend": "sram",
+    "service_value_memory_backend": "macro_banked_4x16x64x32"
+  },
+  "outputs": {
+    "campaign_dir": "runs/campaigns/npu/attention_exact_partial_c1_workload_correspondence_v1/results",
+    "results_csv": "runs/campaigns/npu/attention_exact_partial_c1_workload_correspondence_v1/results/results.csv",
+    "report_md": "runs/campaigns/npu/attention_exact_partial_c1_workload_correspondence_v1/results/report.md"
+  }
+}


### PR DESCRIPTION
## Summary
- add a source-pinned control-plane task contract for the merged 131k Llama7B workload-correspondence probe
- bound evaluator resources and emit exactly one lightweight JSON artifact
- add the committed campaign descriptor and focused task-generator coverage

## Verification
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/python -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -k 'workload_correspondence_campaign or exact_partial_physical_recost'`
- `python3 -m pytest -q tests/test_probe_attention_decode_score_multivalue_service_workload_correspondence.py`
- `python3 scripts/validate_runs.py --skip_eval_queue`
