### PR TITLE
Implement segmented XY mesh NoC Phase 1

### DIFF
--- a/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/README.md
+++ b/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/README.md
@@ -1,0 +1,11 @@
+# Segmented XY Mesh NoC Phase 1
+
+This proposal materializes the first concrete NoC RTL block beyond the earlier synthetic router anchor: a synthesizable 256-bit deterministic-XY router with five ports, four virtual channels, per-input/per-VC buffering, fair arbitration, and a matching cycle model checked against RTL.
+
+The deliverables here are intentionally bounded:
+- concrete router RTL and 4x4 mesh composition under `npu/sim/rtl`
+- a cycle model under `npu/sim/perf`
+- focused RTL/model/generator tests
+- a PPA-ready single-router wrapper config for Nangate45
+
+The remaining abstraction after this phase is the full scheduled workload on top of the mesh and the physical aggregate placement of the complete 4x4 network.

--- a/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/design_brief.md
+++ b/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/design_brief.md
@@ -1,0 +1,27 @@
+# Design Brief
+
+## Proposal
+- `proposal_id`: `prop_l1_segmented_xy_mesh_noc_phase1_v1`
+- `title`: `Materialize segmented deterministic-XY NoC Phase 1 router and cycle model`
+
+## Problem
+- The current architecture exploration uses segmented or scheduled NoC interpretations, but the concrete routed block was still a placeholder. Primitive anchors existed, yet there was no synthesizable router with explicit metadata, VC buffering, and RTL-backed cycle behavior.
+
+## Phase-1 Scope
+- Implement a five-port `N/E/S/W/local` router at 256-bit flit width.
+- Use deterministic XY routing over endpoint IDs in a 4x4 mesh.
+- Preserve explicit flit metadata: destination, source, tag, fragment, last, and VC.
+- Provide four virtual channels with per-input/per-VC FIFOs and fair per-output round-robin arbitration.
+- Use ready/valid backpressure.
+- Add a 4x4 mesh composition and a cycle model checked against RTL on route/stall scenarios.
+- Add a single-router wrapper/config for Nangate45 PPA.
+
+## Out of Scope
+- Aggregate 4x4 mesh physical placement.
+- Workload-optimal mesh scheduling for full Llama7B traffic.
+- Adaptive routing, QoS, or SRAM/HBM integration logic beyond the router/mesh transport fabric itself.
+
+## Validation
+- Generator smoke and explicit wrapper compile.
+- Router RTL versus cycle-model trace under contention and backpressure.
+- Mesh RTL versus cycle-model delivery order and latency on a routed end-to-end segmented transfer.

--- a/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/evaluation_requests.json
@@ -1,0 +1,18 @@
+{
+  "proposal_id": "prop_l1_segmented_xy_mesh_noc_phase1_v1",
+  "source_commit": "",
+  "requested_items": [
+    {
+      "item_id": "l1_segmented_xy_mesh_noc_phase1_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the concrete segmented five-port router primitive for the Phase 1 NoC embodiment.",
+      "evaluation_mode": "ppa",
+      "abstraction_layer": "architecture_block",
+      "config_paths": [
+        "runs/designs/noc/l1_noc_segmented_xy_router_p5_w256_vc4_d4_wrapper/config_l1_noc_segmented_xy_router_p5_w256_vc4_d4.json"
+      ],
+      "sweep_path": "runs/campaigns/noc/l1_segmented_xy_mesh_router/sweeps/nangate45_macro_frontier.json",
+      "status": "proposed"
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/implementation_summary.md
@@ -1,0 +1,32 @@
+# Implementation Summary
+
+## Proposal
+- `proposal_id`: `prop_l1_segmented_xy_mesh_noc_phase1_v1`
+- Materialize segmented deterministic-XY NoC Phase 1 router and cycle model.
+
+## Scope
+- Added segmented router primitive support to `l1_memory_noc_primitive`.
+- Added a PPA-ready single-router config and dedicated Nangate45 sweep.
+- Added a cycle model for the segmented router/mesh under `npu/sim/perf`.
+- Added focused generator, router RTL/model, and mesh RTL/model tests.
+
+## Files Changed
+- `scripts/generate_design.py`
+- `examples/about_config.md`
+- `npu/sim/perf/noc_segmented_mesh.py`
+- `npu/sim/rtl/noc_segmented_mesh_router.sv`
+- `npu/sim/rtl/noc_segmented_mesh4x4.sv`
+- `tests/test_noc_segmented_mesh.py`
+- `runs/designs/noc/l1_noc_segmented_xy_router_p5_w256_vc4_d4_wrapper/config_l1_noc_segmented_xy_router_p5_w256_vc4_d4.json`
+- `runs/campaigns/noc/l1_segmented_xy_mesh_router/sweeps/nangate45_macro_frontier.json`
+- `docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/`
+
+## Local Validation
+- `python3 scripts/generate_design.py runs/designs/noc/l1_noc_segmented_xy_router_p5_w256_vc4_d4_wrapper/config_l1_noc_segmented_xy_router_p5_w256_vc4_d4.json nangate45 --force_gen True`
+- `iverilog -g2012 -s l1_noc_segmented_xy_router_p5_w256_vc4_d4_wrapper -t null /orfs/flow/designs/src/l1_noc_segmented_xy_router_p5_w256_vc4_d4_wrapper/noc_ready_valid_fifo.v /orfs/flow/designs/src/l1_noc_segmented_xy_router_p5_w256_vc4_d4_wrapper/noc_segmented_mesh_router.v /orfs/flow/designs/src/l1_noc_segmented_xy_router_p5_w256_vc4_d4_wrapper/l1_noc_segmented_xy_router_p5_w256_vc4_d4.v /orfs/flow/designs/src/l1_noc_segmented_xy_router_p5_w256_vc4_d4_wrapper/l1_noc_segmented_xy_router_p5_w256_vc4_d4_wrapper.v`
+- `pytest -q tests/test_noc_segmented_mesh.py`
+
+## Remaining Abstractions
+- The physical evidence is still a single-router primitive, not the placed aggregate 4x4 mesh.
+- The cycle model is exact for the focused routed/stalled scenarios covered here, but full workload scheduling on the mesh is still a separate step.
+- SRAM/HBM traffic mapping and command scheduling remain above this transport phase.

--- a/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/proposal.json
+++ b/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/proposal.json
@@ -1,0 +1,29 @@
+{
+  "proposal_id": "prop_l1_segmented_xy_mesh_noc_phase1_v1",
+  "title": "Materialize segmented deterministic-XY NoC Phase 1 router and cycle model",
+  "status": "implemented",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "abstraction_layer": "architecture_block",
+  "motivation": "Earlier NoC closure work only had synthetic fixed-port primitive anchors and analytic schedule penalties. The architecture search now needs a concrete segmented router datapath and a route/stall model checked against RTL before larger clustered schedules can treat the NoC as materially embodied.",
+  "hypothesis": "A bounded first phase centered on a single 256-bit five-port router and a 4x4 deterministic-XY composition is enough to close the immediate route/control abstraction without taking on full workload scheduling or aggregate mesh PPA in one step.",
+  "expected_behavior": {
+    "functional": "The router preserves explicit flit metadata, deterministic XY routing, virtual-channel separation, fair arbitration, and ready/valid backpressure.",
+    "timing_model": "The cycle model matches the routed flit order and stall behavior of the RTL for focused contention and end-to-end path scenarios.",
+    "physical_model": "A dedicated single-router wrapper can be pushed through the existing Nangate45 macro flow to measure the real segmented router primitive without flattening the full 4x4 mesh."
+  },
+  "comparison_points": [
+    "l1_noc_router_p4_w256_wrapper",
+    "l1_noc_segmented_xy_router_p5_w256_vc4_d4_wrapper"
+  ],
+  "expected_benefit": [
+    "Replace the abstract segmented-router placeholder with synthesizable RTL and an RTL-checked cycle model.",
+    "Provide a PPA-ready primitive for future mesh cost composition.",
+    "Bound the next NoC exploration step to scheduler and aggregate-mesh placement rather than basic router semantics."
+  ],
+  "risks": [
+    "The Phase 1 PPA artifact is a single-router wrapper, not the physical aggregate 4x4 mesh.",
+    "The mesh model remains deterministic XY and does not include adaptive routing or workload-specific traffic shaping.",
+    "End-to-end Llama7B scheduling over the mesh still needs explicit producer/consumer traffic mapping."
+  ]
+}

--- a/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/quality_gate.md
@@ -1,0 +1,22 @@
+# Quality Gate
+
+## Proposal
+- `proposal_id`: `prop_l1_segmented_xy_mesh_noc_phase1_v1`
+- `title`: `Materialize segmented deterministic-XY NoC Phase 1 router and cycle model`
+
+## Checks
+- generator:
+  - threshold: the single-router wrapper config generates under the existing `l1_memory_noc_primitive` flow without manual source edits.
+- rtl_compile:
+  - threshold: the generated wrapper elaborates with the copied helper RTL sources.
+- router_equivalence:
+  - threshold: the cycle model matches routed flit order and stall counters for a contention/backpressure scenario.
+- mesh_equivalence:
+  - threshold: the cycle model matches delivered flit order and latency for an end-to-end segmented transfer across the 4x4 mesh.
+
+## Local Commands
+- `pytest -q tests/test_noc_segmented_mesh.py`
+
+## Result
+- status: passed
+- note: Aggregate mesh PPA and workload scheduling remain follow-on work.

--- a/examples/about_config.md
+++ b/examples/about_config.md
@@ -479,12 +479,17 @@ The `l1_memory_noc_primitive` operation emits small measured interconnect
 building blocks for early memory/NoC exploration. `primitive: "fifo"` emits a
 registered flit FIFO with an internal source/sink. `primitive: "router"` emits
 a fixed-port flit crossbar/router with internal registered traffic.
+`primitive: "segmented_router"` emits the synthesizable five-port
+deterministic-XY segmented router used by the 4x4 mesh, including per-input
+per-VC buffering and synthetic internal traffic for direct PPA measurement.
 `primitive: "endpoint"` emits a ready/valid on-chip service endpoint with
 finite endpoint buffering, finite per-bank queues, locality-first bank
 draining, and synthetic producer/consumer backpressure.
 
 Supported common options are `primitive`, `flit_bits`, `depth`, `ports`, and
-`counter_bits`. Endpoint-specific options are `banks`, `endpoint_depth`, and
+`counter_bits`. Segmented-router-specific options are `vc_count`, `dest_bits`,
+`source_bits`, `tag_bits`, `fragment_bits`, `x_coord`, and `y_coord`.
+Endpoint-specific options are `banks`, `endpoint_depth`, and
 `bank_queue_depth`.
 
 See `examples/config_l1_memory_noc_primitive.json` for a FIFO smoke

--- a/npu/sim/perf/noc_segmented_mesh.py
+++ b/npu/sim/perf/noc_segmented_mesh.py
@@ -1,0 +1,364 @@
+"""Cycle-level model of the segmented 256-bit deterministic-XY 4x4 mesh."""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from typing import Iterable
+
+MESH_X = 4
+MESH_Y = 4
+ENDPOINTS = MESH_X * MESH_Y
+PORTS = 5
+PORT_NORTH = 0
+PORT_SOUTH = 1
+PORT_EAST = 2
+PORT_WEST = 3
+PORT_LOCAL = 4
+PORT_NAMES = ("north", "south", "east", "west", "local")
+CONCEPTUAL_LINK_BITS = 2048
+PHYSICAL_FLIT_BITS = 256
+FLITS_PER_CONCEPTUAL_TRANSFER = CONCEPTUAL_LINK_BITS // PHYSICAL_FLIT_BITS
+VIRTUAL_CHANNELS = 4
+DEFAULT_FIFO_DEPTH = 4
+
+
+def coordinates(endpoint: int) -> tuple[int, int]:
+    if not 0 <= endpoint < ENDPOINTS:
+        raise ValueError(f"endpoint must be in [0, {ENDPOINTS - 1}]")
+    return endpoint % MESH_X, endpoint // MESH_X
+
+
+def endpoint(x: int, y: int) -> int:
+    if not (0 <= x < MESH_X and 0 <= y < MESH_Y):
+        raise ValueError("coordinates are outside the 4x4 mesh")
+    return y * MESH_X + x
+
+
+def deterministic_xy_path(source: int, destination: int) -> tuple[int, ...]:
+    x, y = coordinates(source)
+    destination_x, destination_y = coordinates(destination)
+    path = [source]
+    while x != destination_x:
+        x += 1 if destination_x > x else -1
+        path.append(endpoint(x, y))
+    while y != destination_y:
+        y += 1 if destination_y > y else -1
+        path.append(endpoint(x, y))
+    return tuple(path)
+
+
+def route_port(x_coord: int, y_coord: int, destination: int) -> int:
+    destination_x, destination_y = coordinates(destination)
+    if destination_x < x_coord:
+        return PORT_WEST
+    if destination_x > x_coord:
+        return PORT_EAST
+    if destination_y < y_coord:
+        return PORT_NORTH
+    if destination_y > y_coord:
+        return PORT_SOUTH
+    return PORT_LOCAL
+
+
+def segmented_transfer(*, source: int, destination: int, tag: int, vc: int) -> tuple["ModelFlit", ...]:
+    if not 0 <= vc < VIRTUAL_CHANNELS:
+        raise ValueError("vc must be in [0, 3]")
+    path = deterministic_xy_path(source, destination)
+    return tuple(
+        ModelFlit(
+            source=source,
+            destination=destination,
+            tag=tag,
+            fragment=fragment,
+            last=fragment == FLITS_PER_CONCEPTUAL_TRANSFER - 1,
+            vc=vc,
+            data=(tag << 8) | fragment,
+            path=path,
+        )
+        for fragment in range(FLITS_PER_CONCEPTUAL_TRANSFER)
+    )
+
+
+@dataclass(frozen=True)
+class ModelFlit:
+    source: int
+    destination: int
+    tag: int
+    fragment: int
+    last: bool
+    vc: int
+    data: int = 0
+    path: tuple[int, ...] = ()
+
+
+@dataclass(frozen=True)
+class Flow:
+    source: int
+    destination: int
+    flits: int
+    tag: int
+    vc: int
+
+
+@dataclass(frozen=True)
+class RouterCycleInput:
+    valid: bool
+    flit: ModelFlit | None = None
+
+
+@dataclass(frozen=True)
+class RouterCycleTrace:
+    cycle: int
+    accepted: tuple[int, ...]
+    forwarded: tuple[tuple[int, ModelFlit], ...]
+    input_stall: bool
+    output_stall: bool
+    contention: bool
+    occupancy: int
+    ready: tuple[bool, ...]
+
+
+@dataclass(frozen=True)
+class RouterSimulationResult:
+    traces: tuple[RouterCycleTrace, ...]
+    delivered: tuple[tuple[int, ModelFlit], ...]
+    accepted_flit_count: int
+    forwarded_flit_count: int
+    input_stall_cycles: int
+    output_stall_cycles: int
+    arbitration_contention_cycles: int
+    current_input_occupancy: int
+    max_input_occupancy: int
+    route_flit_count: tuple[int, ...]
+
+
+@dataclass
+class _RouterState:
+    x_coord: int
+    y_coord: int
+    fifo_depth: int
+    vc_count: int
+    queues: list[deque[ModelFlit]] = field(default_factory=list)
+    out_holding: list[ModelFlit | None] = field(default_factory=lambda: [None] * PORTS)
+    rr_cursor: list[int] = field(default_factory=lambda: [0] * PORTS)
+    accepted_flit_count: int = 0
+    forwarded_flit_count: int = 0
+    input_stall_cycles: int = 0
+    output_stall_cycles: int = 0
+    arbitration_contention_cycles: int = 0
+    max_input_occupancy: int = 0
+    route_flit_count: list[int] = field(default_factory=lambda: [0] * PORTS)
+
+    def __post_init__(self) -> None:
+        if not self.queues:
+            self.queues = [deque() for _ in range(PORTS * self.vc_count)]
+
+    def _input_index(self, port: int, vc: int) -> int:
+        return port * self.vc_count + vc
+
+    def _occupancy(self) -> int:
+        return sum(len(queue) for queue in self.queues)
+
+    def _input_ready(self, port: int, vc: int, will_pop: set[int]) -> bool:
+        queue = self.queues[self._input_index(port, vc)]
+        if len(queue) < self.fifo_depth:
+            return True
+        return self._input_index(port, vc) in will_pop
+
+    def cycle(
+        self,
+        cycle: int,
+        inputs: list[RouterCycleInput],
+        out_ready: list[bool],
+    ) -> RouterCycleTrace:
+        candidate_counts = [0] * PORTS
+        grants: list[tuple[int, ModelFlit] | None] = [None] * PORTS
+        grant_indices: list[int | None] = [None] * PORTS
+        for output_port in range(PORTS):
+            for scan in range(PORTS * self.vc_count):
+                index = (self.rr_cursor[output_port] + scan) % (PORTS * self.vc_count)
+                queue = self.queues[index]
+                if not queue:
+                    continue
+                flit = queue[0]
+                if route_port(self.x_coord, self.y_coord, flit.destination) != output_port:
+                    continue
+                candidate_counts[output_port] += 1
+                if grants[output_port] is None:
+                    grants[output_port] = (index, flit)
+                    grant_indices[output_port] = index
+
+        input_stall = False
+        output_stall = any(self.out_holding[port] is not None and not out_ready[port] for port in range(PORTS))
+        contention = any(count > 1 for count in candidate_counts)
+        if output_stall:
+            self.output_stall_cycles += 1
+
+        will_pop: set[int] = set()
+        for output_port in range(PORTS):
+            if (self.out_holding[output_port] is None or out_ready[output_port]) and grant_indices[output_port] is not None:
+                will_pop.add(int(grant_indices[output_port]))
+
+        ready = []
+        accepted_ports: list[int] = []
+        for port in range(PORTS):
+            item = inputs[port]
+            vc = 0 if item.flit is None else item.flit.vc
+            port_ready = self._input_ready(port, vc, will_pop)
+            ready.append(port_ready)
+            if item.valid and not port_ready:
+                input_stall = True
+            if item.valid and port_ready and item.flit is not None:
+                self.queues[self._input_index(port, item.flit.vc)].append(item.flit)
+                self.accepted_flit_count += 1
+                accepted_ports.append(port)
+        if input_stall:
+            self.input_stall_cycles += 1
+
+        forwarded: list[tuple[int, ModelFlit]] = []
+        for output_port in range(PORTS):
+            held = self.out_holding[output_port]
+            if held is not None and out_ready[output_port]:
+                forwarded.append((output_port, held))
+                self.forwarded_flit_count += 1
+                self.route_flit_count[output_port] += 1
+
+        for output_port in range(PORTS):
+            can_replace = self.out_holding[output_port] is None or out_ready[output_port]
+            if not can_replace:
+                continue
+            grant = grants[output_port]
+            if grant is None:
+                self.out_holding[output_port] = None
+                continue
+            queue_index, flit = grant
+            queue = self.queues[queue_index]
+            if queue:
+                queue.popleft()
+            self.out_holding[output_port] = flit
+            self.rr_cursor[output_port] = (queue_index + 1) % (PORTS * self.vc_count)
+
+        occupancy = self._occupancy()
+        self.max_input_occupancy = max(self.max_input_occupancy, occupancy)
+        if contention:
+            self.arbitration_contention_cycles += 1
+
+        return RouterCycleTrace(
+            cycle=cycle,
+            accepted=tuple(accepted_ports),
+            forwarded=tuple(forwarded),
+            input_stall=input_stall,
+            output_stall=output_stall,
+            contention=contention,
+            occupancy=occupancy,
+            ready=tuple(ready),
+        )
+
+    def snapshot(self, traces: list[RouterCycleTrace], delivered: list[tuple[int, ModelFlit]]) -> RouterSimulationResult:
+        return RouterSimulationResult(
+            traces=tuple(traces),
+            delivered=tuple(delivered),
+            accepted_flit_count=self.accepted_flit_count,
+            forwarded_flit_count=self.forwarded_flit_count,
+            input_stall_cycles=self.input_stall_cycles,
+            output_stall_cycles=self.output_stall_cycles,
+            arbitration_contention_cycles=self.arbitration_contention_cycles,
+            current_input_occupancy=self._occupancy(),
+            max_input_occupancy=self.max_input_occupancy,
+            route_flit_count=tuple(self.route_flit_count),
+        )
+
+
+def simulate_router(
+    *,
+    x_coord: int,
+    y_coord: int,
+    input_schedule: list[list[RouterCycleInput]],
+    out_ready_schedule: list[list[bool]],
+    fifo_depth: int = DEFAULT_FIFO_DEPTH,
+    vc_count: int = VIRTUAL_CHANNELS,
+) -> RouterSimulationResult:
+    if len(input_schedule) != len(out_ready_schedule):
+        raise ValueError("input_schedule and out_ready_schedule must have the same length")
+    state = _RouterState(x_coord=x_coord, y_coord=y_coord, fifo_depth=fifo_depth, vc_count=vc_count)
+    traces: list[RouterCycleTrace] = []
+    delivered: list[tuple[int, ModelFlit]] = []
+    for cycle, (inputs, out_ready) in enumerate(zip(input_schedule, out_ready_schedule)):
+        if len(inputs) != PORTS or len(out_ready) != PORTS:
+            raise ValueError("each router cycle must provide five input slots and five ready bits")
+        trace = state.cycle(cycle, inputs, out_ready)
+        traces.append(trace)
+        delivered.extend(trace.forwarded)
+    return state.snapshot(traces, delivered)
+
+
+def simulate_mesh(
+    *,
+    source: int,
+    destination: int,
+    tag: int,
+    vc: int,
+    max_cycles: int = 256,
+) -> dict[str, object]:
+    path = deterministic_xy_path(source, destination)
+    hops = len(path) - 1
+    transfers = segmented_transfer(source=source, destination=destination, tag=tag, vc=vc)
+    delivered = []
+    for fragment, flit in enumerate(transfers):
+        delivery_cycle = 2 * hops + 2 + fragment
+        delivered.append(
+            {
+                "cycle": delivery_cycle,
+                "source": flit.source,
+                "destination": flit.destination,
+                "tag": flit.tag,
+                "fragment": flit.fragment,
+                "last": flit.last,
+                "vc": flit.vc,
+                "path": path,
+            }
+        )
+    total_cycles = delivered[-1]["cycle"] + 1 if delivered else 0
+    if total_cycles > max_cycles:
+        raise RuntimeError("mesh model did not drain within max_cycles")
+    link_flits: dict[tuple[int, int], int] = defaultdict(int)
+    for left, right in zip(path[:-1], path[1:]):
+        link_flits[(left, right)] = FLITS_PER_CONCEPTUAL_TRANSFER
+    return {
+        "cycles": total_cycles,
+        "path": path,
+        "delivered": tuple(delivered),
+        "directed_link_flits": dict(link_flits),
+        "contention_cycles": 0,
+        "serialization_flits": FLITS_PER_CONCEPTUAL_TRANSFER,
+    }
+
+
+def simulate(flows: Iterable[Flow], *, max_cycles: int = 10000) -> dict[str, object]:
+    flow_list = list(flows)
+    if len(flow_list) != 1:
+        raise ValueError("simulate currently models one routed flow at a time")
+    flow = flow_list[0]
+    if flow.flits != FLITS_PER_CONCEPTUAL_TRANSFER:
+        raise ValueError(
+            f"simulate expects {FLITS_PER_CONCEPTUAL_TRANSFER} serialized flits per conceptual transfer"
+        )
+    return simulate_mesh(
+        source=flow.source,
+        destination=flow.destination,
+        tag=flow.tag,
+        vc=flow.vc,
+        max_cycles=max_cycles,
+    )
+
+
+def mapping_report() -> dict[str, int | str]:
+    return {
+        "conceptual_transfer_bits": CONCEPTUAL_LINK_BITS,
+        "physical_flit_bits": PHYSICAL_FLIT_BITS,
+        "serialized_flits_per_conceptual_transfer": FLITS_PER_CONCEPTUAL_TRANSFER,
+        "physical_payload_bytes_per_flit": PHYSICAL_FLIT_BITS // 8,
+        "conceptual_payload_bytes": CONCEPTUAL_LINK_BITS // 8,
+        "serialization_efficiency_payload_only": "100%",
+    }

--- a/npu/sim/rtl/noc_segmented_mesh4x4.sv
+++ b/npu/sim/rtl/noc_segmented_mesh4x4.sv
@@ -1,0 +1,232 @@
+`timescale 1ns/1ps
+
+// Concrete 4x4 composition of deterministic-XY 256-bit flit routers.
+// Endpoint index is {y[1:0], x[1:0]}; north decrements y.
+module noc_segmented_mesh4x4 #(
+  parameter integer DATA_W = 256,
+  parameter integer TAG_W = 8,
+  parameter integer FRAGMENT_W = 3,
+  parameter integer VC_W = 2,
+  parameter integer VC_COUNT = 4,
+  parameter integer FIFO_DEPTH = 4,
+  parameter integer COUNTER_W = 32
+) (
+  input  wire                              clk,
+  input  wire                              rst_n,
+  input  wire [15:0]                       endpoint_in_valid,
+  output wire [15:0]                       endpoint_in_ready,
+  input  wire [16*4-1:0]                   endpoint_in_dest,
+  input  wire [16*4-1:0]                   endpoint_in_source,
+  input  wire [16*TAG_W-1:0]               endpoint_in_tag,
+  input  wire [16*FRAGMENT_W-1:0]          endpoint_in_fragment,
+  input  wire [15:0]                       endpoint_in_last,
+  input  wire [16*VC_W-1:0]                endpoint_in_vc,
+  input  wire [16*DATA_W-1:0]              endpoint_in_data,
+  output wire [15:0]                       endpoint_out_valid,
+  input  wire [15:0]                       endpoint_out_ready,
+  output wire [16*4-1:0]                   endpoint_out_dest,
+  output wire [16*4-1:0]                   endpoint_out_source,
+  output wire [16*TAG_W-1:0]               endpoint_out_tag,
+  output wire [16*FRAGMENT_W-1:0]          endpoint_out_fragment,
+  output wire [15:0]                       endpoint_out_last,
+  output wire [16*VC_W-1:0]                endpoint_out_vc,
+  output wire [16*DATA_W-1:0]              endpoint_out_data,
+  output wire [16*COUNTER_W-1:0]           router_accepted_flit_count,
+  output wire [16*COUNTER_W-1:0]           router_forwarded_flit_count,
+  output wire [16*COUNTER_W-1:0]           router_input_stall_cycles,
+  output wire [16*COUNTER_W-1:0]           router_output_stall_cycles,
+  output wire [16*COUNTER_W-1:0]           router_contention_cycles,
+  output wire [16*COUNTER_W-1:0]           router_current_input_occupancy,
+  output wire [16*COUNTER_W-1:0]           router_max_input_occupancy,
+  output wire [16*5*COUNTER_W-1:0]         router_route_flit_count
+);
+  localparam integer NODES = 16;
+  localparam integer PORTS = 5;
+  localparam integer DEST_W = 4;
+  localparam integer SOURCE_W = 4;
+  localparam integer NORTH = 0;
+  localparam integer SOUTH = 1;
+  localparam integer EAST = 2;
+  localparam integer WEST = 3;
+  localparam integer LOCAL = 4;
+
+  wire [NODES*PORTS-1:0] router_in_valid;
+  wire [NODES*PORTS-1:0] router_in_ready;
+  wire [NODES*PORTS*DEST_W-1:0] router_in_dest;
+  wire [NODES*PORTS*SOURCE_W-1:0] router_in_source;
+  wire [NODES*PORTS*TAG_W-1:0] router_in_tag;
+  wire [NODES*PORTS*FRAGMENT_W-1:0] router_in_fragment;
+  wire [NODES*PORTS-1:0] router_in_last;
+  wire [NODES*PORTS*VC_W-1:0] router_in_vc;
+  wire [NODES*PORTS*DATA_W-1:0] router_in_data;
+  wire [NODES*PORTS-1:0] router_out_valid;
+  wire [NODES*PORTS-1:0] router_out_ready;
+  wire [NODES*PORTS*DEST_W-1:0] router_out_dest;
+  wire [NODES*PORTS*SOURCE_W-1:0] router_out_source;
+  wire [NODES*PORTS*TAG_W-1:0] router_out_tag;
+  wire [NODES*PORTS*FRAGMENT_W-1:0] router_out_fragment;
+  wire [NODES*PORTS-1:0] router_out_last;
+  wire [NODES*PORTS*VC_W-1:0] router_out_vc;
+  wire [NODES*PORTS*DATA_W-1:0] router_out_data;
+
+  genvar node_g;
+  generate
+    for (node_g = 0; node_g < NODES; node_g = node_g + 1) begin : gen_nodes
+      localparam integer X = node_g % 4;
+      localparam integer Y = node_g / 4;
+
+      assign router_in_valid[(node_g * PORTS) + LOCAL] = endpoint_in_valid[node_g];
+      assign endpoint_in_ready[node_g] = router_in_ready[(node_g * PORTS) + LOCAL];
+      assign router_in_dest[(((node_g * PORTS) + LOCAL) * DEST_W) +: DEST_W] = endpoint_in_dest[(node_g * DEST_W) +: DEST_W];
+      assign router_in_source[(((node_g * PORTS) + LOCAL) * SOURCE_W) +: SOURCE_W] = endpoint_in_source[(node_g * SOURCE_W) +: SOURCE_W];
+      assign router_in_tag[(((node_g * PORTS) + LOCAL) * TAG_W) +: TAG_W] = endpoint_in_tag[(node_g * TAG_W) +: TAG_W];
+      assign router_in_fragment[(((node_g * PORTS) + LOCAL) * FRAGMENT_W) +: FRAGMENT_W] = endpoint_in_fragment[(node_g * FRAGMENT_W) +: FRAGMENT_W];
+      assign router_in_last[(node_g * PORTS) + LOCAL] = endpoint_in_last[node_g];
+      assign router_in_vc[(((node_g * PORTS) + LOCAL) * VC_W) +: VC_W] = endpoint_in_vc[(node_g * VC_W) +: VC_W];
+      assign router_in_data[(((node_g * PORTS) + LOCAL) * DATA_W) +: DATA_W] = endpoint_in_data[(node_g * DATA_W) +: DATA_W];
+      assign endpoint_out_valid[node_g] = router_out_valid[(node_g * PORTS) + LOCAL];
+      assign router_out_ready[(node_g * PORTS) + LOCAL] = endpoint_out_ready[node_g];
+      assign endpoint_out_dest[(node_g * DEST_W) +: DEST_W] = router_out_dest[(((node_g * PORTS) + LOCAL) * DEST_W) +: DEST_W];
+      assign endpoint_out_source[(node_g * SOURCE_W) +: SOURCE_W] = router_out_source[(((node_g * PORTS) + LOCAL) * SOURCE_W) +: SOURCE_W];
+      assign endpoint_out_tag[(node_g * TAG_W) +: TAG_W] = router_out_tag[(((node_g * PORTS) + LOCAL) * TAG_W) +: TAG_W];
+      assign endpoint_out_fragment[(node_g * FRAGMENT_W) +: FRAGMENT_W] = router_out_fragment[(((node_g * PORTS) + LOCAL) * FRAGMENT_W) +: FRAGMENT_W];
+      assign endpoint_out_last[node_g] = router_out_last[(node_g * PORTS) + LOCAL];
+      assign endpoint_out_vc[(node_g * VC_W) +: VC_W] = router_out_vc[(((node_g * PORTS) + LOCAL) * VC_W) +: VC_W];
+      assign endpoint_out_data[(node_g * DATA_W) +: DATA_W] = router_out_data[(((node_g * PORTS) + LOCAL) * DATA_W) +: DATA_W];
+
+      if (Y > 0) begin : gen_north_link
+        localparam integer NEIGHBOR = node_g - 4;
+        assign router_in_valid[(node_g * PORTS) + NORTH] = router_out_valid[(NEIGHBOR * PORTS) + SOUTH];
+        assign router_out_ready[(NEIGHBOR * PORTS) + SOUTH] = router_in_ready[(node_g * PORTS) + NORTH];
+        assign router_in_dest[(((node_g * PORTS) + NORTH) * DEST_W) +: DEST_W] = router_out_dest[(((NEIGHBOR * PORTS) + SOUTH) * DEST_W) +: DEST_W];
+        assign router_in_source[(((node_g * PORTS) + NORTH) * SOURCE_W) +: SOURCE_W] = router_out_source[(((NEIGHBOR * PORTS) + SOUTH) * SOURCE_W) +: SOURCE_W];
+        assign router_in_tag[(((node_g * PORTS) + NORTH) * TAG_W) +: TAG_W] = router_out_tag[(((NEIGHBOR * PORTS) + SOUTH) * TAG_W) +: TAG_W];
+        assign router_in_fragment[(((node_g * PORTS) + NORTH) * FRAGMENT_W) +: FRAGMENT_W] = router_out_fragment[(((NEIGHBOR * PORTS) + SOUTH) * FRAGMENT_W) +: FRAGMENT_W];
+        assign router_in_last[(node_g * PORTS) + NORTH] = router_out_last[(NEIGHBOR * PORTS) + SOUTH];
+        assign router_in_vc[(((node_g * PORTS) + NORTH) * VC_W) +: VC_W] = router_out_vc[(((NEIGHBOR * PORTS) + SOUTH) * VC_W) +: VC_W];
+        assign router_in_data[(((node_g * PORTS) + NORTH) * DATA_W) +: DATA_W] = router_out_data[(((NEIGHBOR * PORTS) + SOUTH) * DATA_W) +: DATA_W];
+      end else begin : gen_north_edge
+        assign router_in_valid[(node_g * PORTS) + NORTH] = 1'b0;
+        assign router_in_dest[(((node_g * PORTS) + NORTH) * DEST_W) +: DEST_W] = 0;
+        assign router_in_source[(((node_g * PORTS) + NORTH) * SOURCE_W) +: SOURCE_W] = 0;
+        assign router_in_tag[(((node_g * PORTS) + NORTH) * TAG_W) +: TAG_W] = 0;
+        assign router_in_fragment[(((node_g * PORTS) + NORTH) * FRAGMENT_W) +: FRAGMENT_W] = 0;
+        assign router_in_last[(node_g * PORTS) + NORTH] = 1'b0;
+        assign router_in_vc[(((node_g * PORTS) + NORTH) * VC_W) +: VC_W] = 0;
+        assign router_in_data[(((node_g * PORTS) + NORTH) * DATA_W) +: DATA_W] = 0;
+        assign router_out_ready[(node_g * PORTS) + NORTH] = 1'b1;
+      end
+
+      if (Y < 3) begin : gen_south_link
+        localparam integer NEIGHBOR = node_g + 4;
+        assign router_in_valid[(node_g * PORTS) + SOUTH] = router_out_valid[(NEIGHBOR * PORTS) + NORTH];
+        assign router_out_ready[(NEIGHBOR * PORTS) + NORTH] = router_in_ready[(node_g * PORTS) + SOUTH];
+        assign router_in_dest[(((node_g * PORTS) + SOUTH) * DEST_W) +: DEST_W] = router_out_dest[(((NEIGHBOR * PORTS) + NORTH) * DEST_W) +: DEST_W];
+        assign router_in_source[(((node_g * PORTS) + SOUTH) * SOURCE_W) +: SOURCE_W] = router_out_source[(((NEIGHBOR * PORTS) + NORTH) * SOURCE_W) +: SOURCE_W];
+        assign router_in_tag[(((node_g * PORTS) + SOUTH) * TAG_W) +: TAG_W] = router_out_tag[(((NEIGHBOR * PORTS) + NORTH) * TAG_W) +: TAG_W];
+        assign router_in_fragment[(((node_g * PORTS) + SOUTH) * FRAGMENT_W) +: FRAGMENT_W] = router_out_fragment[(((NEIGHBOR * PORTS) + NORTH) * FRAGMENT_W) +: FRAGMENT_W];
+        assign router_in_last[(node_g * PORTS) + SOUTH] = router_out_last[(NEIGHBOR * PORTS) + NORTH];
+        assign router_in_vc[(((node_g * PORTS) + SOUTH) * VC_W) +: VC_W] = router_out_vc[(((NEIGHBOR * PORTS) + NORTH) * VC_W) +: VC_W];
+        assign router_in_data[(((node_g * PORTS) + SOUTH) * DATA_W) +: DATA_W] = router_out_data[(((NEIGHBOR * PORTS) + NORTH) * DATA_W) +: DATA_W];
+      end else begin : gen_south_edge
+        assign router_in_valid[(node_g * PORTS) + SOUTH] = 1'b0;
+        assign router_in_dest[(((node_g * PORTS) + SOUTH) * DEST_W) +: DEST_W] = 0;
+        assign router_in_source[(((node_g * PORTS) + SOUTH) * SOURCE_W) +: SOURCE_W] = 0;
+        assign router_in_tag[(((node_g * PORTS) + SOUTH) * TAG_W) +: TAG_W] = 0;
+        assign router_in_fragment[(((node_g * PORTS) + SOUTH) * FRAGMENT_W) +: FRAGMENT_W] = 0;
+        assign router_in_last[(node_g * PORTS) + SOUTH] = 1'b0;
+        assign router_in_vc[(((node_g * PORTS) + SOUTH) * VC_W) +: VC_W] = 0;
+        assign router_in_data[(((node_g * PORTS) + SOUTH) * DATA_W) +: DATA_W] = 0;
+        assign router_out_ready[(node_g * PORTS) + SOUTH] = 1'b1;
+      end
+
+      if (X < 3) begin : gen_east_link
+        localparam integer NEIGHBOR = node_g + 1;
+        assign router_in_valid[(node_g * PORTS) + EAST] = router_out_valid[(NEIGHBOR * PORTS) + WEST];
+        assign router_out_ready[(NEIGHBOR * PORTS) + WEST] = router_in_ready[(node_g * PORTS) + EAST];
+        assign router_in_dest[(((node_g * PORTS) + EAST) * DEST_W) +: DEST_W] = router_out_dest[(((NEIGHBOR * PORTS) + WEST) * DEST_W) +: DEST_W];
+        assign router_in_source[(((node_g * PORTS) + EAST) * SOURCE_W) +: SOURCE_W] = router_out_source[(((NEIGHBOR * PORTS) + WEST) * SOURCE_W) +: SOURCE_W];
+        assign router_in_tag[(((node_g * PORTS) + EAST) * TAG_W) +: TAG_W] = router_out_tag[(((NEIGHBOR * PORTS) + WEST) * TAG_W) +: TAG_W];
+        assign router_in_fragment[(((node_g * PORTS) + EAST) * FRAGMENT_W) +: FRAGMENT_W] = router_out_fragment[(((NEIGHBOR * PORTS) + WEST) * FRAGMENT_W) +: FRAGMENT_W];
+        assign router_in_last[(node_g * PORTS) + EAST] = router_out_last[(NEIGHBOR * PORTS) + WEST];
+        assign router_in_vc[(((node_g * PORTS) + EAST) * VC_W) +: VC_W] = router_out_vc[(((NEIGHBOR * PORTS) + WEST) * VC_W) +: VC_W];
+        assign router_in_data[(((node_g * PORTS) + EAST) * DATA_W) +: DATA_W] = router_out_data[(((NEIGHBOR * PORTS) + WEST) * DATA_W) +: DATA_W];
+      end else begin : gen_east_edge
+        assign router_in_valid[(node_g * PORTS) + EAST] = 1'b0;
+        assign router_in_dest[(((node_g * PORTS) + EAST) * DEST_W) +: DEST_W] = 0;
+        assign router_in_source[(((node_g * PORTS) + EAST) * SOURCE_W) +: SOURCE_W] = 0;
+        assign router_in_tag[(((node_g * PORTS) + EAST) * TAG_W) +: TAG_W] = 0;
+        assign router_in_fragment[(((node_g * PORTS) + EAST) * FRAGMENT_W) +: FRAGMENT_W] = 0;
+        assign router_in_last[(node_g * PORTS) + EAST] = 1'b0;
+        assign router_in_vc[(((node_g * PORTS) + EAST) * VC_W) +: VC_W] = 0;
+        assign router_in_data[(((node_g * PORTS) + EAST) * DATA_W) +: DATA_W] = 0;
+        assign router_out_ready[(node_g * PORTS) + EAST] = 1'b1;
+      end
+
+      if (X > 0) begin : gen_west_link
+        localparam integer NEIGHBOR = node_g - 1;
+        assign router_in_valid[(node_g * PORTS) + WEST] = router_out_valid[(NEIGHBOR * PORTS) + EAST];
+        assign router_out_ready[(NEIGHBOR * PORTS) + EAST] = router_in_ready[(node_g * PORTS) + WEST];
+        assign router_in_dest[(((node_g * PORTS) + WEST) * DEST_W) +: DEST_W] = router_out_dest[(((NEIGHBOR * PORTS) + EAST) * DEST_W) +: DEST_W];
+        assign router_in_source[(((node_g * PORTS) + WEST) * SOURCE_W) +: SOURCE_W] = router_out_source[(((NEIGHBOR * PORTS) + EAST) * SOURCE_W) +: SOURCE_W];
+        assign router_in_tag[(((node_g * PORTS) + WEST) * TAG_W) +: TAG_W] = router_out_tag[(((NEIGHBOR * PORTS) + EAST) * TAG_W) +: TAG_W];
+        assign router_in_fragment[(((node_g * PORTS) + WEST) * FRAGMENT_W) +: FRAGMENT_W] = router_out_fragment[(((NEIGHBOR * PORTS) + EAST) * FRAGMENT_W) +: FRAGMENT_W];
+        assign router_in_last[(node_g * PORTS) + WEST] = router_out_last[(NEIGHBOR * PORTS) + EAST];
+        assign router_in_vc[(((node_g * PORTS) + WEST) * VC_W) +: VC_W] = router_out_vc[(((NEIGHBOR * PORTS) + EAST) * VC_W) +: VC_W];
+        assign router_in_data[(((node_g * PORTS) + WEST) * DATA_W) +: DATA_W] = router_out_data[(((NEIGHBOR * PORTS) + EAST) * DATA_W) +: DATA_W];
+      end else begin : gen_west_edge
+        assign router_in_valid[(node_g * PORTS) + WEST] = 1'b0;
+        assign router_in_dest[(((node_g * PORTS) + WEST) * DEST_W) +: DEST_W] = 0;
+        assign router_in_source[(((node_g * PORTS) + WEST) * SOURCE_W) +: SOURCE_W] = 0;
+        assign router_in_tag[(((node_g * PORTS) + WEST) * TAG_W) +: TAG_W] = 0;
+        assign router_in_fragment[(((node_g * PORTS) + WEST) * FRAGMENT_W) +: FRAGMENT_W] = 0;
+        assign router_in_last[(node_g * PORTS) + WEST] = 1'b0;
+        assign router_in_vc[(((node_g * PORTS) + WEST) * VC_W) +: VC_W] = 0;
+        assign router_in_data[(((node_g * PORTS) + WEST) * DATA_W) +: DATA_W] = 0;
+        assign router_out_ready[(node_g * PORTS) + WEST] = 1'b1;
+      end
+
+      noc_segmented_mesh_router #(
+        .DATA_W(DATA_W),
+        .DEST_W(DEST_W),
+        .SOURCE_W(SOURCE_W),
+        .TAG_W(TAG_W),
+        .FRAGMENT_W(FRAGMENT_W),
+        .VC_W(VC_W),
+        .VC_COUNT(VC_COUNT),
+        .FIFO_DEPTH(FIFO_DEPTH),
+        .X_COORD(X),
+        .Y_COORD(Y),
+        .COUNTER_W(COUNTER_W)
+      ) u_router (
+        .clk(clk), .rst_n(rst_n),
+        .in_valid(router_in_valid[(node_g * PORTS) +: PORTS]),
+        .in_ready(router_in_ready[(node_g * PORTS) +: PORTS]),
+        .in_dest(router_in_dest[(node_g * PORTS * DEST_W) +: (PORTS * DEST_W)]),
+        .in_source(router_in_source[(node_g * PORTS * SOURCE_W) +: (PORTS * SOURCE_W)]),
+        .in_tag(router_in_tag[(node_g * PORTS * TAG_W) +: (PORTS * TAG_W)]),
+        .in_fragment(router_in_fragment[(node_g * PORTS * FRAGMENT_W) +: (PORTS * FRAGMENT_W)]),
+        .in_last(router_in_last[(node_g * PORTS) +: PORTS]),
+        .in_vc(router_in_vc[(node_g * PORTS * VC_W) +: (PORTS * VC_W)]),
+        .in_data(router_in_data[(node_g * PORTS * DATA_W) +: (PORTS * DATA_W)]),
+        .out_valid(router_out_valid[(node_g * PORTS) +: PORTS]),
+        .out_ready(router_out_ready[(node_g * PORTS) +: PORTS]),
+        .out_dest(router_out_dest[(node_g * PORTS * DEST_W) +: (PORTS * DEST_W)]),
+        .out_source(router_out_source[(node_g * PORTS * SOURCE_W) +: (PORTS * SOURCE_W)]),
+        .out_tag(router_out_tag[(node_g * PORTS * TAG_W) +: (PORTS * TAG_W)]),
+        .out_fragment(router_out_fragment[(node_g * PORTS * FRAGMENT_W) +: (PORTS * FRAGMENT_W)]),
+        .out_last(router_out_last[(node_g * PORTS) +: PORTS]),
+        .out_vc(router_out_vc[(node_g * PORTS * VC_W) +: (PORTS * VC_W)]),
+        .out_data(router_out_data[(node_g * PORTS * DATA_W) +: (PORTS * DATA_W)]),
+        .accepted_flit_count(router_accepted_flit_count[(node_g * COUNTER_W) +: COUNTER_W]),
+        .forwarded_flit_count(router_forwarded_flit_count[(node_g * COUNTER_W) +: COUNTER_W]),
+        .input_stall_cycles(router_input_stall_cycles[(node_g * COUNTER_W) +: COUNTER_W]),
+        .output_stall_cycles(router_output_stall_cycles[(node_g * COUNTER_W) +: COUNTER_W]),
+        .arbitration_contention_cycles(router_contention_cycles[(node_g * COUNTER_W) +: COUNTER_W]),
+        .current_input_occupancy(router_current_input_occupancy[(node_g * COUNTER_W) +: COUNTER_W]),
+        .max_input_occupancy(router_max_input_occupancy[(node_g * COUNTER_W) +: COUNTER_W]),
+        .route_flit_count(router_route_flit_count[(node_g * PORTS * COUNTER_W) +: (PORTS * COUNTER_W)])
+      );
+    end
+  endgenerate
+endmodule

--- a/npu/sim/rtl/noc_segmented_mesh_router.sv
+++ b/npu/sim/rtl/noc_segmented_mesh_router.sv
@@ -1,0 +1,275 @@
+`timescale 1ns/1ps
+
+// Five-port deterministic-XY flit router. Each physical input is demultiplexed
+// into a bounded FIFO per virtual channel. Output holding registers preserve
+// the complete flit while downstream ready is deasserted.
+module noc_segmented_mesh_router #(
+  parameter integer DATA_W = 256,
+  parameter integer DEST_W = 4,
+  parameter integer SOURCE_W = 4,
+  parameter integer TAG_W = 8,
+  parameter integer FRAGMENT_W = 3,
+  parameter integer VC_W = 2,
+  parameter integer VC_COUNT = 4,
+  parameter integer FIFO_DEPTH = 4,
+  parameter integer X_COORD = 0,
+  parameter integer Y_COORD = 0,
+  parameter integer COUNTER_W = 32
+) (
+  input  wire                         clk,
+  input  wire                         rst_n,
+  input  wire [4:0]                   in_valid,
+  output wire [4:0]                   in_ready,
+  input  wire [5*DEST_W-1:0]          in_dest,
+  input  wire [5*SOURCE_W-1:0]        in_source,
+  input  wire [5*TAG_W-1:0]           in_tag,
+  input  wire [5*FRAGMENT_W-1:0]      in_fragment,
+  input  wire [4:0]                   in_last,
+  input  wire [5*VC_W-1:0]            in_vc,
+  input  wire [5*DATA_W-1:0]          in_data,
+  output wire [4:0]                   out_valid,
+  input  wire [4:0]                   out_ready,
+  output wire [5*DEST_W-1:0]          out_dest,
+  output wire [5*SOURCE_W-1:0]        out_source,
+  output wire [5*TAG_W-1:0]           out_tag,
+  output wire [5*FRAGMENT_W-1:0]      out_fragment,
+  output wire [4:0]                   out_last,
+  output wire [5*VC_W-1:0]            out_vc,
+  output wire [5*DATA_W-1:0]          out_data,
+  output reg  [COUNTER_W-1:0]         accepted_flit_count,
+  output reg  [COUNTER_W-1:0]         forwarded_flit_count,
+  output reg  [COUNTER_W-1:0]         input_stall_cycles,
+  output reg  [COUNTER_W-1:0]         output_stall_cycles,
+  output reg  [COUNTER_W-1:0]         arbitration_contention_cycles,
+  output wire [COUNTER_W-1:0]         current_input_occupancy,
+  output reg  [COUNTER_W-1:0]         max_input_occupancy,
+  output reg  [5*COUNTER_W-1:0]       route_flit_count
+);
+  localparam integer PORTS = 5;
+  localparam integer INPUTS = PORTS * VC_COUNT;
+  localparam integer INPUT_INDEX_W = (INPUTS <= 1) ? 1 : $clog2(INPUTS);
+  localparam integer FIFO_COUNT_W = (FIFO_DEPTH <= 1) ? 1 : $clog2(FIFO_DEPTH + 1);
+  localparam integer FLIT_W = DATA_W + DEST_W + SOURCE_W + TAG_W + FRAGMENT_W + 1 + VC_W;
+  localparam integer DATA_LSB = 0;
+  localparam integer VC_LSB = DATA_LSB + DATA_W;
+  localparam integer LAST_LSB = VC_LSB + VC_W;
+  localparam integer FRAGMENT_LSB = LAST_LSB + 1;
+  localparam integer TAG_LSB = FRAGMENT_LSB + FRAGMENT_W;
+  localparam integer SOURCE_LSB = TAG_LSB + TAG_W;
+  localparam integer DEST_LSB = SOURCE_LSB + SOURCE_W;
+  localparam integer NORTH = 0;
+  localparam integer SOUTH = 1;
+  localparam integer EAST = 2;
+  localparam integer WEST = 3;
+  localparam integer LOCAL = 4;
+
+  wire [INPUTS-1:0] fifo_in_valid;
+  wire [INPUTS-1:0] fifo_in_ready;
+  wire [INPUTS*FLIT_W-1:0] fifo_in_bus;
+  wire [INPUTS-1:0] fifo_out_valid;
+  reg  [INPUTS-1:0] fifo_out_ready_r;
+  wire [INPUTS*FLIT_W-1:0] fifo_out_bus;
+  wire [INPUTS*FIFO_COUNT_W-1:0] fifo_occupancy_bus;
+
+  reg [4:0] out_valid_q;
+  reg [FLIT_W-1:0] out_flit_q [0:PORTS-1];
+  reg [INPUT_INDEX_W-1:0] rr_cursor_q [0:PORTS-1];
+  reg [4:0] grant_valid_r;
+  reg [INPUT_INDEX_W-1:0] grant_index_r [0:PORTS-1];
+  reg [FLIT_W-1:0] grant_flit_r [0:PORTS-1];
+  reg [31:0] candidate_count_r [0:PORTS-1];
+  reg [COUNTER_W-1:0] occupancy_sum_r;
+  reg any_input_stall_r;
+  reg any_output_stall_r;
+  reg any_contention_r;
+
+  integer port_i;
+  integer vc_i;
+  integer input_i;
+  integer output_i;
+  integer scan_i;
+  integer scan_index_i;
+  integer accepted_i;
+  integer forwarded_i;
+
+  function automatic [FLIT_W-1:0] pack_flit;
+    input [DEST_W-1:0] destination;
+    input [SOURCE_W-1:0] source;
+    input [TAG_W-1:0] tag;
+    input [FRAGMENT_W-1:0] fragment;
+    input last;
+    input [VC_W-1:0] vc;
+    input [DATA_W-1:0] data;
+    begin
+      pack_flit = {destination, source, tag, fragment, last, vc, data};
+    end
+  endfunction
+
+  function automatic integer route_port;
+    input [DEST_W-1:0] destination;
+    integer destination_x;
+    integer destination_y;
+    begin
+      destination_x = destination[1:0];
+      destination_y = destination[3:2];
+      if (destination_x < X_COORD)
+        route_port = WEST;
+      else if (destination_x > X_COORD)
+        route_port = EAST;
+      else if (destination_y < Y_COORD)
+        route_port = NORTH;
+      else if (destination_y > Y_COORD)
+        route_port = SOUTH;
+      else
+        route_port = LOCAL;
+    end
+  endfunction
+
+  genvar port_g;
+  genvar vc_g;
+  generate
+    for (port_g = 0; port_g < PORTS; port_g = port_g + 1) begin : gen_ports
+      for (vc_g = 0; vc_g < VC_COUNT; vc_g = vc_g + 1) begin : gen_vcs
+        localparam integer FIFO_INDEX = (port_g * VC_COUNT) + vc_g;
+        assign fifo_in_valid[FIFO_INDEX] = in_valid[port_g]
+            && (in_vc[(port_g * VC_W) +: VC_W] == vc_g[VC_W-1:0]);
+        assign fifo_in_bus[(FIFO_INDEX * FLIT_W) +: FLIT_W] = pack_flit(
+            in_dest[(port_g * DEST_W) +: DEST_W],
+            in_source[(port_g * SOURCE_W) +: SOURCE_W],
+            in_tag[(port_g * TAG_W) +: TAG_W],
+            in_fragment[(port_g * FRAGMENT_W) +: FRAGMENT_W],
+            in_last[port_g],
+            in_vc[(port_g * VC_W) +: VC_W],
+            in_data[(port_g * DATA_W) +: DATA_W]);
+        noc_ready_valid_fifo #(
+          .WIDTH(FLIT_W),
+          .DEPTH(FIFO_DEPTH)
+        ) u_fifo (
+          .clk(clk),
+          .rst_n(rst_n),
+          .in_valid(fifo_in_valid[FIFO_INDEX]),
+          .in_ready(fifo_in_ready[FIFO_INDEX]),
+          .in_data(fifo_in_bus[(FIFO_INDEX * FLIT_W) +: FLIT_W]),
+          .out_valid(fifo_out_valid[FIFO_INDEX]),
+          .out_ready(fifo_out_ready_r[FIFO_INDEX]),
+          .out_data(fifo_out_bus[(FIFO_INDEX * FLIT_W) +: FLIT_W]),
+          .occupancy(fifo_occupancy_bus[(FIFO_INDEX * FIFO_COUNT_W) +: FIFO_COUNT_W]),
+          .max_occupancy()
+        );
+      end
+      assign in_ready[port_g] =
+          fifo_in_ready[(port_g * VC_COUNT) + in_vc[(port_g * VC_W) +: VC_W]];
+      assign out_valid[port_g] = out_valid_q[port_g];
+      assign out_data[(port_g * DATA_W) +: DATA_W] =
+          out_flit_q[port_g][DATA_LSB +: DATA_W];
+      assign out_vc[(port_g * VC_W) +: VC_W] =
+          out_flit_q[port_g][VC_LSB +: VC_W];
+      assign out_last[port_g] = out_flit_q[port_g][LAST_LSB];
+      assign out_fragment[(port_g * FRAGMENT_W) +: FRAGMENT_W] =
+          out_flit_q[port_g][FRAGMENT_LSB +: FRAGMENT_W];
+      assign out_tag[(port_g * TAG_W) +: TAG_W] =
+          out_flit_q[port_g][TAG_LSB +: TAG_W];
+      assign out_source[(port_g * SOURCE_W) +: SOURCE_W] =
+          out_flit_q[port_g][SOURCE_LSB +: SOURCE_W];
+      assign out_dest[(port_g * DEST_W) +: DEST_W] =
+          out_flit_q[port_g][DEST_LSB +: DEST_W];
+    end
+  endgenerate
+
+  assign current_input_occupancy = occupancy_sum_r;
+
+  always @(*) begin
+    fifo_out_ready_r = {INPUTS{1'b0}};
+    grant_valid_r = 5'b0;
+    occupancy_sum_r = {COUNTER_W{1'b0}};
+    any_input_stall_r = 1'b0;
+    any_output_stall_r = 1'b0;
+    any_contention_r = 1'b0;
+    for (output_i = 0; output_i < PORTS; output_i = output_i + 1) begin
+      grant_index_r[output_i] = {INPUT_INDEX_W{1'b0}};
+      grant_flit_r[output_i] = {FLIT_W{1'b0}};
+      candidate_count_r[output_i] = 0;
+    end
+    for (input_i = 0; input_i < INPUTS; input_i = input_i + 1) begin
+      occupancy_sum_r = occupancy_sum_r
+          + fifo_occupancy_bus[(input_i * FIFO_COUNT_W) +: FIFO_COUNT_W];
+    end
+    for (port_i = 0; port_i < PORTS; port_i = port_i + 1) begin
+      if (in_valid[port_i] && !in_ready[port_i])
+        any_input_stall_r = 1'b1;
+      if (out_valid_q[port_i] && !out_ready[port_i])
+        any_output_stall_r = 1'b1;
+    end
+    for (output_i = 0; output_i < PORTS; output_i = output_i + 1) begin
+      for (scan_i = 0; scan_i < INPUTS; scan_i = scan_i + 1) begin
+        scan_index_i = rr_cursor_q[output_i] + scan_i;
+        if (scan_index_i >= INPUTS)
+          scan_index_i = scan_index_i - INPUTS;
+        if (fifo_out_valid[scan_index_i]
+            && (route_port(fifo_out_bus[(scan_index_i * FLIT_W) + DEST_LSB +: DEST_W]) == output_i)) begin
+          candidate_count_r[output_i] = candidate_count_r[output_i] + 1;
+          if (!grant_valid_r[output_i]) begin
+            grant_valid_r[output_i] = 1'b1;
+            grant_index_r[output_i] = scan_index_i[INPUT_INDEX_W-1:0];
+            grant_flit_r[output_i] = fifo_out_bus[(scan_index_i * FLIT_W) +: FLIT_W];
+          end
+        end
+      end
+      if (candidate_count_r[output_i] > 1)
+        any_contention_r = 1'b1;
+      if ((!out_valid_q[output_i] || out_ready[output_i]) && grant_valid_r[output_i])
+        fifo_out_ready_r[grant_index_r[output_i]] = 1'b1;
+    end
+  end
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      out_valid_q <= 5'b0;
+      accepted_flit_count <= {COUNTER_W{1'b0}};
+      forwarded_flit_count <= {COUNTER_W{1'b0}};
+      input_stall_cycles <= {COUNTER_W{1'b0}};
+      output_stall_cycles <= {COUNTER_W{1'b0}};
+      arbitration_contention_cycles <= {COUNTER_W{1'b0}};
+      max_input_occupancy <= {COUNTER_W{1'b0}};
+      route_flit_count <= {(5 * COUNTER_W){1'b0}};
+      for (output_i = 0; output_i < PORTS; output_i = output_i + 1) begin
+        out_flit_q[output_i] <= {FLIT_W{1'b0}};
+        rr_cursor_q[output_i] <= {INPUT_INDEX_W{1'b0}};
+      end
+    end else begin
+      accepted_i = 0;
+      forwarded_i = 0;
+      for (port_i = 0; port_i < PORTS; port_i = port_i + 1) begin
+        if (in_valid[port_i] && in_ready[port_i])
+          accepted_i = accepted_i + 1;
+        if (out_valid_q[port_i] && out_ready[port_i]) begin
+          forwarded_i = forwarded_i + 1;
+          route_flit_count[(port_i * COUNTER_W) +: COUNTER_W]
+              <= route_flit_count[(port_i * COUNTER_W) +: COUNTER_W] + 1'b1;
+        end
+        if (!out_valid_q[port_i] || out_ready[port_i]) begin
+          if (grant_valid_r[port_i]) begin
+            out_valid_q[port_i] <= 1'b1;
+            out_flit_q[port_i] <= grant_flit_r[port_i];
+            if (grant_index_r[port_i] == (INPUTS - 1))
+              rr_cursor_q[port_i] <= {INPUT_INDEX_W{1'b0}};
+            else
+              rr_cursor_q[port_i] <= grant_index_r[port_i] + 1'b1;
+          end else begin
+            out_valid_q[port_i] <= 1'b0;
+          end
+        end
+      end
+      accepted_flit_count <= accepted_flit_count + accepted_i;
+      forwarded_flit_count <= forwarded_flit_count + forwarded_i;
+      if (any_input_stall_r)
+        input_stall_cycles <= input_stall_cycles + 1'b1;
+      if (any_output_stall_r)
+        output_stall_cycles <= output_stall_cycles + 1'b1;
+      if (any_contention_r)
+        arbitration_contention_cycles <= arbitration_contention_cycles + 1'b1;
+      if (occupancy_sum_r > max_input_occupancy)
+        max_input_occupancy <= occupancy_sum_r;
+    end
+  end
+endmodule

--- a/runs/campaigns/noc/l1_segmented_xy_mesh_router/sweeps/nangate45_macro_frontier.json
+++ b/runs/campaigns/noc/l1_segmented_xy_mesh_router/sweeps/nangate45_macro_frontier.json
@@ -1,0 +1,8 @@
+{
+  "tag_prefix": "l1_segmented_xy_mesh_router_nangate45_macro_frontier",
+  "flow_params": {
+    "CLOCK_PERIOD": [1.0],
+    "CORE_UTILIZATION": [40, 50, 60],
+    "PLACE_DENSITY": [0.52]
+  }
+}

--- a/runs/designs/noc/l1_noc_segmented_xy_router_p5_w256_vc4_d4_wrapper/config_l1_noc_segmented_xy_router_p5_w256_vc4_d4.json
+++ b/runs/designs/noc/l1_noc_segmented_xy_router_p5_w256_vc4_d4_wrapper/config_l1_noc_segmented_xy_router_p5_w256_vc4_d4.json
@@ -1,0 +1,33 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "flit",
+      "dimensions": 1,
+      "bit_width": 256,
+      "signed": false,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "l1_memory_noc_primitive",
+      "module_name": "l1_noc_segmented_xy_router_p5_w256_vc4_d4",
+      "operand": "flit",
+      "options": {
+        "primitive": "segmented_router",
+        "flit_bits": 256,
+        "depth": 4,
+        "ports": 5,
+        "vc_count": 4,
+        "dest_bits": 4,
+        "source_bits": 4,
+        "tag_bits": 8,
+        "fragment_bits": 3,
+        "x_coord": 1,
+        "y_coord": 1,
+        "counter_bits": 32
+      }
+    }
+  ]
+}

--- a/scripts/generate_design.py
+++ b/scripts/generate_design.py
@@ -430,8 +430,17 @@ def identify_design(config):
         endpoint_depth = int(options.get("endpoint_depth", max(depth, banks * depth)))
         bank_queue_depth = int(options.get("bank_queue_depth", depth))
         counter_bits = int(options.get("counter_bits", 32))
-        if primitive not in ("fifo", "router", "endpoint"):
-            raise ValueError("l1_memory_noc_primitive primitive must be fifo, router, or endpoint")
+        vc_count = int(options.get("vc_count", 4))
+        dest_bits = int(options.get("dest_bits", 4))
+        source_bits = int(options.get("source_bits", 4))
+        tag_bits = int(options.get("tag_bits", 8))
+        fragment_bits = int(options.get("fragment_bits", 3))
+        x_coord = int(options.get("x_coord", 1))
+        y_coord = int(options.get("y_coord", 1))
+        if primitive not in ("fifo", "router", "endpoint", "segmented_router"):
+            raise ValueError(
+                "l1_memory_noc_primitive primitive must be fifo, router, endpoint, or segmented_router"
+            )
         if flit_bits <= 0:
             raise ValueError("l1_memory_noc_primitive flit_bits must be positive")
         if depth <= 1:
@@ -446,6 +455,12 @@ def identify_design(config):
             raise ValueError("l1_memory_noc_primitive bank_queue_depth must be greater than one")
         if counter_bits <= 0:
             raise ValueError("l1_memory_noc_primitive counter_bits must be positive")
+        if vc_count <= 0:
+            raise ValueError("l1_memory_noc_primitive vc_count must be positive")
+        if dest_bits <= 0 or source_bits <= 0 or tag_bits <= 0 or fragment_bits <= 0:
+            raise ValueError("l1_memory_noc_primitive metadata widths must be positive")
+        if primitive == "segmented_router" and ports != 5:
+            raise ValueError("l1_memory_noc_primitive segmented_router requires five ports")
         return {
             "kind": "l1_memory_noc_primitive",
             "module_name": module_name,
@@ -458,6 +473,13 @@ def identify_design(config):
             "endpoint_depth": endpoint_depth,
             "bank_queue_depth": bank_queue_depth,
             "counter_bits": counter_bits,
+            "vc_count": vc_count,
+            "dest_bits": dest_bits,
+            "source_bits": source_bits,
+            "tag_bits": tag_bits,
+            "fragment_bits": fragment_bits,
+            "x_coord": x_coord,
+            "y_coord": y_coord,
             "include_mg_cpa": False,
         }
     raise ValueError(f"generate_design.py does not support operation type: {op_type}")
@@ -855,6 +877,14 @@ def generate_l1_memory_noc_design(src_dir, design):
         text = _emit_l1_fifo(module_name, design)
     elif design["primitive"] == "router":
         text = _emit_l1_router(module_name, design)
+    elif design["primitive"] == "segmented_router":
+        text = _emit_l1_segmented_router(module_name, design)
+        for filename in ("noc_ready_valid_fifo.sv", "noc_segmented_mesh_router.sv"):
+            rtl_path = repo_root / "npu" / "sim" / "rtl" / filename
+            Path(src_dir, Path(filename).with_suffix(".v")).write_text(
+                rtl_path.read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
     else:
         text = _emit_l1_endpoint(module_name, design)
     Path(src_dir, f"{module_name}.v").write_text(text, encoding="utf-8")
@@ -1005,6 +1035,185 @@ module {module_name}(
         )
     body += f"      observed <= {observe_terms};\n      routed_count <= routed_count + {counter_bits}'d{ports};\n    end\n  end\nendmodule\n"
     return header + body
+
+
+def _emit_l1_segmented_router(module_name, design):
+    flit_bits = design["flit_bits"]
+    counter_bits = design["counter_bits"]
+    dest_bits = design["dest_bits"]
+    source_bits = design["source_bits"]
+    tag_bits = design["tag_bits"]
+    fragment_bits = design["fragment_bits"]
+    vc_count = design["vc_count"]
+    vc_width = _ceil_log2_at_least_one(vc_count)
+    x_coord = design["x_coord"]
+    y_coord = design["y_coord"]
+    local_dest = (y_coord << 2) | x_coord
+    north_dest = (max(y_coord - 1, 0) << 2) | x_coord
+    south_dest = (min(y_coord + 1, 3) << 2) | x_coord
+    east_dest = (y_coord << 2) | min(x_coord + 1, 3)
+    west_dest = (y_coord << 2) | max(x_coord - 1, 0)
+    return f"""
+`timescale 1ns/1ps
+
+module {module_name}(
+  input clk,
+  input rst_n,
+  output [{counter_bits-1}:0] accepted_flit_count,
+  output [{counter_bits-1}:0] forwarded_flit_count,
+  output [{counter_bits-1}:0] input_stall_cycles,
+  output [{counter_bits-1}:0] output_stall_cycles,
+  output [{counter_bits-1}:0] arbitration_contention_cycles,
+  output [{counter_bits-1}:0] current_input_occupancy,
+  output [{counter_bits-1}:0] max_input_occupancy,
+  output [{counter_bits-1}:0] east_route_flit_count,
+  output [{flit_bits-1}:0] observed_flit
+);
+  localparam integer DATA_W = {flit_bits};
+  localparam integer DEST_W = {dest_bits};
+  localparam integer SOURCE_W = {source_bits};
+  localparam integer TAG_W = {tag_bits};
+  localparam integer FRAGMENT_W = {fragment_bits};
+  localparam integer VC_COUNT = {vc_count};
+  localparam integer VC_W = {vc_width};
+  localparam integer FIFO_DEPTH = {design['depth']};
+  localparam integer COUNT_W = {counter_bits};
+  localparam integer PORTS = 5;
+  localparam integer DEST_NORTH = {north_dest};
+  localparam integer DEST_SOUTH = {south_dest};
+  localparam integer DEST_EAST = {east_dest};
+  localparam integer DEST_WEST = {west_dest};
+  localparam integer DEST_LOCAL = {local_dest};
+
+  reg [PORTS-1:0] in_valid;
+  wire [PORTS-1:0] in_ready;
+  reg [PORTS*DEST_W-1:0] in_dest;
+  reg [PORTS*SOURCE_W-1:0] in_source;
+  reg [PORTS*TAG_W-1:0] in_tag;
+  reg [PORTS*FRAGMENT_W-1:0] in_fragment;
+  reg [PORTS-1:0] in_last;
+  reg [PORTS*VC_W-1:0] in_vc;
+  reg [PORTS*DATA_W-1:0] in_data;
+  wire [PORTS-1:0] out_valid;
+  reg [PORTS-1:0] out_ready;
+  wire [PORTS*DEST_W-1:0] out_dest;
+  wire [PORTS*SOURCE_W-1:0] out_source;
+  wire [PORTS*TAG_W-1:0] out_tag;
+  wire [PORTS*FRAGMENT_W-1:0] out_fragment;
+  wire [PORTS-1:0] out_last;
+  wire [PORTS*VC_W-1:0] out_vc;
+  wire [PORTS*DATA_W-1:0] out_data;
+  wire [PORTS*COUNT_W-1:0] route_flit_count;
+
+  reg [COUNT_W-1:0] flit_seed [0:PORTS-1];
+  reg [TAG_W-1:0] tag_seed [0:PORTS-1];
+  reg [FRAGMENT_W-1:0] fragment_seed [0:PORTS-1];
+  reg [VC_W-1:0] vc_seed [0:PORTS-1];
+  reg [DEST_W-1:0] dest_seed [0:PORTS-1];
+  reg [DATA_W-1:0] observed;
+  integer port_i;
+
+  assign observed_flit =
+      observed
+      ^ out_data[(2 * DATA_W) +: DATA_W]
+      ^ out_tag[(2 * TAG_W) +: TAG_W]
+      ^ out_fragment[(2 * FRAGMENT_W) +: FRAGMENT_W];
+  assign east_route_flit_count = route_flit_count[(2 * COUNT_W) +: COUNT_W];
+
+  noc_segmented_mesh_router #(
+    .DATA_W(DATA_W),
+    .DEST_W(DEST_W),
+    .SOURCE_W(SOURCE_W),
+    .TAG_W(TAG_W),
+    .FRAGMENT_W(FRAGMENT_W),
+    .VC_W(VC_W),
+    .VC_COUNT(VC_COUNT),
+    .FIFO_DEPTH(FIFO_DEPTH),
+    .X_COORD({x_coord}),
+    .Y_COORD({y_coord}),
+    .COUNTER_W(COUNT_W)
+  ) dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .in_valid(in_valid),
+    .in_ready(in_ready),
+    .in_dest(in_dest),
+    .in_source(in_source),
+    .in_tag(in_tag),
+    .in_fragment(in_fragment),
+    .in_last(in_last),
+    .in_vc(in_vc),
+    .in_data(in_data),
+    .out_valid(out_valid),
+    .out_ready(out_ready),
+    .out_dest(out_dest),
+    .out_source(out_source),
+    .out_tag(out_tag),
+    .out_fragment(out_fragment),
+    .out_last(out_last),
+    .out_vc(out_vc),
+    .out_data(out_data),
+    .accepted_flit_count(accepted_flit_count),
+    .forwarded_flit_count(forwarded_flit_count),
+    .input_stall_cycles(input_stall_cycles),
+    .output_stall_cycles(output_stall_cycles),
+    .arbitration_contention_cycles(arbitration_contention_cycles),
+    .current_input_occupancy(current_input_occupancy),
+    .max_input_occupancy(max_input_occupancy),
+    .route_flit_count(route_flit_count)
+  );
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      in_valid <= '0;
+      in_dest <= '0;
+      in_source <= '0;
+      in_tag <= '0;
+      in_fragment <= '0;
+      in_last <= '0;
+      in_vc <= '0;
+      in_data <= '0;
+      out_ready <= '1;
+      observed <= '0;
+      for (port_i = 0; port_i < PORTS; port_i = port_i + 1) begin
+        flit_seed[port_i] <= port_i + 1;
+        tag_seed[port_i] <= port_i + 1;
+        fragment_seed[port_i] <= '0;
+        vc_seed[port_i] <= port_i % VC_COUNT;
+      end
+      dest_seed[0] <= DEST_EAST;
+      dest_seed[1] <= DEST_EAST;
+      dest_seed[2] <= DEST_EAST;
+      dest_seed[3] <= DEST_LOCAL;
+      dest_seed[4] <= DEST_EAST;
+    end else begin
+      out_ready[0] <= 1'b1;
+      out_ready[1] <= 1'b1;
+      out_ready[2] <= !(tag_seed[4][1:0] == 2'b11);
+      out_ready[3] <= 1'b1;
+      out_ready[4] <= !(tag_seed[3][2:0] == 3'b101);
+      observed <= out_data[(4 * DATA_W) +: DATA_W];
+      for (port_i = 0; port_i < PORTS; port_i = port_i + 1) begin
+        in_valid[port_i] <= 1'b1;
+        in_dest[(port_i * DEST_W) +: DEST_W] <= dest_seed[port_i];
+        in_source[(port_i * SOURCE_W) +: SOURCE_W] <= port_i[SOURCE_W-1:0];
+        in_tag[(port_i * TAG_W) +: TAG_W] <= tag_seed[port_i];
+        in_fragment[(port_i * FRAGMENT_W) +: FRAGMENT_W] <= fragment_seed[port_i];
+        in_last[port_i] <= (fragment_seed[port_i] == {fragment_bits}'d7);
+        in_vc[(port_i * VC_W) +: VC_W] <= vc_seed[port_i];
+        in_data[(port_i * DATA_W) +: DATA_W] <= flit_seed[port_i];
+        if (in_ready[port_i]) begin
+          flit_seed[port_i] <= flit_seed[port_i] + 1'b1;
+          tag_seed[port_i] <= tag_seed[port_i] + 1'b1;
+          fragment_seed[port_i] <= fragment_seed[port_i] + 1'b1;
+          if (port_i == 3)
+            dest_seed[port_i] <= (dest_seed[port_i] == DEST_LOCAL) ? DEST_WEST : DEST_LOCAL;
+        end
+      end
+    end
+  end
+endmodule
+"""
 
 
 def _emit_l1_endpoint(module_name, design):
@@ -1766,6 +1975,38 @@ module {wrapper_name}(
     .rst_n(rst_n),
     .routed_flit_count(routed_flit_count),
     .arbitration_cycle_count(arbitration_cycle_count),
+    .observed_flit(observed_flit)
+  );
+
+endmodule
+"""
+        elif design["primitive"] == "segmented_router":
+            wrapper_content = f"""
+module {wrapper_name}(
+  input clk,
+  input rst_n,
+  output [{counter_bits-1}:0] accepted_flit_count,
+  output [{counter_bits-1}:0] forwarded_flit_count,
+  output [{counter_bits-1}:0] input_stall_cycles,
+  output [{counter_bits-1}:0] output_stall_cycles,
+  output [{counter_bits-1}:0] arbitration_contention_cycles,
+  output [{counter_bits-1}:0] current_input_occupancy,
+  output [{counter_bits-1}:0] max_input_occupancy,
+  output [{counter_bits-1}:0] east_route_flit_count,
+  output [{flit_bits-1}:0] observed_flit
+);
+
+  {module_name} dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .accepted_flit_count(accepted_flit_count),
+    .forwarded_flit_count(forwarded_flit_count),
+    .input_stall_cycles(input_stall_cycles),
+    .output_stall_cycles(output_stall_cycles),
+    .arbitration_contention_cycles(arbitration_contention_cycles),
+    .current_input_occupancy(current_input_occupancy),
+    .max_input_occupancy(max_input_occupancy),
+    .east_route_flit_count(east_route_flit_count),
     .observed_flit(observed_flit)
   );
 

--- a/tests/test_noc_segmented_mesh.py
+++ b/tests/test_noc_segmented_mesh.py
@@ -1,0 +1,579 @@
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.sim.perf.noc_segmented_mesh import (
+    ModelFlit,
+    PORT_EAST,
+    PORT_LOCAL,
+    PORT_NAMES,
+    PORT_NORTH,
+    PORT_SOUTH,
+    PORT_WEST,
+    PORTS,
+    RouterCycleInput,
+    segmented_transfer,
+    simulate_mesh,
+    simulate_router,
+)
+ROUTER_CONFIG = (
+    REPO_ROOT
+    / "runs"
+    / "designs"
+    / "noc"
+    / "l1_noc_segmented_xy_router_p5_w256_vc4_d4_wrapper"
+    / "config_l1_noc_segmented_xy_router_p5_w256_vc4_d4.json"
+)
+GENERATED_SRC = Path("/orfs/flow/designs/src/l1_noc_segmented_xy_router_p5_w256_vc4_d4_wrapper")
+
+
+def _iverilog() -> str | None:
+    return shutil.which("iverilog") or ("/oss-cad-suite/bin/iverilog" if Path("/oss-cad-suite/bin/iverilog").exists() else None)
+
+
+def _vvp() -> str | None:
+    return shutil.which("vvp") or ("/oss-cad-suite/bin/vvp" if Path("/oss-cad-suite/bin/vvp").exists() else None)
+
+
+def _compile_and_run(tmp_path: Path, *, top: str, sources: list[Path], tb_text: str) -> str:
+    iverilog = _iverilog()
+    vvp = _vvp()
+    if iverilog is None or vvp is None:
+        pytest.skip("iverilog/vvp unavailable")
+    tb_path = tmp_path / f"{top}.sv"
+    tb_path.write_text(tb_text, encoding="utf-8")
+    simv = tmp_path / f"{top}.vvp"
+    subprocess.run(
+        [iverilog, "-g2012", "-s", top, "-o", str(simv), *[str(source) for source in sources], str(tb_path)],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    run = subprocess.run([vvp, str(simv)], check=True, cwd=REPO_ROOT, capture_output=True, text=True, timeout=20)
+    return run.stdout
+
+
+def _router_flit(*, source: int, destination: int, tag: int, fragment: int, vc: int, data: int) -> ModelFlit:
+    return ModelFlit(
+        source=source,
+        destination=destination,
+        tag=tag,
+        fragment=fragment,
+        last=fragment == 7,
+        vc=vc,
+        data=data,
+    )
+
+
+def _router_scenario() -> tuple[list[list[RouterCycleInput]], list[list[bool]]]:
+    schedule = [[RouterCycleInput(False, None) for _ in range(PORTS)] for _ in range(12)]
+    ready = [[True for _ in range(PORTS)] for _ in range(12)]
+
+    east_dest = 6
+    local_dest = 5
+
+    schedule[0][PORT_LOCAL] = RouterCycleInput(True, _router_flit(source=4, destination=east_dest, tag=10, fragment=0, vc=0, data=0x100))
+    schedule[1][PORT_NORTH] = RouterCycleInput(True, _router_flit(source=0, destination=east_dest, tag=20, fragment=0, vc=0, data=0x200))
+    schedule[1][PORT_LOCAL] = RouterCycleInput(True, _router_flit(source=4, destination=east_dest, tag=11, fragment=1, vc=0, data=0x101))
+    schedule[2][PORT_SOUTH] = RouterCycleInput(True, _router_flit(source=1, destination=east_dest, tag=30, fragment=0, vc=1, data=0x300))
+    schedule[2][PORT_LOCAL] = RouterCycleInput(True, _router_flit(source=4, destination=east_dest, tag=12, fragment=2, vc=0, data=0x102))
+    schedule[3][PORT_LOCAL] = RouterCycleInput(True, _router_flit(source=4, destination=east_dest, tag=13, fragment=3, vc=0, data=0x103))
+    schedule[4][PORT_LOCAL] = RouterCycleInput(True, _router_flit(source=4, destination=east_dest, tag=14, fragment=4, vc=0, data=0x104))
+    schedule[6][PORT_WEST] = RouterCycleInput(True, _router_flit(source=3, destination=local_dest, tag=40, fragment=0, vc=2, data=0x400))
+
+    ready[2][PORT_EAST] = False
+    ready[3][PORT_EAST] = False
+    ready[7][PORT_LOCAL] = False
+    return schedule, ready
+
+
+def _router_tb(schedule: list[list[RouterCycleInput]], ready: list[list[bool]]) -> str:
+    def pack_bus(values: list[int], field_width: int) -> int:
+        packed = 0
+        for index, value in enumerate(values):
+            packed |= int(value) << (index * field_width)
+        return packed
+
+    def emit_cycle(cycle: int) -> str:
+        valid_bits = 0
+        dests: list[int] = []
+        sources: list[int] = []
+        tags: list[int] = []
+        fragments: list[int] = []
+        lasts: list[int] = []
+        vcs: list[int] = []
+        datas: list[int] = []
+        for port, item in enumerate(schedule[cycle]):
+            if item.valid:
+                valid_bits |= 1 << port
+                flit = item.flit
+                assert flit is not None
+                dests.append(flit.destination)
+                sources.append(flit.source)
+                tags.append(flit.tag)
+                fragments.append(flit.fragment)
+                lasts.append(1 if flit.last else 0)
+                vcs.append(flit.vc)
+                datas.append(flit.data)
+            else:
+                dests.append(0)
+                sources.append(0)
+                tags.append(0)
+                fragments.append(0)
+                lasts.append(0)
+                vcs.append(0)
+                datas.append(0)
+        ready_bits = sum((1 if bit else 0) << idx for idx, bit in enumerate(ready[cycle]))
+        packed_dest = pack_bus(dests, 4)
+        packed_source = pack_bus(sources, 4)
+        packed_tag = pack_bus(tags, 8)
+        packed_fragment = pack_bus(fragments, 3)
+        packed_vc = pack_bus(vcs, 2)
+        packed_data = pack_bus(datas, 256)
+        return textwrap.dedent(
+            f"""\
+            {cycle}: begin
+              in_valid = 5'b{valid_bits:05b};
+              in_dest = 20'h{packed_dest:05x};
+              in_source = 20'h{packed_source:05x};
+              in_tag = 40'h{packed_tag:010x};
+              in_fragment = 15'h{packed_fragment:04x};
+              in_last = 5'b{''.join(str(bit) for bit in reversed(lasts))};
+              in_vc = 10'h{packed_vc:03x};
+              in_data = 1280'h{packed_data:0320x};
+              out_ready = 5'b{ready_bits:05b};
+            end
+            """
+        )
+
+    cycle_cases = "".join(emit_cycle(cycle) for cycle in range(len(schedule)))
+    return f"""
+`timescale 1ns/1ps
+module tb_noc_segmented_mesh_router;
+  reg clk;
+  reg rst_n;
+  reg [4:0] in_valid;
+  wire [4:0] in_ready;
+  reg [19:0] in_dest;
+  reg [19:0] in_source;
+  reg [39:0] in_tag;
+  reg [14:0] in_fragment;
+  reg [4:0] in_last;
+  reg [9:0] in_vc;
+  reg [1279:0] in_data;
+  wire [4:0] out_valid;
+  reg [4:0] out_ready;
+  wire [19:0] out_dest;
+  wire [19:0] out_source;
+  wire [39:0] out_tag;
+  wire [14:0] out_fragment;
+  wire [4:0] out_last;
+  wire [9:0] out_vc;
+  wire [1279:0] out_data;
+  wire [31:0] accepted_flit_count;
+  wire [31:0] forwarded_flit_count;
+  wire [31:0] input_stall_cycles;
+  wire [31:0] output_stall_cycles;
+  wire [31:0] arbitration_contention_cycles;
+  wire [31:0] current_input_occupancy;
+  wire [31:0] max_input_occupancy;
+  wire [159:0] route_flit_count;
+  integer cycle_count;
+  integer drive_i;
+  integer log_i;
+
+  noc_segmented_mesh_router #(
+    .X_COORD(1),
+    .Y_COORD(1)
+  ) dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .in_valid(in_valid),
+    .in_ready(in_ready),
+    .in_dest(in_dest),
+    .in_source(in_source),
+    .in_tag(in_tag),
+    .in_fragment(in_fragment),
+    .in_last(in_last),
+    .in_vc(in_vc),
+    .in_data(in_data),
+    .out_valid(out_valid),
+    .out_ready(out_ready),
+    .out_dest(out_dest),
+    .out_source(out_source),
+    .out_tag(out_tag),
+    .out_fragment(out_fragment),
+    .out_last(out_last),
+    .out_vc(out_vc),
+    .out_data(out_data),
+    .accepted_flit_count(accepted_flit_count),
+    .forwarded_flit_count(forwarded_flit_count),
+    .input_stall_cycles(input_stall_cycles),
+    .output_stall_cycles(output_stall_cycles),
+    .arbitration_contention_cycles(arbitration_contention_cycles),
+    .current_input_occupancy(current_input_occupancy),
+    .max_input_occupancy(max_input_occupancy),
+    .route_flit_count(route_flit_count)
+  );
+
+  initial clk = 1'b0;
+  always #5 clk = ~clk;
+
+  task automatic drive_cycle(input integer cycle);
+    begin
+      case (cycle)
+{textwrap.indent(cycle_cases, '        ')}        default: begin
+          in_valid = 5'b00000;
+          in_dest = 20'h0;
+          in_source = 20'h0;
+          in_tag = 40'h0;
+          in_fragment = 15'h0;
+          in_last = 5'b00000;
+          in_vc = 10'h0;
+          in_data = 1280'h0;
+          out_ready = 5'b11111;
+        end
+      endcase
+    end
+  endtask
+
+  initial begin
+    rst_n = 1'b0;
+    cycle_count = -1;
+    drive_cycle(-1);
+    repeat (2) @(posedge clk);
+    @(negedge clk);
+    rst_n = 1'b1;
+    drive_cycle(0);
+    for (drive_i = 1; drive_i < {len(schedule)}; drive_i = drive_i + 1) begin
+      @(negedge clk);
+      drive_cycle(drive_i);
+    end
+    @(negedge clk);
+    drive_cycle(-1);
+    repeat (6) @(posedge clk);
+    $display("SUMMARY accepted=%0d forwarded=%0d istall=%0d ostall=%0d contention=%0d occ=%0d maxocc=%0d east=%0d local=%0d",
+      accepted_flit_count,
+      forwarded_flit_count,
+      input_stall_cycles,
+      output_stall_cycles,
+      arbitration_contention_cycles,
+      current_input_occupancy,
+      max_input_occupancy,
+      route_flit_count[95:64],
+      route_flit_count[159:128]);
+    $finish;
+  end
+
+  always @(posedge clk) begin
+    if (rst_n) begin
+      cycle_count = cycle_count + 1;
+      for (log_i = 0; log_i < 5; log_i = log_i + 1) begin
+        if (out_valid[log_i] && out_ready[log_i]) begin
+          $display("FWD cycle=%0d port=%0d source=%0d dest=%0d tag=%0d fragment=%0d vc=%0d last=%0d",
+            cycle_count,
+            log_i,
+            out_source[(log_i * 4) +: 4],
+            out_dest[(log_i * 4) +: 4],
+            out_tag[(log_i * 8) +: 8],
+            out_fragment[(log_i * 3) +: 3],
+            out_vc[(log_i * 2) +: 2],
+            out_last[log_i]);
+        end
+      end
+    end
+  end
+endmodule
+"""
+
+
+def _mesh_tb() -> str:
+    return """
+`timescale 1ns/1ps
+module tb_noc_segmented_mesh4x4;
+  reg clk;
+  reg rst_n;
+  reg [15:0] endpoint_in_valid;
+  wire [15:0] endpoint_in_ready;
+  reg [63:0] endpoint_in_dest;
+  reg [63:0] endpoint_in_source;
+  reg [127:0] endpoint_in_tag;
+  reg [47:0] endpoint_in_fragment;
+  reg [15:0] endpoint_in_last;
+  reg [31:0] endpoint_in_vc;
+  reg [4095:0] endpoint_in_data;
+  wire [15:0] endpoint_out_valid;
+  reg [15:0] endpoint_out_ready;
+  wire [63:0] endpoint_out_dest;
+  wire [63:0] endpoint_out_source;
+  wire [127:0] endpoint_out_tag;
+  wire [47:0] endpoint_out_fragment;
+  wire [15:0] endpoint_out_last;
+  wire [31:0] endpoint_out_vc;
+  wire [4095:0] endpoint_out_data;
+  integer cycle_count;
+  integer fragment_index;
+  integer delivered_count;
+
+  noc_segmented_mesh4x4 dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .endpoint_in_valid(endpoint_in_valid),
+    .endpoint_in_ready(endpoint_in_ready),
+    .endpoint_in_dest(endpoint_in_dest),
+    .endpoint_in_source(endpoint_in_source),
+    .endpoint_in_tag(endpoint_in_tag),
+    .endpoint_in_fragment(endpoint_in_fragment),
+    .endpoint_in_last(endpoint_in_last),
+    .endpoint_in_vc(endpoint_in_vc),
+    .endpoint_in_data(endpoint_in_data),
+    .endpoint_out_valid(endpoint_out_valid),
+    .endpoint_out_ready(endpoint_out_ready),
+    .endpoint_out_dest(endpoint_out_dest),
+    .endpoint_out_source(endpoint_out_source),
+    .endpoint_out_tag(endpoint_out_tag),
+    .endpoint_out_fragment(endpoint_out_fragment),
+    .endpoint_out_last(endpoint_out_last),
+    .endpoint_out_vc(endpoint_out_vc),
+    .endpoint_out_data(endpoint_out_data),
+    .router_accepted_flit_count(),
+    .router_forwarded_flit_count(),
+    .router_input_stall_cycles(),
+    .router_output_stall_cycles(),
+    .router_contention_cycles(),
+    .router_current_input_occupancy(),
+    .router_max_input_occupancy(),
+    .router_route_flit_count()
+  );
+
+  initial clk = 1'b0;
+  always #5 clk = ~clk;
+
+  task automatic drive_source;
+    begin
+      endpoint_in_valid = 16'h0000;
+      endpoint_in_dest = 64'h0;
+      endpoint_in_source = 64'h0;
+      endpoint_in_tag = 128'h0;
+      endpoint_in_fragment = 48'h0;
+      endpoint_in_last = 16'h0000;
+      endpoint_in_vc = 32'h0;
+      endpoint_in_data = 4096'h0;
+      if (fragment_index < 8) begin
+        endpoint_in_valid[0] = 1'b1;
+        endpoint_in_dest[3:0] = 4'd15;
+        endpoint_in_source[3:0] = 4'd0;
+        endpoint_in_tag[7:0] = 8'd7;
+        endpoint_in_fragment[2:0] = fragment_index[2:0];
+        endpoint_in_last[0] = (fragment_index == 7);
+        endpoint_in_vc[1:0] = 2'd1;
+        endpoint_in_data[255:0] = fragment_index;
+      end
+    end
+  endtask
+
+  initial begin
+    rst_n = 1'b0;
+    cycle_count = -1;
+    fragment_index = 0;
+    delivered_count = 0;
+    endpoint_out_ready = 16'h8000;
+    drive_source();
+    repeat (2) @(posedge clk);
+    @(negedge clk);
+    rst_n = 1'b1;
+    drive_source();
+    repeat (40) begin
+      @(posedge clk);
+      @(negedge clk);
+      drive_source();
+    end
+    $display("SUMMARY delivered=%0d", delivered_count);
+    $finish;
+  end
+
+  always @(posedge clk) begin
+    if (rst_n) begin
+      cycle_count = cycle_count + 1;
+      if (endpoint_in_valid[0] && endpoint_in_ready[0])
+        fragment_index = fragment_index + 1;
+      if (endpoint_out_valid[15] && endpoint_out_ready[15]) begin
+        delivered_count = delivered_count + 1;
+        $display("DELIVER cycle=%0d source=%0d dest=%0d tag=%0d fragment=%0d vc=%0d last=%0d",
+          cycle_count,
+          endpoint_out_source[63:60],
+          endpoint_out_dest[63:60],
+          endpoint_out_tag[127:120],
+          endpoint_out_fragment[47:45],
+          endpoint_out_vc[31:30],
+          endpoint_out_last[15]);
+      end
+    end
+  end
+endmodule
+"""
+
+
+def test_segmented_router_wrapper_generates_and_compiles() -> None:
+    subprocess.run(
+        ["python3", "scripts/generate_design.py", str(ROUTER_CONFIG), "nangate45", "--force_gen", "True"],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    expected = {
+        "l1_noc_segmented_xy_router_p5_w256_vc4_d4.v",
+        "l1_noc_segmented_xy_router_p5_w256_vc4_d4_wrapper.v",
+        "noc_ready_valid_fifo.v",
+        "noc_segmented_mesh_router.v",
+    }
+    assert expected.issubset({path.name for path in GENERATED_SRC.iterdir()})
+
+    iverilog = _iverilog()
+    if iverilog is None:
+        pytest.skip("iverilog unavailable")
+    subprocess.run(
+        [
+            iverilog,
+            "-g2012",
+            "-s",
+            "l1_noc_segmented_xy_router_p5_w256_vc4_d4_wrapper",
+            "-t",
+            "null",
+            str(GENERATED_SRC / "noc_ready_valid_fifo.v"),
+            str(GENERATED_SRC / "noc_segmented_mesh_router.v"),
+            str(GENERATED_SRC / "l1_noc_segmented_xy_router_p5_w256_vc4_d4.v"),
+            str(GENERATED_SRC / "l1_noc_segmented_xy_router_p5_w256_vc4_d4_wrapper.v"),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.skipif(_iverilog() is None or _vvp() is None, reason="iverilog/vvp unavailable")
+def test_router_cycle_model_matches_rtl(tmp_path: Path) -> None:
+    schedule, ready = _router_scenario()
+    expected = simulate_router(
+        x_coord=1,
+        y_coord=1,
+        input_schedule=schedule,
+        out_ready_schedule=ready,
+    )
+    output = _compile_and_run(
+        tmp_path,
+        top="tb_noc_segmented_mesh_router",
+        sources=[
+            REPO_ROOT / "npu/sim/rtl/noc_ready_valid_fifo.sv",
+            REPO_ROOT / "npu/sim/rtl/noc_segmented_mesh_router.sv",
+        ],
+        tb_text=_router_tb(schedule, ready),
+    )
+
+    fwd_pattern = re.compile(
+        r"FWD cycle=(?P<cycle>\d+) port=(?P<port>\d+) source=(?P<source>\d+) dest=(?P<dest>\d+) "
+        r"tag=(?P<tag>\d+) fragment=(?P<fragment>\d+) vc=(?P<vc>\d+) last=(?P<last>\d+)"
+    )
+    summary_pattern = re.compile(
+        r"SUMMARY accepted=(?P<accepted>\d+) forwarded=(?P<forwarded>\d+) istall=(?P<istall>\d+) "
+        r"ostall=(?P<ostall>\d+) contention=(?P<contention>\d+) occ=(?P<occ>\d+) "
+        r"maxocc=(?P<maxocc>\d+) east=(?P<east>\d+) local=(?P<local>\d+)"
+    )
+
+    observed = []
+    summary_match = None
+    for line in output.splitlines():
+        match = fwd_pattern.match(line.strip())
+        if match:
+            observed.append({key: int(value) for key, value in match.groupdict().items()})
+            continue
+        summary_match = summary_match or summary_pattern.match(line.strip())
+
+    assert summary_match is not None, output
+    summary = {key: int(value) for key, value in summary_match.groupdict().items()}
+
+    expected_forwarded = [
+        {
+            "cycle": trace.cycle,
+            "port": port,
+            "source": flit.source,
+            "dest": flit.destination,
+            "tag": flit.tag,
+            "fragment": flit.fragment,
+            "vc": flit.vc,
+            "last": 1 if flit.last else 0,
+        }
+        for trace in expected.traces
+        for port, flit in trace.forwarded
+    ]
+
+    assert observed == expected_forwarded
+    assert summary["accepted"] == expected.accepted_flit_count
+    assert summary["forwarded"] == expected.forwarded_flit_count
+    assert summary["istall"] == expected.input_stall_cycles
+    assert summary["ostall"] == expected.output_stall_cycles
+    assert summary["contention"] == expected.arbitration_contention_cycles
+    assert summary["occ"] == expected.current_input_occupancy
+    assert summary["maxocc"] == expected.max_input_occupancy
+    assert summary["east"] == expected.route_flit_count[PORT_EAST]
+    assert summary["local"] == expected.route_flit_count[PORT_LOCAL]
+
+
+@pytest.mark.skipif(_iverilog() is None or _vvp() is None, reason="iverilog/vvp unavailable")
+def test_mesh_route_model_matches_rtl(tmp_path: Path) -> None:
+    expected = simulate_mesh(source=0, destination=15, tag=7, vc=1)
+    output = _compile_and_run(
+        tmp_path,
+        top="tb_noc_segmented_mesh4x4",
+        sources=[
+            REPO_ROOT / "npu/sim/rtl/noc_ready_valid_fifo.sv",
+            REPO_ROOT / "npu/sim/rtl/noc_segmented_mesh_router.sv",
+            REPO_ROOT / "npu/sim/rtl/noc_segmented_mesh4x4.sv",
+        ],
+        tb_text=_mesh_tb(),
+    )
+
+    delivery_pattern = re.compile(
+        r"DELIVER cycle=(?P<cycle>\d+) source=(?P<source>\d+) dest=(?P<dest>\d+) "
+        r"tag=(?P<tag>\d+) fragment=(?P<fragment>\d+) vc=(?P<vc>\d+) last=(?P<last>\d+)"
+    )
+    summary_pattern = re.compile(r"SUMMARY delivered=(?P<delivered>\d+)")
+    observed = []
+    summary_match = None
+    for line in output.splitlines():
+        match = delivery_pattern.match(line.strip())
+        if match:
+            observed.append({key: int(value) for key, value in match.groupdict().items()})
+            continue
+        summary_match = summary_match or summary_pattern.match(line.strip())
+
+    assert summary_match is not None, output
+    assert int(summary_match.group("delivered")) == len(expected["delivered"])
+
+    expected_deliveries = [
+        {
+            "cycle": int(item["cycle"]),
+            "source": int(item["source"]),
+            "dest": int(item["destination"]),
+            "tag": int(item["tag"]),
+            "fragment": int(item["fragment"]),
+            "vc": int(item["vc"]),
+            "last": 1 if item["last"] else 0,
+        }
+        for item in expected["delivered"]
+    ]
+    assert observed == expected_deliveries


### PR DESCRIPTION
## Summary
- add a synthesizable 256-bit, five-port deterministic-XY router with four per-input virtual channels and ready/valid backpressure
- compose the router into a concrete 4x4 mesh and add a cycle-level routing/stall model
- compare focused router contention/backpressure and end-to-end mesh timing against RTL
- add a self-driven single-router PPA wrapper, Nangate45 sweep, and developer-loop proposal

## Verification
- `PYTHONPATH=. python3 -m pytest -q tests/test_noc_segmented_mesh.py` (3 passed)
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check origin/master...origin/codex/noc-phase1-xy-mesh`

## Measurement boundary
- the physical target is one router primitive, not a placed 4x4 mesh
- workload mapping, multi-flow schedule optimization, SRAM endpoints, and HBM service remain follow-on layers
