### PR TITLE
control_plane: prove exact source identity for generated jobs

### DIFF
--- a/control_plane/control_plane/services/generation_source_identity.py
+++ b/control_plane/control_plane/services/generation_source_identity.py
@@ -63,7 +63,6 @@ def resolve_source_commit(
     source_commit: str | None,
     *,
     error_factory: Callable[[str], Exception],
-    subject: str,
 ) -> str:
     resolved = str(source_commit or "").strip()
     if resolved:
@@ -202,11 +201,21 @@ def validate_generation_source_identity(
             ),
         )
     identity = raw_identity
+    version = identity.get("version")
     identity_source = str(identity.get("declared_source_commit") or "").strip()
     repo_head = str(identity.get("repo_head_sha") or "").strip()
     relation = str(identity.get("relation") or "").strip()
     proof = str(identity.get("proof") or "").strip()
     clean = identity.get("clean")
+    if version != GENERATION_SOURCE_IDENTITY_VERSION:
+        _raise(
+            error_factory,
+            (
+                f"{context} has generation_source_identity with unsupported version={version!r}; "
+                f"expected version={GENERATION_SOURCE_IDENTITY_VERSION}. "
+                "Regenerate the queue item with the exact-generation worktree contract."
+            ),
+        )
     if identity_source != required_sha or repo_head != required_sha or relation != "exact":
         _raise(
             error_factory,
@@ -226,11 +235,11 @@ def validate_generation_source_identity(
                 "Regenerate the queue item from a clean checkout whose HEAD exactly matches the declared source commit."
             ),
         )
-    if proof and proof != "generator_worktree_head_exact":
+    if proof != "generator_worktree_head_exact":
         _raise(
             error_factory,
             (
-                f"{context} has unsupported generation_source_identity proof={proof}. "
+                f"{context} has unsupported generation_source_identity proof={proof or '<missing>'}. "
                 "Regenerate the queue item with the exact-generation worktree contract."
             ),
         )

--- a/control_plane/control_plane/services/generation_source_identity.py
+++ b/control_plane/control_plane/services/generation_source_identity.py
@@ -38,6 +38,26 @@ def _git_stdout(
     return stdout
 
 
+def _git_status_porcelain(
+    repo_root: Path,
+    *,
+    error_factory: Callable[[str], Exception],
+    failure_message: str,
+) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "status", "--porcelain"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        detail = f": {stderr}" if stderr else ""
+        _raise(error_factory, f"{failure_message}{detail}")
+    return result.stdout
+
+
 def resolve_source_commit(
     repo_root: Path,
     source_commit: str | None,
@@ -134,12 +154,31 @@ def build_generation_source_identity(
                 "source commit."
             ),
         )
+    porcelain = _git_status_porcelain(
+        repo_root,
+        error_factory=error_factory,
+        failure_message=f"failed to resolve git status for {context} in repo_root {repo_root}",
+    )
+    if porcelain:
+        status_lines = [line.rstrip() for line in porcelain.splitlines() if line.strip()]
+        preview = "; ".join(status_lines[:5])
+        if len(status_lines) > 5:
+            preview += "; ..."
+        _raise(
+            error_factory,
+            (
+                f"{context} requires a clean exact-generation worktree: declared source_commit={declared_source_commit}, "
+                f"repo HEAD={repo_head}, git status --porcelain is not empty ({preview}). "
+                "Commit, stash, or remove tracked and untracked changes, then regenerate the item from the declared source commit."
+            ),
+        )
     return {
         "version": GENERATION_SOURCE_IDENTITY_VERSION,
         "declared_source_commit": declared_source_commit,
         "repo_head_sha": repo_head,
         "relation": "exact",
         "proof": "generator_worktree_head_exact",
+        "clean": True,
     }
 
 
@@ -167,6 +206,7 @@ def validate_generation_source_identity(
     repo_head = str(identity.get("repo_head_sha") or "").strip()
     relation = str(identity.get("relation") or "").strip()
     proof = str(identity.get("proof") or "").strip()
+    clean = identity.get("clean")
     if identity_source != required_sha or repo_head != required_sha or relation != "exact":
         _raise(
             error_factory,
@@ -175,6 +215,15 @@ def validate_generation_source_identity(
                 f"source_commit={required_sha}: declared_source_commit={identity_source or '<missing>'}, "
                 f"repo_head_sha={repo_head or '<missing>'}, relation={relation or '<missing>'}. "
                 "Regenerate the queue item from the declared source commit."
+            ),
+        )
+    if clean is not True:
+        _raise(
+            error_factory,
+            (
+                f"{context} has generation_source_identity that does not prove a clean generation worktree for "
+                f"declared source_commit={required_sha}: clean={clean!r}. "
+                "Regenerate the queue item from a clean checkout whose HEAD exactly matches the declared source commit."
             ),
         )
     if proof and proof != "generator_worktree_head_exact":

--- a/control_plane/control_plane/services/generation_source_identity.py
+++ b/control_plane/control_plane/services/generation_source_identity.py
@@ -1,0 +1,187 @@
+"""Helpers for proving manifest generation came from the declared source tree."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+
+GENERATION_SOURCE_IDENTITY_VERSION = 1
+
+
+def _raise(error_factory: Callable[[str], Exception], message: str) -> None:
+    raise error_factory(message)
+
+
+def _git_stdout(
+    repo_root: Path,
+    args: list[str],
+    *,
+    error_factory: Callable[[str], Exception],
+    failure_message: str,
+) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        detail = f": {stderr}" if stderr else ""
+        _raise(error_factory, f"{failure_message}{detail}")
+    stdout = result.stdout.strip()
+    if not stdout:
+        _raise(error_factory, f"{failure_message}: empty git output")
+    return stdout
+
+
+def resolve_source_commit(
+    repo_root: Path,
+    source_commit: str | None,
+    *,
+    error_factory: Callable[[str], Exception],
+    subject: str,
+) -> str:
+    resolved = str(source_commit or "").strip()
+    if resolved:
+        try:
+            subprocess.run(
+                ["git", "-C", str(repo_root), "cat-file", "-e", f"{resolved}^{{commit}}"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            stderr = (exc.stderr or "").strip()
+            detail = f": {stderr}" if stderr else ""
+            _raise(
+                error_factory,
+                f"provided source_commit does not resolve to a commit in repo_root {repo_root}: {resolved}{detail}",
+            )
+        normalized = _git_stdout(
+            repo_root,
+            ["rev-parse", f"{resolved}^{{commit}}"],
+            error_factory=error_factory,
+            failure_message=(
+                f"provided source_commit resolved to empty git rev-parse output in repo_root {repo_root}: {resolved}"
+            ),
+        )
+        try:
+            subprocess.run(
+                ["git", "-C", str(repo_root), "fetch", "--quiet", "origin"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            refs = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(repo_root),
+                    "for-each-ref",
+                    "refs/remotes/origin",
+                    "--contains",
+                    normalized,
+                    "--format=%(refname)",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            stderr = (exc.stderr or "").strip()
+            detail = f": {stderr}" if stderr else ""
+            _raise(
+                error_factory,
+                f"failed to verify source_commit against origin for repo_root {repo_root}: {normalized}{detail}",
+            )
+        if not refs.stdout.strip():
+            _raise(
+                error_factory,
+                f"provided source_commit is not reachable from origin in repo_root {repo_root}: {normalized}",
+            )
+        return normalized
+    return _git_stdout(
+        repo_root,
+        ["rev-parse", "HEAD"],
+        error_factory=error_factory,
+        failure_message=f"failed to resolve source commit from repo_root {repo_root}",
+    )
+
+
+def build_generation_source_identity(
+    repo_root: Path,
+    *,
+    declared_source_commit: str,
+    error_factory: Callable[[str], Exception],
+    context: str,
+) -> dict[str, object]:
+    repo_head = _git_stdout(
+        repo_root,
+        ["rev-parse", "HEAD"],
+        error_factory=error_factory,
+        failure_message=f"failed to resolve repo HEAD for {context} in repo_root {repo_root}",
+    )
+    if repo_head != declared_source_commit:
+        _raise(
+            error_factory,
+            (
+                f"{context} requires an exact-generation worktree: declared source_commit={declared_source_commit}, "
+                f"repo HEAD={repo_head}. Regenerate the item from a checkout whose HEAD exactly matches the declared "
+                "source commit."
+            ),
+        )
+    return {
+        "version": GENERATION_SOURCE_IDENTITY_VERSION,
+        "declared_source_commit": declared_source_commit,
+        "repo_head_sha": repo_head,
+        "relation": "exact",
+        "proof": "generator_worktree_head_exact",
+    }
+
+
+def validate_generation_source_identity(
+    payload: dict[str, object],
+    *,
+    declared_source_commit: str | None,
+    error_factory: Callable[[str], Exception],
+    context: str,
+) -> None:
+    required_sha = str(declared_source_commit or "").strip()
+    if not required_sha:
+        return
+    raw_identity = payload.get("generation_source_identity")
+    if not isinstance(raw_identity, dict):
+        _raise(
+            error_factory,
+            (
+                f"{context} declares source_commit={required_sha} but is missing generation_source_identity. "
+                "Regenerate the queue item from a worktree whose HEAD exactly matches the declared source commit."
+            ),
+        )
+    identity = raw_identity
+    identity_source = str(identity.get("declared_source_commit") or "").strip()
+    repo_head = str(identity.get("repo_head_sha") or "").strip()
+    relation = str(identity.get("relation") or "").strip()
+    proof = str(identity.get("proof") or "").strip()
+    if identity_source != required_sha or repo_head != required_sha or relation != "exact":
+        _raise(
+            error_factory,
+            (
+                f"{context} has generation_source_identity that does not prove exact generation from declared "
+                f"source_commit={required_sha}: declared_source_commit={identity_source or '<missing>'}, "
+                f"repo_head_sha={repo_head or '<missing>'}, relation={relation or '<missing>'}. "
+                "Regenerate the queue item from the declared source commit."
+            ),
+        )
+    if proof and proof != "generator_worktree_head_exact":
+        _raise(
+            error_factory,
+            (
+                f"{context} has unsupported generation_source_identity proof={proof}. "
+                "Regenerate the queue item with the exact-generation worktree contract."
+            ),
+        )

--- a/control_plane/control_plane/services/generation_source_identity.py
+++ b/control_plane/control_plane/services/generation_source_identity.py
@@ -58,6 +58,49 @@ def _git_status_porcelain(
     return result.stdout
 
 
+def _verify_commit_reachable_from_origin(
+    repo_root: Path,
+    commit_sha: str,
+    *,
+    commit_label: str,
+    error_factory: Callable[[str], Exception],
+) -> None:
+    try:
+        subprocess.run(
+            ["git", "-C", str(repo_root), "fetch", "--quiet", "origin"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        refs = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "for-each-ref",
+                "refs/remotes/origin",
+                "--contains",
+                commit_sha,
+                "--format=%(refname)",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        detail = f": {stderr}" if stderr else ""
+        _raise(
+            error_factory,
+            f"failed to verify {commit_label} against origin for repo_root {repo_root}: {commit_sha}{detail}",
+        )
+    if not refs.stdout.strip():
+        _raise(
+            error_factory,
+            f"{commit_label} is not reachable from origin in repo_root {repo_root}: {commit_sha}",
+        )
+
+
 def resolve_source_commit(
     repo_root: Path,
     source_commit: str | None,
@@ -88,47 +131,26 @@ def resolve_source_commit(
                 f"provided source_commit resolved to empty git rev-parse output in repo_root {repo_root}: {resolved}"
             ),
         )
-        try:
-            subprocess.run(
-                ["git", "-C", str(repo_root), "fetch", "--quiet", "origin"],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            refs = subprocess.run(
-                [
-                    "git",
-                    "-C",
-                    str(repo_root),
-                    "for-each-ref",
-                    "refs/remotes/origin",
-                    "--contains",
-                    normalized,
-                    "--format=%(refname)",
-                ],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-        except subprocess.CalledProcessError as exc:
-            stderr = (exc.stderr or "").strip()
-            detail = f": {stderr}" if stderr else ""
-            _raise(
-                error_factory,
-                f"failed to verify source_commit against origin for repo_root {repo_root}: {normalized}{detail}",
-            )
-        if not refs.stdout.strip():
-            _raise(
-                error_factory,
-                f"provided source_commit is not reachable from origin in repo_root {repo_root}: {normalized}",
-            )
+        _verify_commit_reachable_from_origin(
+            repo_root,
+            normalized,
+            commit_label="provided source_commit",
+            error_factory=error_factory,
+        )
         return normalized
-    return _git_stdout(
+    normalized = _git_stdout(
         repo_root,
         ["rev-parse", "HEAD"],
         error_factory=error_factory,
         failure_message=f"failed to resolve source commit from repo_root {repo_root}",
     )
+    _verify_commit_reachable_from_origin(
+        repo_root,
+        normalized,
+        commit_label="resolved repo HEAD source_commit",
+        error_factory=error_factory,
+    )
+    return normalized
 
 
 def build_generation_source_identity(

--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -8,7 +8,6 @@ from hashlib import sha256
 import json
 import os
 import shlex
-import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +19,10 @@ from control_plane.models.task_requests import TaskRequest
 from control_plane.models.work_items import WorkItem
 from control_plane.services.dependency_gate import evaluate_work_item_dependencies
 from control_plane.services.docs_paths import canonicalize_proposal_path, resolve_proposal_dir, resolve_proposal_file
+from control_plane.services.generation_source_identity import (
+    build_generation_source_identity,
+    resolve_source_commit as resolve_generation_source_commit,
+)
 from control_plane.services.proposal_scaffold import ensure_proposal_scaffold
 from control_plane.services.source_requirement import build_source_requirement
 
@@ -474,74 +477,12 @@ def _required_l1_runtime_submodules() -> list[str]:
 
 
 def _resolve_source_commit(repo_root: Path, source_commit: str | None) -> str:
-    resolved = str(source_commit or "").strip()
-    if resolved:
-        try:
-            subprocess.run(
-                ["git", "-C", str(repo_root), "cat-file", "-e", f"{resolved}^{{commit}}"],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            result = subprocess.run(
-                ["git", "-C", str(repo_root), "rev-parse", f"{resolved}^{{commit}}"],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-        except subprocess.CalledProcessError as exc:
-            stderr = (exc.stderr or "").strip()
-            detail = f": {stderr}" if stderr else ""
-            raise Layer1TaskGenerationError(
-                f"provided source_commit does not resolve to a commit in repo_root {repo_root}: {resolved}{detail}"
-            ) from exc
-        normalized = result.stdout.strip()
-        if not normalized:
-            raise Layer1TaskGenerationError(
-                f"provided source_commit resolved to empty git rev-parse output in repo_root {repo_root}: {resolved}"
-            )
-        try:
-            subprocess.run(
-                ["git", "-C", str(repo_root), "fetch", "--quiet", "origin"],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            refs = subprocess.run(
-                [
-                    "git", "-C", str(repo_root), "for-each-ref", "refs/remotes/origin",
-                    "--contains", normalized, "--format=%(refname)",
-                ],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-        except subprocess.CalledProcessError as exc:
-            stderr = (exc.stderr or "").strip()
-            detail = f": {stderr}" if stderr else ""
-            raise Layer1TaskGenerationError(
-                f"failed to verify source_commit against origin for repo_root {repo_root}: {normalized}{detail}"
-            ) from exc
-        if not refs.stdout.strip():
-            raise Layer1TaskGenerationError(
-                f"provided source_commit is not reachable from origin in repo_root {repo_root}: {normalized}"
-            )
-        return normalized
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except subprocess.CalledProcessError as exc:
-        stderr = (exc.stderr or "").strip()
-        detail = f": {stderr}" if stderr else ""
-        raise Layer1TaskGenerationError(f"failed to resolve source commit from repo_root {repo_root}{detail}") from exc
-    resolved = result.stdout.strip()
-    if not resolved:
-        raise Layer1TaskGenerationError(f"failed to resolve source commit from repo_root {repo_root}: empty git rev-parse output")
-    return resolved
+    return resolve_generation_source_commit(
+        repo_root,
+        source_commit,
+        error_factory=Layer1TaskGenerationError,
+        subject="Layer1 task generation source_commit",
+    )
 
 
 def _contains_disabled_hierarchy(value: object) -> bool:
@@ -2461,6 +2402,13 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
         raise Layer1TaskGenerationError("config_paths must not be empty")
 
     repo_root = Path(request.repo_root).resolve()
+    source_commit = _resolve_source_commit(repo_root, request.source_commit)
+    generation_source_identity = build_generation_source_identity(
+        repo_root,
+        declared_source_commit=source_commit,
+        error_factory=Layer1TaskGenerationError,
+        context=f"Layer1 task generation for {request.item_id or request.sweep_path}",
+    )
     sweep_path = _repo_rel(request.sweep_path, repo_root)
     config_paths = [_repo_rel(path, repo_root) for path in request.config_paths]
     out_root = _repo_rel(request.out_root, repo_root)
@@ -2536,7 +2484,6 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
         sweep_path=(repo_root / sweep_path).resolve(),
         abstraction_layer=effective_abstraction_layer,
     )
-    source_commit = _resolve_source_commit(repo_root, request.source_commit)
 
     effective_make_target = request.make_target
     if not effective_make_target and _is_gqa_lanes2_macro_hier_placement_sweep(
@@ -2696,6 +2643,7 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
         repo_root=repo_root,
         required_sha=source_commit,
     )
+    payload["generation_source_identity"] = generation_source_identity
     if request.update_proposal_files:
         _upsert_evaluation_request_entry(
             repo_root=repo_root,

--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -481,7 +481,6 @@ def _resolve_source_commit(repo_root: Path, source_commit: str | None) -> str:
         repo_root,
         source_commit,
         error_factory=Layer1TaskGenerationError,
-        subject="Layer1 task generation source_commit",
     )
 
 
@@ -2403,12 +2402,6 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
 
     repo_root = Path(request.repo_root).resolve()
     source_commit = _resolve_source_commit(repo_root, request.source_commit)
-    generation_source_identity = build_generation_source_identity(
-        repo_root,
-        declared_source_commit=source_commit,
-        error_factory=Layer1TaskGenerationError,
-        context=f"Layer1 task generation for {request.item_id or request.sweep_path}",
-    )
     sweep_path = _repo_rel(request.sweep_path, repo_root)
     config_paths = [_repo_rel(path, repo_root) for path in request.config_paths]
     out_root = _repo_rel(request.out_root, repo_root)
@@ -2643,7 +2636,6 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
         repo_root=repo_root,
         required_sha=source_commit,
     )
-    payload["generation_source_identity"] = generation_source_identity
     if request.update_proposal_files:
         _upsert_evaluation_request_entry(
             repo_root=repo_root,
@@ -2664,6 +2656,12 @@ def generate_l1_sweep_task(session: Session, request: Layer1SweepGenerateRequest
             acceptance_notes=request.acceptance_notes,
             source_commit=source_commit,
         )
+    payload["generation_source_identity"] = build_generation_source_identity(
+        repo_root,
+        declared_source_commit=source_commit,
+        error_factory=Layer1TaskGenerationError,
+        context=f"Layer1 task generation for {item_id}",
+    )
 
     initial_state = WorkItemState.DISPATCH_PENDING
     transient_work_item = WorkItem(

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -559,7 +559,6 @@ def _resolve_source_commit(repo_root: Path, source_commit: str | None) -> str:
         repo_root,
         source_commit,
         error_factory=Layer2TaskGenerationError,
-        subject="Layer2 task generation source_commit",
     )
 
 
@@ -12807,12 +12806,6 @@ def _build_payload(
 def generate_l2_campaign_task(session: Session, request: Layer2CampaignGenerateRequest) -> Layer2TaskGenerateResult:
     repo_root = Path(request.repo_root).resolve()
     source_commit = _resolve_source_commit(repo_root, request.source_commit)
-    generation_source_identity = build_generation_source_identity(
-        repo_root,
-        declared_source_commit=source_commit,
-        error_factory=Layer2TaskGenerationError,
-        context=f"Layer2 task generation for {request.item_id or request.campaign_path}",
-    )
     campaign_path = _repo_rel(request.campaign_path, repo_root)
     base_campaign = _load_json((repo_root / campaign_path).resolve())
 
@@ -12946,7 +12939,12 @@ def generate_l2_campaign_task(session: Session, request: Layer2CampaignGenerateR
         repo_root=repo_root,
         required_sha=source_commit,
     )
-    payload["generation_source_identity"] = generation_source_identity
+    payload["generation_source_identity"] = build_generation_source_identity(
+        repo_root,
+        declared_source_commit=source_commit,
+        error_factory=Layer2TaskGenerationError,
+        context=f"Layer2 task generation for {item_id}",
+    )
     initial_state = WorkItemState.DISPATCH_PENDING
     transient_work_item = WorkItem(
         work_item_key=f"l2_campaign:{item_id}",

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -20,6 +20,10 @@ from control_plane.models.task_requests import TaskRequest
 from control_plane.models.work_items import WorkItem
 from control_plane.services.dependency_gate import evaluate_work_item_dependencies
 from control_plane.services.docs_paths import canonicalize_proposal_path, resolve_proposal_dir
+from control_plane.services.generation_source_identity import (
+    build_generation_source_identity,
+    resolve_source_commit as resolve_generation_source_commit,
+)
 from control_plane.services.proposal_scaffold import ensure_proposal_scaffold
 from control_plane.services.source_requirement import build_source_requirement
 
@@ -551,74 +555,12 @@ def _upsert_requested_item_entry(
 
 
 def _resolve_source_commit(repo_root: Path, source_commit: str | None) -> str:
-    resolved = str(source_commit or "").strip()
-    if resolved:
-        try:
-            subprocess.run(
-                ["git", "-C", str(repo_root), "cat-file", "-e", f"{resolved}^{{commit}}"],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            result = subprocess.run(
-                ["git", "-C", str(repo_root), "rev-parse", f"{resolved}^{{commit}}"],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-        except subprocess.CalledProcessError as exc:
-            stderr = (exc.stderr or "").strip()
-            detail = f": {stderr}" if stderr else ""
-            raise Layer2TaskGenerationError(
-                f"provided source_commit does not resolve to a commit in repo_root {repo_root}: {resolved}{detail}"
-            ) from exc
-        normalized = result.stdout.strip()
-        if not normalized:
-            raise Layer2TaskGenerationError(
-                f"provided source_commit resolved to empty git rev-parse output in repo_root {repo_root}: {resolved}"
-            )
-        try:
-            subprocess.run(
-                ["git", "-C", str(repo_root), "fetch", "--quiet", "origin"],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            refs = subprocess.run(
-                [
-                    "git", "-C", str(repo_root), "for-each-ref", "refs/remotes/origin",
-                    "--contains", normalized, "--format=%(refname)",
-                ],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-        except subprocess.CalledProcessError as exc:
-            stderr = (exc.stderr or "").strip()
-            detail = f": {stderr}" if stderr else ""
-            raise Layer2TaskGenerationError(
-                f"failed to verify source_commit against origin for repo_root {repo_root}: {normalized}{detail}"
-            ) from exc
-        if not refs.stdout.strip():
-            raise Layer2TaskGenerationError(
-                f"provided source_commit is not reachable from origin in repo_root {repo_root}: {normalized}"
-            )
-        return normalized
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except subprocess.CalledProcessError as exc:
-        stderr = (exc.stderr or "").strip()
-        detail = f": {stderr}" if stderr else ""
-        raise Layer2TaskGenerationError(f"failed to resolve source commit from repo_root {repo_root}{detail}") from exc
-    resolved = result.stdout.strip()
-    if not resolved:
-        raise Layer2TaskGenerationError(f"failed to resolve source commit from repo_root {repo_root}: empty git rev-parse output")
-    return resolved
+    return resolve_generation_source_commit(
+        repo_root,
+        source_commit,
+        error_factory=Layer2TaskGenerationError,
+        subject="Layer2 task generation source_commit",
+    )
 
 
 def _uniq(items: list[str]) -> list[str]:
@@ -12864,6 +12806,13 @@ def _build_payload(
 
 def generate_l2_campaign_task(session: Session, request: Layer2CampaignGenerateRequest) -> Layer2TaskGenerateResult:
     repo_root = Path(request.repo_root).resolve()
+    source_commit = _resolve_source_commit(repo_root, request.source_commit)
+    generation_source_identity = build_generation_source_identity(
+        repo_root,
+        declared_source_commit=source_commit,
+        error_factory=Layer2TaskGenerationError,
+        context=f"Layer2 task generation for {request.item_id or request.campaign_path}",
+    )
     campaign_path = _repo_rel(request.campaign_path, repo_root)
     base_campaign = _load_json((repo_root / campaign_path).resolve())
 
@@ -12939,7 +12888,6 @@ def generate_l2_campaign_task(session: Session, request: Layer2CampaignGenerateR
         key="reason",
         explicit=request.expected_reason,
     )
-    source_commit = _resolve_source_commit(repo_root, request.source_commit)
     if request.update_proposal_files:
         _upsert_requested_item_entry(
             repo_root=repo_root,
@@ -12998,6 +12946,7 @@ def generate_l2_campaign_task(session: Session, request: Layer2CampaignGenerateR
         repo_root=repo_root,
         required_sha=source_commit,
     )
+    payload["generation_source_identity"] = generation_source_identity
     initial_state = WorkItemState.DISPATCH_PENDING
     transient_work_item = WorkItem(
         work_item_key=f"l2_campaign:{item_id}",

--- a/control_plane/control_plane/services/queue_importer.py
+++ b/control_plane/control_plane/services/queue_importer.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from hashlib import sha256
-import subprocess
 import json
 from pathlib import Path
 import re
@@ -16,6 +15,10 @@ from control_plane.models.enums import FlowName, LayerName, QueueReconciliationD
 from control_plane.models.queue_reconciliations import QueueReconciliation
 from control_plane.models.task_requests import TaskRequest
 from control_plane.models.work_items import WorkItem
+from control_plane.services.generation_source_identity import (
+    resolve_source_commit as resolve_generation_source_commit,
+    validate_generation_source_identity,
+)
 
 
 _STATE_RANK = {
@@ -134,57 +137,12 @@ def _resolve_source_commit(repo_root: Path, source_commit: str | None) -> str | 
     resolved = str(source_commit or "").strip()
     if not resolved:
         return None
-    try:
-        subprocess.run(
-            ["git", "-C", str(repo_root), "cat-file", "-e", f"{resolved}^{{commit}}"],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        result = subprocess.run(
-            ["git", "-C", str(repo_root), "rev-parse", f"{resolved}^{{commit}}"],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except subprocess.CalledProcessError as exc:
-        stderr = (exc.stderr or "").strip()
-        detail = f": {stderr}" if stderr else ""
-        raise QueueImportError(
-            f"provided source_commit does not resolve to a commit in repo_root {repo_root}: {resolved}{detail}"
-        ) from exc
-    normalized = result.stdout.strip()
-    if not normalized:
-        raise QueueImportError(
-            f"provided source_commit resolved to empty git rev-parse output in repo_root {repo_root}: {resolved}"
-        )
-    try:
-        subprocess.run(
-            ["git", "-C", str(repo_root), "fetch", "--quiet", "origin"],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        refs = subprocess.run(
-            [
-                "git", "-C", str(repo_root), "for-each-ref", "refs/remotes/origin",
-                "--contains", normalized, "--format=%(refname)",
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except subprocess.CalledProcessError as exc:
-        stderr = (exc.stderr or "").strip()
-        detail = f": {stderr}" if stderr else ""
-        raise QueueImportError(
-            f"failed to verify source_commit against origin for repo_root {repo_root}: {normalized}{detail}"
-        ) from exc
-    if not refs.stdout.strip():
-        raise QueueImportError(
-            f"provided source_commit is not reachable from origin in repo_root {repo_root}: {normalized}"
-        )
-    return normalized
+    return resolve_generation_source_commit(
+        repo_root,
+        resolved,
+        error_factory=QueueImportError,
+        subject="queue import source_commit",
+    )
 
 
 def _merge_state(current: WorkItemState, imported: WorkItemState) -> WorkItemState:
@@ -226,6 +184,12 @@ def import_queue_item(session: Session, request: QueueImportRequest) -> QueueImp
     resolved_source_commit = _resolve_source_commit(
         repo_root,
         request.source_commit or _payload_source_commit(payload),
+    )
+    validate_generation_source_identity(
+        payload,
+        declared_source_commit=resolved_source_commit,
+        error_factory=QueueImportError,
+        context=f"queue import {queue_file}",
     )
     item_id = payload.get("item_id")
     if not item_id:

--- a/control_plane/control_plane/services/queue_importer.py
+++ b/control_plane/control_plane/services/queue_importer.py
@@ -141,7 +141,6 @@ def _resolve_source_commit(repo_root: Path, source_commit: str | None) -> str | 
         repo_root,
         resolved,
         error_factory=QueueImportError,
-        subject="queue import source_commit",
     )
 
 

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -2556,6 +2556,13 @@ def test_generate_l1_sweep_task_creates_ready_work_item() -> None:
             assert payload["source_requirement"]["required_sha"] == source_commit
             assert payload["source_requirement"]["required_ref"] == "origin/master"
             assert payload["source_requirement"]["requires_daemon_restart"] is True
+            assert payload["generation_source_identity"] == {
+                "version": 1,
+                "declared_source_commit": source_commit,
+                "repo_head_sha": source_commit,
+                "relation": "exact",
+                "proof": "generator_worktree_head_exact",
+            }
             assert payload["task"]["inputs"]["sweeps"] == [sweep_path]
             assert payload["task"]["acceptance"][0] == (
                 "Each generated wrapper metrics.csv contains at least one status=ok row for the queued sweep"
@@ -2566,6 +2573,54 @@ def test_generate_l1_sweep_task_creates_ready_work_item() -> None:
             ]
             assert payload["developer_loop"]["abstraction"] == {"layer": "circuit_block"}
             assert payload["handoff"]["pr_body_fields"]["queue_item_id"] == result.item_id
+
+
+def test_generate_l1_sweep_task_rejects_mismatched_generation_worktree() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_repo(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        mismatch_file = repo_root / "HEAD_ONLY.txt"
+        mismatch_file.write_text("mismatch\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(repo_root), "add", "HEAD_ONLY.txt"], check=True, capture_output=True, text=True)
+        subprocess.run(
+            ["git", "-C", str(repo_root), "commit", "-m", "local head drift"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        head_commit = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            try:
+                generate_l1_sweep_task(
+                    session,
+                    Layer1SweepGenerateRequest(
+                        repo_root=str(repo_root),
+                        sweep_path=sweep_path,
+                        config_paths=[config_path],
+                        platform="nangate45",
+                        out_root="runs/designs/activations",
+                        requested_by="@tester",
+                        source_commit=source_commit,
+                    ),
+                )
+            except Layer1TaskGenerationError as exc:
+                message = str(exc)
+                assert "exact-generation worktree" in message
+                assert source_commit in message
+                assert head_commit in message
+                assert "Regenerate the item from a checkout whose HEAD exactly matches the declared source commit." in message
+            else:
+                raise AssertionError("expected Layer1TaskGenerationError for mismatched generation worktree")
 
 
 def test_generate_l1_sweep_task_uses_boundary_metrics_acceptance() -> None:

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -326,6 +326,11 @@ def _commit_repo_changes(repo_root: Path, message: str) -> str:
     return result.stdout.strip()
 
 
+def _make_l1_request(**kwargs: object) -> Layer1SweepGenerateRequest:
+    kwargs.setdefault("update_proposal_files", False)
+    return Layer1SweepGenerateRequest(**kwargs)
+
+
 def _copy_fixture_file(*, src_repo_root: Path, dst_repo_root: Path, rel_path: str) -> None:
     src = src_repo_root / rel_path
     dst = dst_repo_root / rel_path
@@ -2523,7 +2528,7 @@ def test_generate_l1_sweep_task_creates_ready_work_item() -> None:
             ):
                 result = generate_l1_sweep_task(
                     session,
-                    Layer1SweepGenerateRequest(
+                    _make_l1_request(
                         repo_root=str(repo_root),
                         sweep_path=sweep_path,
                         config_paths=[config_path],
@@ -2612,7 +2617,7 @@ def test_generate_l1_sweep_task_rejects_mismatched_generation_worktree() -> None
             try:
                 generate_l1_sweep_task(
                     session,
-                    Layer1SweepGenerateRequest(
+                    _make_l1_request(
                         repo_root=str(repo_root),
                         sweep_path=sweep_path,
                         config_paths=[config_path],
@@ -2647,7 +2652,7 @@ def test_generate_l1_sweep_task_rejects_tracked_dirty_generation_worktree() -> N
             try:
                 generate_l1_sweep_task(
                     session,
-                    Layer1SweepGenerateRequest(
+                    _make_l1_request(
                         repo_root=str(repo_root),
                         sweep_path=sweep_path,
                         config_paths=[config_path],
@@ -2682,7 +2687,7 @@ def test_generate_l1_sweep_task_rejects_untracked_generation_worktree() -> None:
             try:
                 generate_l1_sweep_task(
                     session,
-                    Layer1SweepGenerateRequest(
+                    _make_l1_request(
                         repo_root=str(repo_root),
                         sweep_path=sweep_path,
                         config_paths=[config_path],
@@ -2718,7 +2723,7 @@ def test_generate_l1_sweep_task_uses_boundary_metrics_acceptance() -> None:
             ):
                 result = generate_l1_sweep_task(
                     session,
-                    Layer1SweepGenerateRequest(
+                    _make_l1_request(
                         repo_root=str(repo_root),
                         sweep_path=sweep_path,
                         config_paths=[config_path],
@@ -2752,7 +2757,7 @@ def test_generate_l1_sweep_task_uses_acceptance_notes_for_boundary_evidence() ->
             ):
                 result = generate_l1_sweep_task(
                     session,
-                    Layer1SweepGenerateRequest(
+                    _make_l1_request(
                         repo_root=str(repo_root),
                         sweep_path=sweep_path,
                         config_paths=[config_path],
@@ -2790,7 +2795,7 @@ def test_generate_l1_sweep_task_requeues_failed_item_on_upsert() -> None:
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -2809,7 +2814,7 @@ def test_generate_l1_sweep_task_requeues_failed_item_on_upsert() -> None:
 
             generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -2839,7 +2844,7 @@ def test_generate_l1_sweep_task_expands_expected_outputs_for_multi_trial_items()
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -2876,7 +2881,7 @@ def test_generate_l1_sweep_task_run_sweep_command_includes_all_wrapper_configs()
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path, second_config_path],
@@ -2911,7 +2916,7 @@ def test_generate_l1_sweep_task_supports_bf16_recip_norm_wrapper_config() -> Non
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -2944,7 +2949,7 @@ def test_generate_l1_sweep_task_supports_score_tie_rank_wrapper_config() -> None
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -2977,7 +2982,7 @@ def test_generate_l1_sweep_task_supports_logit_rank_wrapper_config() -> None:
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -3010,7 +3015,7 @@ def test_generate_l1_sweep_task_supports_candidate_stream_merge_fifo_wrapper_con
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -3043,7 +3048,7 @@ def test_generate_l1_sweep_task_supports_attention_kv_tile_wrapper_config() -> N
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -3083,9 +3088,37 @@ def test_generate_l1_sweep_task_records_requested_item_in_proposal_evaluation_re
         create_all(engine)
 
         with Session(engine) as session:
+            try:
+                generate_l1_sweep_task(
+                    session,
+                    _make_l1_request(
+                        repo_root=str(repo_root),
+                        sweep_path=sweep_path,
+                        config_paths=[config_path],
+                        platform="nangate45",
+                        out_root="runs/designs/activations",
+                        item_id="l1_demo_softmax_proposal_r1",
+                        requested_by="@tester",
+                        source_commit=source_commit,
+                        proposal_id="prop_l1_demo_v1",
+                        proposal_path="docs/proposals/prop_l1_demo_v1",
+                        abstraction_layer="circuit_block",
+                        acceptance_notes="Accept flow_failed rows as explicit boundary evidence.",
+                        update_proposal_files=True,
+                    ),
+                )
+            except Layer1TaskGenerationError as exc:
+                assert "clean exact-generation worktree" in str(exc)
+            else:
+                raise AssertionError("expected Layer1TaskGenerationError")
+
+            assert session.query(WorkItem).count() == 0
+            assert session.query(TaskRequest).count() == 0
+
+            clean_commit = _commit_repo_changes(repo_root, "commit l1 proposal metadata fixture")
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -3093,11 +3126,12 @@ def test_generate_l1_sweep_task_records_requested_item_in_proposal_evaluation_re
                     out_root="runs/designs/activations",
                     item_id="l1_demo_softmax_proposal_r1",
                     requested_by="@tester",
-                    source_commit=source_commit,
+                    source_commit=clean_commit,
                     proposal_id="prop_l1_demo_v1",
                     proposal_path="docs/proposals/prop_l1_demo_v1",
                     abstraction_layer="circuit_block",
                     acceptance_notes="Accept flow_failed rows as explicit boundary evidence.",
+                    update_proposal_files=False,
                 ),
             )
 
@@ -3166,7 +3200,7 @@ def test_generate_l1_sweep_task_can_refresh_db_without_updating_proposal_files()
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -3210,7 +3244,7 @@ def test_generate_l1_sweep_task_rejects_db_creation_when_proposal_upsert_dirties
             try:
                 generate_l1_sweep_task(
                     session,
-                    Layer1SweepGenerateRequest(
+                    _make_l1_request(
                         repo_root=str(repo_root),
                         sweep_path=sweep_path,
                         config_paths=[config_path],
@@ -3221,6 +3255,7 @@ def test_generate_l1_sweep_task_rejects_db_creation_when_proposal_upsert_dirties
                         source_commit=source_commit,
                         proposal_id="prop_l1_dirty_generation_guard_v1",
                         proposal_path="docs/proposals/prop_l1_dirty_generation_guard_v1",
+                        update_proposal_files=True,
                     ),
                 )
             except Layer1TaskGenerationError as exc:
@@ -3255,7 +3290,7 @@ def test_generate_l1_sweep_task_succeeds_after_committed_rerun_without_proposal_
             try:
                 generate_l1_sweep_task(
                     session,
-                    Layer1SweepGenerateRequest(
+                    _make_l1_request(
                         repo_root=str(repo_root),
                         sweep_path=sweep_path,
                         config_paths=[config_path],
@@ -3266,6 +3301,7 @@ def test_generate_l1_sweep_task_succeeds_after_committed_rerun_without_proposal_
                         source_commit=source_commit,
                         proposal_id="prop_l1_dirty_generation_guard_v1",
                         proposal_path="docs/proposals/prop_l1_dirty_generation_guard_v1",
+                        update_proposal_files=True,
                     ),
                 )
             except Layer1TaskGenerationError:
@@ -3276,7 +3312,7 @@ def test_generate_l1_sweep_task_succeeds_after_committed_rerun_without_proposal_
             clean_commit = _commit_repo_changes(repo_root, "commit l1 proposal upsert artifacts")
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -3355,7 +3391,7 @@ def test_generate_l1_sweep_task_inherits_proposal_dependencies_and_starts_blocke
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -3402,7 +3438,7 @@ def test_generate_l1_sweep_task_explicit_dependencies_create_blocked_item_withou
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -3451,7 +3487,7 @@ def test_generate_l1_sweep_task_starts_dispatch_pending_when_dependency_is_merge
 
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -3535,7 +3571,7 @@ def test_generate_l1_sweep_task_auto_discovers_proposal_for_existing_item() -> N
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -3604,9 +3640,36 @@ def test_generate_l1_sweep_task_strips_placeholder_requested_items_from_template
         create_all(engine)
 
         with Session(engine) as session:
+            try:
+                generate_l1_sweep_task(
+                    session,
+                    _make_l1_request(
+                        repo_root=str(repo_root),
+                        sweep_path=sweep_path,
+                        config_paths=[config_path],
+                        platform="nangate45",
+                        out_root="runs/designs/activations",
+                        item_id="l1_demo_softmax_template_r1",
+                        requested_by="@tester",
+                        source_commit=source_commit,
+                        proposal_id="prop_l1_template_v1",
+                        proposal_path="docs/proposals/prop_l1_template_v1",
+                        abstraction_layer="circuit_block",
+                        update_proposal_files=True,
+                    ),
+                )
+            except Layer1TaskGenerationError as exc:
+                assert "clean exact-generation worktree" in str(exc)
+            else:
+                raise AssertionError("expected Layer1TaskGenerationError")
+
+            assert session.query(WorkItem).count() == 0
+            assert session.query(TaskRequest).count() == 0
+
+            clean_commit = _commit_repo_changes(repo_root, "commit l1 template proposal fixture")
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -3614,10 +3677,11 @@ def test_generate_l1_sweep_task_strips_placeholder_requested_items_from_template
                     out_root="runs/designs/activations",
                     item_id="l1_demo_softmax_template_r1",
                     requested_by="@tester",
-                    source_commit=source_commit,
+                    source_commit=clean_commit,
                     proposal_id="prop_l1_template_v1",
                     proposal_path="docs/proposals/prop_l1_template_v1",
                     abstraction_layer="circuit_block",
+                    update_proposal_files=False,
                 ),
             )
 
@@ -3660,7 +3724,7 @@ def test_generate_l1_sweep_task_omits_runtime_submodules_when_image_provides_dep
             ):
                 result = generate_l1_sweep_task(
                     session,
-                    Layer1SweepGenerateRequest(
+                    _make_l1_request(
                         repo_root=str(repo_root),
                         sweep_path=sweep_path,
                         config_paths=[config_path],
@@ -3692,7 +3756,7 @@ def test_generate_l1_sweep_task_upserts_existing_item() -> None:
         with Session(engine) as session:
             first = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -3706,7 +3770,7 @@ def test_generate_l1_sweep_task_upserts_existing_item() -> None:
             )
             second = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -3738,7 +3802,7 @@ def test_generate_l1_sweep_task_preserves_running_item_on_upsert_even_when_new_d
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -3756,7 +3820,7 @@ def test_generate_l1_sweep_task_preserves_running_item_on_upsert_even_when_new_d
 
             generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -3792,7 +3856,7 @@ def test_generate_l1_sweep_task_preserves_merged_item_on_upsert() -> None:
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -3809,7 +3873,7 @@ def test_generate_l1_sweep_task_preserves_merged_item_on_upsert() -> None:
 
             generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -3853,7 +3917,7 @@ def test_generate_l1_sweep_task_supports_integrated_npu_block_configs() -> None:
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -3912,7 +3976,7 @@ def test_generate_l1_sweep_task_supports_dense_gemm_tile_configs() -> None:
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -3966,7 +4030,7 @@ def test_generate_l1_sweep_task_supports_dense_gemm_tile_stream_configs() -> Non
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -4006,7 +4070,7 @@ def test_generate_l1_sweep_task_supports_attention_dual_stream_composed_configs(
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -4067,7 +4131,7 @@ def test_generate_l1_sweep_task_supports_attention_command_dispatch_configs() ->
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -4127,7 +4191,7 @@ def test_generate_l1_sweep_task_supports_attention_score32_exact_root_finalizer_
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -4187,7 +4251,7 @@ def test_generate_l1_sweep_task_supports_attention_score32_exact_partial_tree_co
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -4249,7 +4313,7 @@ def test_generate_l1_sweep_task_supports_attention_score32_exact_partial_tree_fo
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -4287,7 +4351,7 @@ def test_generate_l1_sweep_task_supports_attention_score32_exact_partial_pair_me
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -4344,7 +4408,7 @@ def test_generate_l1_sweep_task_supports_attention_score32_exact_partial_pair_me
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -4488,7 +4552,7 @@ def test_generate_l1_sweep_task_supports_attention_score32_exact_banked_finalize
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -4554,7 +4618,7 @@ def test_generate_l1_sweep_task_supports_attention_hbm_replay_controller_configs
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -4617,7 +4681,7 @@ def test_generate_l1_sweep_task_supports_multi_attention_hbm_replay_controller_c
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path, second_config_path],
@@ -4666,7 +4730,7 @@ def test_generate_l1_sweep_task_supports_attention_schedule_wrapper_configs() ->
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -4726,7 +4790,7 @@ def test_generate_l1_sweep_task_supports_attention_separated_cluster_configs() -
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -4769,7 +4833,7 @@ def test_generate_l1_sweep_task_supports_attention_two_pass_stream_configs() -> 
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -4811,7 +4875,7 @@ def test_generate_l1_sweep_task_supports_attention_score_bank_proxy_configs() ->
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -4852,7 +4916,7 @@ def test_generate_l1_sweep_task_supports_attention_decode_score_local_cluster_co
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -4899,7 +4963,7 @@ def test_generate_l1_sweep_task_supports_attention_decode_score_multivalue_clust
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -4951,7 +5015,7 @@ def test_generate_l1_sweep_task_supports_attention_decode_score_multivalue_servi
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -5365,7 +5429,7 @@ def test_generate_l1_sweep_task_checked_in_service_requests_gate_and_refresh_rel
         with Session(engine) as session:
             c1_result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=c1_sweep_path,
                     config_paths=[c1_config_path],
@@ -5398,7 +5462,7 @@ def test_generate_l1_sweep_task_checked_in_service_requests_gate_and_refresh_rel
 
             c2_result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=c2_sweep_path,
                     config_paths=[c2_config_path],
@@ -5493,7 +5557,7 @@ def test_generate_l1_sweep_task_adds_bridge_checker_for_exact_8ns_multivalue_clu
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -5530,7 +5594,7 @@ def test_generate_l1_sweep_task_does_not_apply_v4_checker_to_legacy_v3_identity(
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -5562,7 +5626,7 @@ def test_generate_l1_sweep_task_adds_binary_fsm_checker_for_retry_8ns_multivalue
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -5612,7 +5676,7 @@ def test_generate_l1_sweep_task_adds_targeted_binary_fsm_retry_profile_and_diagn
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -5667,7 +5731,7 @@ def test_generate_l1_sweep_task_adds_explicit_onehot_retry_profile_and_diagnosti
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -5962,7 +6026,7 @@ def test_generate_l1_sweep_task_adds_lanes2_macro_hier_placement_checker() -> No
 
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -6034,7 +6098,7 @@ def test_generate_l1_sweep_task_supports_attention_decode_score_multivalue_gqa_g
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -6095,7 +6159,7 @@ def test_generate_l1_sweep_task_supports_attention_decode_score_multivalue_gqa_a
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -6154,7 +6218,7 @@ def test_generate_l1_sweep_task_supports_multi_attention_command_dispatch_config
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path, second_config_path],
@@ -6206,7 +6270,7 @@ def test_generate_l1_sweep_task_supports_multi_attention_score32_exact_local_tem
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path, second_config_path],
@@ -6308,7 +6372,7 @@ def test_generate_l1_sweep_task_supports_multi_attention_score32_exact_local_tem
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path, second_config_path],
@@ -6407,7 +6471,7 @@ def test_generate_l1_sweep_task_adds_macro_hardening_for_gqa8_folded_mersenne_ma
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -6482,7 +6546,7 @@ def test_generate_l1_sweep_task_supports_multi_attention_score32_exact_root_fina
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path, second_config_path],
@@ -6530,7 +6594,7 @@ def test_generate_l1_sweep_task_emits_commands_for_each_attention_score32_exact_
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path, second_config_path],
@@ -6578,7 +6642,7 @@ def test_generate_l1_sweep_task_emits_commands_for_each_attention_score32_exact_
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path, second_config_path],
@@ -6628,7 +6692,7 @@ def test_generate_l1_sweep_task_emits_commands_for_each_attention_score32_exact_
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path, second_config_path, third_config_path, fourth_config_path],
@@ -6691,7 +6755,7 @@ def test_generate_l1_sweep_task_supports_attention_score32_exact_finalizer_bank_
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=config_paths,
@@ -6853,7 +6917,7 @@ def test_generate_l1_sweep_task_emits_commands_for_each_integrated_block_config(
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path, second_config_rel],
@@ -6900,7 +6964,7 @@ def test_generate_l1_sweep_task_rejects_flattened_architecture_block_sweeps() ->
             try:
                 generate_l1_sweep_task(
                     session,
-                    Layer1SweepGenerateRequest(
+                    _make_l1_request(
                         repo_root=str(repo_root),
                         sweep_path=sweep_path,
                         config_paths=[config_path],
@@ -6928,7 +6992,7 @@ def test_generate_l1_sweep_task_supports_make_target_for_integrated_blocks() -> 
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -6966,7 +7030,7 @@ def test_generate_l1_sweep_task_accepts_hierarchical_architecture_block_sweeps()
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -7010,7 +7074,7 @@ def test_generate_l1_sweep_task_defaults_source_commit_from_repo_head() -> None:
                 with Session(engine) as session:
                     result = generate_l1_sweep_task(
                         session,
-                        Layer1SweepGenerateRequest(
+                        _make_l1_request(
                             repo_root=str(repo_root),
                             sweep_path=sweep_path,
                             config_paths=[config_path],
@@ -7039,7 +7103,7 @@ def test_generate_l1_sweep_task_accepts_explicit_hierarchical_architecture_block
         with Session(engine) as session:
             result = generate_l1_sweep_task(
                 session,
-                Layer1SweepGenerateRequest(
+                _make_l1_request(
                     repo_root=str(repo_root),
                     sweep_path=sweep_path,
                     config_paths=[config_path],
@@ -7090,7 +7154,7 @@ def test_generate_l1_sweep_task_rejects_disabled_hierarchy_in_explicit_param_set
             try:
                 generate_l1_sweep_task(
                     session,
-                    Layer1SweepGenerateRequest(
+                    _make_l1_request(
                         repo_root=str(repo_root),
                         sweep_path=sweep_path,
                         config_paths=[config_path],
@@ -7119,7 +7183,7 @@ def test_generate_l1_sweep_task_rejects_invalid_explicit_source_commit() -> None
             try:
                 generate_l1_sweep_task(
                     session,
-                    Layer1SweepGenerateRequest(
+                    _make_l1_request(
                         repo_root=str(repo_root),
                         sweep_path=sweep_path,
                         config_paths=[config_path],
@@ -7153,7 +7217,7 @@ def test_generate_l1_sweep_task_rejects_source_commit_not_pushed_to_origin() -> 
             try:
                 generate_l1_sweep_task(
                     session,
-                    Layer1SweepGenerateRequest(
+                    _make_l1_request(
                         repo_root=str(repo_root),
                         sweep_path=sweep_path,
                         config_paths=[config_path],

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -318,6 +318,14 @@ def _init_git_repo(repo_root: Path) -> str:
     return result.stdout.strip()
 
 
+def _commit_repo_changes(repo_root: Path, message: str) -> str:
+    subprocess.run(["git", "-C", str(repo_root), "add", "-A"], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(repo_root), "commit", "-m", message], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(repo_root), "push", "origin", "HEAD:master"], check=True, capture_output=True, text=True)
+    result = subprocess.run(["git", "-C", str(repo_root), "rev-parse", "HEAD"], check=True, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
 def _copy_fixture_file(*, src_repo_root: Path, dst_repo_root: Path, rel_path: str) -> None:
     src = src_repo_root / rel_path
     dst = dst_repo_root / rel_path
@@ -2562,6 +2570,7 @@ def test_generate_l1_sweep_task_creates_ready_work_item() -> None:
                 "repo_head_sha": source_commit,
                 "relation": "exact",
                 "proof": "generator_worktree_head_exact",
+                "clean": True,
             }
             assert payload["task"]["inputs"]["sweeps"] == [sweep_path]
             assert payload["task"]["acceptance"][0] == (
@@ -2621,6 +2630,76 @@ def test_generate_l1_sweep_task_rejects_mismatched_generation_worktree() -> None
                 assert "Regenerate the item from a checkout whose HEAD exactly matches the declared source commit." in message
             else:
                 raise AssertionError("expected Layer1TaskGenerationError for mismatched generation worktree")
+
+
+def test_generate_l1_sweep_task_rejects_tracked_dirty_generation_worktree() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_repo(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        tracked_file = repo_root / config_path
+        tracked_file.write_text(tracked_file.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            try:
+                generate_l1_sweep_task(
+                    session,
+                    Layer1SweepGenerateRequest(
+                        repo_root=str(repo_root),
+                        sweep_path=sweep_path,
+                        config_paths=[config_path],
+                        platform="nangate45",
+                        out_root="runs/designs/activations",
+                        requested_by="@tester",
+                        source_commit=source_commit,
+                    ),
+                )
+            except Layer1TaskGenerationError as exc:
+                message = str(exc)
+                assert "clean exact-generation worktree" in message
+                assert "git status --porcelain is not empty" in message
+                assert f" M {config_path}" in message or f"M {config_path}" in message
+                assert "Commit, stash, or remove tracked and untracked changes" in message
+            else:
+                raise AssertionError("expected Layer1TaskGenerationError for tracked dirty generation worktree")
+
+
+def test_generate_l1_sweep_task_rejects_untracked_generation_worktree() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_repo(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        untracked_rel = "examples/untracked_probe.json"
+        (repo_root / untracked_rel).write_text('{"probe": true}\n', encoding="utf-8")
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            try:
+                generate_l1_sweep_task(
+                    session,
+                    Layer1SweepGenerateRequest(
+                        repo_root=str(repo_root),
+                        sweep_path=sweep_path,
+                        config_paths=[config_path],
+                        platform="nangate45",
+                        out_root="runs/designs/activations",
+                        requested_by="@tester",
+                        source_commit=source_commit,
+                    ),
+                )
+            except Layer1TaskGenerationError as exc:
+                message = str(exc)
+                assert "clean exact-generation worktree" in message
+                assert "git status --porcelain is not empty" in message
+                assert f"?? {untracked_rel}" in message
+                assert "Commit, stash, or remove tracked and untracked changes" in message
+            else:
+                raise AssertionError("expected Layer1TaskGenerationError for untracked generation worktree")
 
 
 def test_generate_l1_sweep_task_uses_boundary_metrics_acceptance() -> None:
@@ -3255,6 +3334,7 @@ def test_generate_l1_sweep_task_starts_dispatch_pending_when_dependency_is_merge
                 expected_output_rel="runs/campaigns/l2_demo_equivalence_v1/summary.csv",
             )
             session.commit()
+            source_commit = _commit_repo_changes(repo_root, "commit seeded dependency artifacts")
 
             result = generate_l1_sweep_task(
                 session,
@@ -3653,6 +3733,7 @@ def test_generate_l1_sweep_task_supports_integrated_npu_block_configs() -> None:
             json.dumps({"proposal_id": "prop_l1_npu_nm1_sigmoid_vec_enable_v1", "abstraction_layer": "architecture_block"}, indent=2) + "\n",
             encoding="utf-8",
         )
+        source_commit = _commit_repo_changes(repo_root, "commit proposal metadata fixture")
         engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
         create_all(engine)
 
@@ -6801,30 +6882,36 @@ def test_generate_l1_sweep_task_defaults_source_commit_from_repo_head() -> None:
         engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
         create_all(engine)
 
-        with patch("control_plane.services.l1_task_generator.subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(
-                args=["git", "-C", str(repo_root), "rev-parse", "HEAD"],
-                returncode=0,
-                stdout="deadbeefcafefeed\n",
-                stderr="",
-            )
-            with Session(engine) as session:
-                result = generate_l1_sweep_task(
-                    session,
-                    Layer1SweepGenerateRequest(
-                        repo_root=str(repo_root),
-                        sweep_path=sweep_path,
-                        config_paths=[config_path],
-                        platform="nangate45",
-                        out_root="runs/designs/activations",
-                        requested_by="@tester",
-                    ),
-                )
+        with patch("control_plane.services.l1_task_generator._resolve_source_commit", return_value="deadbeefcafefeed") as mock_resolve:
+            with patch(
+                "control_plane.services.l1_task_generator.build_generation_source_identity",
+                return_value={
+                    "version": 1,
+                    "declared_source_commit": "deadbeefcafefeed",
+                    "repo_head_sha": "deadbeefcafefeed",
+                    "relation": "exact",
+                    "proof": "generator_worktree_head_exact",
+                    "clean": True,
+                },
+            ) as mock_identity:
+                with Session(engine) as session:
+                    result = generate_l1_sweep_task(
+                        session,
+                        Layer1SweepGenerateRequest(
+                            repo_root=str(repo_root),
+                            sweep_path=sweep_path,
+                            config_paths=[config_path],
+                            platform="nangate45",
+                            out_root="runs/designs/activations",
+                            requested_by="@tester",
+                        ),
+                    )
 
-                work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
-                assert work_item.source_commit == "deadbeefcafefeed"
-                assert work_item.task_request.source_commit == "deadbeefcafefeed"
-                mock_run.assert_called_once()
+                    work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+                    assert work_item.source_commit == "deadbeefcafefeed"
+                    assert work_item.task_request.source_commit == "deadbeefcafefeed"
+                    mock_resolve.assert_called_once()
+                    mock_identity.assert_called_once()
 
 
 def test_generate_l1_sweep_task_accepts_explicit_hierarchical_architecture_block_sweeps() -> None:

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -7231,3 +7231,74 @@ def test_generate_l1_sweep_task_rejects_source_commit_not_pushed_to_origin() -> 
                 assert "not reachable from origin" in str(exc)
             else:
                 raise AssertionError("expected Layer1TaskGenerationError")
+
+
+def test_generate_l1_sweep_task_rejects_implicit_source_commit_when_head_not_pushed_to_origin() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_repo(repo_root)
+        _init_git_repo(repo_root)
+        extra = repo_root / "LOCAL_ONLY.txt"
+        extra.write_text("local only\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(repo_root), "add", "LOCAL_ONLY.txt"], check=True, capture_output=True, text=True)
+        subprocess.run(["git", "-C", str(repo_root), "commit", "-m", "local only"], check=True, capture_output=True, text=True)
+        local_only_commit = subprocess.run(["git", "-C", str(repo_root), "rev-parse", "HEAD"], check=True, capture_output=True, text=True).stdout.strip()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            try:
+                generate_l1_sweep_task(
+                    session,
+                    _make_l1_request(
+                        repo_root=str(repo_root),
+                        sweep_path=sweep_path,
+                        config_paths=[config_path],
+                        platform="nangate45",
+                        out_root="runs/designs/activations",
+                        requested_by="@tester",
+                    ),
+                )
+            except Layer1TaskGenerationError as exc:
+                message = str(exc)
+                assert "resolved repo HEAD source_commit is not reachable from origin" in message
+                assert local_only_commit in message
+            else:
+                raise AssertionError("expected Layer1TaskGenerationError")
+
+
+def test_generate_l1_sweep_task_accepts_implicit_source_commit_from_pushed_head() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_repo(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l1_sweep_task(
+                session,
+                _make_l1_request(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/activations",
+                    requested_by="@tester",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert result.status == "applied"
+            assert work_item.source_commit == source_commit
+            assert work_item.task_request.source_commit == source_commit
+            assert work_item.task_request.request_payload["generation_source_identity"] == {
+                "version": 1,
+                "declared_source_commit": source_commit,
+                "repo_head_sha": source_commit,
+                "relation": "exact",
+                "proof": "generator_worktree_head_exact",
+                "clean": True,
+            }

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -3191,6 +3191,119 @@ def test_generate_l1_sweep_task_can_refresh_db_without_updating_proposal_files()
         assert evaluation_requests_path.read_text(encoding="utf-8") == before
 
 
+def test_generate_l1_sweep_task_rejects_db_creation_when_proposal_upsert_dirties_worktree() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_repo(repo_root)
+        proposal_dir = repo_root / "docs" / "proposals" / "prop_l1_dirty_generation_guard_v1"
+        proposal_dir.mkdir(parents=True, exist_ok=True)
+        (proposal_dir / "proposal.json").write_text(
+            json.dumps({"proposal_id": "prop_l1_dirty_generation_guard_v1", "abstraction_layer": "circuit_block"}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            try:
+                generate_l1_sweep_task(
+                    session,
+                    Layer1SweepGenerateRequest(
+                        repo_root=str(repo_root),
+                        sweep_path=sweep_path,
+                        config_paths=[config_path],
+                        platform="nangate45",
+                        out_root="runs/designs/activations",
+                        item_id="l1_demo_dirty_generation_guard_r1",
+                        requested_by="@tester",
+                        source_commit=source_commit,
+                        proposal_id="prop_l1_dirty_generation_guard_v1",
+                        proposal_path="docs/proposals/prop_l1_dirty_generation_guard_v1",
+                    ),
+                )
+            except Layer1TaskGenerationError as exc:
+                message = str(exc)
+                assert "clean exact-generation worktree" in message
+                assert "git status --porcelain is not empty" in message
+                assert "docs/proposals/prop_l1_dirty_generation_guard_v1/" in message
+            else:
+                raise AssertionError("expected Layer1TaskGenerationError")
+
+            assert session.query(WorkItem).count() == 0
+            assert session.query(TaskRequest).count() == 0
+            assert (proposal_dir / "evaluation_requests.json").exists()
+
+
+def test_generate_l1_sweep_task_succeeds_after_committed_rerun_without_proposal_updates() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        config_path, sweep_path = _write_example_repo(repo_root)
+        proposal_dir = repo_root / "docs" / "proposals" / "prop_l1_dirty_generation_guard_v1"
+        proposal_dir.mkdir(parents=True, exist_ok=True)
+        (proposal_dir / "proposal.json").write_text(
+            json.dumps({"proposal_id": "prop_l1_dirty_generation_guard_v1", "abstraction_layer": "circuit_block"}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            try:
+                generate_l1_sweep_task(
+                    session,
+                    Layer1SweepGenerateRequest(
+                        repo_root=str(repo_root),
+                        sweep_path=sweep_path,
+                        config_paths=[config_path],
+                        platform="nangate45",
+                        out_root="runs/designs/activations",
+                        item_id="l1_demo_dirty_generation_guard_r1",
+                        requested_by="@tester",
+                        source_commit=source_commit,
+                        proposal_id="prop_l1_dirty_generation_guard_v1",
+                        proposal_path="docs/proposals/prop_l1_dirty_generation_guard_v1",
+                    ),
+                )
+            except Layer1TaskGenerationError:
+                pass
+            else:
+                raise AssertionError("expected initial Layer1TaskGenerationError")
+
+            clean_commit = _commit_repo_changes(repo_root, "commit l1 proposal upsert artifacts")
+            result = generate_l1_sweep_task(
+                session,
+                Layer1SweepGenerateRequest(
+                    repo_root=str(repo_root),
+                    sweep_path=sweep_path,
+                    config_paths=[config_path],
+                    platform="nangate45",
+                    out_root="runs/designs/activations",
+                    item_id="l1_demo_dirty_generation_guard_r1",
+                    requested_by="@tester",
+                    source_commit=clean_commit,
+                    proposal_id="prop_l1_dirty_generation_guard_v1",
+                    proposal_path="docs/proposals/prop_l1_dirty_generation_guard_v1",
+                    update_proposal_files=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert result.status == "applied"
+            assert work_item.source_commit == clean_commit
+            assert work_item.task_request.request_payload["generation_source_identity"] == {
+                "version": 1,
+                "declared_source_commit": clean_commit,
+                "repo_head_sha": clean_commit,
+                "relation": "exact",
+                "proof": "generator_worktree_head_exact",
+                "clean": True,
+            }
+
+
 def test_generate_l1_sweep_task_inherits_proposal_dependencies_and_starts_blocked() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -141,6 +141,11 @@ def _commit_repo_changes(repo_root: Path, message: str) -> str:
     return result.stdout.strip()
 
 
+def _make_l2_request(**kwargs: object) -> Layer2CampaignGenerateRequest:
+    kwargs.setdefault("update_proposal_files", False)
+    return Layer2CampaignGenerateRequest(**kwargs)
+
+
 def _write_q20_pwl_recip_div_recost_proposal(repo_root: Path) -> None:
     proposal_dir = (
         repo_root
@@ -208,13 +213,42 @@ def test_generate_l2_campaign_task_creates_ready_work_item() -> None:
         create_all(engine)
 
         with Session(engine) as session:
+            try:
+                generate_l2_campaign_task(
+                    session,
+                    _make_l2_request(
+                        repo_root=str(repo_root),
+                        campaign_path=campaign_path,
+                        requested_by="@tester",
+                        source_commit=source_commit,
+                        objective_profiles_json="runs/campaigns/npu/base/objective_profiles.json",
+                        proposal_id="prop_l2_demo_v1",
+                        proposal_path="docs/developer_loop/prop_l2_demo_v1",
+                        evaluation_mode="paired_comparison",
+                        abstraction_layer="full_architecture",
+                        expected_direction="better_than_historical",
+                        expected_reason="Candidate should improve the measured baseline.",
+                        comparison_role="candidate",
+                        paired_baseline_item_id="l2_demo_baseline",
+                        update_proposal_files=True,
+                    ),
+                )
+            except Layer2TaskGenerationError as exc:
+                assert "clean exact-generation worktree" in str(exc)
+            else:
+                raise AssertionError("expected Layer2TaskGenerationError")
+
+            assert session.query(WorkItem).count() == 0
+            assert session.query(TaskRequest).count() == 0
+
+            clean_commit = _commit_repo_changes(repo_root, "commit l2 proposal metadata fixture")
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
-                    source_commit=source_commit,
+                    source_commit=clean_commit,
                     objective_profiles_json="runs/campaigns/npu/base/objective_profiles.json",
                     proposal_id="prop_l2_demo_v1",
                     proposal_path="docs/developer_loop/prop_l2_demo_v1",
@@ -224,6 +258,7 @@ def test_generate_l2_campaign_task_creates_ready_work_item() -> None:
                     expected_reason="Candidate should improve the measured baseline.",
                     comparison_role="candidate",
                     paired_baseline_item_id="l2_demo_baseline",
+                    update_proposal_files=False,
                 ),
             )
 
@@ -288,13 +323,13 @@ def test_generate_l2_campaign_task_creates_ready_work_item() -> None:
             ]
             payload = work_item.task_request.request_payload
             assert payload["layer"] == "layer2"
-            assert payload["source_requirement"]["required_sha"] == source_commit
+            assert payload["source_requirement"]["required_sha"] == clean_commit
             assert payload["source_requirement"]["required_ref"] == "origin/master"
             assert payload["source_requirement"]["requires_daemon_restart"] is True
             assert payload["generation_source_identity"] == {
                 "version": 1,
-                "declared_source_commit": source_commit,
-                "repo_head_sha": source_commit,
+                "declared_source_commit": clean_commit,
+                "repo_head_sha": clean_commit,
                 "relation": "exact",
                 "proof": "generator_worktree_head_exact",
                 "clean": True,
@@ -360,7 +395,7 @@ def test_generate_l2_campaign_task_rejects_mismatched_generation_worktree() -> N
             try:
                 generate_l2_campaign_task(
                     session,
-                    Layer2CampaignGenerateRequest(
+                    _make_l2_request(
                         repo_root=str(repo_root),
                         campaign_path=campaign_path,
                         requested_by="@tester",
@@ -392,7 +427,7 @@ def test_generate_l2_campaign_task_rejects_tracked_dirty_generation_worktree() -
             try:
                 generate_l2_campaign_task(
                     session,
-                    Layer2CampaignGenerateRequest(
+                    _make_l2_request(
                         repo_root=str(repo_root),
                         campaign_path=campaign_path,
                         requested_by="@tester",
@@ -425,7 +460,7 @@ def test_generate_l2_campaign_task_rejects_untracked_generation_worktree() -> No
             try:
                 generate_l2_campaign_task(
                     session,
-                    Layer2CampaignGenerateRequest(
+                    _make_l2_request(
                         repo_root=str(repo_root),
                         campaign_path=campaign_path,
                         requested_by="@tester",
@@ -454,7 +489,7 @@ def test_generate_l2_campaign_task_adds_decoder_probability_path_evidence() -> N
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -520,7 +555,7 @@ def test_generate_l2_campaign_task_adds_decoder_probability_sweep_evidence() -> 
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -576,7 +611,7 @@ def test_generate_l2_campaign_task_adds_decoder_probability_sensitivity_evidence
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -630,7 +665,7 @@ def test_generate_l2_campaign_task_adds_decoder_probability_fp_sensitivity_evide
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -684,7 +719,7 @@ def test_generate_l2_campaign_task_adds_decoder_distribution_robustness_evidence
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -732,7 +767,7 @@ def test_generate_l2_campaign_task_adds_decoder_survivor_prompt_stress_evidence(
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -780,7 +815,7 @@ def test_generate_l2_campaign_task_adds_decoder_survivor_cost_proxy_evidence() -
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -825,7 +860,7 @@ def test_generate_l2_campaign_task_adds_decoder_pwl_frontier_detail_evidence() -
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -874,7 +909,7 @@ def test_generate_l2_campaign_task_adds_decoder_q8_normalization_frontier_eviden
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -948,7 +983,7 @@ def test_generate_l2_campaign_task_adds_decoder_q8_normalization_distribution_ev
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -1009,7 +1044,7 @@ def test_generate_l2_campaign_task_adds_decoder_q8_normalization_distribution_br
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -1070,7 +1105,7 @@ def test_generate_l2_campaign_task_adds_decoder_quantization_outline_evidence() 
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -1114,7 +1149,7 @@ def test_generate_l2_campaign_task_adds_decoder_pwl_failure_diagnosis_evidence()
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -1166,7 +1201,7 @@ def test_generate_l2_campaign_task_adds_decoder_bf16_pwl_recoverability_evidence
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -1215,7 +1250,7 @@ def test_generate_l2_campaign_task_adds_decoder_bf16_pwl_recovery_evidence() -> 
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -1275,7 +1310,7 @@ def test_generate_l2_campaign_task_adds_decoder_bf16_pwl_scale_probe_evidence() 
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -1335,7 +1370,7 @@ def test_generate_l2_campaign_task_adds_decoder_trained_tiny_quality_evidence() 
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -1391,7 +1426,7 @@ def test_generate_l2_campaign_task_adds_decoder_distilgpt2_quality_evidence() ->
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -1453,7 +1488,7 @@ def test_generate_l2_campaign_task_adds_decoder_distilgpt2_prompt_stress_evidenc
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -1515,7 +1550,7 @@ def test_generate_l2_campaign_task_adds_decoder_gpt2_quality_evidence() -> None:
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -1580,7 +1615,7 @@ def test_generate_l2_campaign_task_adds_decoder_gpt2_prompt_stress_evidence() ->
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -1645,7 +1680,7 @@ def test_generate_l2_campaign_task_adds_decoder_gpt2_tie_rank_frontier_evidence(
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -1698,7 +1733,7 @@ def test_generate_l2_campaign_task_adds_decoder_gpt2_logit_rank_bypass_evidence(
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -1757,7 +1792,7 @@ def test_generate_l2_campaign_task_adds_decoder_logit_rank_streaming_hierarchy_e
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -1829,7 +1864,7 @@ def test_generate_l2_campaign_task_adds_decoder_logit_rank_streaming_overlap_evi
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -1912,7 +1947,7 @@ def test_generate_l2_campaign_task_adds_decoder_logit_rank_streaming_producer_in
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -1966,7 +2001,7 @@ def test_generate_l2_campaign_task_adds_decoder_output_projection_service_eviden
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -2009,7 +2044,7 @@ def test_generate_l2_campaign_task_adds_decoder_producer_ranker_coupled_noc_evid
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -2070,7 +2105,7 @@ def test_generate_l2_campaign_task_adds_decoder_producer_ranker_service_compatib
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -2128,7 +2163,7 @@ def test_generate_l2_campaign_task_adds_decoder_serial_ranker_producer_replay() 
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -2187,7 +2222,7 @@ def test_generate_l2_campaign_task_adds_decoder_serial_lpc1_producer_coupled_wra
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -2245,7 +2280,7 @@ def test_generate_l2_campaign_task_adds_decoder_output_projection_cadence_sensit
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -2301,7 +2336,7 @@ def test_generate_l2_campaign_task_adds_decoder_resident_weight_ranker_fallback(
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -2360,7 +2395,7 @@ def test_generate_l2_campaign_task_adds_decoder_resident_ranktree_fallback_promo
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -2418,7 +2453,7 @@ def test_generate_l2_campaign_task_adds_decoder_output_projection_ranker_policy(
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -2476,7 +2511,7 @@ def test_generate_l2_campaign_task_adds_decoder_output_projection_ranker_wrapper
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -2535,7 +2570,7 @@ def test_generate_l2_campaign_task_adds_decoder_output_projection_ranker_wrapper
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -2593,7 +2628,7 @@ def test_generate_l2_campaign_task_adds_decoder_output_projection_producer_ranke
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -2649,7 +2684,7 @@ def test_generate_l2_campaign_task_adds_decoder_producer_ranker_policy_calibrati
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -2703,7 +2738,7 @@ def test_generate_l2_campaign_task_adds_decoder_stage_breakdown_evidence() -> No
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -2748,7 +2783,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_memory_evidence() -
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -2803,7 +2838,7 @@ def test_generate_l2_campaign_task_adds_decoder_frontier_synthesis_evidence() ->
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -2856,7 +2891,7 @@ def test_generate_l2_campaign_task_adds_decoder_frontier_synthesis_integrated_ev
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -2907,7 +2942,7 @@ def test_generate_l2_campaign_task_adds_decoder_frontier_synthesis_policy_calibr
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -2959,7 +2994,7 @@ def test_generate_l2_campaign_task_adds_decoder_output_projection_producer_memor
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -3011,7 +3046,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_capacity_noc() -> N
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -3063,7 +3098,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_noc_scheduler() -> 
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -3115,7 +3150,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_spill_scheduler() -
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -3167,7 +3202,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_hbm_controller() ->
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -3219,7 +3254,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_fronti
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -3274,7 +3309,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_qualit
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -3338,7 +3373,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_qualit
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -3411,7 +3446,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_qualit
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -3464,7 +3499,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_memory
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -3526,7 +3561,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_physical_hbm_comput
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -3591,7 +3626,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_compute_floor_gap()
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -3650,7 +3685,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_compute_ceiling_env
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -3711,7 +3746,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_quality_gate() -> N
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -3763,7 +3798,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_clustered_schedule_
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -3816,7 +3851,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_quality_proxy() -> 
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -3867,7 +3902,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_native_gqa_proxy() 
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -3921,7 +3956,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_trace_calibration()
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -3972,7 +4007,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_model_native_qualit
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -4027,7 +4062,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_model_native_qualit
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -4109,7 +4144,7 @@ def test_generate_l2_campaign_task_adds_decoder_attention_kv_model_native_recove
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -4166,7 +4201,7 @@ def test_generate_l2_campaign_task_adds_decoder_output_projection_weight_store_f
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -4218,7 +4253,7 @@ def test_generate_l2_campaign_task_adds_decoder_output_projection_weight_store_i
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -4275,7 +4310,7 @@ def test_generate_l2_campaign_task_adds_decoder_output_projection_weight_fetch_w
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -4331,7 +4366,7 @@ def test_generate_l2_campaign_task_adds_decoder_producer_ranker_memory_integrati
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -4383,7 +4418,7 @@ def test_generate_l2_campaign_task_adds_decoder_producer_ranker_ready_valid_equi
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -4438,7 +4473,7 @@ def test_generate_l2_campaign_task_adds_decoder_producer_ranker_physical_wrapper
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -4491,7 +4526,7 @@ def test_generate_l2_campaign_task_adds_decoder_pipelined_ranker_architecture() 
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -4541,7 +4576,7 @@ def test_generate_l2_campaign_task_adds_decoder_rank_tree_architecture() -> None
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -4591,7 +4626,7 @@ def test_generate_l2_campaign_task_adds_decoder_serial_ranker_architecture() -> 
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -4641,7 +4676,7 @@ def test_generate_l2_campaign_task_adds_decoder_producer_synth_boundary_evidence
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -4696,7 +4731,7 @@ def test_generate_l2_campaign_task_adds_decoder_producer_extended_synth_boundary
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -4736,7 +4771,7 @@ def test_generate_l2_campaign_task_adds_decoder_producer_pnr_feasibility_evidenc
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -4789,7 +4824,7 @@ def test_generate_l2_campaign_task_adds_decoder_producer_nm16_pnr_feasibility_ev
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -4833,7 +4868,7 @@ def test_generate_l2_campaign_task_adds_decoder_producer_isolated_synth_evidence
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -4891,7 +4926,7 @@ def test_generate_l2_campaign_task_adds_decoder_producer_top_ablation_evidence()
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -4943,7 +4978,7 @@ def test_generate_l2_campaign_task_adds_decoder_producer_cq_ablation_evidence() 
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -4994,7 +5029,7 @@ def test_generate_l2_campaign_task_adds_decoder_producer_softmax_event_ablation_
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -5045,7 +5080,7 @@ def test_generate_l2_campaign_task_adds_decoder_pwl_logit_sensitivity_ladder_evi
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -5104,7 +5139,7 @@ def test_generate_l2_campaign_task_adds_decoder_pwl_survivor_distribution_eviden
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -5164,7 +5199,7 @@ def test_generate_l2_campaign_task_adds_decoder_pwl_bitwidth_boundary_evidence()
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     requested_by="@tester",
@@ -5249,7 +5284,7 @@ def test_generate_l2_campaign_task_recovers_metadata_from_evaluation_requests() 
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_demo_candidate_r1",
@@ -5321,7 +5356,7 @@ def test_generate_l2_campaign_task_preserves_revision_metadata_on_materializatio
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=requested_item_id,
@@ -5394,7 +5429,7 @@ def test_generate_l2_campaign_task_can_refresh_db_without_updating_proposal_file
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_demo_candidate_r1",
@@ -5439,7 +5474,7 @@ def test_generate_l2_campaign_task_rejects_db_creation_when_proposal_upsert_dirt
             try:
                 generate_l2_campaign_task(
                     session,
-                    Layer2CampaignGenerateRequest(
+                    _make_l2_request(
                         repo_root=str(repo_root),
                         campaign_path=campaign_path,
                         item_id="l2_demo_dirty_generation_guard_r1",
@@ -5447,6 +5482,7 @@ def test_generate_l2_campaign_task_rejects_db_creation_when_proposal_upsert_dirt
                         source_commit=source_commit,
                         proposal_id="prop_l2_dirty_generation_guard_v1",
                         proposal_path="docs/developer_loop/prop_l2_dirty_generation_guard_v1",
+                        update_proposal_files=True,
                     ),
                 )
             except Layer2TaskGenerationError as exc:
@@ -5481,7 +5517,7 @@ def test_generate_l2_campaign_task_succeeds_after_committed_rerun_without_propos
             try:
                 generate_l2_campaign_task(
                     session,
-                    Layer2CampaignGenerateRequest(
+                    _make_l2_request(
                         repo_root=str(repo_root),
                         campaign_path=campaign_path,
                         item_id="l2_demo_dirty_generation_guard_r1",
@@ -5489,6 +5525,7 @@ def test_generate_l2_campaign_task_succeeds_after_committed_rerun_without_propos
                         source_commit=source_commit,
                         proposal_id="prop_l2_dirty_generation_guard_v1",
                         proposal_path="docs/developer_loop/prop_l2_dirty_generation_guard_v1",
+                        update_proposal_files=True,
                     ),
                 )
             except Layer2TaskGenerationError:
@@ -5499,7 +5536,7 @@ def test_generate_l2_campaign_task_succeeds_after_committed_rerun_without_propos
             clean_commit = _commit_repo_changes(repo_root, "commit l2 proposal upsert artifacts")
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_demo_dirty_generation_guard_r1",
@@ -5569,7 +5606,7 @@ def test_generate_l2_campaign_task_blocks_when_dependency_not_merged() -> None:
 
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_demo_candidate",
@@ -5606,7 +5643,7 @@ def test_generate_l2_campaign_task_upserts_existing_item() -> None:
         with Session(engine) as session:
             first = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_demo_campaign",
@@ -5616,7 +5653,7 @@ def test_generate_l2_campaign_task_upserts_existing_item() -> None:
             )
             second = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_demo_campaign",
@@ -5653,7 +5690,7 @@ def test_generate_l2_campaign_task_requeues_failed_item_on_upsert() -> None:
         with Session(engine) as session:
             generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_demo_campaign",
@@ -5667,7 +5704,7 @@ def test_generate_l2_campaign_task_requeues_failed_item_on_upsert() -> None:
 
             generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_demo_campaign",
@@ -5704,7 +5741,7 @@ def test_generate_l2_campaign_task_defaults_source_commit_from_repo_head() -> No
                 with Session(engine) as session:
                     result = generate_l2_campaign_task(
                         session,
-                        Layer2CampaignGenerateRequest(
+                        _make_l2_request(
                             repo_root=str(repo_root),
                             campaign_path=campaign_path,
                             requested_by="@tester",
@@ -5731,7 +5768,7 @@ def test_generate_l2_campaign_task_rejects_invalid_explicit_source_commit() -> N
             try:
                 generate_l2_campaign_task(
                     session,
-                    Layer2CampaignGenerateRequest(
+                    _make_l2_request(
                         repo_root=str(repo_root),
                         campaign_path=campaign_path,
                         requested_by="@tester",
@@ -5762,7 +5799,7 @@ def test_generate_l2_campaign_task_rejects_source_commit_not_pushed_to_origin() 
             try:
                 generate_l2_campaign_task(
                     session,
-                    Layer2CampaignGenerateRequest(
+                    _make_l2_request(
                         repo_root=str(repo_root),
                         campaign_path=campaign_path,
                         requested_by="@tester",
@@ -5787,7 +5824,7 @@ def test_generate_l2_campaign_task_adds_attention_sram_profile_evidence() -> Non
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_sram_profile_v1",
@@ -5826,7 +5863,7 @@ def test_generate_l2_campaign_task_adds_attention_local_sram_capacity_evidence()
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_local_sram_capacity_llama7b_v1",
@@ -5875,7 +5912,7 @@ def test_generate_l2_campaign_task_adds_attention_measured_sram_rebalance_eviden
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_measured_sram_rebalance_llama7b_v1",
@@ -5938,7 +5975,7 @@ def test_generate_l2_campaign_task_adds_softmax_recip_lut_measured_sram_rebalanc
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_measured_sram_rebalance_softmax_recip_lut_llama7b_v1",
@@ -5992,7 +6029,7 @@ def test_generate_l2_campaign_task_adds_attention_measured_hbm_service_evidence(
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_measured_hbm_service_llama7b_v1",
@@ -6038,7 +6075,7 @@ def test_generate_l2_campaign_task_adds_softmax_recip_lut_measured_hbm_service_e
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_measured_hbm_service_softmax_recip_lut_llama7b_v1",
@@ -6091,7 +6128,7 @@ def test_generate_l2_campaign_task_adds_attention_hbm_closed_onchip_schedule_evi
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_hbm_closed_onchip_schedule_llama7b_v1",
@@ -6137,7 +6174,7 @@ def test_generate_l2_campaign_task_adds_softmax_recip_lut_hbm_closed_onchip_sche
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_hbm_closed_onchip_schedule_softmax_recip_lut_llama7b_v1",
@@ -6195,7 +6232,7 @@ def test_generate_l2_campaign_task_adds_attention_subtile_pipeline_schedule_evid
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_subtile_pipeline_schedule_llama7b_v1",
@@ -6241,7 +6278,7 @@ def test_generate_l2_campaign_task_adds_softmax_recip_lut_subtile_pipeline_sched
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_subtile_pipeline_schedule_softmax_recip_lut_llama7b_v1",
@@ -6299,7 +6336,7 @@ def test_generate_l2_campaign_task_adds_attention_dual_stream_physical_feasibili
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_dual_stream_physical_feasibility_llama7b_v1",
@@ -6348,7 +6385,7 @@ def test_generate_l2_campaign_task_adds_softmax_recip_lut_dual_stream_physical_f
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_dual_stream_physical_feasibility_softmax_recip_lut_llama7b_v1",
@@ -6409,7 +6446,7 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_physical_fea
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_composed_datapath_physical_feasibility_softmax_recip_lut_llama7b_v1",
@@ -6463,7 +6500,7 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_variant_fron
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_composed_datapath_recip_lut_variant_frontier_llama7b_v1",
@@ -6525,7 +6562,7 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_q12_pwl_fron
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_composed_datapath_q12_pwl_softmax_frontier_llama7b_v1",
@@ -6579,7 +6616,7 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_q20_pwl_reci
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_composed_datapath_q20_pwl_recip_div_reduced_replica_llama7b_v1",
@@ -6651,7 +6688,7 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_fron
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_composed_datapath_score32_w16_exact_div_frontier_llama7b_v1",
@@ -6704,7 +6741,7 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_redu
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_composed_datapath_score32_w16_exact_div_reduced_replica_llama7b_v1",
@@ -6752,7 +6789,7 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_exp_lut_comm
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=(
@@ -6833,7 +6870,7 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_exp_lut_meas
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=(
@@ -6910,7 +6947,7 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_exp_lut_sche
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=(
@@ -6978,7 +7015,7 @@ def test_generate_l2_campaign_task_adds_attention_score32_exp_lut_measured_wrapp
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_score32_exp_lut_measured_wrapper_promotion_llama7b_v1",
@@ -7075,7 +7112,7 @@ def test_generate_l2_campaign_task_adds_attention_score32_exp_lut_service_closur
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_score32_exp_lut_service_closure_llama7b_v1",
@@ -7138,7 +7175,7 @@ def test_generate_l2_campaign_task_adds_attention_score32_exp_lut_hbm_dram_servi
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1",
@@ -7213,7 +7250,7 @@ def test_generate_l2_campaign_task_adds_attention_score32_hbm_controller_replay_
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1",
@@ -7272,7 +7309,7 @@ def test_generate_l2_campaign_task_adds_attention_score32_integrated_frontier_ra
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_score32_integrated_frontier_ranking_llama7b_v1",
@@ -7339,7 +7376,7 @@ def test_generate_l2_campaign_task_adds_schedule_wrapper_integrated_frontier_ran
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_score32_schedule_wrapper_integrated_frontier_ranking_llama7b_v1",
@@ -7386,7 +7423,7 @@ def test_generate_l2_campaign_task_adds_schedule_wrapper_postroute_activity_powe
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_score32_schedule_wrapper_postroute_activity_power_llama7b_v1",
@@ -7426,7 +7463,7 @@ def test_generate_l2_campaign_task_adds_schedule_wrapper_activity_integrated_fro
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_score32_schedule_wrapper_activity_integrated_frontier_ranking_llama7b_v1",
@@ -7466,7 +7503,7 @@ def test_generate_l2_campaign_task_adds_attention_score32_hbm_controller_replay_
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1",
@@ -7537,7 +7574,7 @@ def test_generate_l2_campaign_task_adds_attention_score32_hbm_controller_replay_
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_score32_hbm_controller_replay_integrated_frontier_ranking_llama7b_v1",
@@ -7590,7 +7627,7 @@ def test_generate_l2_campaign_task_adds_attention_score32_compute_activity_energ
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_score32_compute_activity_energy_llama7b_v1",
@@ -7649,7 +7686,7 @@ def test_generate_l2_campaign_task_adds_attention_score32_exact_reduction_recost
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r2",
@@ -7757,7 +7794,7 @@ def test_generate_l2_campaign_task_keeps_item_specific_outputs_for_score32_exact
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1_r3",
@@ -7812,7 +7849,7 @@ def test_generate_l2_campaign_task_adds_folded_global_exact_reduction_recost_evi
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_score32_folded_global_exact_reduction_recost_llama7b_v2_r1",
@@ -7927,7 +7964,7 @@ def test_generate_l2_campaign_task_adds_score32_exact_reduction_full_gqa8_rerank
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank_llama7b_v1",
@@ -8021,7 +8058,7 @@ def test_generate_l2_campaign_task_adds_attention_score32_separated_compute_reco
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_score32_separated_compute_recost_llama7b_v1",
@@ -8094,7 +8131,7 @@ def test_generate_l2_campaign_task_adds_attention_separated_cluster_equivalence(
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_separated_cluster_equivalence_llama7b_v1",
@@ -8137,7 +8174,7 @@ def test_generate_l2_campaign_task_adds_attention_hierarchical_softmax_architect
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_hierarchical_softmax_architecture_llama7b_v1",
@@ -8179,7 +8216,7 @@ def test_generate_l2_campaign_task_adds_attention_two_pass_global_max_equivalenc
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_two_pass_global_max_rtl_equivalence_llama7b_v1",
@@ -8217,7 +8254,7 @@ def test_generate_l2_campaign_task_adds_attention_two_pass_stream_equivalence() 
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_two_pass_stream_rtl_equivalence_llama7b_v1",
@@ -8255,7 +8292,7 @@ def test_generate_l2_campaign_task_adds_attention_two_pass_stream_iterdiv_equiva
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_two_pass_stream_iterdiv_rtl_equivalence_llama7b_v1",
@@ -8294,7 +8331,7 @@ def test_generate_l2_campaign_task_adds_attention_score32_exp_lut_sram_hierarchy
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_score32_exp_lut_sram_hierarchy_envelope_llama7b_v1",
@@ -8354,7 +8391,7 @@ def test_generate_l2_campaign_task_adds_two_pass_score_sram_reservation() -> Non
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_two_pass_score_sram_reservation_llama7b_v1",
@@ -8395,7 +8432,7 @@ def test_generate_l2_campaign_task_adds_two_pass_integrated_frontier_ranking() -
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_two_pass_integrated_frontier_ranking_llama7b_v1",
@@ -8435,7 +8472,7 @@ def test_generate_l2_campaign_task_adds_separated_two_pass_frontier() -> None:
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_separated_two_pass_frontier_llama7b_v1",
@@ -8478,7 +8515,7 @@ def test_generate_l2_campaign_task_adds_operational_component_frontier() -> None
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_operational_component_frontier_llama7b_v1",
@@ -8521,7 +8558,7 @@ def test_generate_l2_campaign_task_adds_operational_dense_tile_equivalence() -> 
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_operational_dense_tile_equivalence_llama7b_v1",
@@ -8557,7 +8594,7 @@ def test_generate_l2_campaign_task_adds_decode_score_tile_equivalence() -> None:
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_decode_score_tile_m1x8_equivalence_llama7b_v1",
@@ -8593,7 +8630,7 @@ def test_generate_l2_campaign_task_adds_decode_score_local_cluster_equivalence()
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_decode_score_local_cluster_equivalence_llama7b_v1",
@@ -8629,7 +8666,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_equivale
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
@@ -8665,7 +8702,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_group_equiva
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_decode_score_multivalue_gqa_group_equivalence_llama7b_v1",
@@ -8716,7 +8753,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_folded_lane_
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=(
@@ -8763,7 +8800,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_array_equiva
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=(
@@ -8834,7 +8871,7 @@ def test_generate_l2_campaign_task_uses_direct_gqa_group_equivalence_for_v2_cons
             for item_id, abstraction_layer, input_key in cases:
                 result = generate_l2_campaign_task(
                     session,
-                    Layer2CampaignGenerateRequest(
+                    _make_l2_request(
                         repo_root=str(repo_root),
                         campaign_path=campaign_path,
                         item_id=item_id,
@@ -8866,7 +8903,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_activity
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v1",
@@ -8946,7 +8983,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_activity
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v2",
@@ -8992,7 +9029,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_activity
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_decode_score_multivalue_cluster_activity_power_llama7b_v16",
@@ -9381,7 +9418,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_group_activi
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_decode_score_multivalue_gqa8_group_activity_power_llama7b_v1",
@@ -9471,7 +9508,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_group_activi
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_decode_score_multivalue_gqa8_group_activity_power_llama7b_v1",
@@ -9532,7 +9569,7 @@ def test_generate_l2_campaign_task_adds_folded_gqa_lane_activity_power() -> None
                 )
                 result = generate_l2_campaign_task(
                     session,
-                    Layer2CampaignGenerateRequest(
+                    _make_l2_request(
                         repo_root=str(repo_root),
                         campaign_path=campaign_path,
                         item_id=item_id,
@@ -9594,7 +9631,7 @@ def test_generate_l2_campaign_task_folded_lane_activity_reads_revisioned_cluster
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=item_id,
@@ -9639,7 +9676,7 @@ def test_generate_l2_campaign_task_cluster_frontier_uses_cluster_activity_v2_dep
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
@@ -9696,7 +9733,7 @@ def test_generate_l2_campaign_task_adds_decode_score_tile_frontier() -> None:
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_decode_score_tile_frontier_llama7b_v1",
@@ -9733,7 +9770,7 @@ def test_generate_l2_campaign_task_adds_decode_score_local_cluster_frontier() ->
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_decode_score_local_cluster_frontier_llama7b_v1",
@@ -9768,7 +9805,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_cluster_frontier
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1_r1",
@@ -9865,7 +9902,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_integrated_servi
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_decode_score_multivalue_integrated_service_llama7b_v1",
@@ -9950,7 +9987,7 @@ def test_generate_l2_campaign_task_adds_exact_partial_integrated_service_equival
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=item_id,
@@ -10041,7 +10078,7 @@ def test_generate_l2_campaign_task_adds_finalized_cdc_lane_probe_campaign() -> N
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=item_id,
@@ -10123,7 +10160,7 @@ def test_generate_l2_campaign_task_adds_workload_correspondence_campaign() -> No
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=item_id,
@@ -10209,7 +10246,7 @@ def test_generate_l2_campaign_task_adds_exact_partial_physical_recost_consumer()
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=item_id,
@@ -10276,7 +10313,7 @@ def test_exact_partial_physical_recost_consumer_rejects_missing_dependency() -> 
         ):
             generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=(
@@ -10319,7 +10356,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_activity
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=(
@@ -10431,7 +10468,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_c2_activ
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=(
@@ -10490,7 +10527,7 @@ def test_generate_l2_campaign_task_cluster_frontier_uses_cluster_activity_v1_dep
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_decode_score_multivalue_cluster_frontier_llama7b_v1",
@@ -10529,7 +10566,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_measured
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=(
@@ -10647,7 +10684,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_measured
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=(
@@ -10729,7 +10766,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_group_fronti
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_decode_score_multivalue_gqa8_group_frontier_llama7b_v1",
@@ -10787,7 +10824,7 @@ def test_generate_l2_campaign_task_adds_folded_gqa_frontier() -> None:
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=(
@@ -10836,7 +10873,7 @@ def test_generate_l2_campaign_task_adds_decode_score_multivalue_gqa_array_fronti
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=(
@@ -10895,7 +10932,7 @@ def test_generate_l2_campaign_task_uses_v2_gqa_evidence_for_v2_frontiers() -> No
         with Session(engine) as session:
             group_result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=(
@@ -10916,7 +10953,7 @@ def test_generate_l2_campaign_task_uses_v2_gqa_evidence_for_v2_frontiers() -> No
 
             array_result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=(
@@ -10950,7 +10987,7 @@ def test_generate_l2_campaign_task_adds_score_bank_proxy_equivalence() -> None:
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_score_bank_proxy_equivalence_llama7b_v1",
@@ -10986,7 +11023,7 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_score24_redu
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_composed_datapath_score24_w16_exact_div_reduced_replica_llama7b_v1",
@@ -11039,7 +11076,7 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_reci
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_composed_datapath_score32_w16_recip_lut_q16_reduced_replica_llama7b_v1",
@@ -11094,7 +11131,7 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_exp_
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_composed_datapath_score32_exp_lut_div_reduced_replica_llama7b_v1",
@@ -11181,7 +11218,7 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_exp_
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_composed_datapath_score32_exp_lut_div_parallelism_recost_llama7b_v1",
@@ -11244,7 +11281,7 @@ def test_generate_l2_campaign_task_adds_attention_composed_datapath_score32_spli
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_composed_datapath_score32_w16_exact_div_split2_reduced_replica_llama7b_v1",
@@ -11297,7 +11334,7 @@ def test_generate_l2_campaign_task_adds_attention_integrated_abstraction_closure
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_integrated_abstraction_closure_llama7b_v1",
@@ -11372,7 +11409,7 @@ def test_generate_l2_campaign_task_adds_attention_integrated_energy_closure_evid
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_integrated_energy_closure_llama7b_v1",
@@ -11440,7 +11477,7 @@ def test_generate_l2_campaign_task_adds_attention_hbm_energy_sensitivity_evidenc
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_hbm_energy_sensitivity_llama7b_v1",
@@ -11508,7 +11545,7 @@ def test_generate_l2_campaign_task_adds_attention_hbm_dram_service_energy_eviden
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_hbm_dram_service_energy_llama7b_v1",
@@ -11581,7 +11618,7 @@ def test_generate_l2_campaign_task_adds_attention_hbm_energy_calibration_evidenc
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_hbm_energy_calibration_llama7b_v1",
@@ -11650,7 +11687,7 @@ def test_generate_l2_campaign_task_adds_attention_hbm_command_calibrated_service
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_hbm_command_calibrated_service_llama7b_v1",
@@ -11723,7 +11760,7 @@ def test_generate_l2_campaign_task_adds_attention_measured_compute_energy_closur
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_measured_compute_energy_closure_llama7b_v1",
@@ -11796,7 +11833,7 @@ def test_generate_l2_campaign_task_adds_dense_gemm_v3_measured_compute_closure_e
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_dense_gemm_v3_measured_compute_closure_llama7b_v1",
@@ -11869,7 +11906,7 @@ def test_generate_l2_campaign_task_adds_mixed_int8_energy_closure_evidence() -> 
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_mixed_int8_energy_closure_llama7b_v1",
@@ -11925,7 +11962,7 @@ def test_generate_l2_campaign_task_adds_mixed_int8_native_quality_evidence() -> 
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_mixed_int8_native_quality_llama7b_v1",
@@ -11989,7 +12026,7 @@ def test_generate_l2_campaign_task_adds_mixed_int8_native_quality_ablation_evide
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_mixed_int8_native_quality_ablation_llama7b_v1",
@@ -12053,7 +12090,7 @@ def test_generate_l2_campaign_task_adds_mixed_int8_score_boundary_evidence() -> 
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_mixed_int8_score_boundary_llama7b_v1",
@@ -12116,7 +12153,7 @@ def test_generate_l2_campaign_task_adds_mixed_int8_high_score_boundary_evidence(
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_mixed_int8_high_score_boundary_llama7b_v1",
@@ -12184,7 +12221,7 @@ def test_generate_l2_campaign_task_adds_mixed_int8_broad_native_quality_evidence
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_mixed_int8_broad_native_quality_llama7b_v1",
@@ -12256,7 +12293,7 @@ def test_generate_l2_campaign_task_adds_mixed_int8_q12_pwl_native_quality_eviden
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_mixed_int8_q12_pwl_native_quality_llama7b_v1",
@@ -12329,7 +12366,7 @@ def test_generate_l2_campaign_task_adds_mixed_int8_q24_pwl_native_quality_eviden
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_mixed_int8_q24_pwl_native_quality_llama7b_v1",
@@ -12406,7 +12443,7 @@ def test_generate_l2_campaign_task_adds_mixed_int8_q12_pwl_proxy_audit_evidence(
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_mixed_int8_q12_pwl_proxy_audit_llama7b_v1",
@@ -12486,7 +12523,7 @@ def test_generate_l2_campaign_task_adds_mixed_int8_score_precision_recovery_evid
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_mixed_int8_score_precision_recovery_llama7b_v1",
@@ -12578,7 +12615,7 @@ def test_generate_l2_campaign_task_adds_mixed_int8_score_margin_audit_evidence()
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_mixed_int8_score_margin_audit_llama7b_v1",
@@ -12642,7 +12679,7 @@ def test_generate_l2_campaign_task_adds_mixed_int8_generation_quality_evidence()
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_mixed_int8_generation_quality_llama7b_v1",
@@ -12708,7 +12745,7 @@ def test_generate_l2_campaign_task_adds_score32_w16_recip_lut_q16_generation_qua
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=(
@@ -12790,7 +12827,7 @@ def test_generate_l2_campaign_task_adds_score32_w16_rtl_exact_generation_quality
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_mixed_int8_score32_w16_rtl_exact_generation_quality_llama7b_v1",
@@ -12860,7 +12897,7 @@ def test_generate_l2_campaign_task_adds_score32_exp_lut_div_generation_quality_e
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1",
@@ -12941,7 +12978,7 @@ def test_generate_l2_campaign_task_adds_score32_zero_tail_generation_quality_evi
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_score32_zero_tail_two_pass_generation_quality_llama7b_v1",
@@ -12983,7 +13020,7 @@ def test_generate_l2_campaign_task_adds_score24_w16_rtl_exact_generation_quality
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_mixed_int8_score24_w16_rtl_exact_generation_quality_llama7b_v1",
@@ -13053,7 +13090,7 @@ def test_generate_l2_campaign_task_adds_score32_w16_rtl_recip_precision_generati
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=(
@@ -13136,7 +13173,7 @@ def test_generate_l2_campaign_task_adds_softmax_replacement_generation_quality_e
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_mixed_int8_softmax_replacement_generation_quality_llama7b_v1",
@@ -13204,7 +13241,7 @@ def test_generate_l2_campaign_task_adds_mixed_int8_quality_backed_frontier_evide
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_mixed_int8_quality_backed_frontier_llama7b_v1",
@@ -13285,7 +13322,7 @@ def test_generate_l2_campaign_task_adds_mixed_int8_quality_energy_frontier_evide
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_mixed_int8_quality_energy_frontier_llama7b_v1",
@@ -13364,7 +13401,7 @@ def test_generate_l2_campaign_task_adds_attention_mixed_precision_quality_eviden
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_mixed_precision_quality_llama7b_v1",
@@ -13411,7 +13448,7 @@ def test_generate_l2_campaign_task_adds_attention_softmax_pow2sum_quality_eviden
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_softmax_pow2sum_quality_llama7b_v1",
@@ -13458,7 +13495,7 @@ def test_generate_l2_campaign_task_adds_attention_softmax_recip_lut_quality_evid
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_softmax_recip_lut_quality_llama7b_v1",
@@ -13505,7 +13542,7 @@ def test_generate_l2_campaign_task_adds_attention_mixed_precision_physical_feasi
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_mixed_precision_physical_feasibility_llama7b_v1",
@@ -13555,7 +13592,7 @@ def test_generate_l2_campaign_task_adds_attention_mixed_precision_int8_compute_p
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_llama7b_v1",
@@ -13610,7 +13647,7 @@ def test_generate_l2_campaign_task_adds_attention_mixed_precision_int8_compute_p
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_mixed_precision_int8_compute_physical_feasibility_softmax_recip_lut_llama7b_v1",
@@ -13687,7 +13724,7 @@ def test_generate_l2_campaign_task_adds_attention_noc_profile_evidence() -> None
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_noc_profile_v1",
@@ -13725,7 +13762,7 @@ def test_generate_l2_campaign_task_adds_all_measured_l1_attention_evidence() -> 
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_all_measured_l1_clustered_schedule_v1",
@@ -13771,7 +13808,7 @@ def test_generate_l2_campaign_task_adds_dense_tile_all_measured_l1_attention_evi
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_dense_tile_all_measured_l1_clustered_schedule_v1",
@@ -13818,7 +13855,7 @@ def test_generate_l2_campaign_task_adds_dense_tile_endpoint_measured_l1_attentio
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_dense_tile_endpoint_measured_l1_clustered_schedule_v1",
@@ -13865,7 +13902,7 @@ def test_generate_l2_campaign_task_adds_dense_tile_reduction_noc_frontier_eviden
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_dense_tile_reduction_noc_frontier_llama7b_v1",
@@ -13914,7 +13951,7 @@ def test_generate_l2_campaign_task_adds_dense_tile_topology_scheduler_pairs_evid
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_dense_tile_topology_scheduler_pairs_llama7b_v1",
@@ -13962,7 +13999,7 @@ def test_generate_l2_campaign_task_adds_dense_tile_endpoint_topology_scheduler_p
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_dense_tile_endpoint_topology_scheduler_pairs_llama7b_v1",
@@ -14009,7 +14046,7 @@ def test_generate_l2_campaign_task_adds_dense_tile_topology_derived_schedule_evi
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_dense_tile_topology_derived_schedule_llama7b_v1",
@@ -14057,7 +14094,7 @@ def test_generate_l2_campaign_task_adds_dense_tile_endpoint_topology_derived_sch
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_dense_tile_endpoint_topology_derived_schedule_llama7b_v1",
@@ -14106,7 +14143,7 @@ def test_generate_l2_campaign_task_adds_sram_noc_constrained_schedule_evidence()
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_sram_noc_constrained_schedule_llama7b_v1",
@@ -14156,7 +14193,7 @@ def test_generate_l2_campaign_task_adds_endpoint_sram_noc_constrained_schedule_e
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_endpoint_sram_noc_constrained_schedule_llama7b_v1",
@@ -14208,7 +14245,7 @@ def test_generate_l2_campaign_task_adds_endpoint_sram_noc_full_search_schedule_e
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_endpoint_sram_noc_full_search_schedule_llama7b_v1",
@@ -14266,7 +14303,7 @@ def test_generate_l2_campaign_task_adds_endpoint_sram_noc_full_search_softmax_re
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_llama7b_v1",
@@ -14340,7 +14377,7 @@ def test_generate_l2_campaign_task_adds_onchip_service_schedule_evidence() -> No
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_onchip_service_schedule_llama7b_v1",
@@ -14390,7 +14427,7 @@ def test_generate_l2_campaign_task_adds_endpoint_full_onchip_service_schedule_ev
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_llama7b_v1",
@@ -14443,7 +14480,7 @@ def test_generate_l2_campaign_task_adds_softmax_recip_lut_endpoint_full_onchip_s
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_endpoint_full_onchip_service_schedule_softmax_recip_lut_llama7b_v1",
@@ -14489,7 +14526,7 @@ def test_generate_l2_campaign_task_adds_endpoint_ready_valid_service_evidence() 
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_endpoint_ready_valid_service_llama7b_v1",
@@ -14539,7 +14576,7 @@ def test_generate_l2_campaign_task_adds_softmax_recip_lut_endpoint_ready_valid_s
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_endpoint_ready_valid_service_softmax_recip_lut_llama7b_v1",
@@ -14585,7 +14622,7 @@ def test_generate_l2_campaign_task_adds_endpoint_router_sram_composition_evidenc
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_endpoint_router_sram_composition_llama7b_v1",
@@ -14649,7 +14686,7 @@ def test_generate_l2_campaign_task_adds_softmax_recip_lut_endpoint_router_sram_s
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_kv_endpoint_router_sram_composition_softmax_recip_lut_llama7b_v1",
@@ -14708,7 +14745,7 @@ def test_generate_l2_campaign_task_adds_attention_pwl_recip_lut_boundary_evidenc
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id="l2_decoder_attention_pwl_recip_lut_boundary_llama7b_v1",
@@ -14759,7 +14796,7 @@ def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_equivalence_evidence()
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=(
@@ -14893,7 +14930,7 @@ def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_rotation_equivalence_e
         with Session(engine) as session:
             result = generate_l2_campaign_task(
                 session,
-                Layer2CampaignGenerateRequest(
+                _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
                     item_id=(

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -283,6 +283,13 @@ def test_generate_l2_campaign_task_creates_ready_work_item() -> None:
             assert payload["source_requirement"]["required_sha"] == source_commit
             assert payload["source_requirement"]["required_ref"] == "origin/master"
             assert payload["source_requirement"]["requires_daemon_restart"] is True
+            assert payload["generation_source_identity"] == {
+                "version": 1,
+                "declared_source_commit": source_commit,
+                "repo_head_sha": source_commit,
+                "relation": "exact",
+                "proof": "generator_worktree_head_exact",
+            }
             assert payload["task"]["inputs"]["candidate_manifests"] == [
                 "runs/candidates/nangate45/module_candidates.json"
             ]
@@ -314,6 +321,51 @@ def test_generate_l2_campaign_task_creates_ready_work_item() -> None:
             }
             assert payload["task"]["commands"][0]["name"] == "fetch_models"
             assert "--run_physical" in payload["task"]["commands"][2]["run"]
+
+
+def test_generate_l2_campaign_task_rejects_mismatched_generation_worktree() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        mismatch_file = repo_root / "HEAD_ONLY.txt"
+        mismatch_file.write_text("mismatch\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(repo_root), "add", "HEAD_ONLY.txt"], check=True, capture_output=True, text=True)
+        subprocess.run(
+            ["git", "-C", str(repo_root), "commit", "-m", "local head drift"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        head_commit = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            try:
+                generate_l2_campaign_task(
+                    session,
+                    Layer2CampaignGenerateRequest(
+                        repo_root=str(repo_root),
+                        campaign_path=campaign_path,
+                        requested_by="@tester",
+                        source_commit=source_commit,
+                    ),
+                )
+            except Layer2TaskGenerationError as exc:
+                message = str(exc)
+                assert "exact-generation worktree" in message
+                assert source_commit in message
+                assert head_commit in message
+                assert "Regenerate the item from a checkout whose HEAD exactly matches the declared source commit." in message
+            else:
+                raise AssertionError("expected Layer2TaskGenerationError for mismatched generation worktree")
 
 
 def test_generate_l2_campaign_task_adds_decoder_probability_path_evidence() -> None:

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5812,6 +5812,71 @@ def test_generate_l2_campaign_task_rejects_source_commit_not_pushed_to_origin() 
                 raise AssertionError("expected Layer2TaskGenerationError")
 
 
+def test_generate_l2_campaign_task_rejects_implicit_source_commit_when_head_not_pushed_to_origin() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        _init_git_repo(repo_root)
+        extra = repo_root / "LOCAL_ONLY.txt"
+        extra.write_text("local only\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(repo_root), "add", "LOCAL_ONLY.txt"], check=True, capture_output=True, text=True)
+        subprocess.run(["git", "-C", str(repo_root), "commit", "-m", "local only"], check=True, capture_output=True, text=True)
+        local_only_commit = subprocess.run(["git", "-C", str(repo_root), "rev-parse", "HEAD"], check=True, capture_output=True, text=True).stdout.strip()
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            try:
+                generate_l2_campaign_task(
+                    session,
+                    _make_l2_request(
+                        repo_root=str(repo_root),
+                        campaign_path=campaign_path,
+                        requested_by="@tester",
+                    ),
+                )
+            except Layer2TaskGenerationError as exc:
+                message = str(exc)
+                assert "resolved repo HEAD source_commit is not reachable from origin" in message
+                assert local_only_commit in message
+            else:
+                raise AssertionError("expected Layer2TaskGenerationError")
+
+
+def test_generate_l2_campaign_task_accepts_implicit_source_commit_from_pushed_head() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                _make_l2_request(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    requested_by="@tester",
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert result.status == "applied"
+            assert work_item.source_commit == source_commit
+            assert work_item.task_request.source_commit == source_commit
+            assert work_item.task_request.request_payload["generation_source_identity"] == {
+                "version": 1,
+                "declared_source_commit": source_commit,
+                "repo_head_sha": source_commit,
+                "relation": "exact",
+                "proof": "generator_worktree_head_exact",
+                "clean": True,
+            }
+
+
 def test_generate_l2_campaign_task_adds_attention_sram_profile_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -133,6 +133,14 @@ def _init_git_repo(repo_root: Path) -> str:
     return result.stdout.strip()
 
 
+def _commit_repo_changes(repo_root: Path, message: str) -> str:
+    subprocess.run(["git", "-C", str(repo_root), "add", "-A"], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(repo_root), "commit", "-m", message], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(repo_root), "push", "origin", "HEAD:master"], check=True, capture_output=True, text=True)
+    result = subprocess.run(["git", "-C", str(repo_root), "rev-parse", "HEAD"], check=True, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
 def _write_q20_pwl_recip_div_recost_proposal(repo_root: Path) -> None:
     proposal_dir = (
         repo_root
@@ -289,6 +297,7 @@ def test_generate_l2_campaign_task_creates_ready_work_item() -> None:
                 "repo_head_sha": source_commit,
                 "relation": "exact",
                 "proof": "generator_worktree_head_exact",
+                "clean": True,
             }
             assert payload["task"]["inputs"]["candidate_manifests"] == [
                 "runs/candidates/nangate45/module_candidates.json"
@@ -366,6 +375,71 @@ def test_generate_l2_campaign_task_rejects_mismatched_generation_worktree() -> N
                 assert "Regenerate the item from a checkout whose HEAD exactly matches the declared source commit." in message
             else:
                 raise AssertionError("expected Layer2TaskGenerationError for mismatched generation worktree")
+
+
+def test_generate_l2_campaign_task_rejects_tracked_dirty_generation_worktree() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        tracked_file = repo_root / campaign_path
+        tracked_file.write_text(tracked_file.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            try:
+                generate_l2_campaign_task(
+                    session,
+                    Layer2CampaignGenerateRequest(
+                        repo_root=str(repo_root),
+                        campaign_path=campaign_path,
+                        requested_by="@tester",
+                        source_commit=source_commit,
+                    ),
+                )
+            except Layer2TaskGenerationError as exc:
+                message = str(exc)
+                assert "clean exact-generation worktree" in message
+                assert "git status --porcelain is not empty" in message
+                assert f" M {campaign_path}" in message or f"M {campaign_path}" in message
+                assert "Commit, stash, or remove tracked and untracked changes" in message
+            else:
+                raise AssertionError("expected Layer2TaskGenerationError for tracked dirty generation worktree")
+
+
+def test_generate_l2_campaign_task_rejects_untracked_generation_worktree() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        untracked_rel = "runs/campaigns/npu/demo_campaign/local_override.py"
+        (repo_root / untracked_rel).parent.mkdir(parents=True, exist_ok=True)
+        (repo_root / untracked_rel).write_text("OVERRIDE = True\n", encoding="utf-8")
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            try:
+                generate_l2_campaign_task(
+                    session,
+                    Layer2CampaignGenerateRequest(
+                        repo_root=str(repo_root),
+                        campaign_path=campaign_path,
+                        requested_by="@tester",
+                        source_commit=source_commit,
+                    ),
+                )
+            except Layer2TaskGenerationError as exc:
+                message = str(exc)
+                assert "clean exact-generation worktree" in message
+                assert "git status --porcelain is not empty" in message
+                assert f"?? {untracked_rel}" in message
+                assert "Commit, stash, or remove tracked and untracked changes" in message
+            else:
+                raise AssertionError("expected Layer2TaskGenerationError for untracked generation worktree")
 
 
 def test_generate_l2_campaign_task_adds_decoder_probability_path_evidence() -> None:
@@ -5168,6 +5242,7 @@ def test_generate_l2_campaign_task_recovers_metadata_from_evaluation_requests() 
             + "\n",
             encoding="utf-8",
         )
+        _commit_repo_changes(repo_root, "commit evaluation request metadata fixture")
         engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
         create_all(engine)
 
@@ -5239,6 +5314,7 @@ def test_generate_l2_campaign_task_preserves_revision_metadata_on_materializatio
             + "\n",
             encoding="utf-8",
         )
+        source_commit = _commit_repo_changes(repo_root, "commit revision metadata fixture")
         engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
         create_all(engine)
 
@@ -5310,6 +5386,7 @@ def test_generate_l2_campaign_task_can_refresh_db_without_updating_proposal_file
             + "\n",
             encoding="utf-8",
         )
+        source_commit = _commit_repo_changes(repo_root, "commit refresh metadata fixture")
         before = evaluation_requests_path.read_text(encoding="utf-8")
         engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
         create_all(engine)
@@ -5510,27 +5587,33 @@ def test_generate_l2_campaign_task_defaults_source_commit_from_repo_head() -> No
         engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
         create_all(engine)
 
-        with patch("control_plane.services.l2_task_generator.subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(
-                args=["git", "-C", str(repo_root), "rev-parse", "HEAD"],
-                returncode=0,
-                stdout="feedface12345678\n",
-                stderr="",
-            )
-            with Session(engine) as session:
-                result = generate_l2_campaign_task(
-                    session,
-                    Layer2CampaignGenerateRequest(
-                        repo_root=str(repo_root),
-                        campaign_path=campaign_path,
-                        requested_by="@tester",
-                    ),
-                )
+        with patch("control_plane.services.l2_task_generator._resolve_source_commit", return_value="feedface12345678") as mock_resolve:
+            with patch(
+                "control_plane.services.l2_task_generator.build_generation_source_identity",
+                return_value={
+                    "version": 1,
+                    "declared_source_commit": "feedface12345678",
+                    "repo_head_sha": "feedface12345678",
+                    "relation": "exact",
+                    "proof": "generator_worktree_head_exact",
+                    "clean": True,
+                },
+            ) as mock_identity:
+                with Session(engine) as session:
+                    result = generate_l2_campaign_task(
+                        session,
+                        Layer2CampaignGenerateRequest(
+                            repo_root=str(repo_root),
+                            campaign_path=campaign_path,
+                            requested_by="@tester",
+                        ),
+                    )
 
-                work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
-                assert work_item.source_commit == "feedface12345678"
-                assert work_item.task_request.source_commit == "feedface12345678"
-                mock_run.assert_called_once()
+                    work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+                    assert work_item.source_commit == "feedface12345678"
+                    assert work_item.task_request.source_commit == "feedface12345678"
+                    mock_resolve.assert_called_once()
+                    mock_identity.assert_called_once()
 
 
 def test_generate_l2_campaign_task_rejects_invalid_explicit_source_commit() -> None:

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -5419,7 +5419,109 @@ def test_generate_l2_campaign_task_can_refresh_db_without_updating_proposal_file
                 "requires_materialized_refs": True,
             }
 
-        assert evaluation_requests_path.read_text(encoding="utf-8") == before
+
+def test_generate_l2_campaign_task_rejects_db_creation_when_proposal_upsert_dirties_worktree() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        proposal_dir = repo_root / "docs" / "developer_loop" / "prop_l2_dirty_generation_guard_v1"
+        proposal_dir.mkdir(parents=True, exist_ok=True)
+        (proposal_dir / "proposal.json").write_text(
+            json.dumps({"proposal_id": "prop_l2_dirty_generation_guard_v1"}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            try:
+                generate_l2_campaign_task(
+                    session,
+                    Layer2CampaignGenerateRequest(
+                        repo_root=str(repo_root),
+                        campaign_path=campaign_path,
+                        item_id="l2_demo_dirty_generation_guard_r1",
+                        requested_by="@tester",
+                        source_commit=source_commit,
+                        proposal_id="prop_l2_dirty_generation_guard_v1",
+                        proposal_path="docs/developer_loop/prop_l2_dirty_generation_guard_v1",
+                    ),
+                )
+            except Layer2TaskGenerationError as exc:
+                message = str(exc)
+                assert "clean exact-generation worktree" in message
+                assert "git status --porcelain is not empty" in message
+                assert "docs/developer_loop/prop_l2_dirty_generation_guard_v1/" in message
+            else:
+                raise AssertionError("expected Layer2TaskGenerationError")
+
+            assert session.query(WorkItem).count() == 0
+            assert session.query(TaskRequest).count() == 0
+            assert (proposal_dir / "evaluation_requests.json").exists()
+
+
+def test_generate_l2_campaign_task_succeeds_after_committed_rerun_without_proposal_updates() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        proposal_dir = repo_root / "docs" / "developer_loop" / "prop_l2_dirty_generation_guard_v1"
+        proposal_dir.mkdir(parents=True, exist_ok=True)
+        (proposal_dir / "proposal.json").write_text(
+            json.dumps({"proposal_id": "prop_l2_dirty_generation_guard_v1"}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            try:
+                generate_l2_campaign_task(
+                    session,
+                    Layer2CampaignGenerateRequest(
+                        repo_root=str(repo_root),
+                        campaign_path=campaign_path,
+                        item_id="l2_demo_dirty_generation_guard_r1",
+                        requested_by="@tester",
+                        source_commit=source_commit,
+                        proposal_id="prop_l2_dirty_generation_guard_v1",
+                        proposal_path="docs/developer_loop/prop_l2_dirty_generation_guard_v1",
+                    ),
+                )
+            except Layer2TaskGenerationError:
+                pass
+            else:
+                raise AssertionError("expected initial Layer2TaskGenerationError")
+
+            clean_commit = _commit_repo_changes(repo_root, "commit l2 proposal upsert artifacts")
+            result = generate_l2_campaign_task(
+                session,
+                Layer2CampaignGenerateRequest(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_demo_dirty_generation_guard_r1",
+                    requested_by="@tester",
+                    source_commit=clean_commit,
+                    proposal_id="prop_l2_dirty_generation_guard_v1",
+                    proposal_path="docs/developer_loop/prop_l2_dirty_generation_guard_v1",
+                    update_proposal_files=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            assert result.status == "applied"
+            assert work_item.source_commit == clean_commit
+            assert work_item.task_request.request_payload["generation_source_identity"] == {
+                "version": 1,
+                "declared_source_commit": clean_commit,
+                "repo_head_sha": clean_commit,
+                "relation": "exact",
+                "proof": "generator_worktree_head_exact",
+                "clean": True,
+            }
 
 
 def test_generate_l2_campaign_task_blocks_when_dependency_not_merged() -> None:

--- a/control_plane/control_plane/tests/test_queue_importer.py
+++ b/control_plane/control_plane/tests/test_queue_importer.py
@@ -58,6 +58,7 @@ def _stamp_generation_identity(payload: dict[str, object], source_commit: str) -
         "repo_head_sha": source_commit,
         "relation": "exact",
         "proof": "generator_worktree_head_exact",
+        "clean": True,
     }
     return payload
 
@@ -311,6 +312,32 @@ def test_import_rejects_declared_source_without_generation_identity(tmp_path: Pa
             assert "missing generation_source_identity" in message
             assert source_commit in message
             assert "Regenerate the queue item from a worktree whose HEAD exactly matches the declared source commit." in message
+        else:
+            raise AssertionError("expected QueueImportError")
+
+
+def test_import_rejects_declared_source_with_nonclean_generation_identity(tmp_path: Path) -> None:
+    repo_root, queue_file, source_commit = _make_queue_import_repo(tmp_path)
+    payload = json.loads(queue_file.read_text(encoding="utf-8"))
+    stamped = _stamp_generation_identity(payload, source_commit)
+    stamped["generation_source_identity"]["clean"] = False
+    queue_file.write_text(json.dumps(stamped, indent=2) + "\n", encoding="utf-8")
+
+    with make_session() as session:
+        try:
+            import_queue_item(
+                session,
+                QueueImportRequest(
+                    repo_root=str(repo_root),
+                    queue_path=str(queue_file),
+                    source_commit=source_commit,
+                ),
+            )
+        except QueueImportError as exc:
+            message = str(exc)
+            assert "does not prove a clean generation worktree" in message
+            assert "clean=False" in message
+            assert "Regenerate the queue item from a clean checkout whose HEAD exactly matches the declared source commit." in message
         else:
             raise AssertionError("expected QueueImportError")
 

--- a/control_plane/control_plane/tests/test_queue_importer.py
+++ b/control_plane/control_plane/tests/test_queue_importer.py
@@ -13,6 +13,7 @@ from control_plane.db import create_all
 from control_plane.models.queue_reconciliations import QueueReconciliation
 from control_plane.models.task_requests import TaskRequest
 from control_plane.models.work_items import WorkItem
+from control_plane.services.generation_source_identity import GENERATION_SOURCE_IDENTITY_VERSION
 from control_plane.services.queue_importer import QueueImportConflict, QueueImportError, QueueImportRequest, import_queue_item
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -53,7 +54,7 @@ def _stamp_generation_identity(payload: dict[str, object], source_commit: str) -
         "requires_daemon_restart": True,
     }
     payload["generation_source_identity"] = {
-        "version": 1,
+        "version": GENERATION_SOURCE_IDENTITY_VERSION,
         "declared_source_commit": source_commit,
         "repo_head_sha": source_commit,
         "relation": "exact",
@@ -338,6 +339,105 @@ def test_import_rejects_declared_source_with_nonclean_generation_identity(tmp_pa
             assert "does not prove a clean generation worktree" in message
             assert "clean=False" in message
             assert "Regenerate the queue item from a clean checkout whose HEAD exactly matches the declared source commit." in message
+        else:
+            raise AssertionError("expected QueueImportError")
+
+
+def test_import_rejects_declared_source_with_missing_generation_identity_version(tmp_path: Path) -> None:
+    repo_root, queue_file, source_commit = _make_queue_import_repo(tmp_path)
+    payload = json.loads(queue_file.read_text(encoding="utf-8"))
+    stamped = _stamp_generation_identity(payload, source_commit)
+    stamped["generation_source_identity"].pop("version")
+    queue_file.write_text(json.dumps(stamped, indent=2) + "\n", encoding="utf-8")
+
+    with make_session() as session:
+        try:
+            import_queue_item(
+                session,
+                QueueImportRequest(
+                    repo_root=str(repo_root),
+                    queue_path=str(queue_file),
+                    source_commit=source_commit,
+                ),
+            )
+        except QueueImportError as exc:
+            message = str(exc)
+            assert f"unsupported version=None; expected version={GENERATION_SOURCE_IDENTITY_VERSION}" in message
+        else:
+            raise AssertionError("expected QueueImportError")
+
+
+def test_import_rejects_declared_source_with_wrong_generation_identity_version(tmp_path: Path) -> None:
+    repo_root, queue_file, source_commit = _make_queue_import_repo(tmp_path)
+    payload = json.loads(queue_file.read_text(encoding="utf-8"))
+    stamped = _stamp_generation_identity(payload, source_commit)
+    stamped["generation_source_identity"]["version"] = GENERATION_SOURCE_IDENTITY_VERSION + 1
+    queue_file.write_text(json.dumps(stamped, indent=2) + "\n", encoding="utf-8")
+
+    with make_session() as session:
+        try:
+            import_queue_item(
+                session,
+                QueueImportRequest(
+                    repo_root=str(repo_root),
+                    queue_path=str(queue_file),
+                    source_commit=source_commit,
+                ),
+            )
+        except QueueImportError as exc:
+            message = str(exc)
+            assert (
+                f"unsupported version={GENERATION_SOURCE_IDENTITY_VERSION + 1}; expected version={GENERATION_SOURCE_IDENTITY_VERSION}"
+                in message
+            )
+        else:
+            raise AssertionError("expected QueueImportError")
+
+
+def test_import_rejects_declared_source_with_missing_generation_identity_proof(tmp_path: Path) -> None:
+    repo_root, queue_file, source_commit = _make_queue_import_repo(tmp_path)
+    payload = json.loads(queue_file.read_text(encoding="utf-8"))
+    stamped = _stamp_generation_identity(payload, source_commit)
+    stamped["generation_source_identity"].pop("proof")
+    queue_file.write_text(json.dumps(stamped, indent=2) + "\n", encoding="utf-8")
+
+    with make_session() as session:
+        try:
+            import_queue_item(
+                session,
+                QueueImportRequest(
+                    repo_root=str(repo_root),
+                    queue_path=str(queue_file),
+                    source_commit=source_commit,
+                ),
+            )
+        except QueueImportError as exc:
+            message = str(exc)
+            assert "unsupported generation_source_identity proof=<missing>" in message
+        else:
+            raise AssertionError("expected QueueImportError")
+
+
+def test_import_rejects_declared_source_with_wrong_generation_identity_proof(tmp_path: Path) -> None:
+    repo_root, queue_file, source_commit = _make_queue_import_repo(tmp_path)
+    payload = json.loads(queue_file.read_text(encoding="utf-8"))
+    stamped = _stamp_generation_identity(payload, source_commit)
+    stamped["generation_source_identity"]["proof"] = "different_proof"
+    queue_file.write_text(json.dumps(stamped, indent=2) + "\n", encoding="utf-8")
+
+    with make_session() as session:
+        try:
+            import_queue_item(
+                session,
+                QueueImportRequest(
+                    repo_root=str(repo_root),
+                    queue_path=str(queue_file),
+                    source_commit=source_commit,
+                ),
+            )
+        except QueueImportError as exc:
+            message = str(exc)
+            assert "unsupported generation_source_identity proof=different_proof" in message
         else:
             raise AssertionError("expected QueueImportError")
 

--- a/control_plane/control_plane/tests/test_queue_importer.py
+++ b/control_plane/control_plane/tests/test_queue_importer.py
@@ -45,8 +45,30 @@ def make_session() -> Session:
     return Session(engine)
 
 
+def _stamp_generation_identity(payload: dict[str, object], source_commit: str) -> dict[str, object]:
+    payload["source_requirement"] = {
+        "version": 1,
+        "required_ref": "origin/master",
+        "required_sha": source_commit,
+        "requires_daemon_restart": True,
+    }
+    payload["generation_source_identity"] = {
+        "version": 1,
+        "declared_source_commit": source_commit,
+        "repo_head_sha": source_commit,
+        "relation": "exact",
+        "proof": "generator_worktree_head_exact",
+    }
+    return payload
+
+
 def test_import_real_queue_item(tmp_path: Path) -> None:
     repo_root, queue_file, source_commit = _make_queue_import_repo(tmp_path)
+    payload = json.loads(queue_file.read_text(encoding="utf-8"))
+    queue_file.write_text(
+        json.dumps(_stamp_generation_identity(payload, source_commit), indent=2) + "\n",
+        encoding="utf-8",
+    )
     with make_session() as session:
         result = import_queue_item(
             session,
@@ -69,13 +91,10 @@ def test_import_real_queue_item(tmp_path: Path) -> None:
 def test_import_uses_payload_source_requirement(tmp_path: Path) -> None:
     repo_root, queue_file, source_commit = _make_queue_import_repo(tmp_path)
     payload = json.loads(queue_file.read_text(encoding="utf-8"))
-    payload["source_requirement"] = {
-        "version": 1,
-        "required_ref": "origin/master",
-        "required_sha": source_commit,
-        "requires_daemon_restart": True,
-    }
-    queue_file.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    queue_file.write_text(
+        json.dumps(_stamp_generation_identity(payload, source_commit), indent=2) + "\n",
+        encoding="utf-8",
+    )
 
     with make_session() as session:
         import_queue_item(
@@ -111,6 +130,11 @@ def test_import_same_item_is_idempotent() -> None:
 
 def test_import_preserves_explicit_task_type_on_export_roundtrip(tmp_path: Path) -> None:
     repo_root, queue_file, source_commit = _make_queue_import_repo(tmp_path)
+    payload = json.loads(queue_file.read_text(encoding="utf-8"))
+    queue_file.write_text(
+        json.dumps(_stamp_generation_identity(payload, source_commit), indent=2) + "\n",
+        encoding="utf-8",
+    )
     exported = tmp_path / "roundtrip.json"
 
     with make_session() as session:
@@ -218,6 +242,11 @@ def test_import_route_accepts_post_with_sqlite_file(tmp_path: Path) -> None:
     from control_plane.api.app import create_app
 
     repo_root, queue_file, source_commit = _make_queue_import_repo(tmp_path)
+    payload = json.loads(queue_file.read_text(encoding="utf-8"))
+    queue_file.write_text(
+        json.dumps(_stamp_generation_identity(payload, source_commit), indent=2) + "\n",
+        encoding="utf-8",
+    )
     db_file = tmp_path / "cp.db"
     payload = {
         "repo_root": str(repo_root),
@@ -260,6 +289,28 @@ def test_import_rejects_invalid_source_commit() -> None:
             )
         except QueueImportError as exc:
             assert "provided source_commit does not resolve to a commit" in str(exc)
+        else:
+            raise AssertionError("expected QueueImportError")
+
+
+def test_import_rejects_declared_source_without_generation_identity(tmp_path: Path) -> None:
+    repo_root, queue_file, source_commit = _make_queue_import_repo(tmp_path)
+
+    with make_session() as session:
+        try:
+            import_queue_item(
+                session,
+                QueueImportRequest(
+                    repo_root=str(repo_root),
+                    queue_path=str(queue_file),
+                    source_commit=source_commit,
+                ),
+            )
+        except QueueImportError as exc:
+            message = str(exc)
+            assert "missing generation_source_identity" in message
+            assert source_commit in message
+            assert "Regenerate the queue item from a worktree whose HEAD exactly matches the declared source commit." in message
         else:
             raise AssertionError("expected QueueImportError")
 

--- a/docs/developer_agent_first_read.md
+++ b/docs/developer_agent_first_read.md
@@ -74,12 +74,15 @@ This set is the default startup context.
 
 When a proposal or evaluation request declares a `source_commit`, the developer
 agent must generate Layer 1 / Layer 2 queue manifests from a worktree whose
-`HEAD` exactly matches that commit.
+`HEAD` exactly matches that commit and whose `git status --porcelain` output is
+empty.
 
 Practical implications:
 - the repo content being read for generation must come from that exact checkout
 - the imported control-plane Python package must also come from that exact
   checkout
+- tracked or untracked local edits are not allowed during generation because the
+  manifest would no longer be provable from the declared tree
 - if `HEAD` drifts after the commit is recorded, regenerate the item from a
   matching worktree instead of reusing the old process or queue JSON
 

--- a/docs/developer_agent_first_read.md
+++ b/docs/developer_agent_first_read.md
@@ -70,6 +70,19 @@ Read these in order for every new developer-agent session:
 
 This set is the default startup context.
 
+## Exact Generation Rule
+
+When a proposal or evaluation request declares a `source_commit`, the developer
+agent must generate Layer 1 / Layer 2 queue manifests from a worktree whose
+`HEAD` exactly matches that commit.
+
+Practical implications:
+- the repo content being read for generation must come from that exact checkout
+- the imported control-plane Python package must also come from that exact
+  checkout
+- if `HEAD` drifts after the commit is recorded, regenerate the item from a
+  matching worktree instead of reusing the old process or queue JSON
+
 ## Topic-Specific Baseline Read
 
 After the mandatory set, read only the baselines relevant to the current topic.

--- a/docs/developer_agent_orchestration.md
+++ b/docs/developer_agent_orchestration.md
@@ -234,9 +234,15 @@ PYTHONPATH="$repo_root/control_plane" \
   --repo-root "$repo_root" ...
 ```
 
-`source_commit` in proposal metadata only constrains the evaluator checkout; it
-does not constrain which control-plane Python package imports are used when
-generating local DB manifests.
+Exact-generation-worktree rule:
+- when `source_commit` is declared for an L1/L2 item, generate the DB item from
+  a worktree whose `HEAD` exactly equals that commit
+- use the same worktree for both repo content reads and control-plane Python
+  imports
+- do not generate from checkout A while declaring `source_commit` from checkout
+  B
+- queue JSON import is only legitimate when the manifest carries proof that it
+  was generated from that exact declared tree
 
 After proposal metadata is committed, always rerun generation with
 `--no-update-proposal-files` so only evaluation requests are regenerated.

--- a/docs/developer_agent_orchestration.md
+++ b/docs/developer_agent_orchestration.md
@@ -237,6 +237,8 @@ PYTHONPATH="$repo_root/control_plane" \
 Exact-generation-worktree rule:
 - when `source_commit` is declared for an L1/L2 item, generate the DB item from
   a worktree whose `HEAD` exactly equals that commit
+- require `git status --porcelain` to be empty in that worktree, including
+  untracked files
 - use the same worktree for both repo content reads and control-plane Python
   imports
 - do not generate from checkout A while declaring `source_commit` from checkout


### PR DESCRIPTION
## Summary

- require L1/L2 generation from a clean worktree whose HEAD exactly matches the declared source commit
- require the resolved commit, including implicit HEAD, to be reachable from origin
- stamp versioned source-identity proof into generated manifests and validate it during queue import
- move proof generation after proposal updates so proposal mutation cannot create a falsely clean DB item
- document the required two-pass proposal generation workflow

## Root cause

A generator process could read code from one checkout while declaring a different evaluator source commit. That allowed stale command manifests, including the failed generic validation command in the CDC lane probe, to be queued under an apparently valid source requirement.

## Validation

- focused source identity/import/generator tests: 20 passed
- full queue importer + L1 + L2 suites: 351 passed; 6 pre-existing checked-in proposal fixture failures also reproduce on origin/master
- git diff --check: clean
