### PR TITLE
npu: add corrected exact-partial physical recost retry

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -7873,6 +7873,15 @@ def _decoder_attention_decode_score_multivalue_service_exact_partial_physical_re
     proposal_id: str | None = None,
     proposal_path: str | None = None,
 ) -> dict[str, Any]:
+    expected_item_id = (
+        "l2_decoder_attention_decode_score_multivalue_service_"
+        "exact_partial_physical_recost_10ns_12ns_v1_r1"
+    )
+    if str(item_id).strip() != expected_item_id:
+        raise Layer2TaskGenerationError(
+            "exact-partial physical recost only permits the immutable _r1 retry item; "
+            "the blocked v1 item must remain untouched"
+        )
     expected_proposal_id = (
         "prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1"
     )

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -7885,9 +7885,9 @@ def _decoder_attention_decode_score_multivalue_service_exact_partial_physical_re
         "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
         (
             "l2_decoder_attention_decode_score_multivalue_service_"
-            "finalized_cdc_lane_probe_10ns_12ns_v1"
+            "finalized_cdc_lane_probe_10ns_12ns_v1_r1"
         ),
-        "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1",
+        "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1",
     ]
     normalized_dependencies = [
         str(dependency).strip()

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -10292,7 +10292,7 @@ def test_generate_l2_campaign_task_adds_exact_partial_physical_recost_consumer()
         create_all(engine)
         item_id = (
             "l2_decoder_attention_decode_score_multivalue_service_"
-            "exact_partial_physical_recost_10ns_12ns_v1"
+            "exact_partial_physical_recost_10ns_12ns_v1_r1"
         )
         proposal_id = (
             "prop_l2_decoder_attention_decode_score_multivalue_service_"
@@ -10303,9 +10303,9 @@ def test_generate_l2_campaign_task_adds_exact_partial_physical_recost_consumer()
             "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
             (
                 "l2_decoder_attention_decode_score_multivalue_service_"
-                "finalized_cdc_lane_probe_10ns_12ns_v1"
+                "finalized_cdc_lane_probe_10ns_12ns_v1_r1"
             ),
-            "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1",
+            "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1",
         ]
 
         with Session(engine) as session:
@@ -10353,6 +10353,24 @@ def test_generate_l2_campaign_task_adds_exact_partial_physical_recost_consumer()
                 decoder_inputs["decode_score_multivalue_service_exact_partial_physical_recost_out"],
                 decoder_inputs["decode_score_multivalue_service_exact_partial_physical_recost_csv_out"],
             ]
+            assert decoder_inputs[
+                "decode_score_multivalue_service_exact_partial_physical_recost_physical_dependency_item_id"
+            ] == "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1"
+            assert decoder_inputs[
+                "decode_score_multivalue_service_exact_partial_physical_recost_functional_dependency_item_id"
+            ] == (
+                "l2_decoder_attention_decode_score_multivalue_service_"
+                "finalized_cdc_lane_probe_10ns_12ns_v1_r1"
+            )
+            assert decoder_inputs[
+                "decode_score_multivalue_service_exact_partial_physical_recost_workload_dependency_item_id"
+            ] == "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1"
+            assert decoder_inputs[
+                "decode_score_multivalue_service_exact_partial_physical_recost_out"
+            ].endswith("_v1_r1.json")
+            assert decoder_inputs[
+                "decode_score_multivalue_service_exact_partial_physical_recost_csv_out"
+            ].endswith("_v1_r1.csv")
             assert payload["developer_loop"]["dependencies"] == {
                 "item_ids": dependencies,
                 "requires_merged_inputs": True,
@@ -10383,7 +10401,7 @@ def test_exact_partial_physical_recost_consumer_rejects_missing_dependency() -> 
                     campaign_path=campaign_path,
                     item_id=(
                         "l2_decoder_attention_decode_score_multivalue_service_"
-                        "exact_partial_physical_recost_10ns_12ns_v1"
+                        "exact_partial_physical_recost_10ns_12ns_v1_r1"
                     ),
                     proposal_id=(
                         "prop_l2_decoder_attention_decode_score_multivalue_service_"

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -10427,6 +10427,58 @@ def test_exact_partial_physical_recost_consumer_rejects_missing_dependency() -> 
             )
 
 
+def test_exact_partial_physical_recost_consumer_rejects_obsolete_v1_item_id() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_committed_exact_partial_physical_recost_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        dependencies = [
+            "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
+            (
+                "l2_decoder_attention_decode_score_multivalue_service_"
+                "finalized_cdc_lane_probe_10ns_12ns_v1_r1"
+            ),
+            "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1",
+        ]
+
+        with Session(engine) as session, pytest.raises(
+            Layer2TaskGenerationError,
+            match="blocked v1 item must remain untouched",
+        ):
+            generate_l2_campaign_task(
+                session,
+                _make_l2_request(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=(
+                        "l2_decoder_attention_decode_score_multivalue_service_"
+                        "exact_partial_physical_recost_10ns_12ns_v1"
+                    ),
+                    proposal_id=(
+                        "prop_l2_decoder_attention_decode_score_multivalue_service_"
+                        "exact_partial_physical_recost_v1"
+                    ),
+                    proposal_path=(
+                        "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_"
+                        "exact_partial_physical_recost_v1/proposal.json"
+                    ),
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    abstraction_layer=(
+                        "decoder_attention_decode_score_multivalue_service_"
+                        "exact_partial_physical_recost"
+                    ),
+                    depends_on_item_ids=dependencies,
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+
 def test_generate_l2_campaign_task_adds_decode_score_multivalue_service_activity_power() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/evaluation_requests.json
@@ -1,12 +1,12 @@
 {
   "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1",
-  "source_commit_note": "After merge and after both dependency outputs are materialized, generate from current origin/master so source_requirement.required_sha pins the merged aggregate driver and consumer wiring. Do not dispatch this preparation branch.",
+  "source_commit_note": "Historical v1 remains blocked and must stay untouched. After merge and after all three corrected dependency outputs are materialized, generate only the fresh _r1 DB item from a clean exact-source worktree at the merge commit with proposal updates disabled so source_requirement.required_sha pins the merged aggregate driver and corrected dependency consumer wiring. Do not dispatch this preparation branch.",
   "requested_items": [
     {
-      "item_id": "l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1",
+      "item_id": "l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r1",
       "task_type": "l2_campaign",
-      "title": "Exact-partial composed-service 10 ns / 12 ns physical recost",
-      "objective": "Record one fail-closed aggregate report and four-row CSV for divider_lanes 1, 2, 4, and 8.",
+      "title": "Exact-partial composed-service 10 ns / 12 ns physical recost retry",
+      "objective": "Record one fail-closed aggregate report and four-row CSV for divider_lanes 1, 2, 4, and 8 using the corrected functional and workload retry materializations.",
       "status": "ready_to_queue_after_merge_and_dependencies",
       "evaluation_mode": "frontier_detail",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost",
@@ -14,19 +14,23 @@
       "cost_class": "lightweight",
       "depends_on_item_ids": [
         "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
-        "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1",
-        "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1"
+        "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r1",
+        "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "run_physical": false,
       "campaign_path": "runs/campaigns/npu/attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/campaign.json",
+      "revision": {
+        "reason": "replace_blocked_original_dependency_ids_with_materialized_retry_dependencies",
+        "preserve_blocked_item_id": "l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1"
+      },
       "expected_outputs": [
-        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost__l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1.json",
-        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost__l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1.csv"
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost__l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r1.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost__l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r1.csv"
       ],
-      "acceptance_notes": "Fail closed unless all three exact dependency items are satisfied and all four lane-matched 12 ns temporal bundles, hashed finalized-CDC probe summaries, and the passing 131k Llama7B workload-correspondence report are materialized. Require four rows ordered [1,2,4,8], source-domain single-FIFO accounting from the 10 ns row, the 12 ns destination diagnostic row, preserved overlap/serial timing bounds, conservative affine workload projections, and bounded provisional energy provenance. Emit no per-lane recost files.",
-      "notes": "Queue only from merged origin/master after dependency materialization. This preparation request must not be dispatched."
+      "acceptance_notes": "Fail closed unless all three exact dependency items are satisfied and all four lane-matched 12 ns temporal bundles, hashed finalized-CDC retry probe summaries, and the passing 131k Llama7B workload-correspondence retry report are materialized. Require four rows ordered [1,2,4,8], source-domain single-FIFO accounting from the 10 ns row, the 12 ns destination diagnostic row, preserved overlap/serial timing bounds, conservative affine workload projections, and bounded provisional energy provenance. Emit no per-lane recost files.",
+      "notes": "Queue only from merged origin/master after corrected dependency materialization. Generate the _r1 item only; preserve the blocked v1 item/history without mutation or requeue."
     }
   ]
 }

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/proposal.json
@@ -37,26 +37,35 @@
   },
   "required_evaluations": [
     {
-      "item_id": "l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1",
+      "item_id": "l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r1",
       "task_type": "l2_campaign",
-      "objective": "Record the fail-closed four-lane exact-partial composed-service physical recost at the selected 10 ns / 12 ns domain pair.",
+      "objective": "Record the fail-closed four-lane exact-partial composed-service physical recost retry at the selected 10 ns / 12 ns domain pair using the corrected functional and workload materializations.",
       "evaluation_mode": "frontier_detail",
       "abstraction_layer": "decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost",
       "comparison_role": "lane_matched_composed_physical_recost",
       "depends_on_item_ids": [
         "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
-        "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1",
-        "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1"
+        "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r1",
+        "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "run_physical": false,
-      "status": "pending_implementation_merge",
+      "revision": {
+        "reason": "replace_blocked_original_dependency_ids_with_materialized_retry_dependencies",
+        "preserve_blocked_item_id": "l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1",
+        "corrected_dependency_item_ids": [
+          "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
+          "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r1",
+          "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1"
+        ]
+      },
       "expected_result": {
         "direction": "record_bounded_exact_partial_composed_service_physical_recost",
-        "reason": "Preserve lane-matched functional cycle counts, conservative 131k Llama7B affine projections, single-FIFO accounting, additive standalone physical measurements, and bounded provisional energy provenance across all four divider-lane points."
+        "reason": "Preserve lane-matched functional cycle counts, conservative 131k Llama7B affine projections, single-FIFO accounting, additive standalone physical measurements, and bounded provisional energy provenance across all four divider-lane points while consuming the corrected finalized-CDC and workload retry artifacts only."
       },
-      "notes": "Generate only after this implementation and all three dependency outputs are merged/materialized on current origin/master. Do not dispatch, open a PR, or queue from this preparation branch."
+      "status": "pending_implementation_merge",
+      "notes": "Historical blocked v1 DB/run history remains authoritative for the obsolete request and must not be mutated or requeued. After this implementation merges, generate the fresh _r1 DB item only from a clean exact-source worktree at the merge commit with proposal updates disabled, and queue only after all three corrected dependency outputs are merged/materialized on current origin/master."
     }
   ],
   "source_refs": [

--- a/npu/eval/run_attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign.py
+++ b/npu/eval/run_attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign.py
@@ -27,15 +27,15 @@ AuditRunner = Callable[..., JsonDict]
 _CAMPAIGN_MODEL = "attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign_v1"
 _SUMMARY_MODEL = "attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign_summary_v1"
 _AUDIT_MODEL = "decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1"
-_CAMPAIGN_ID = "attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1"
+_CAMPAIGN_ID = "attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r1"
 _PROPOSAL_ID = "prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1"
 _PROPOSAL_PATH = f"docs/proposals/{_PROPOSAL_ID}/proposal.json"
 _PHYSICAL_DEPENDENCY = "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1"
 _FUNCTIONAL_DEPENDENCY = (
-    "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1"
+    "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r1"
 )
 _WORKLOAD_DEPENDENCY = (
-    "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1"
+    "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1"
 )
 _DEPENDENCIES = (_PHYSICAL_DEPENDENCY, _FUNCTIONAL_DEPENDENCY, _WORKLOAD_DEPENDENCY)
 _LANES = (1, 2, 4, 8)

--- a/runs/campaigns/npu/attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/campaign.json
+++ b/runs/campaigns/npu/attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/campaign.json
@@ -1,14 +1,14 @@
 {
   "model": "attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign_v1",
-  "campaign_id": "attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1",
+  "campaign_id": "attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r1",
   "proposal_ref": {
     "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1",
     "proposal_path": "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/proposal.json"
   },
   "depends_on_item_ids": [
     "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
-    "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1",
-    "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1"
+    "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r1",
+    "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1"
   ],
   "fixed_inputs": {
     "service_activity_power_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_activity_power__l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1_r8.json",
@@ -27,8 +27,8 @@
       "config_json": "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_destination_domain_physical/config.json",
       "macro_manifest_json": "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_destination_domain_physical/macro_manifest.json"
     },
-    "functional_probe_summary_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1/campaign_summary.json",
-    "workload_correspondence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_exact_partial_c1_workload_correspondence__l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1.json"
+    "functional_probe_summary_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r1/campaign_summary.json",
+    "workload_correspondence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_exact_partial_c1_workload_correspondence__l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1.json"
   },
   "points": [
     {
@@ -37,7 +37,7 @@
       "temporal_metrics_csv": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l1/metrics.csv",
       "temporal_config_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l1/config.json",
       "temporal_macro_manifest_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l1/macro_manifest.json",
-      "functional_probe_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1/lane1.json"
+      "functional_probe_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r1/lane1.json"
     },
     {
       "divider_lanes": 2,
@@ -45,7 +45,7 @@
       "temporal_metrics_csv": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l2/metrics.csv",
       "temporal_config_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l2/config.json",
       "temporal_macro_manifest_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l2/macro_manifest.json",
-      "functional_probe_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1/lane2.json"
+      "functional_probe_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r1/lane2.json"
     },
     {
       "divider_lanes": 4,
@@ -53,7 +53,7 @@
       "temporal_metrics_csv": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l4/metrics.csv",
       "temporal_config_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l4/config.json",
       "temporal_macro_manifest_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l4/macro_manifest.json",
-      "functional_probe_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1/lane4.json"
+      "functional_probe_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r1/lane4.json"
     },
     {
       "divider_lanes": 8,
@@ -61,14 +61,14 @@
       "temporal_metrics_csv": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l8/metrics.csv",
       "temporal_config_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l8/config.json",
       "temporal_macro_manifest_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l8/macro_manifest.json",
-      "functional_probe_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1/lane8.json"
+      "functional_probe_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r1/lane8.json"
     }
   ],
   "outputs": {
     "campaign_dir": "runs/campaigns/npu/attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/results",
     "results_csv": "runs/campaigns/npu/attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/results/results.csv",
     "report_md": "runs/campaigns/npu/attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/results/report.md",
-    "report_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost__l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1.json",
-    "rows_csv": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost__l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1.csv"
+    "report_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost__l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r1.json",
+    "rows_csv": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost__l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r1.csv"
   }
 }

--- a/tests/test_run_attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign.py
+++ b/tests/test_run_attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign.py
@@ -153,12 +153,27 @@ def test_committed_campaign_contract_requires_exact_dependencies() -> None:
     campaign = json.loads((REPO_ROOT / CAMPAIGN_REL).read_text(encoding="utf-8"))
     validated = _validate_campaign(campaign)
 
+    assert validated["campaign_id"] == (
+        "attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r1"
+    )
     assert [point["divider_lanes"] for point in validated["points"]] == [1, 2, 4, 8]
     assert validated["depends_on_item_ids"] == [
         "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
-        "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1",
-        "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1",
+        "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r1",
+        "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1",
     ]
+    assert validated["fixed_inputs"]["functional_probe_summary_json"].endswith(
+        "_finalized_cdc_lane_probe_10ns_12ns_v1_r1/campaign_summary.json"
+    )
+    assert validated["fixed_inputs"]["workload_correspondence_json"].endswith(
+        "_exact_partial_c1_workload_correspondence_llama7b_v1_r1.json"
+    )
+    assert validated["outputs"]["report_json"].endswith(
+        "_exact_partial_physical_recost_10ns_12ns_v1_r1.json"
+    )
+    assert validated["outputs"]["rows_csv"].endswith(
+        "_exact_partial_physical_recost_10ns_12ns_v1_r1.csv"
+    )
 
     campaign["depends_on_item_ids"].pop()
     with pytest.raises(ValueError, match="must require exactly"):


### PR DESCRIPTION
## Summary

- add immutable `_r1` recost wiring for the corrected physical, finalized-CDC probe, and workload-correspondence dependency items
- consume only retry artifact paths and emit separate `_v1_r1` JSON/CSV outputs
- preserve the blocked original v1 item as history and reject attempts to regenerate it through the new specialization
- keep DB generation merge-pending under the exact-source workflow

## Root cause

The original recost hardcoded failed/original functional and workload dependency IDs. Those items can never satisfy the dependency gate even after their corrected immutable retries merge.

## Validation

- focused L2 generator tests: 3 passed
- recost campaign contract/runner tests: 5 passed
- git diff --check: clean
