### PR TITLE
npu: model full-workload segmented-mesh scheduling

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/README.md
@@ -1,6 +1,6 @@
 # Score32 NoC Phase 2 Schedule
 
-This proposal introduces a bounded Phase 2 score32 NoC schedule report that:
+This proposal introduces a Phase 2 score32 NoC schedule report that:
 
 - consumes the existing Llama7B score32 recost artifact and measured L1 cost profile
 - materializes an explicit static 4x4 mesh mapping for shared-SRAM and root-reduction traffic

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/README.md
@@ -6,4 +6,4 @@ This proposal introduces a bounded Phase 2 score32 NoC schedule report that:
 - materializes an explicit static 4x4 mesh mapping for shared-SRAM and root-reduction traffic
 - uses the cycle-by-cycle multi-flow segmented mesh model instead of a one-flow bandwidth scalar
 
-The requested L2 job is intentionally lightweight: one simulated wave, no HBM/DRAM timing claim, and no DB insertion from this patch.
+The checked-in report generator now defaults to the full declared workload. A lightweight bounded run is still available, but only when `--wave-limit` is passed explicitly. The requested L2 job stays intentionally lightweight, with no HBM/DRAM timing claim and no DB insertion from this patch.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/README.md
@@ -1,0 +1,9 @@
+# Score32 NoC Phase 2 Schedule
+
+This proposal introduces a bounded Phase 2 score32 NoC schedule report that:
+
+- consumes the existing Llama7B score32 recost artifact and measured L1 cost profile
+- materializes an explicit static 4x4 mesh mapping for shared-SRAM and root-reduction traffic
+- uses the cycle-by-cycle multi-flow segmented mesh model instead of a one-flow bandwidth scalar
+
+The requested L2 job is intentionally lightweight: one simulated wave, no HBM/DRAM timing claim, and no DB insertion from this patch.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/evaluation_requests.json
@@ -1,0 +1,22 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_noc_phase2_schedule_v1",
+  "source_commit_note": "Replace with the merged commit that adds the Phase 2 multi-flow segmented-mesh simulator, the score32 schedule materializer, focused tests, and this proposal before dispatch.",
+  "items": [
+    {
+      "item_id": "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the bounded one-wave score32 segmented-mesh Phase 2 schedule materializer and record routed drain cycles, contention, and explicit assumptions.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_noc_phase2_schedule",
+      "cost_class": "low",
+      "comparison_role": "closure_detail",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": false,
+      "acceptance_notes": "Do not insert a DB task from this patch. This request is checked in only so the evaluator can dispatch it later from a merged source. The intended command is the bounded one-wave invocation of npu/eval/measure_llm_decoder_attention_score32_noc_phase2_schedule.py and it must preserve the no-HBM/DRAM claim.",
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use the bounded routed service summary to decide whether the next score32 composed rerank can replace the old NoC scalar or still needs a tighter SRAM-placement adapter."
+      }
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/evaluation_requests.json
@@ -5,17 +5,17 @@
     {
       "item_id": "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1",
       "task_type": "l2_campaign",
-      "objective": "Run the bounded one-wave score32 segmented-mesh Phase 2 schedule materializer and record routed drain cycles, contention, and explicit assumptions.",
+      "objective": "Run the score32 segmented-mesh Phase 2 schedule materializer and record routed drain cycles, contention, and explicit assumptions, defaulting to the full declared workload unless a bounded wave limit is passed explicitly.",
       "evaluation_mode": "frontier_detail",
       "abstraction_layer": "decoder_attention_score32_noc_phase2_schedule",
       "cost_class": "low",
       "comparison_role": "closure_detail",
       "requires_merged_inputs": true,
       "requires_materialized_refs": false,
-      "acceptance_notes": "Do not insert a DB task from this patch. This request is checked in only so the evaluator can dispatch it later from a merged source. The intended command is the bounded one-wave invocation of npu/eval/measure_llm_decoder_attention_score32_noc_phase2_schedule.py and it must preserve the no-HBM/DRAM claim.",
+      "acceptance_notes": "Do not insert a DB task from this patch. This request is checked in only so the evaluator can dispatch it later from a merged source. The default command should run the full declared workload; an explicit lightweight bounded dispatch may pass --wave-limit 1 when only a quick routed spot-check is desired. Every invocation must preserve the no-HBM/DRAM claim.",
       "expected_result": {
         "direction": "iterate",
-        "reason": "Use the bounded routed service summary to decide whether the next score32 composed rerank can replace the old NoC scalar or still needs a tighter SRAM-placement adapter."
+        "reason": "Use the routed service summary to decide whether the next score32 composed rerank can replace the old NoC scalar or still needs a tighter SRAM-placement adapter."
       }
     }
   ]

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/proposal.json
@@ -6,7 +6,7 @@
   "kind": "architecture",
   "abstraction_layer": "decoder_attention_score32_noc_phase2_schedule",
   "title": "Score32 segmented-mesh Phase 2 scheduling closure",
-  "hypothesis": "The existing Llama7B score32 producer/SRAM/local-reducer/root traffic artifacts can be restated as an explicit static 4x4 mesh schedule and simulated cycle by cycle, replacing the old one-flow NoC helper with a bounded routed service proof that still makes no HBM/DRAM claim.",
+  "hypothesis": "The existing Llama7B score32 producer/SRAM/local-reducer/root traffic artifacts can be restated as an explicit static 4x4 mesh schedule and simulated cycle by cycle, replacing the old one-flow NoC helper with a full-workload default routed service proof that still makes no HBM/DRAM claim.",
   "direct_comparison": {
     "primary_question": "When the checked-in score32 recost traffic quantities are mapped onto an explicit static 4x4 segmented mesh with 4 VCs and deterministic XY routing, what routed drain time, contention, and link pressure appear for the bounded one-wave schedule?",
     "include": [
@@ -36,7 +36,7 @@
     {
       "item_id": "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1",
       "task_type": "l2_campaign",
-      "objective": "Run the bounded one-wave score32 segmented-mesh Phase 2 schedule materializer and record routed drain cycles, contention, and explicit assumptions.",
+      "objective": "Run the score32 segmented-mesh Phase 2 schedule materializer and record routed drain cycles, contention, and explicit assumptions, defaulting to the full declared workload unless a bounded wave limit is passed explicitly.",
       "evaluation_mode": "frontier_detail",
       "abstraction_layer": "decoder_attention_score32_noc_phase2_schedule",
       "cost_class": "low",
@@ -45,7 +45,7 @@
       "requires_materialized_refs": false,
       "expected_result": {
         "direction": "iterate",
-        "reason": "Use the bounded routed service summary to decide whether the next score32 composed rerank can replace the old NoC scalar or still needs a tighter SRAM-placement adapter."
+        "reason": "Use the routed service summary to decide whether the next score32 composed rerank can replace the old NoC scalar or still needs a tighter SRAM-placement adapter."
       }
     }
   ],

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/proposal.json
@@ -1,0 +1,60 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_noc_phase2_schedule_v1",
+  "created_utc": "2026-08-10T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "abstraction_layer": "decoder_attention_score32_noc_phase2_schedule",
+  "title": "Score32 segmented-mesh Phase 2 scheduling closure",
+  "hypothesis": "The existing Llama7B score32 producer/SRAM/local-reducer/root traffic artifacts can be restated as an explicit static 4x4 mesh schedule and simulated cycle by cycle, replacing the old one-flow NoC helper with a bounded routed service proof that still makes no HBM/DRAM claim.",
+  "direct_comparison": {
+    "primary_question": "When the checked-in score32 recost traffic quantities are mapped onto an explicit static 4x4 segmented mesh with 4 VCs and deterministic XY routing, what routed drain time, contention, and link pressure appear for the bounded one-wave schedule?",
+    "include": [
+      "existing score32 exact-reduction recost artifact quantities",
+      "measured L1 local datapath and on-chip endpoint profile selection from the repo",
+      "static shared-SRAM home mapping and fixed root endpoint",
+      "cycle-by-cycle multi-flow 4x4 segmented mesh simulation"
+    ],
+    "exclude": [
+      "HBM/DRAM timing or controller behavior",
+      "dynamic routing or adaptive scheduling",
+      "new router RTL changes unless a proven bug is found"
+    ]
+  },
+  "expected_benefit": [
+    "removes the remaining one-flow NoC shortcut from the score32 path",
+    "makes every routed traffic assumption explicit and reviewable",
+    "creates a lightweight L2 closure point before wider composed score32 reranking"
+  ],
+  "risks": [
+    "the static shared-SRAM home mapping is still an adapter, not a measured SRAM placement",
+    "bounded one-wave schedule evidence should not be promoted into a full HBM-backed latency claim",
+    "command/control cadence remains inherited from the checked-in recost artifact"
+  ],
+  "needs_mapper_change": false,
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Run the bounded one-wave score32 segmented-mesh Phase 2 schedule materializer and record routed drain cycles, contention, and explicit assumptions.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_noc_phase2_schedule",
+      "cost_class": "low",
+      "comparison_role": "closure_detail",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": false,
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use the bounded routed service summary to decide whether the next score32 composed rerank can replace the old NoC scalar or still needs a tighter SRAM-placement adapter."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exact_reduction_recost__l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1.json",
+    "runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_all_measured_endpoint_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/sim/perf/noc_segmented_mesh.py",
+    "npu/eval/measure_llm_decoder_attention_score32_noc_phase2_schedule.py"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/proposal.json
@@ -8,7 +8,7 @@
   "title": "Score32 segmented-mesh Phase 2 scheduling closure",
   "hypothesis": "The existing Llama7B score32 producer/SRAM/local-reducer/root traffic artifacts can be restated as an explicit static 4x4 mesh schedule and simulated cycle by cycle, replacing the old one-flow NoC helper with a full-workload default routed service proof that still makes no HBM/DRAM claim.",
   "direct_comparison": {
-    "primary_question": "When the checked-in score32 recost traffic quantities are mapped onto an explicit static 4x4 segmented mesh with 4 VCs and deterministic XY routing, what routed drain time, contention, and link pressure appear for the bounded one-wave schedule?",
+    "primary_question": "When the full checked-in score32 recost traffic quantities are mapped onto an explicit static 4x4 segmented mesh with 4 VCs and deterministic XY routing, what routed drain time, contention, and link pressure appear across all declared waves?",
     "include": [
       "existing score32 exact-reduction recost artifact quantities",
       "measured L1 local datapath and on-chip endpoint profile selection from the repo",
@@ -28,7 +28,8 @@
   ],
   "risks": [
     "the static shared-SRAM home mapping is still an adapter, not a measured SRAM placement",
-    "bounded one-wave schedule evidence should not be promoted into a full HBM-backed latency claim",
+    "full on-chip routed schedule evidence must not be promoted into a full HBM-backed latency claim",
+    "release queues are logical zero-copy source descriptors backed by retained SRAM data; their control/storage implementation is not measured here",
     "command/control cadence remains inherited from the checked-in recost artifact"
   ],
   "needs_mapper_change": false,

--- a/npu/eval/measure_llm_decoder_attention_score32_noc_phase2_schedule.py
+++ b/npu/eval/measure_llm_decoder_attention_score32_noc_phase2_schedule.py
@@ -679,9 +679,11 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "HBM/DRAM timing is intentionally excluded; no remote traffic or timing claim is made for HBM service.",
             "Each packet carries up to packet_payload_bytes of payload and is segmented into 256-bit flits with no extra header flit modeled.",
             "The performance model does not perform packet reassembly; the checked artifact therefore fails closed unless 8-bit tag reuse is provably non-overlapping for each (source, destination, vc) tuple over packet lifetime intervals.",
+            "Per-endpoint release queues are logical zero-copy descriptors over payloads retained in source SRAM or reducer state, not physically costed flit FIFOs; endpoint packetizer/control storage remains outside this result.",
         ],
         "remaining_abstractions": [
             "The schedule uses static wave timing from checked-in recost quantities and does not yet prove end-to-end command/control RTL cadence.",
+            "The source-descriptor queues and producer backpressure/control needed to retain payloads until injection are not yet embodied or physically measured.",
             "Shared SRAM home placement is deterministic and explicit, but still a topology adapter rather than a measured SRAM floorplan.",
             "HBM/DRAM service and controller timing remain intentionally out of scope.",
             "Root-finalizer internal compute is not rerouted here; the mesh model stops at root ingress.",

--- a/npu/eval/measure_llm_decoder_attention_score32_noc_phase2_schedule.py
+++ b/npu/eval/measure_llm_decoder_attention_score32_noc_phase2_schedule.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Build a bounded Phase 2 routed NoC schedule from existing Llama7B score32 artifacts."""
+"""Build a Phase 2 routed NoC schedule from existing Llama7B score32 artifacts."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ import json
 import math
 import sys
 from collections import Counter
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -35,6 +36,22 @@ DEFAULT_MEASURED_L1_COSTS = Path(
 )
 
 
+@dataclass(frozen=True)
+class PacketSpec:
+    flow_name: str
+    packet_index: int
+    source: int
+    destination: int
+    vc: int
+    release_cycle: int
+    payload_bytes: int
+    data_seed: int
+
+    @property
+    def label(self) -> str:
+        return f"{self.flow_name}::p{self.packet_index}"
+
+
 def _load_json(path: Path) -> JsonDict:
     return json.loads(path.read_text(encoding="utf-8"))
 
@@ -50,6 +67,163 @@ def _int_list(value: str) -> list[int]:
     if not items:
         raise argparse.ArgumentTypeError("expected comma-separated integers")
     return items
+
+
+def _build_packet_specs(
+    *,
+    flow_name: str,
+    source: int,
+    destination: int,
+    payload_bytes: int,
+    vc: int,
+    release_cycle: int,
+    packet_payload_bytes: int,
+    data_seed_base: int,
+) -> list[PacketSpec]:
+    packet_count = _ceil_div(payload_bytes, packet_payload_bytes)
+    specs: list[PacketSpec] = []
+    remaining = payload_bytes
+    for packet_index in range(packet_count):
+        packet_bytes = min(packet_payload_bytes, remaining)
+        remaining -= packet_bytes
+        specs.append(
+            PacketSpec(
+                flow_name=flow_name,
+                packet_index=packet_index,
+                source=source,
+                destination=destination,
+                vc=vc,
+                release_cycle=release_cycle,
+                payload_bytes=packet_bytes,
+                data_seed=data_seed_base + packet_index,
+            )
+        )
+    return specs
+
+
+def _packetize_specs_with_wide_tags(specs: list[PacketSpec]) -> list[TrafficFlow]:
+    flows: list[TrafficFlow] = []
+    for ordinal, spec in enumerate(specs):
+        flows.append(
+            TrafficFlow(
+                name=spec.label,
+                source=spec.source,
+                destination=spec.destination,
+                payload_bytes=spec.payload_bytes,
+                vc=spec.vc,
+                release_cycle=spec.release_cycle,
+                packet_payload_bytes=spec.payload_bytes,
+                tag_base=ordinal,
+                data_seed=spec.data_seed,
+            )
+        )
+    return flows
+
+
+def _prove_ordered_tuple_stream(
+    *,
+    packet_specs: list[PacketSpec],
+    mesh_result: Any,
+) -> JsonDict:
+    expected_by_tuple: dict[tuple[int, int, int], list[PacketSpec]] = {}
+    for spec in packet_specs:
+        expected_by_tuple.setdefault((spec.source, spec.destination, spec.vc), []).append(spec)
+    for specs in expected_by_tuple.values():
+        specs.sort(key=lambda spec: (spec.release_cycle, spec.packet_index, spec.label))
+
+    deliveries_by_label: dict[str, list[Any]] = {}
+    tuple_delivery_labels: dict[tuple[int, int, int], list[str]] = {}
+    for delivery in mesh_result.deliveries:
+        deliveries_by_label.setdefault(delivery.flit.label, []).append(delivery)
+        tuple_key = (delivery.flit.source, delivery.flit.destination, delivery.flit.vc)
+        labels = tuple_delivery_labels.setdefault(tuple_key, [])
+        if not labels or labels[-1] != delivery.flit.label:
+            labels.append(delivery.flit.label)
+
+    tuple_summaries: list[JsonDict] = []
+    max_packet_flits = 0
+    for key, specs in sorted(expected_by_tuple.items()):
+        expected_labels = [spec.label for spec in specs]
+        observed_labels = tuple_delivery_labels.get(key, [])
+        last_release = -1
+        for spec in specs:
+            deliveries = deliveries_by_label.get(spec.label)
+            if not deliveries:
+                raise ValueError(f"missing delivery record for packet {spec.label}")
+            expected_fragments = list(range(len(deliveries)))
+            fragments = [delivery.flit.fragment for delivery in deliveries]
+            if fragments != expected_fragments:
+                raise ValueError(
+                    f"tuple stream fragment order violated for packet {spec.label}: "
+                    f"expected {expected_fragments}, observed {fragments}"
+                )
+            if [bool(delivery.flit.last) for delivery in deliveries[:-1]] != [False] * max(0, len(deliveries) - 1):
+                raise ValueError(f"packet {spec.label} asserted last before its final fragment")
+            if not deliveries[-1].flit.last:
+                raise ValueError(f"packet {spec.label} did not terminate with last=1")
+            if spec.release_cycle < last_release:
+                raise ValueError(f"packet release order is not monotonic for tuple {key}")
+            last_release = spec.release_cycle
+            max_packet_flits = max(max_packet_flits, len(deliveries))
+        if observed_labels != expected_labels:
+            raise ValueError(
+                f"tuple packet order violated for source={key[0]} destination={key[1]} vc={key[2]}: "
+                f"expected {expected_labels[:8]}..., observed {observed_labels[:8]}..."
+            )
+        tuple_summaries.append(
+            {
+                "source": key[0],
+                "destination": key[1],
+                "vc": key[2],
+                "packet_count": len(specs),
+                "max_packet_flits": max(len(deliveries_by_label[spec.label]) for spec in specs),
+                "min_packet_flits": min(len(deliveries_by_label[spec.label]) for spec in specs),
+            }
+        )
+    return {
+        "tuple_summaries": tuple_summaries,
+        "max_packet_flits": max_packet_flits,
+    }
+
+
+def _audit_8bit_tag_reuse(packet_specs: list[PacketSpec]) -> JsonDict:
+    by_tuple: dict[tuple[int, int, int], list[PacketSpec]] = {}
+    for spec in packet_specs:
+        by_tuple.setdefault((spec.source, spec.destination, spec.vc), []).append(spec)
+
+    tuple_summaries: list[JsonDict] = []
+    max_packets_per_tuple = 0
+    max_packets_tuple: tuple[int, int, int] | None = None
+    for key, specs in sorted(by_tuple.items()):
+        ordered = sorted(specs, key=lambda spec: (spec.release_cycle, spec.packet_index, spec.label))
+        packet_count = len(ordered)
+        unique_tags_used = min(256, packet_count)
+        tag_reuse_count = max(0, packet_count - unique_tags_used)
+        if packet_count > max_packets_per_tuple:
+            max_packets_per_tuple = packet_count
+            max_packets_tuple = key
+        tuple_summaries.append(
+            {
+                "source": key[0],
+                "destination": key[1],
+                "vc": key[2],
+                "packet_count": packet_count,
+                "unique_tags_used": unique_tags_used,
+                "tag_reuse_count": tag_reuse_count,
+                "concrete_tag_policy": "packet_sequence_index mod 256",
+            }
+        )
+    return {
+        "tuple_summaries": tuple_summaries,
+        "max_packets_per_tuple": max_packets_per_tuple,
+        "max_packets_tuple": {
+            "source": max_packets_tuple[0],
+            "destination": max_packets_tuple[1],
+            "vc": max_packets_tuple[2],
+        }
+        if max_packets_tuple is not None
+        else None,
+    }
 
 
 def _require_fields(payload: JsonDict, fields: list[str], *, label: str) -> None:
@@ -199,9 +373,12 @@ def build_report(args: argparse.Namespace) -> JsonDict:
     shared_tile_payload_bytes = int(math.ceil(full_tile_bytes * float(source_row["shared_byte_share"])))
     local_tile_payload_bytes = full_tile_bytes - shared_tile_payload_bytes
     tile_count = _ceil_div(sequence_length, tile_tokens)
-    wave_count = min(declared_tile_waves, args.wave_limit if args.wave_limit is not None else declared_tile_waves)
+    requested_wave_limit = args.wave_limit
+    wave_count = min(declared_tile_waves, requested_wave_limit if requested_wave_limit is not None else declared_tile_waves)
     if wave_count <= 0:
         raise ValueError("wave_limit must leave at least one simulated wave")
+    simulated_tiles = min(tile_count, wave_count * active_clusters)
+    coverage = "workload_complete" if wave_count == declared_tile_waves and simulated_tiles == tile_count else "bounded"
 
     mapping = _choose_home_mapping(
         cluster_endpoints,
@@ -219,12 +396,12 @@ def build_report(args: argparse.Namespace) -> JsonDict:
     tile_attention_cycles = int(source_row["tile_attention_cycles"])
     reduction_payload_bytes = int(source_row["partial_reduction_payload_bytes"])
 
-    flows: list[TrafficFlow] = []
+    packet_specs: list[PacketSpec] = []
     local_only_shared_bytes = 0
     local_only_reduction_bytes = 0
     remote_shared_hops: list[int] = []
     remote_reduction_hops: list[int] = []
-    flow_counter = 0
+    packet_seed_counter = 0
 
     for wave in range(wave_count):
         wave_tiles = min(active_clusters, max(0, tile_count - wave * active_clusters))
@@ -244,50 +421,49 @@ def build_report(args: argparse.Namespace) -> JsonDict:
                     local_only_shared_bytes += shared_tile_payload_bytes
                 else:
                     remote_shared_hops.append(_hop_count(home_endpoint, compute_endpoint))
-                    flows.append(
-                        TrafficFlow(
-                            name=f"shared_w{wave}_c{cluster_index}",
-                            source=home_endpoint,
-                            destination=compute_endpoint,
-                            payload_bytes=shared_tile_payload_bytes,
-                            vc=int(args.shared_vc),
-                            release_cycle=wave_start,
-                            packet_payload_bytes=packet_payload_bytes,
-                            tag_base=(flow_counter * 37) & 0xFF,
-                            data_seed=flow_counter,
-                        )
+                    new_specs = _build_packet_specs(
+                        flow_name=f"shared_w{wave}_c{cluster_index}",
+                        source=home_endpoint,
+                        destination=compute_endpoint,
+                        payload_bytes=shared_tile_payload_bytes,
+                        vc=int(args.shared_vc),
+                        release_cycle=wave_start,
+                        packet_payload_bytes=packet_payload_bytes,
+                        data_seed_base=packet_seed_counter,
                     )
-                    flow_counter += 1
+                    packet_specs.extend(new_specs)
+                    packet_seed_counter += len(new_specs)
             if reduction_payload_bytes > 0:
                 if compute_endpoint == root_endpoint:
                     local_only_reduction_bytes += reduction_payload_bytes
                 else:
                     remote_reduction_hops.append(_hop_count(compute_endpoint, root_endpoint))
-                    flows.append(
-                        TrafficFlow(
-                            name=f"reduction_w{wave}_c{cluster_index}",
-                            source=compute_endpoint,
-                            destination=root_endpoint,
-                            payload_bytes=reduction_payload_bytes,
-                            vc=int(args.reduction_vc),
-                            release_cycle=reduction_release,
-                            packet_payload_bytes=packet_payload_bytes,
-                            tag_base=(flow_counter * 37) & 0xFF,
-                            data_seed=flow_counter,
-                        )
+                    new_specs = _build_packet_specs(
+                        flow_name=f"reduction_w{wave}_c{cluster_index}",
+                        source=compute_endpoint,
+                        destination=root_endpoint,
+                        payload_bytes=reduction_payload_bytes,
+                        vc=int(args.reduction_vc),
+                        release_cycle=reduction_release,
+                        packet_payload_bytes=packet_payload_bytes,
+                        data_seed_base=packet_seed_counter,
                     )
-                    flow_counter += 1
+                    packet_specs.extend(new_specs)
+                    packet_seed_counter += len(new_specs)
 
-    scheduled_flits = [scheduled for flow in flows for scheduled in packetize_traffic_flow(flow)]
+    traffic_flows = _packetize_specs_with_wide_tags(packet_specs)
+    scheduled_flits = [scheduled for flow in traffic_flows for scheduled in packetize_traffic_flow(flow)]
     mesh_result = simulate_scheduled_flits(scheduled_flits, max_cycles=args.max_cycles)
-    flow_names = {flow.name for flow in flows}
+    flow_names = {spec.flow_name for spec in packet_specs}
     if not flow_names:
-        raise ValueError("bounded Phase 2 schedule produced no remote NoC traffic")
+        raise ValueError("Phase 2 schedule produced no remote NoC traffic")
+    tuple_stream_proof = _prove_ordered_tuple_stream(packet_specs=packet_specs, mesh_result=mesh_result)
+    tag_audit = _audit_8bit_tag_reuse(packet_specs)
 
     delivery_by_prefix = Counter()
     last_delivery_cycle_by_prefix: dict[str, int] = {}
     for delivery in mesh_result.deliveries:
-        prefix = delivery.flit.label.split("_", 1)[0]
+        prefix = delivery.flit.label.split("::", 1)[0].split("_", 1)[0]
         delivery_by_prefix[prefix] += 1
         last_delivery_cycle_by_prefix[prefix] = max(
             delivery.cycle,
@@ -307,10 +483,10 @@ def build_report(args: argparse.Namespace) -> JsonDict:
     )
 
     total_shared_remote_bytes = sum(
-        flow.payload_bytes for flow in flows if flow.name.startswith("shared_")
+        spec.payload_bytes for spec in packet_specs if spec.flow_name.startswith("shared_")
     )
     total_reduction_remote_bytes = sum(
-        flow.payload_bytes for flow in flows if flow.name.startswith("reduction_")
+        spec.payload_bytes for spec in packet_specs if spec.flow_name.startswith("reduction_")
     )
 
     payload = {
@@ -329,6 +505,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "tile_tokens": tile_tokens,
             "declared_tile_waves": declared_tile_waves,
             "simulated_wave_count": wave_count,
+            "coverage": coverage,
             "hidden_size": hidden_size,
             "attention_heads": attention_heads,
             "kv_heads": kv_heads,
@@ -347,7 +524,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "partial_reduction_payload_bytes": reduction_payload_bytes,
             "cross_tile_reduction_payload_bytes_declared": int(source_row["cross_tile_reduction_payload_bytes"]),
             "tile_count": tile_count,
-            "simulated_tiles": min(tile_count, wave_count * active_clusters),
+            "simulated_tiles": simulated_tiles,
         },
         "mapping": {
             "cluster_endpoints": cluster_endpoints,
@@ -364,6 +541,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "packet_payload_bytes": packet_payload_bytes,
             "shared_vc": int(args.shared_vc),
             "reduction_vc": int(args.reduction_vc),
+            "requested_wave_limit": requested_wave_limit,
             "qkv_cycles_before_wave0": qkv_cycles,
             "tile_attention_cycles_per_wave": tile_attention_cycles,
             "reduction_release_offset_cycles": tile_attention_cycles,
@@ -371,9 +549,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
         "simulation": {
             "cycles_to_drain": mesh_result.cycles,
             "scheduled_flit_count": len(scheduled_flits),
-            "scheduled_packet_count": sum(
-                _ceil_div(flow.payload_bytes, packet_payload_bytes) for flow in flows
-            ),
+            "scheduled_packet_count": len(packet_specs),
             "endpoint_injected_flit_count": mesh_result.endpoint_injected_flit_count,
             "delivered_flit_count": len(mesh_result.deliveries),
             "router_contention_cycles": router_contention_cycles,
@@ -409,9 +585,23 @@ def build_report(args: argparse.Namespace) -> JsonDict:
                 for (source, destination), count in link_usage.most_common(12)
             ],
         },
+        "tag_semantics": {
+            "tag_width_bits": 8,
+            "assignment_scope": "per (source, destination, vc) ordered packet stream",
+            "collision_free_reuse_invariant": "Packet identity is proven by ordered (source, destination, vc) stream boundaries plus the last bit; concrete 8-bit tags may therefore be reused within a tuple without introducing ambiguity in the modeled stream.",
+            "packet_identity_modeled_by_simulator": "source, destination, vc, label, packet-local fragment index, and last bit; 8-bit wire tags are audited after routing because the performance model does not perform packet reassembly.",
+            "ordered_tuple_stream_proven": True,
+            "ordered_tuple_stream_summary": tuple_stream_proof["tuple_summaries"],
+            "ordered_tuple_stream_max_packet_flits": tuple_stream_proof["max_packet_flits"],
+            "tuple_summaries": tag_audit["tuple_summaries"],
+            "max_packets_per_tuple": tag_audit["max_packets_per_tuple"],
+            "max_packets_tuple": tag_audit["max_packets_tuple"],
+        },
         "flow_summary": {
-            "remote_shared_flow_count": sum(1 for flow in flows if flow.name.startswith("shared_")),
-            "remote_reduction_flow_count": sum(1 for flow in flows if flow.name.startswith("reduction_")),
+            "remote_shared_flow_count": sum(1 for name in flow_names if name.startswith("shared_")),
+            "remote_reduction_flow_count": sum(1 for name in flow_names if name.startswith("reduction_")),
+            "remote_shared_packet_count": sum(1 for spec in packet_specs if spec.flow_name.startswith("shared_")),
+            "remote_reduction_packet_count": sum(1 for spec in packet_specs if spec.flow_name.startswith("reduction_")),
             "remote_shared_bytes": total_shared_remote_bytes,
             "remote_reduction_bytes": total_reduction_remote_bytes,
             "local_only_shared_bytes": local_only_shared_bytes,
@@ -427,6 +617,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "Wave start and reduction release times are derived from the checked-in score32 recost quantities qkv_cycles and tile_attention_cycles only.",
             "HBM/DRAM timing is intentionally excluded; no remote traffic or timing claim is made for HBM service.",
             "Each packet carries up to packet_payload_bytes of payload and is segmented into 256-bit flits with no extra header flit modeled.",
+            "The performance model does not perform packet reassembly; the checked artifact therefore fails closed unless 8-bit tag reuse is provably non-overlapping for each (source, destination, vc) tuple over packet lifetime intervals.",
         ],
         "remaining_abstractions": [
             "The schedule uses static wave timing from checked-in recost quantities and does not yet prove end-to-end command/control RTL cadence.",
@@ -447,6 +638,7 @@ def write_report(payload: JsonDict, report: Path) -> None:
         f"- source recost: `{payload['source_artifacts']['score32_recost_json']}`",
         f"- measured L1 cost file: `{payload['source_artifacts']['measured_l1_costs_json']}`",
         f"- measured L1 profile: `{payload['source_artifacts']['measured_l1_profile']}`",
+        f"- coverage: `{payload['source_contract']['coverage']}`",
         f"- declared waves: `{payload['source_contract']['declared_tile_waves']}`",
         f"- simulated waves: `{payload['source_contract']['simulated_wave_count']}`",
         "",
@@ -468,10 +660,17 @@ def write_report(payload: JsonDict, report: Path) -> None:
         "## Routed Result",
         "",
         f"- drain cycles: `{payload['simulation']['cycles_to_drain']}`",
+        f"- scheduled packets: `{payload['simulation']['scheduled_packet_count']}`",
         f"- scheduled flits: `{payload['simulation']['scheduled_flit_count']}`",
         f"- contention cycles: `{payload['simulation']['router_contention_cycles']}`",
         f"- max router input occupancy: `{payload['simulation']['max_router_input_occupancy']}`",
         f"- total endpoint input stall cycles: `{payload['simulation']['endpoint_input_stall_cycles_total']}`",
+        "",
+        "## Tag Semantics",
+        "",
+        f"- 8-bit tag reuse invariant: `{payload['tag_semantics']['collision_free_reuse_invariant']}`",
+        f"- ordered tuple stream proven: `{payload['tag_semantics']['ordered_tuple_stream_proven']}`",
+        f"- max packets per tuple: `{payload['tag_semantics']['max_packets_per_tuple']}`",
         "",
         "## Assumptions",
         "",
@@ -498,7 +697,7 @@ def main() -> int:
     parser.add_argument("--measured-l1-costs", type=Path, default=DEFAULT_MEASURED_L1_COSTS)
     parser.add_argument("--out", required=True, type=Path)
     parser.add_argument("--report", required=True, type=Path)
-    parser.add_argument("--wave-limit", type=int, default=1)
+    parser.add_argument("--wave-limit", type=int, default=None)
     parser.add_argument("--packet-payload-bytes", type=int, default=256)
     parser.add_argument("--cluster-endpoints", type=_int_list, default=None)
     parser.add_argument("--root-endpoint", type=int, default=15)

--- a/npu/eval/measure_llm_decoder_attention_score32_noc_phase2_schedule.py
+++ b/npu/eval/measure_llm_decoder_attention_score32_noc_phase2_schedule.py
@@ -120,6 +120,10 @@ def _packetize_specs_with_wide_tags(specs: list[PacketSpec]) -> list[TrafficFlow
     return flows
 
 
+def _packet_flit_count(payload_bytes: int) -> int:
+    return _ceil_div(payload_bytes, 32)
+
+
 def _prove_ordered_tuple_stream(
     *,
     packet_specs: list[PacketSpec],
@@ -131,6 +135,11 @@ def _prove_ordered_tuple_stream(
     for specs in expected_by_tuple.values():
         specs.sort(key=lambda spec: (spec.release_cycle, spec.packet_index, spec.label))
 
+    injected_by_label: dict[str, list[tuple[int, Any]]] = {}
+    for trace in mesh_result.traces:
+        for _, flit in trace.injected:
+            injected_by_label.setdefault(flit.label, []).append((trace.cycle, flit))
+
     deliveries_by_label: dict[str, list[Any]] = {}
     tuple_delivery_labels: dict[tuple[int, int, int], list[str]] = {}
     for delivery in mesh_result.deliveries:
@@ -140,6 +149,7 @@ def _prove_ordered_tuple_stream(
         if not labels or labels[-1] != delivery.flit.label:
             labels.append(delivery.flit.label)
 
+    packet_windows: dict[str, JsonDict] = {}
     tuple_summaries: list[JsonDict] = []
     max_packet_flits = 0
     for key, specs in sorted(expected_by_tuple.items()):
@@ -147,15 +157,25 @@ def _prove_ordered_tuple_stream(
         observed_labels = tuple_delivery_labels.get(key, [])
         last_release = -1
         for spec in specs:
+            injections = injected_by_label.get(spec.label)
             deliveries = deliveries_by_label.get(spec.label)
+            if not injections:
+                raise ValueError(f"missing injection record for packet {spec.label}")
             if not deliveries:
                 raise ValueError(f"missing delivery record for packet {spec.label}")
-            expected_fragments = list(range(len(deliveries)))
-            fragments = [delivery.flit.fragment for delivery in deliveries]
-            if fragments != expected_fragments:
+            expected_flits = _packet_flit_count(spec.payload_bytes)
+            expected_fragments = list(range(expected_flits))
+            injected_fragments = [flit.fragment for _, flit in injections]
+            if injected_fragments != expected_fragments:
+                raise ValueError(
+                    f"tuple stream injection fragment order violated for packet {spec.label}: "
+                    f"expected {expected_fragments}, observed {injected_fragments}"
+                )
+            delivered_fragments = [delivery.flit.fragment for delivery in deliveries]
+            if delivered_fragments != expected_fragments:
                 raise ValueError(
                     f"tuple stream fragment order violated for packet {spec.label}: "
-                    f"expected {expected_fragments}, observed {fragments}"
+                    f"expected {expected_fragments}, observed {delivered_fragments}"
                 )
             if [bool(delivery.flit.last) for delivery in deliveries[:-1]] != [False] * max(0, len(deliveries) - 1):
                 raise ValueError(f"packet {spec.label} asserted last before its final fragment")
@@ -165,6 +185,16 @@ def _prove_ordered_tuple_stream(
                 raise ValueError(f"packet release order is not monotonic for tuple {key}")
             last_release = spec.release_cycle
             max_packet_flits = max(max_packet_flits, len(deliveries))
+            packet_windows[spec.label] = {
+                "source": spec.source,
+                "destination": spec.destination,
+                "vc": spec.vc,
+                "injection_first_cycle": injections[0][0],
+                "injection_last_cycle": injections[-1][0],
+                "delivery_first_cycle": deliveries[0].cycle,
+                "delivery_last_cycle": deliveries[-1].cycle,
+                "flit_count": expected_flits,
+            }
         if observed_labels != expected_labels:
             raise ValueError(
                 f"tuple packet order violated for source={key[0]} destination={key[1]} vc={key[2]}: "
@@ -181,12 +211,13 @@ def _prove_ordered_tuple_stream(
             }
         )
     return {
+        "packet_windows": packet_windows,
         "tuple_summaries": tuple_summaries,
         "max_packet_flits": max_packet_flits,
     }
 
 
-def _audit_8bit_tag_reuse(packet_specs: list[PacketSpec]) -> JsonDict:
+def _audit_8bit_tag_reuse(*, packet_specs: list[PacketSpec], packet_windows: dict[str, JsonDict]) -> JsonDict:
     by_tuple: dict[tuple[int, int, int], list[PacketSpec]] = {}
     for spec in packet_specs:
         by_tuple.setdefault((spec.source, spec.destination, spec.vc), []).append(spec)
@@ -199,6 +230,30 @@ def _audit_8bit_tag_reuse(packet_specs: list[PacketSpec]) -> JsonDict:
         packet_count = len(ordered)
         unique_tags_used = min(256, packet_count)
         tag_reuse_count = max(0, packet_count - unique_tags_used)
+        overlap_checked_count = 0
+        min_nonoverlap_gap_cycles: int | None = None
+        prior_by_tag: dict[int, JsonDict] = {}
+        for tuple_packet_sequence_index, spec in enumerate(ordered):
+            low_tag = tuple_packet_sequence_index % 256
+            window = packet_windows.get(spec.label)
+            if window is None:
+                raise ValueError(f"missing packet timing window for packet {spec.label}")
+            prior = prior_by_tag.get(low_tag)
+            if prior is not None:
+                overlap_checked_count += 1
+                if window["injection_first_cycle"] <= prior["delivery_last_cycle"]:
+                    raise ValueError(
+                        "8-bit tag reuse lifetime overlap for "
+                        f"source={key[0]} destination={key[1]} vc={key[2]} tag={low_tag}: "
+                        f"prior delivery_last_cycle={prior['delivery_last_cycle']}, "
+                        f"next injection_first_cycle={window['injection_first_cycle']}"
+                    )
+                gap_cycles = int(window["injection_first_cycle"] - prior["delivery_last_cycle"])
+                if min_nonoverlap_gap_cycles is None or gap_cycles < min_nonoverlap_gap_cycles:
+                    min_nonoverlap_gap_cycles = gap_cycles
+            prior_by_tag[low_tag] = {
+                "delivery_last_cycle": int(window["delivery_last_cycle"]),
+            }
         if packet_count > max_packets_per_tuple:
             max_packets_per_tuple = packet_count
             max_packets_tuple = key
@@ -210,6 +265,8 @@ def _audit_8bit_tag_reuse(packet_specs: list[PacketSpec]) -> JsonDict:
                 "packet_count": packet_count,
                 "unique_tags_used": unique_tags_used,
                 "tag_reuse_count": tag_reuse_count,
+                "overlap_checked_count": overlap_checked_count,
+                "min_nonoverlap_gap_cycles": min_nonoverlap_gap_cycles,
                 "concrete_tag_policy": "packet_sequence_index mod 256",
             }
         )
@@ -458,7 +515,10 @@ def build_report(args: argparse.Namespace) -> JsonDict:
     if not flow_names:
         raise ValueError("Phase 2 schedule produced no remote NoC traffic")
     tuple_stream_proof = _prove_ordered_tuple_stream(packet_specs=packet_specs, mesh_result=mesh_result)
-    tag_audit = _audit_8bit_tag_reuse(packet_specs)
+    tag_audit = _audit_8bit_tag_reuse(
+        packet_specs=packet_specs,
+        packet_windows=tuple_stream_proof["packet_windows"],
+    )
 
     delivery_by_prefix = Counter()
     last_delivery_cycle_by_prefix: dict[str, int] = {}
@@ -588,8 +648,9 @@ def build_report(args: argparse.Namespace) -> JsonDict:
         "tag_semantics": {
             "tag_width_bits": 8,
             "assignment_scope": "per (source, destination, vc) ordered packet stream",
-            "collision_free_reuse_invariant": "Packet identity is proven by ordered (source, destination, vc) stream boundaries plus the last bit; concrete 8-bit tags may therefore be reused within a tuple without introducing ambiguity in the modeled stream.",
-            "packet_identity_modeled_by_simulator": "source, destination, vc, label, packet-local fragment index, and last bit; 8-bit wire tags are audited after routing because the performance model does not perform packet reassembly.",
+            "collision_free_reuse_proven": True,
+            "collision_free_reuse_invariant": "Concrete low_tag = tuple packet sequence index mod 256. For every reused (source, destination, vc, low_tag), the next packet's first injection cycle is strictly greater than the prior packet's last delivery cycle; same-cycle reuse is treated as ambiguous and rejected.",
+            "packet_identity_modeled_by_simulator": "source, destination, vc, label, packet-local fragment index, and last bit; 8-bit wire tags are audited after routing because the performance model does not perform packet reassembly or claim standalone reassembly correctness.",
             "ordered_tuple_stream_proven": True,
             "ordered_tuple_stream_summary": tuple_stream_proof["tuple_summaries"],
             "ordered_tuple_stream_max_packet_flits": tuple_stream_proof["max_packet_flits"],
@@ -668,6 +729,7 @@ def write_report(payload: JsonDict, report: Path) -> None:
         "",
         "## Tag Semantics",
         "",
+        f"- collision-free reuse proven: `{payload['tag_semantics']['collision_free_reuse_proven']}`",
         f"- 8-bit tag reuse invariant: `{payload['tag_semantics']['collision_free_reuse_invariant']}`",
         f"- ordered tuple stream proven: `{payload['tag_semantics']['ordered_tuple_stream_proven']}`",
         f"- max packets per tuple: `{payload['tag_semantics']['max_packets_per_tuple']}`",

--- a/npu/eval/measure_llm_decoder_attention_score32_noc_phase2_schedule.py
+++ b/npu/eval/measure_llm_decoder_attention_score32_noc_phase2_schedule.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+"""Build a bounded Phase 2 routed NoC schedule from existing Llama7B score32 artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from npu.sim.perf.noc_segmented_mesh import (  # noqa: E402
+    TrafficFlow,
+    coordinates,
+    deterministic_xy_path,
+    packetize_traffic_flow,
+    simulate_scheduled_flits,
+)
+
+JsonDict = dict[str, Any]
+
+DEFAULT_SOURCE_JSON = Path(
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+    "decoder_attention_score32_exact_reduction_recost__"
+    "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1.json"
+)
+DEFAULT_MEASURED_L1_COSTS = Path(
+    "runs/campaigns/npu/l1_measured_costs/llama7b_attention_local_costs_all_measured_endpoint_v1.json"
+)
+
+
+def _load_json(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _ceil_div(numerator: int | float, denominator: int | float) -> int:
+    if float(numerator) <= 0.0:
+        return 0
+    return int(math.ceil(float(numerator) / float(denominator)))
+
+
+def _int_list(value: str) -> list[int]:
+    items = [int(item.strip()) for item in value.split(",") if item.strip()]
+    if not items:
+        raise argparse.ArgumentTypeError("expected comma-separated integers")
+    return items
+
+
+def _require_fields(payload: JsonDict, fields: list[str], *, label: str) -> None:
+    missing = [field for field in fields if field not in payload]
+    if missing:
+        raise ValueError(f"{label} is missing required quantities: {', '.join(missing)}")
+
+
+def _profile_by_name(costs_payload: JsonDict, name: str) -> JsonDict:
+    profiles = costs_payload.get("profiles")
+    if not isinstance(profiles, list):
+        raise ValueError("measured L1 cost payload must provide a profiles list")
+    for profile in profiles:
+        if isinstance(profile, dict) and str(profile.get("name")) == name:
+            return profile
+    raise ValueError(f"measured L1 cost payload does not contain profile {name!r}")
+
+
+def _hop_count(source: int, destination: int) -> int:
+    return len(deterministic_xy_path(source, destination)) - 1
+
+
+def _format_endpoint(node: int) -> str:
+    x_coord, y_coord = coordinates(node)
+    return f"{node}({x_coord},{y_coord})"
+
+
+def _choose_home_mapping(
+    cluster_endpoints: list[int],
+    *,
+    wave_count: int,
+    tile_count: int,
+    active_clusters: int,
+    declared_noc_hops: int,
+) -> JsonDict:
+    target_average = max(1.0, declared_noc_hops / 2.0)
+    best_choice: JsonDict | None = None
+    count = len(cluster_endpoints)
+    for stride in range(1, count):
+        if math.gcd(stride, count) != 1:
+            continue
+        for offset in range(count):
+            loads = Counter()
+            remote_hops: list[int] = []
+            total_hops = 0
+            remote_tiles = 0
+            for wave in range(wave_count):
+                wave_tiles = min(active_clusters, max(0, tile_count - wave * active_clusters))
+                for cluster_index in range(wave_tiles):
+                    compute = cluster_endpoints[cluster_index]
+                    home = cluster_endpoints[(cluster_index + offset + ((wave + 1) * stride)) % count]
+                    loads[home] += 1
+                    hops = _hop_count(home, compute)
+                    total_hops += hops
+                    if home != compute:
+                        remote_tiles += 1
+                        remote_hops.append(hops)
+            if remote_tiles == 0:
+                continue
+            average_remote_hops = sum(remote_hops) / len(remote_hops)
+            score = (
+                abs(max(remote_hops) - declared_noc_hops),
+                abs(average_remote_hops - target_average),
+                max(loads.values()) - min(loads.values()),
+                offset,
+                stride,
+            )
+            choice = {
+                "offset": offset,
+                "stride": stride,
+                "average_remote_hops": round(average_remote_hops, 6),
+                "worst_remote_hops": max(remote_hops),
+                "remote_tile_count": remote_tiles,
+                "per_home_tile_count": dict(sorted(loads.items())),
+                "score": score,
+            }
+            if best_choice is None or score < best_choice["score"]:
+                best_choice = choice
+    if best_choice is None:
+        raise ValueError("failed to construct a deterministic shared-SRAM home mapping")
+    return best_choice
+
+
+def _home_endpoint(cluster_endpoints: list[int], *, cluster_index: int, wave: int, offset: int, stride: int) -> int:
+    return cluster_endpoints[(cluster_index + offset + ((wave + 1) * stride)) % len(cluster_endpoints)]
+
+
+def build_report(args: argparse.Namespace) -> JsonDict:
+    repo_root = args.repo_root.resolve()
+    source_json = repo_root / args.source_json
+    costs_json = repo_root / args.measured_l1_costs
+    source_payload = _load_json(source_json)
+    source_row = source_payload.get("best_requested")
+    if not isinstance(source_row, dict):
+        raise ValueError("source recost payload is missing best_requested")
+    _require_fields(
+        source_row,
+        [
+            "active_clusters",
+            "cluster_count",
+            "sequence_length",
+            "tile_tokens",
+            "tile_waves",
+            "hidden_size",
+            "attention_heads",
+            "kv_heads",
+            "kv_bits",
+            "shared_byte_share",
+            "partial_reduction_payload_bytes",
+            "cross_tile_reduction_payload_bytes",
+            "tile_attention_cycles",
+            "qkv_cycles",
+            "noc_hops",
+            "measured_l1_profile",
+        ],
+        label="source best_requested",
+    )
+    costs_payload = _load_json(costs_json)
+    measured_profile = _profile_by_name(costs_payload, str(source_row["measured_l1_profile"]))
+
+    active_clusters = int(source_row["active_clusters"])
+    cluster_count = int(source_row["cluster_count"])
+    if active_clusters <= 0 or active_clusters > 16 or cluster_count > 16:
+        raise ValueError("Phase 2 scheduler only supports up to the 4x4 mesh envelope")
+
+    cluster_endpoints = list(args.cluster_endpoints or list(range(active_clusters)))
+    if len(cluster_endpoints) < active_clusters:
+        raise ValueError("cluster_endpoints must name at least active_clusters endpoints")
+    cluster_endpoints = cluster_endpoints[:active_clusters]
+    if len(set(cluster_endpoints)) != len(cluster_endpoints):
+        raise ValueError("cluster_endpoints must be unique")
+    if any(endpoint < 0 or endpoint >= 16 for endpoint in cluster_endpoints):
+        raise ValueError("cluster_endpoints must be mesh endpoints in [0, 15]")
+    root_endpoint = int(args.root_endpoint)
+    if root_endpoint < 0 or root_endpoint >= 16:
+        raise ValueError("root_endpoint must be in [0, 15]")
+
+    hidden_size = int(source_row["hidden_size"])
+    attention_heads = int(source_row["attention_heads"])
+    kv_heads = int(source_row["kv_heads"])
+    kv_bits = int(source_row["kv_bits"])
+    tile_tokens = int(source_row["tile_tokens"])
+    sequence_length = int(source_row["sequence_length"])
+    declared_tile_waves = int(source_row["tile_waves"])
+    head_dim = hidden_size // attention_heads
+    full_tile_bytes = int(2 * tile_tokens * kv_heads * head_dim * kv_bits / 8)
+    shared_tile_payload_bytes = int(math.ceil(full_tile_bytes * float(source_row["shared_byte_share"])))
+    local_tile_payload_bytes = full_tile_bytes - shared_tile_payload_bytes
+    tile_count = _ceil_div(sequence_length, tile_tokens)
+    wave_count = min(declared_tile_waves, args.wave_limit if args.wave_limit is not None else declared_tile_waves)
+    if wave_count <= 0:
+        raise ValueError("wave_limit must leave at least one simulated wave")
+
+    mapping = _choose_home_mapping(
+        cluster_endpoints,
+        wave_count=wave_count,
+        tile_count=tile_count,
+        active_clusters=active_clusters,
+        declared_noc_hops=int(source_row["noc_hops"]),
+    )
+
+    packet_payload_bytes = int(args.packet_payload_bytes)
+    if packet_payload_bytes <= 0 or packet_payload_bytes > 256:
+        raise ValueError("packet_payload_bytes must be in [1, 256]")
+
+    qkv_cycles = int(source_row["qkv_cycles"])
+    tile_attention_cycles = int(source_row["tile_attention_cycles"])
+    reduction_payload_bytes = int(source_row["partial_reduction_payload_bytes"])
+
+    flows: list[TrafficFlow] = []
+    local_only_shared_bytes = 0
+    local_only_reduction_bytes = 0
+    remote_shared_hops: list[int] = []
+    remote_reduction_hops: list[int] = []
+    flow_counter = 0
+
+    for wave in range(wave_count):
+        wave_tiles = min(active_clusters, max(0, tile_count - wave * active_clusters))
+        wave_start = qkv_cycles + (wave * tile_attention_cycles)
+        reduction_release = wave_start + tile_attention_cycles
+        for cluster_index in range(wave_tiles):
+            compute_endpoint = cluster_endpoints[cluster_index]
+            home_endpoint = _home_endpoint(
+                cluster_endpoints,
+                cluster_index=cluster_index,
+                wave=wave,
+                offset=int(mapping["offset"]),
+                stride=int(mapping["stride"]),
+            )
+            if shared_tile_payload_bytes > 0:
+                if home_endpoint == compute_endpoint:
+                    local_only_shared_bytes += shared_tile_payload_bytes
+                else:
+                    remote_shared_hops.append(_hop_count(home_endpoint, compute_endpoint))
+                    flows.append(
+                        TrafficFlow(
+                            name=f"shared_w{wave}_c{cluster_index}",
+                            source=home_endpoint,
+                            destination=compute_endpoint,
+                            payload_bytes=shared_tile_payload_bytes,
+                            vc=int(args.shared_vc),
+                            release_cycle=wave_start,
+                            packet_payload_bytes=packet_payload_bytes,
+                            tag_base=(flow_counter * 37) & 0xFF,
+                            data_seed=flow_counter,
+                        )
+                    )
+                    flow_counter += 1
+            if reduction_payload_bytes > 0:
+                if compute_endpoint == root_endpoint:
+                    local_only_reduction_bytes += reduction_payload_bytes
+                else:
+                    remote_reduction_hops.append(_hop_count(compute_endpoint, root_endpoint))
+                    flows.append(
+                        TrafficFlow(
+                            name=f"reduction_w{wave}_c{cluster_index}",
+                            source=compute_endpoint,
+                            destination=root_endpoint,
+                            payload_bytes=reduction_payload_bytes,
+                            vc=int(args.reduction_vc),
+                            release_cycle=reduction_release,
+                            packet_payload_bytes=packet_payload_bytes,
+                            tag_base=(flow_counter * 37) & 0xFF,
+                            data_seed=flow_counter,
+                        )
+                    )
+                    flow_counter += 1
+
+    scheduled_flits = [scheduled for flow in flows for scheduled in packetize_traffic_flow(flow)]
+    mesh_result = simulate_scheduled_flits(scheduled_flits, max_cycles=args.max_cycles)
+    flow_names = {flow.name for flow in flows}
+    if not flow_names:
+        raise ValueError("bounded Phase 2 schedule produced no remote NoC traffic")
+
+    delivery_by_prefix = Counter()
+    last_delivery_cycle_by_prefix: dict[str, int] = {}
+    for delivery in mesh_result.deliveries:
+        prefix = delivery.flit.label.split("_", 1)[0]
+        delivery_by_prefix[prefix] += 1
+        last_delivery_cycle_by_prefix[prefix] = max(
+            delivery.cycle,
+            last_delivery_cycle_by_prefix.get(prefix, -1),
+        )
+
+    link_usage = Counter(
+        (transfer.source_node, transfer.destination_node) for transfer in mesh_result.link_transfers
+    )
+    router_contention_cycles = sum(
+        1
+        for trace in mesh_result.traces
+        if any(router_trace.contention for router_trace in trace.router_traces)
+    )
+    max_router_input_occupancy = max(
+        summary.max_input_occupancy for summary in mesh_result.router_summaries
+    )
+
+    total_shared_remote_bytes = sum(
+        flow.payload_bytes for flow in flows if flow.name.startswith("shared_")
+    )
+    total_reduction_remote_bytes = sum(
+        flow.payload_bytes for flow in flows if flow.name.startswith("reduction_")
+    )
+
+    payload = {
+        "version": 1,
+        "model": "llama7b_proxy",
+        "profile": "decoder_attention_score32_noc_phase2_schedule",
+        "source_artifacts": {
+            "score32_recost_json": str(args.source_json),
+            "measured_l1_costs_json": str(args.measured_l1_costs),
+            "measured_l1_profile": measured_profile["name"],
+        },
+        "source_contract": {
+            "active_clusters": active_clusters,
+            "cluster_count": cluster_count,
+            "sequence_length": sequence_length,
+            "tile_tokens": tile_tokens,
+            "declared_tile_waves": declared_tile_waves,
+            "simulated_wave_count": wave_count,
+            "hidden_size": hidden_size,
+            "attention_heads": attention_heads,
+            "kv_heads": kv_heads,
+            "kv_bits": kv_bits,
+            "shared_byte_share": float(source_row["shared_byte_share"]),
+            "declared_cross_tile_reduction_cycles": int(source_row["cross_tile_reduction_cycles"]),
+            "declared_noc_hops": int(source_row["noc_hops"]),
+            "topology": source_row.get("topology"),
+            "scheduler_policy": source_row.get("scheduler_policy"),
+            "reduction_strategy": source_row.get("reduction_strategy"),
+        },
+        "traffic_quantities": {
+            "full_tile_bytes": full_tile_bytes,
+            "shared_tile_payload_bytes": shared_tile_payload_bytes,
+            "local_tile_payload_bytes": local_tile_payload_bytes,
+            "partial_reduction_payload_bytes": reduction_payload_bytes,
+            "cross_tile_reduction_payload_bytes_declared": int(source_row["cross_tile_reduction_payload_bytes"]),
+            "tile_count": tile_count,
+            "simulated_tiles": min(tile_count, wave_count * active_clusters),
+        },
+        "mapping": {
+            "cluster_endpoints": cluster_endpoints,
+            "cluster_endpoint_labels": [_format_endpoint(endpoint) for endpoint in cluster_endpoints],
+            "root_endpoint": root_endpoint,
+            "root_endpoint_label": _format_endpoint(root_endpoint),
+            "shared_sram_home_offset": mapping["offset"],
+            "shared_sram_home_stride": mapping["stride"],
+            "shared_sram_average_remote_hops": mapping["average_remote_hops"],
+            "shared_sram_worst_remote_hops": mapping["worst_remote_hops"],
+            "shared_sram_home_load_tiles": mapping["per_home_tile_count"],
+        },
+        "schedule_parameters": {
+            "packet_payload_bytes": packet_payload_bytes,
+            "shared_vc": int(args.shared_vc),
+            "reduction_vc": int(args.reduction_vc),
+            "qkv_cycles_before_wave0": qkv_cycles,
+            "tile_attention_cycles_per_wave": tile_attention_cycles,
+            "reduction_release_offset_cycles": tile_attention_cycles,
+        },
+        "simulation": {
+            "cycles_to_drain": mesh_result.cycles,
+            "scheduled_flit_count": len(scheduled_flits),
+            "scheduled_packet_count": sum(
+                _ceil_div(flow.payload_bytes, packet_payload_bytes) for flow in flows
+            ),
+            "endpoint_injected_flit_count": mesh_result.endpoint_injected_flit_count,
+            "delivered_flit_count": len(mesh_result.deliveries),
+            "router_contention_cycles": router_contention_cycles,
+            "max_router_input_occupancy": max_router_input_occupancy,
+            "endpoint_input_stall_cycles_total": sum(mesh_result.endpoint_input_stall_cycles),
+            "endpoint_input_stall_cycles_by_endpoint": {
+                str(index): int(value)
+                for index, value in enumerate(mesh_result.endpoint_input_stall_cycles)
+                if value
+            },
+            "remote_shared_average_hops_observed": round(
+                sum(remote_shared_hops) / len(remote_shared_hops), 6
+            )
+            if remote_shared_hops
+            else 0.0,
+            "remote_shared_worst_hops_observed": max(remote_shared_hops) if remote_shared_hops else 0,
+            "remote_reduction_average_hops_observed": round(
+                sum(remote_reduction_hops) / len(remote_reduction_hops), 6
+            )
+            if remote_reduction_hops
+            else 0.0,
+            "remote_reduction_worst_hops_observed": max(remote_reduction_hops) if remote_reduction_hops else 0,
+            "delivery_flit_count_by_class": dict(sorted(delivery_by_prefix.items())),
+            "last_delivery_cycle_by_class": dict(sorted(last_delivery_cycle_by_prefix.items())),
+            "top_link_flit_counts": [
+                {
+                    "source": source,
+                    "destination": destination,
+                    "source_label": _format_endpoint(source),
+                    "destination_label": _format_endpoint(destination),
+                    "flits": count,
+                }
+                for (source, destination), count in link_usage.most_common(12)
+            ],
+        },
+        "flow_summary": {
+            "remote_shared_flow_count": sum(1 for flow in flows if flow.name.startswith("shared_")),
+            "remote_reduction_flow_count": sum(1 for flow in flows if flow.name.startswith("reduction_")),
+            "remote_shared_bytes": total_shared_remote_bytes,
+            "remote_reduction_bytes": total_reduction_remote_bytes,
+            "local_only_shared_bytes": local_only_shared_bytes,
+            "local_only_reduction_bytes": local_only_reduction_bytes,
+        },
+        "measured_l1_profile": measured_profile,
+        "explicit_assumptions": [
+            "Producer compute, local SRAM access, and local reducer accumulation stay intra-cluster and do not consume the mesh in this Phase 2 schedule.",
+            "Only two remote traffic classes are routed: shared SRAM tile payloads and local-reducer-to-root partial reductions.",
+            "Tile-to-cluster assignment is static wave-major round robin over the named cluster endpoints.",
+            "Shared SRAM homes use a deterministic rotating stride/offset mapping chosen only from explicit 4x4 permutations to approximate the declared hop envelope while keeping load balanced.",
+            "The root endpoint is explicit and fixed; root-finalizer output remains local to that endpoint.",
+            "Wave start and reduction release times are derived from the checked-in score32 recost quantities qkv_cycles and tile_attention_cycles only.",
+            "HBM/DRAM timing is intentionally excluded; no remote traffic or timing claim is made for HBM service.",
+            "Each packet carries up to packet_payload_bytes of payload and is segmented into 256-bit flits with no extra header flit modeled.",
+        ],
+        "remaining_abstractions": [
+            "The schedule uses static wave timing from checked-in recost quantities and does not yet prove end-to-end command/control RTL cadence.",
+            "Shared SRAM home placement is deterministic and explicit, but still a topology adapter rather than a measured SRAM floorplan.",
+            "HBM/DRAM service and controller timing remain intentionally out of scope.",
+            "Root-finalizer internal compute is not rerouted here; the mesh model stops at root ingress.",
+        ],
+    }
+    return payload
+
+
+def write_report(payload: JsonDict, report: Path) -> None:
+    lines = [
+        "# Llama7B Score32 NoC Phase 2 Schedule",
+        "",
+        "## Source Contract",
+        "",
+        f"- source recost: `{payload['source_artifacts']['score32_recost_json']}`",
+        f"- measured L1 cost file: `{payload['source_artifacts']['measured_l1_costs_json']}`",
+        f"- measured L1 profile: `{payload['source_artifacts']['measured_l1_profile']}`",
+        f"- declared waves: `{payload['source_contract']['declared_tile_waves']}`",
+        f"- simulated waves: `{payload['source_contract']['simulated_wave_count']}`",
+        "",
+        "## Mapping",
+        "",
+        f"- cluster endpoints: `{', '.join(payload['mapping']['cluster_endpoint_labels'])}`",
+        f"- root endpoint: `{payload['mapping']['root_endpoint_label']}`",
+        f"- shared-SRAM stride/offset: `{payload['mapping']['shared_sram_home_stride']}` / `{payload['mapping']['shared_sram_home_offset']}`",
+        f"- shared-SRAM observed average/worst hops: `{payload['mapping']['shared_sram_average_remote_hops']}` / `{payload['mapping']['shared_sram_worst_remote_hops']}`",
+        "",
+        "## Traffic",
+        "",
+        f"- full tile bytes: `{payload['traffic_quantities']['full_tile_bytes']}`",
+        f"- shared tile bytes: `{payload['traffic_quantities']['shared_tile_payload_bytes']}`",
+        f"- local tile bytes: `{payload['traffic_quantities']['local_tile_payload_bytes']}`",
+        f"- reduction bytes per cluster-wave: `{payload['traffic_quantities']['partial_reduction_payload_bytes']}`",
+        f"- simulated tiles: `{payload['traffic_quantities']['simulated_tiles']}`",
+        "",
+        "## Routed Result",
+        "",
+        f"- drain cycles: `{payload['simulation']['cycles_to_drain']}`",
+        f"- scheduled flits: `{payload['simulation']['scheduled_flit_count']}`",
+        f"- contention cycles: `{payload['simulation']['router_contention_cycles']}`",
+        f"- max router input occupancy: `{payload['simulation']['max_router_input_occupancy']}`",
+        f"- total endpoint input stall cycles: `{payload['simulation']['endpoint_input_stall_cycles_total']}`",
+        "",
+        "## Assumptions",
+        "",
+    ]
+    for item in payload["explicit_assumptions"]:
+        lines.append(f"- {item}")
+    lines.extend(
+        [
+            "",
+            "## Remaining Abstractions",
+            "",
+        ]
+    )
+    for item in payload["remaining_abstractions"]:
+        lines.append(f"- {item}")
+    report.parent.mkdir(parents=True, exist_ok=True)
+    report.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--source-json", type=Path, default=DEFAULT_SOURCE_JSON)
+    parser.add_argument("--measured-l1-costs", type=Path, default=DEFAULT_MEASURED_L1_COSTS)
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--report", required=True, type=Path)
+    parser.add_argument("--wave-limit", type=int, default=1)
+    parser.add_argument("--packet-payload-bytes", type=int, default=256)
+    parser.add_argument("--cluster-endpoints", type=_int_list, default=None)
+    parser.add_argument("--root-endpoint", type=int, default=15)
+    parser.add_argument("--shared-vc", type=int, default=0)
+    parser.add_argument("--reduction-vc", type=int, default=1)
+    parser.add_argument("--max-cycles", type=int, default=200000)
+    args = parser.parse_args()
+
+    payload = build_report(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_report(payload, args.report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/sim/perf/noc_segmented_mesh.py
+++ b/npu/sim/perf/noc_segmented_mesh.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from typing import Iterable
@@ -90,6 +91,7 @@ class ModelFlit:
     vc: int
     data: int = 0
     path: tuple[int, ...] = ()
+    label: str = ""
 
 
 @dataclass(frozen=True)
@@ -99,6 +101,26 @@ class Flow:
     flits: int
     tag: int
     vc: int
+    release_cycle: int = 0
+
+
+@dataclass(frozen=True)
+class ScheduledFlit:
+    release_cycle: int
+    flit: ModelFlit
+
+
+@dataclass(frozen=True)
+class TrafficFlow:
+    name: str
+    source: int
+    destination: int
+    payload_bytes: int
+    vc: int
+    release_cycle: int = 0
+    packet_payload_bytes: int = CONCEPTUAL_LINK_BITS // 8
+    tag_base: int = 0
+    data_seed: int = 0
 
 
 @dataclass(frozen=True)
@@ -131,6 +153,57 @@ class RouterSimulationResult:
     current_input_occupancy: int
     max_input_occupancy: int
     route_flit_count: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class RouterPlan:
+    grants: tuple[tuple[int, ModelFlit] | None, ...]
+    grant_indices: tuple[int | None, ...]
+    will_pop: tuple[int, ...]
+    ready: tuple[bool, ...]
+    input_stall: bool
+    output_stall: bool
+    contention: bool
+
+
+@dataclass(frozen=True)
+class MeshLinkTransfer:
+    cycle: int
+    source_node: int
+    source_port: int
+    destination_node: int
+    destination_port: int
+    flit: ModelFlit
+
+
+@dataclass(frozen=True)
+class MeshDelivery:
+    cycle: int
+    endpoint: int
+    flit: ModelFlit
+
+
+@dataclass(frozen=True)
+class MeshCycleTrace:
+    cycle: int
+    router_traces: tuple[RouterCycleTrace, ...]
+    injected: tuple[tuple[int, ModelFlit], ...]
+    deliveries: tuple[MeshDelivery, ...]
+    link_transfers: tuple[MeshLinkTransfer, ...]
+    endpoint_in_ready: tuple[bool, ...]
+    endpoint_out_ready: tuple[bool, ...]
+    endpoint_input_stall: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class MeshSimulationResult:
+    cycles: int
+    traces: tuple[MeshCycleTrace, ...]
+    deliveries: tuple[MeshDelivery, ...]
+    link_transfers: tuple[MeshLinkTransfer, ...]
+    router_summaries: tuple[RouterSimulationResult, ...]
+    endpoint_injected_flit_count: int
+    endpoint_input_stall_cycles: tuple[int, ...]
 
 
 @dataclass
@@ -166,12 +239,14 @@ class _RouterState:
             return True
         return self._input_index(port, vc) in will_pop
 
-    def cycle(
+    def idle(self) -> bool:
+        return self._occupancy() == 0 and all(flit is None for flit in self.out_holding)
+
+    def compute_plan(
         self,
-        cycle: int,
         inputs: list[RouterCycleInput],
         out_ready: list[bool],
-    ) -> RouterCycleTrace:
+    ) -> RouterPlan:
         candidate_counts = [0] * PORTS
         grants: list[tuple[int, ModelFlit] | None] = [None] * PORTS
         grant_indices: list[int | None] = [None] * PORTS
@@ -189,11 +264,8 @@ class _RouterState:
                     grants[output_port] = (index, flit)
                     grant_indices[output_port] = index
 
-        input_stall = False
         output_stall = any(self.out_holding[port] is not None and not out_ready[port] for port in range(PORTS))
         contention = any(count > 1 for count in candidate_counts)
-        if output_stall:
-            self.output_stall_cycles += 1
 
         will_pop: set[int] = set()
         for output_port in range(PORTS):
@@ -201,7 +273,7 @@ class _RouterState:
                 will_pop.add(int(grant_indices[output_port]))
 
         ready = []
-        accepted_ports: list[int] = []
+        input_stall = False
         for port in range(PORTS):
             item = inputs[port]
             vc = 0 if item.flit is None else item.flit.vc
@@ -209,12 +281,31 @@ class _RouterState:
             ready.append(port_ready)
             if item.valid and not port_ready:
                 input_stall = True
-            if item.valid and port_ready and item.flit is not None:
+
+        return RouterPlan(
+            grants=tuple(grants),
+            grant_indices=tuple(grant_indices),
+            will_pop=tuple(sorted(will_pop)),
+            ready=tuple(ready),
+            input_stall=input_stall,
+            output_stall=output_stall,
+            contention=contention,
+        )
+
+    def apply_plan(
+        self,
+        cycle: int,
+        inputs: list[RouterCycleInput],
+        out_ready: list[bool],
+        plan: RouterPlan,
+    ) -> RouterCycleTrace:
+        accepted_ports: list[int] = []
+        for port in range(PORTS):
+            item = inputs[port]
+            if item.valid and plan.ready[port] and item.flit is not None:
                 self.queues[self._input_index(port, item.flit.vc)].append(item.flit)
                 self.accepted_flit_count += 1
                 accepted_ports.append(port)
-        if input_stall:
-            self.input_stall_cycles += 1
 
         forwarded: list[tuple[int, ModelFlit]] = []
         for output_port in range(PORTS):
@@ -228,7 +319,7 @@ class _RouterState:
             can_replace = self.out_holding[output_port] is None or out_ready[output_port]
             if not can_replace:
                 continue
-            grant = grants[output_port]
+            grant = plan.grants[output_port]
             if grant is None:
                 self.out_holding[output_port] = None
                 continue
@@ -239,21 +330,35 @@ class _RouterState:
             self.out_holding[output_port] = flit
             self.rr_cursor[output_port] = (queue_index + 1) % (PORTS * self.vc_count)
 
+        if plan.input_stall:
+            self.input_stall_cycles += 1
+        if plan.output_stall:
+            self.output_stall_cycles += 1
+        if plan.contention:
+            self.arbitration_contention_cycles += 1
+
         occupancy = self._occupancy()
         self.max_input_occupancy = max(self.max_input_occupancy, occupancy)
-        if contention:
-            self.arbitration_contention_cycles += 1
 
         return RouterCycleTrace(
             cycle=cycle,
             accepted=tuple(accepted_ports),
             forwarded=tuple(forwarded),
-            input_stall=input_stall,
-            output_stall=output_stall,
-            contention=contention,
+            input_stall=plan.input_stall,
+            output_stall=plan.output_stall,
+            contention=plan.contention,
             occupancy=occupancy,
-            ready=tuple(ready),
+            ready=plan.ready,
         )
+
+    def cycle(
+        self,
+        cycle: int,
+        inputs: list[RouterCycleInput],
+        out_ready: list[bool],
+    ) -> RouterCycleTrace:
+        plan = self.compute_plan(inputs, out_ready)
+        return self.apply_plan(cycle, inputs, out_ready, plan)
 
     def snapshot(self, traces: list[RouterCycleTrace], delivered: list[tuple[int, ModelFlit]]) -> RouterSimulationResult:
         return RouterSimulationResult(
@@ -293,6 +398,243 @@ def simulate_router(
     return state.snapshot(traces, delivered)
 
 
+def _opposite_port(port: int) -> int:
+    if port == PORT_NORTH:
+        return PORT_SOUTH
+    if port == PORT_SOUTH:
+        return PORT_NORTH
+    if port == PORT_EAST:
+        return PORT_WEST
+    if port == PORT_WEST:
+        return PORT_EAST
+    return PORT_LOCAL
+
+
+def _neighbor(endpoint_id: int, port: int) -> tuple[int, int] | None:
+    x_coord, y_coord = coordinates(endpoint_id)
+    if port == PORT_NORTH and y_coord > 0:
+        node = endpoint(x_coord, y_coord - 1)
+    elif port == PORT_SOUTH and y_coord < MESH_Y - 1:
+        node = endpoint(x_coord, y_coord + 1)
+    elif port == PORT_EAST and x_coord < MESH_X - 1:
+        node = endpoint(x_coord + 1, y_coord)
+    elif port == PORT_WEST and x_coord > 0:
+        node = endpoint(x_coord - 1, y_coord)
+    elif port == PORT_LOCAL:
+        node = endpoint_id
+    else:
+        return None
+    return node, _opposite_port(port)
+
+
+def _conceptual_payload_bytes() -> int:
+    return CONCEPTUAL_LINK_BITS // 8
+
+
+def _flit_payload_bytes() -> int:
+    return PHYSICAL_FLIT_BITS // 8
+
+
+def packetize_traffic_flow(flow: TrafficFlow) -> tuple[ScheduledFlit, ...]:
+    if flow.payload_bytes <= 0:
+        raise ValueError("traffic flow payload_bytes must be positive")
+    if not 0 <= flow.vc < VIRTUAL_CHANNELS:
+        raise ValueError("traffic flow vc must be in [0, 3]")
+    if flow.packet_payload_bytes <= 0 or flow.packet_payload_bytes > _conceptual_payload_bytes():
+        raise ValueError(
+            f"traffic flow packet_payload_bytes must be in [1, {_conceptual_payload_bytes()}]"
+        )
+    packet_count = int(math.ceil(flow.payload_bytes / flow.packet_payload_bytes))
+    remainder = flow.payload_bytes
+    scheduled: list[ScheduledFlit] = []
+    path = deterministic_xy_path(flow.source, flow.destination)
+    for packet_index in range(packet_count):
+        packet_bytes = min(flow.packet_payload_bytes, remainder)
+        remainder -= packet_bytes
+        flit_count = int(math.ceil(packet_bytes / _flit_payload_bytes()))
+        if flit_count > FLITS_PER_CONCEPTUAL_TRANSFER:
+            raise ValueError(
+                "traffic flow packetization exceeds the eight-fragment tagged packet envelope"
+            )
+        tag = (flow.tag_base + packet_index) & 0xFF
+        for fragment in range(flit_count):
+            scheduled.append(
+                ScheduledFlit(
+                    release_cycle=flow.release_cycle,
+                    flit=ModelFlit(
+                        source=flow.source,
+                        destination=flow.destination,
+                        tag=tag,
+                        fragment=fragment,
+                        last=fragment == flit_count - 1,
+                        vc=flow.vc,
+                        data=(flow.data_seed << 16) | (packet_index << 8) | fragment,
+                        path=path,
+                        label=flow.name,
+                    ),
+                )
+            )
+    return tuple(scheduled)
+
+
+def _resolve_endpoint_out_ready(
+    endpoint_out_ready_schedule: list[list[bool]] | None,
+    cycle: int,
+) -> list[bool]:
+    if endpoint_out_ready_schedule is None or cycle >= len(endpoint_out_ready_schedule):
+        return [True] * ENDPOINTS
+    ready = endpoint_out_ready_schedule[cycle]
+    if len(ready) != ENDPOINTS:
+        raise ValueError("endpoint_out_ready_schedule rows must have 16 ready bits")
+    return list(ready)
+
+
+def simulate_scheduled_flits(
+    scheduled_flits: Iterable[ScheduledFlit],
+    *,
+    endpoint_out_ready_schedule: list[list[bool]] | None = None,
+    fifo_depth: int = DEFAULT_FIFO_DEPTH,
+    vc_count: int = VIRTUAL_CHANNELS,
+    max_cycles: int = 100000,
+) -> MeshSimulationResult:
+    ordered = sorted(scheduled_flits, key=lambda item: (item.release_cycle, item.flit.source, item.flit.tag, item.flit.fragment))
+    release_queues: list[deque[ScheduledFlit]] = [deque() for _ in range(ENDPOINTS)]
+    future = deque(ordered)
+    states = [
+        _RouterState(
+            x_coord=coordinates(node)[0],
+            y_coord=coordinates(node)[1],
+            fifo_depth=fifo_depth,
+            vc_count=vc_count,
+        )
+        for node in range(ENDPOINTS)
+    ]
+    router_traces: list[list[RouterCycleTrace]] = [[] for _ in range(ENDPOINTS)]
+    router_forwarded: list[list[tuple[int, ModelFlit]]] = [[] for _ in range(ENDPOINTS)]
+    deliveries: list[MeshDelivery] = []
+    link_transfers: list[MeshLinkTransfer] = []
+    cycle_traces: list[MeshCycleTrace] = []
+    endpoint_input_stall_cycles = [0] * ENDPOINTS
+    endpoint_injected_flit_count = 0
+
+    for cycle in range(max_cycles):
+        while future and future[0].release_cycle <= cycle:
+            released = future.popleft()
+            release_queues[released.flit.source].append(released)
+
+        router_inputs: list[list[RouterCycleInput]] = []
+        for node in range(ENDPOINTS):
+            inputs = [RouterCycleInput(False, None) for _ in range(PORTS)]
+            local_queue = release_queues[node]
+            if local_queue:
+                inputs[PORT_LOCAL] = RouterCycleInput(True, local_queue[0].flit)
+            for port in (PORT_NORTH, PORT_SOUTH, PORT_EAST, PORT_WEST):
+                neighbor = _neighbor(node, port)
+                if neighbor is None:
+                    continue
+                upstream_node, upstream_port = neighbor
+                flit = states[upstream_node].out_holding[upstream_port]
+                if flit is not None:
+                    inputs[port] = RouterCycleInput(True, flit)
+            router_inputs.append(inputs)
+
+        endpoint_out_ready = _resolve_endpoint_out_ready(endpoint_out_ready_schedule, cycle)
+        out_ready = [[False] * PORTS for _ in range(ENDPOINTS)]
+        for node in range(ENDPOINTS):
+            out_ready[node][PORT_LOCAL] = endpoint_out_ready[node]
+
+        plans: list[RouterPlan] = []
+        for _ in range(ENDPOINTS * PORTS * 2):
+            plans = []
+            for node in range(ENDPOINTS):
+                plans.append(states[node].compute_plan(router_inputs[node], out_ready[node]))
+            updated = [[False] * PORTS for _ in range(ENDPOINTS)]
+            for node in range(ENDPOINTS):
+                updated[node][PORT_LOCAL] = endpoint_out_ready[node]
+                for port in (PORT_NORTH, PORT_SOUTH, PORT_EAST, PORT_WEST):
+                    neighbor = _neighbor(node, port)
+                    if neighbor is None:
+                        updated[node][port] = True
+                        continue
+                    downstream_node, downstream_port = neighbor
+                    updated[node][port] = plans[downstream_node].ready[downstream_port]
+            if updated == out_ready:
+                break
+            out_ready = updated
+        else:
+            raise RuntimeError("mesh ready/valid fixpoint did not converge")
+
+        cycle_router_traces: list[RouterCycleTrace] = []
+        cycle_injected: list[tuple[int, ModelFlit]] = []
+        cycle_deliveries: list[MeshDelivery] = []
+        cycle_links: list[MeshLinkTransfer] = []
+        cycle_endpoint_stall: list[int] = []
+
+        for node in range(ENDPOINTS):
+            trace = states[node].apply_plan(cycle, router_inputs[node], out_ready[node], plans[node])
+            cycle_router_traces.append(trace)
+            router_traces[node].append(trace)
+            router_forwarded[node].extend(trace.forwarded)
+            local_queue = release_queues[node]
+            if local_queue and trace.ready[PORT_LOCAL]:
+                cycle_injected.append((node, local_queue.popleft().flit))
+                endpoint_injected_flit_count += 1
+                cycle_endpoint_stall.append(0)
+            else:
+                stalled = 1 if local_queue else 0
+                cycle_endpoint_stall.append(stalled)
+                endpoint_input_stall_cycles[node] += stalled
+            for port, flit in trace.forwarded:
+                if port == PORT_LOCAL:
+                    delivery = MeshDelivery(cycle=cycle, endpoint=node, flit=flit)
+                    deliveries.append(delivery)
+                    cycle_deliveries.append(delivery)
+                    continue
+                neighbor = _neighbor(node, port)
+                if neighbor is None:
+                    continue
+                destination_node, destination_port = neighbor
+                transfer = MeshLinkTransfer(
+                    cycle=cycle,
+                    source_node=node,
+                    source_port=port,
+                    destination_node=destination_node,
+                    destination_port=destination_port,
+                    flit=flit,
+                )
+                link_transfers.append(transfer)
+                cycle_links.append(transfer)
+
+        cycle_traces.append(
+            MeshCycleTrace(
+                cycle=cycle,
+                router_traces=tuple(cycle_router_traces),
+                injected=tuple(cycle_injected),
+                deliveries=tuple(cycle_deliveries),
+                link_transfers=tuple(cycle_links),
+                endpoint_in_ready=tuple(trace.ready[PORT_LOCAL] for trace in cycle_router_traces),
+                endpoint_out_ready=tuple(endpoint_out_ready),
+                endpoint_input_stall=tuple(cycle_endpoint_stall),
+            )
+        )
+
+        if not future and all(not queue for queue in release_queues) and all(state.idle() for state in states):
+            return MeshSimulationResult(
+                cycles=cycle + 1,
+                traces=tuple(cycle_traces),
+                deliveries=tuple(deliveries),
+                link_transfers=tuple(link_transfers),
+                router_summaries=tuple(
+                    state.snapshot(router_traces[node], router_forwarded[node])
+                    for node, state in enumerate(states)
+                ),
+                endpoint_injected_flit_count=endpoint_injected_flit_count,
+                endpoint_input_stall_cycles=tuple(endpoint_input_stall_cycles),
+            )
+
+    raise RuntimeError("mesh model did not drain within max_cycles")
+
+
 def simulate_mesh(
     *,
     source: int,
@@ -302,55 +644,99 @@ def simulate_mesh(
     max_cycles: int = 256,
 ) -> dict[str, object]:
     path = deterministic_xy_path(source, destination)
-    hops = len(path) - 1
-    transfers = segmented_transfer(source=source, destination=destination, tag=tag, vc=vc)
-    delivered = []
-    for fragment, flit in enumerate(transfers):
-        delivery_cycle = 2 * hops + 2 + fragment
-        delivered.append(
-            {
-                "cycle": delivery_cycle,
-                "source": flit.source,
-                "destination": flit.destination,
-                "tag": flit.tag,
-                "fragment": flit.fragment,
-                "last": flit.last,
-                "vc": flit.vc,
-                "path": path,
-            }
-        )
-    total_cycles = delivered[-1]["cycle"] + 1 if delivered else 0
-    if total_cycles > max_cycles:
-        raise RuntimeError("mesh model did not drain within max_cycles")
+    scheduled = [
+        ScheduledFlit(release_cycle=0, flit=flit)
+        for flit in segmented_transfer(source=source, destination=destination, tag=tag, vc=vc)
+    ]
+    result = simulate_scheduled_flits(scheduled, max_cycles=max_cycles)
+    delivered = [
+        {
+            "cycle": delivery.cycle,
+            "source": delivery.flit.source,
+            "destination": delivery.flit.destination,
+            "tag": delivery.flit.tag,
+            "fragment": delivery.flit.fragment,
+            "last": delivery.flit.last,
+            "vc": delivery.flit.vc,
+            "path": path,
+        }
+        for delivery in result.deliveries
+    ]
     link_flits: dict[tuple[int, int], int] = defaultdict(int)
-    for left, right in zip(path[:-1], path[1:]):
-        link_flits[(left, right)] = FLITS_PER_CONCEPTUAL_TRANSFER
+    for transfer in result.link_transfers:
+        link_flits[(transfer.source_node, transfer.destination_node)] += 1
     return {
-        "cycles": total_cycles,
+        "cycles": result.cycles,
         "path": path,
         "delivered": tuple(delivered),
         "directed_link_flits": dict(link_flits),
-        "contention_cycles": 0,
+        "contention_cycles": sum(
+            1
+            for trace in result.traces
+            if any(router_trace.contention for router_trace in trace.router_traces)
+        ),
         "serialization_flits": FLITS_PER_CONCEPTUAL_TRANSFER,
     }
 
 
 def simulate(flows: Iterable[Flow], *, max_cycles: int = 10000) -> dict[str, object]:
     flow_list = list(flows)
-    if len(flow_list) != 1:
-        raise ValueError("simulate currently models one routed flow at a time")
-    flow = flow_list[0]
-    if flow.flits != FLITS_PER_CONCEPTUAL_TRANSFER:
-        raise ValueError(
-            f"simulate expects {FLITS_PER_CONCEPTUAL_TRANSFER} serialized flits per conceptual transfer"
-        )
-    return simulate_mesh(
-        source=flow.source,
-        destination=flow.destination,
-        tag=flow.tag,
-        vc=flow.vc,
-        max_cycles=max_cycles,
-    )
+    scheduled: list[ScheduledFlit] = []
+    for flow in flow_list:
+        if flow.flits <= 0:
+            raise ValueError("flow flits must be positive")
+        if flow.flits % FLITS_PER_CONCEPTUAL_TRANSFER != 0:
+            raise ValueError(
+                f"flow flits must be a multiple of {FLITS_PER_CONCEPTUAL_TRANSFER}"
+            )
+        path = deterministic_xy_path(flow.source, flow.destination)
+        packet_count = flow.flits // FLITS_PER_CONCEPTUAL_TRANSFER
+        for packet_index in range(packet_count):
+            tag = (flow.tag + packet_index) & 0xFF
+            for fragment in range(FLITS_PER_CONCEPTUAL_TRANSFER):
+                scheduled.append(
+                    ScheduledFlit(
+                        release_cycle=flow.release_cycle,
+                        flit=ModelFlit(
+                            source=flow.source,
+                            destination=flow.destination,
+                            tag=tag,
+                            fragment=fragment,
+                            last=fragment == FLITS_PER_CONCEPTUAL_TRANSFER - 1,
+                            vc=flow.vc,
+                            data=(packet_index << 8) | fragment,
+                            path=path,
+                        ),
+                    )
+                )
+    result = simulate_scheduled_flits(scheduled, max_cycles=max_cycles)
+    link_flits: dict[tuple[int, int], int] = defaultdict(int)
+    for transfer in result.link_transfers:
+        link_flits[(transfer.source_node, transfer.destination_node)] += 1
+    return {
+        "cycles": result.cycles,
+        "delivered": tuple(
+            {
+                "cycle": delivery.cycle,
+                "source": delivery.flit.source,
+                "destination": delivery.flit.destination,
+                "tag": delivery.flit.tag,
+                "fragment": delivery.flit.fragment,
+                "last": delivery.flit.last,
+                "vc": delivery.flit.vc,
+                "path": delivery.flit.path,
+                "label": delivery.flit.label,
+            }
+            for delivery in result.deliveries
+        ),
+        "directed_link_flits": dict(link_flits),
+        "contention_cycles": sum(
+            1
+            for trace in result.traces
+            if any(router_trace.contention for router_trace in trace.router_traces)
+        ),
+        "serialization_flits": len(scheduled),
+    }
 
 
 def mapping_report() -> dict[str, int | str]:

--- a/npu/sim/perf/noc_segmented_mesh.py
+++ b/npu/sim/perf/noc_segmented_mesh.py
@@ -456,7 +456,10 @@ def packetize_traffic_flow(flow: TrafficFlow) -> tuple[ScheduledFlit, ...]:
             raise ValueError(
                 "traffic flow packetization exceeds the eight-fragment tagged packet envelope"
             )
-        tag = (flow.tag_base + packet_index) & 0xFF
+        # The performance model keeps a wide synthetic packet sequence tag so
+        # packet ordering cannot be perturbed by 8-bit wraparound. Concrete
+        # 8-bit tag reuse is audited separately by higher-level reports.
+        tag = flow.tag_base + packet_index
         for fragment in range(flit_count):
             scheduled.append(
                 ScheduledFlit(

--- a/tests/test_llm_decoder_attention_score32_noc_phase2_schedule.py
+++ b/tests/test_llm_decoder_attention_score32_noc_phase2_schedule.py
@@ -1,0 +1,57 @@
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from npu.eval.measure_llm_decoder_attention_score32_noc_phase2_schedule import (
+    DEFAULT_MEASURED_L1_COSTS,
+    DEFAULT_SOURCE_JSON,
+    build_report,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _args(**overrides: object) -> argparse.Namespace:
+    values: dict[str, object] = {
+        "repo_root": REPO_ROOT,
+        "source_json": DEFAULT_SOURCE_JSON,
+        "measured_l1_costs": DEFAULT_MEASURED_L1_COSTS,
+        "wave_limit": 1,
+        "packet_payload_bytes": 256,
+        "cluster_endpoints": None,
+        "root_endpoint": 15,
+        "shared_vc": 0,
+        "reduction_vc": 1,
+        "max_cycles": 200000,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def test_score32_noc_phase2_report_is_explicit_and_bounded() -> None:
+    report = build_report(_args())
+
+    assert report["profile"] == "decoder_attention_score32_noc_phase2_schedule"
+    assert report["source_contract"]["simulated_wave_count"] == 1
+    assert report["traffic_quantities"]["simulated_tiles"] == report["source_contract"]["active_clusters"]
+    assert report["flow_summary"]["remote_shared_flow_count"] > 0
+    assert report["flow_summary"]["remote_reduction_flow_count"] > 0
+    assert report["simulation"]["delivered_flit_count"] == report["simulation"]["scheduled_flit_count"]
+    assert report["simulation"]["router_contention_cycles"] > 0
+    assert any(
+        "HBM/DRAM timing is intentionally excluded" in item
+        for item in report["explicit_assumptions"]
+    )
+
+
+def test_score32_noc_phase2_rejects_missing_quantity(tmp_path: Path) -> None:
+    source = json.loads((REPO_ROOT / DEFAULT_SOURCE_JSON).read_text(encoding="utf-8"))
+    del source["best_requested"]["tile_waves"]
+    broken = tmp_path / "broken_source.json"
+    broken.write_text(json.dumps(source), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="tile_waves"):
+        build_report(_args(source_json=broken))

--- a/tests/test_llm_decoder_attention_score32_noc_phase2_schedule.py
+++ b/tests/test_llm_decoder_attention_score32_noc_phase2_schedule.py
@@ -19,7 +19,7 @@ def _args(**overrides: object) -> argparse.Namespace:
         "repo_root": REPO_ROOT,
         "source_json": DEFAULT_SOURCE_JSON,
         "measured_l1_costs": DEFAULT_MEASURED_L1_COSTS,
-        "wave_limit": 1,
+        "wave_limit": None,
         "packet_payload_bytes": 256,
         "cluster_endpoints": None,
         "root_endpoint": 15,
@@ -31,19 +31,47 @@ def _args(**overrides: object) -> argparse.Namespace:
     return argparse.Namespace(**values)
 
 
-def test_score32_noc_phase2_report_is_explicit_and_bounded() -> None:
+def test_score32_noc_phase2_default_report_covers_full_declared_workload() -> None:
     report = build_report(_args())
 
     assert report["profile"] == "decoder_attention_score32_noc_phase2_schedule"
-    assert report["source_contract"]["simulated_wave_count"] == 1
-    assert report["traffic_quantities"]["simulated_tiles"] == report["source_contract"]["active_clusters"]
+    assert report["source_contract"]["coverage"] == "workload_complete"
+    assert report["source_contract"]["simulated_wave_count"] == report["source_contract"]["declared_tile_waves"]
+    assert report["traffic_quantities"]["simulated_tiles"] == report["traffic_quantities"]["tile_count"]
     assert report["flow_summary"]["remote_shared_flow_count"] > 0
     assert report["flow_summary"]["remote_reduction_flow_count"] > 0
     assert report["simulation"]["delivered_flit_count"] == report["simulation"]["scheduled_flit_count"]
     assert report["simulation"]["router_contention_cycles"] > 0
+    assert report["tag_semantics"]["ordered_tuple_stream_proven"] is True
+    assert report["tag_semantics"]["max_packets_per_tuple"] > 256
+    assert any(
+        summary["tag_reuse_count"] > 0
+        for summary in report["tag_semantics"]["tuple_summaries"]
+    )
     assert any(
         "HBM/DRAM timing is intentionally excluded" in item
         for item in report["explicit_assumptions"]
+    )
+
+
+def test_score32_noc_phase2_explicit_wave_limit_is_bounded() -> None:
+    report = build_report(_args(wave_limit=1))
+
+    assert report["source_contract"]["coverage"] == "bounded"
+    assert report["source_contract"]["simulated_wave_count"] == 1
+    assert report["traffic_quantities"]["simulated_tiles"] == report["source_contract"]["active_clusters"]
+    assert report["schedule_parameters"]["requested_wave_limit"] == 1
+
+
+def test_score32_noc_phase2_proves_nonoverlapping_8bit_tag_reuse() -> None:
+    report = build_report(_args(wave_limit=1))
+
+    assert report["tag_semantics"]["tag_width_bits"] == 8
+    assert report["tag_semantics"]["tuple_summaries"]
+    assert report["tag_semantics"]["ordered_tuple_stream_proven"] is True
+    assert all(
+        summary["tag_reuse_count"] == 0
+        for summary in report["tag_semantics"]["tuple_summaries"]
     )
 
 

--- a/tests/test_llm_decoder_attention_score32_noc_phase2_schedule.py
+++ b/tests/test_llm_decoder_attention_score32_noc_phase2_schedule.py
@@ -42,10 +42,19 @@ def test_score32_noc_phase2_default_report_covers_full_declared_workload() -> No
     assert report["flow_summary"]["remote_reduction_flow_count"] > 0
     assert report["simulation"]["delivered_flit_count"] == report["simulation"]["scheduled_flit_count"]
     assert report["simulation"]["router_contention_cycles"] > 0
+    assert report["tag_semantics"]["collision_free_reuse_proven"] is True
     assert report["tag_semantics"]["ordered_tuple_stream_proven"] is True
     assert report["tag_semantics"]["max_packets_per_tuple"] > 256
     assert any(
         summary["tag_reuse_count"] > 0
+        for summary in report["tag_semantics"]["tuple_summaries"]
+    )
+    assert any(
+        summary["overlap_checked_count"] > 0
+        for summary in report["tag_semantics"]["tuple_summaries"]
+    )
+    assert all(
+        summary["min_nonoverlap_gap_cycles"] is None or summary["min_nonoverlap_gap_cycles"] > 0
         for summary in report["tag_semantics"]["tuple_summaries"]
     )
     assert any(
@@ -67,10 +76,15 @@ def test_score32_noc_phase2_proves_nonoverlapping_8bit_tag_reuse() -> None:
     report = build_report(_args(wave_limit=1))
 
     assert report["tag_semantics"]["tag_width_bits"] == 8
+    assert report["tag_semantics"]["collision_free_reuse_proven"] is True
     assert report["tag_semantics"]["tuple_summaries"]
     assert report["tag_semantics"]["ordered_tuple_stream_proven"] is True
     assert all(
         summary["tag_reuse_count"] == 0
+        for summary in report["tag_semantics"]["tuple_summaries"]
+    )
+    assert all(
+        summary["overlap_checked_count"] == 0
         for summary in report["tag_semantics"]["tuple_summaries"]
     )
 

--- a/tests/test_noc_segmented_mesh.py
+++ b/tests/test_noc_segmented_mesh.py
@@ -14,6 +14,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from npu.sim.perf.noc_segmented_mesh import (
+    MeshDelivery,
     ModelFlit,
     PORT_EAST,
     PORT_LOCAL,
@@ -23,9 +24,12 @@ from npu.sim.perf.noc_segmented_mesh import (
     PORT_WEST,
     PORTS,
     RouterCycleInput,
+    TrafficFlow,
+    packetize_traffic_flow,
     segmented_transfer,
     simulate_mesh,
     simulate_router,
+    simulate_scheduled_flits,
 )
 ROUTER_CONFIG = (
     REPO_ROOT
@@ -426,6 +430,242 @@ endmodule
 """
 
 
+def _multiflow_mesh_flows() -> list[TrafficFlow]:
+    return [
+        TrafficFlow(
+            name="shared_a",
+            source=0,
+            destination=15,
+            payload_bytes=256,
+            vc=0,
+            release_cycle=0,
+            packet_payload_bytes=256,
+            tag_base=7,
+            data_seed=1,
+        ),
+        TrafficFlow(
+            name="shared_b",
+            source=1,
+            destination=15,
+            payload_bytes=256,
+            vc=1,
+            release_cycle=0,
+            packet_payload_bytes=256,
+            tag_base=17,
+            data_seed=2,
+        ),
+        TrafficFlow(
+            name="reduction_c",
+            source=4,
+            destination=15,
+            payload_bytes=256,
+            vc=0,
+            release_cycle=0,
+            packet_payload_bytes=256,
+            tag_base=27,
+            data_seed=3,
+        ),
+    ]
+
+
+def _multiflow_mesh_ready() -> list[list[bool]]:
+    ready = [[False for _ in range(16)] for _ in range(64)]
+    for cycle in range(64):
+        ready[cycle][15] = cycle not in {14, 15}
+    return ready
+
+
+def _multiflow_mesh_tb() -> str:
+    return """
+`timescale 1ns/1ps
+module tb_noc_segmented_mesh4x4_multiflow;
+  reg clk;
+  reg rst_n;
+  reg [15:0] endpoint_in_valid;
+  wire [15:0] endpoint_in_ready;
+  reg [63:0] endpoint_in_dest;
+  reg [63:0] endpoint_in_source;
+  reg [127:0] endpoint_in_tag;
+  reg [47:0] endpoint_in_fragment;
+  reg [15:0] endpoint_in_last;
+  reg [31:0] endpoint_in_vc;
+  reg [4095:0] endpoint_in_data;
+  wire [15:0] endpoint_out_valid;
+  reg [15:0] endpoint_out_ready;
+  wire [63:0] endpoint_out_dest;
+  wire [63:0] endpoint_out_source;
+  wire [127:0] endpoint_out_tag;
+  wire [47:0] endpoint_out_fragment;
+  wire [15:0] endpoint_out_last;
+  wire [31:0] endpoint_out_vc;
+  wire [4095:0] endpoint_out_data;
+  wire [511:0] router_accepted_flit_count;
+  wire [511:0] router_forwarded_flit_count;
+  wire [511:0] router_input_stall_cycles;
+  wire [511:0] router_output_stall_cycles;
+  wire [511:0] router_contention_cycles;
+  wire [511:0] router_current_input_occupancy;
+  wire [511:0] router_max_input_occupancy;
+  wire [2559:0] router_route_flit_count;
+  integer cycle_count;
+  integer drive_i;
+  integer idx0;
+  integer idx1;
+  integer idx4;
+  integer delivered_count;
+  integer router_i;
+
+  noc_segmented_mesh4x4 dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .endpoint_in_valid(endpoint_in_valid),
+    .endpoint_in_ready(endpoint_in_ready),
+    .endpoint_in_dest(endpoint_in_dest),
+    .endpoint_in_source(endpoint_in_source),
+    .endpoint_in_tag(endpoint_in_tag),
+    .endpoint_in_fragment(endpoint_in_fragment),
+    .endpoint_in_last(endpoint_in_last),
+    .endpoint_in_vc(endpoint_in_vc),
+    .endpoint_in_data(endpoint_in_data),
+    .endpoint_out_valid(endpoint_out_valid),
+    .endpoint_out_ready(endpoint_out_ready),
+    .endpoint_out_dest(endpoint_out_dest),
+    .endpoint_out_source(endpoint_out_source),
+    .endpoint_out_tag(endpoint_out_tag),
+    .endpoint_out_fragment(endpoint_out_fragment),
+    .endpoint_out_last(endpoint_out_last),
+    .endpoint_out_vc(endpoint_out_vc),
+    .endpoint_out_data(endpoint_out_data),
+    .router_accepted_flit_count(router_accepted_flit_count),
+    .router_forwarded_flit_count(router_forwarded_flit_count),
+    .router_input_stall_cycles(router_input_stall_cycles),
+    .router_output_stall_cycles(router_output_stall_cycles),
+    .router_contention_cycles(router_contention_cycles),
+    .router_current_input_occupancy(router_current_input_occupancy),
+    .router_max_input_occupancy(router_max_input_occupancy),
+    .router_route_flit_count(router_route_flit_count)
+  );
+
+  initial clk = 1'b0;
+  always #5 clk = ~clk;
+
+  task automatic drive_sources;
+    begin
+      endpoint_in_valid = 16'h0000;
+      endpoint_in_dest = 64'h0;
+      endpoint_in_source = 64'h0;
+      endpoint_in_tag = 128'h0;
+      endpoint_in_fragment = 48'h0;
+      endpoint_in_last = 16'h0000;
+      endpoint_in_vc = 32'h0;
+      endpoint_in_data = 4096'h0;
+      if (idx0 < 8) begin
+        endpoint_in_valid[0] = 1'b1;
+        endpoint_in_dest[3:0] = 4'd15;
+        endpoint_in_source[3:0] = 4'd0;
+        endpoint_in_tag[7:0] = 8'd7;
+        endpoint_in_fragment[2:0] = idx0[2:0];
+        endpoint_in_last[0] = (idx0 == 7);
+        endpoint_in_vc[1:0] = 2'd0;
+        endpoint_in_data[255:0] = 256'h1000 + idx0;
+      end
+      if (idx1 < 8) begin
+        endpoint_in_valid[1] = 1'b1;
+        endpoint_in_dest[7:4] = 4'd15;
+        endpoint_in_source[7:4] = 4'd1;
+        endpoint_in_tag[15:8] = 8'd17;
+        endpoint_in_fragment[5:3] = idx1[2:0];
+        endpoint_in_last[1] = (idx1 == 7);
+        endpoint_in_vc[3:2] = 2'd1;
+        endpoint_in_data[511:256] = 256'h2000 + idx1;
+      end
+      if (idx4 < 8) begin
+        endpoint_in_valid[4] = 1'b1;
+        endpoint_in_dest[19:16] = 4'd15;
+        endpoint_in_source[19:16] = 4'd4;
+        endpoint_in_tag[39:32] = 8'd27;
+        endpoint_in_fragment[14:12] = idx4[2:0];
+        endpoint_in_last[4] = (idx4 == 7);
+        endpoint_in_vc[9:8] = 2'd0;
+        endpoint_in_data[1279:1024] = 256'h3000 + idx4;
+      end
+    end
+  endtask
+
+  task automatic drive_ready(input integer cycle);
+    begin
+      endpoint_out_ready = 16'h0000;
+      endpoint_out_ready[15] = (cycle != 14) && (cycle != 15);
+    end
+  endtask
+
+  initial begin
+    rst_n = 1'b0;
+    cycle_count = -1;
+    idx0 = 0;
+    idx1 = 0;
+    idx4 = 0;
+    delivered_count = 0;
+    drive_ready(-1);
+    drive_sources();
+    repeat (2) @(posedge clk);
+    @(negedge clk);
+    rst_n = 1'b1;
+    drive_ready(0);
+    drive_sources();
+    for (drive_i = 1; drive_i < 64; drive_i = drive_i + 1) begin
+      @(posedge clk);
+      @(negedge clk);
+      drive_ready(drive_i);
+      drive_sources();
+    end
+    $display("SUMMARY delivered=%0d", delivered_count);
+    for (router_i = 0; router_i < 16; router_i = router_i + 1) begin
+      $display(
+        "ROUTER node=%0d accepted=%0d forwarded=%0d istall=%0d ostall=%0d contention=%0d maxocc=%0d local=%0d east=%0d south=%0d",
+        router_i,
+        router_accepted_flit_count[(router_i * 32) +: 32],
+        router_forwarded_flit_count[(router_i * 32) +: 32],
+        router_input_stall_cycles[(router_i * 32) +: 32],
+        router_output_stall_cycles[(router_i * 32) +: 32],
+        router_contention_cycles[(router_i * 32) +: 32],
+        router_max_input_occupancy[(router_i * 32) +: 32],
+        router_route_flit_count[((router_i * 5 * 32) + (4 * 32)) +: 32],
+        router_route_flit_count[((router_i * 5 * 32) + (2 * 32)) +: 32],
+        router_route_flit_count[((router_i * 5 * 32) + (1 * 32)) +: 32]
+      );
+    end
+    $finish;
+  end
+
+  always @(posedge clk) begin
+    if (rst_n) begin
+      cycle_count = cycle_count + 1;
+      if (endpoint_in_valid[0] && endpoint_in_ready[0])
+        idx0 = idx0 + 1;
+      if (endpoint_in_valid[1] && endpoint_in_ready[1])
+        idx1 = idx1 + 1;
+      if (endpoint_in_valid[4] && endpoint_in_ready[4])
+        idx4 = idx4 + 1;
+      if (endpoint_out_valid[15] && endpoint_out_ready[15]) begin
+        delivered_count = delivered_count + 1;
+        $display(
+          "DELIVER cycle=%0d source=%0d dest=%0d tag=%0d fragment=%0d vc=%0d last=%0d",
+          cycle_count,
+          endpoint_out_source[63:60],
+          endpoint_out_dest[63:60],
+          endpoint_out_tag[127:120],
+          endpoint_out_fragment[47:45],
+          endpoint_out_vc[31:30],
+          endpoint_out_last[15]
+        );
+      end
+    end
+  end
+endmodule
+"""
+
+
 def test_segmented_router_wrapper_generates_and_compiles() -> None:
     subprocess.run(
         ["python3", "scripts/generate_design.py", str(ROUTER_CONFIG), "nangate45", "--force_gen", "True"],
@@ -577,3 +817,99 @@ def test_mesh_route_model_matches_rtl(tmp_path: Path) -> None:
         for item in expected["delivered"]
     ]
     assert observed == expected_deliveries
+
+
+@pytest.mark.skipif(_iverilog() is None or _vvp() is None, reason="iverilog/vvp unavailable")
+def test_multiflow_mesh_cycle_model_matches_rtl(tmp_path: Path) -> None:
+    flows = _multiflow_mesh_flows()
+    ready = _multiflow_mesh_ready()
+    scheduled = [scheduled for flow in flows for scheduled in packetize_traffic_flow(flow)]
+    expected = simulate_scheduled_flits(scheduled, endpoint_out_ready_schedule=ready, max_cycles=256)
+    output = _compile_and_run(
+        tmp_path,
+        top="tb_noc_segmented_mesh4x4_multiflow",
+        sources=[
+            REPO_ROOT / "npu/sim/rtl/noc_ready_valid_fifo.sv",
+            REPO_ROOT / "npu/sim/rtl/noc_segmented_mesh_router.sv",
+            REPO_ROOT / "npu/sim/rtl/noc_segmented_mesh4x4.sv",
+        ],
+        tb_text=_multiflow_mesh_tb(),
+    )
+
+    delivery_pattern = re.compile(
+        r"DELIVER cycle=(?P<cycle>\d+) source=(?P<source>\d+) dest=(?P<dest>\d+) "
+        r"tag=(?P<tag>\d+) fragment=(?P<fragment>\d+) vc=(?P<vc>\d+) last=(?P<last>\d+)"
+    )
+    summary_pattern = re.compile(r"SUMMARY delivered=(?P<delivered>\d+)")
+    router_pattern = re.compile(
+        r"ROUTER node=(?P<node>\d+) accepted=(?P<accepted>\d+) forwarded=(?P<forwarded>\d+) "
+        r"istall=(?P<istall>\d+) ostall=(?P<ostall>\d+) contention=(?P<contention>\d+) "
+        r"maxocc=(?P<maxocc>\d+) local=(?P<local>\d+) east=(?P<east>\d+) south=(?P<south>\d+)"
+    )
+
+    observed_deliveries = []
+    summary_match = None
+    observed_routers: dict[int, dict[str, int]] = {}
+    for line in output.splitlines():
+        stripped = line.strip()
+        match = delivery_pattern.match(stripped)
+        if match:
+            observed_deliveries.append({key: int(value) for key, value in match.groupdict().items()})
+            continue
+        summary_match = summary_match or summary_pattern.match(stripped)
+        router_match = router_pattern.match(stripped)
+        if router_match:
+            values = {key: int(value) for key, value in router_match.groupdict().items()}
+            observed_routers[values["node"]] = values
+
+    assert summary_match is not None, output
+    assert int(summary_match.group("delivered")) == len(expected.deliveries)
+
+    expected_deliveries = [
+        {
+            "cycle": delivery.cycle,
+            "source": delivery.flit.source,
+            "dest": delivery.flit.destination,
+            "tag": delivery.flit.tag,
+            "fragment": delivery.flit.fragment,
+            "vc": delivery.flit.vc,
+            "last": 1 if delivery.flit.last else 0,
+        }
+        for delivery in expected.deliveries
+    ]
+    assert observed_deliveries == expected_deliveries
+
+    assert len(observed_routers) == 16
+    for node, summary in enumerate(expected.router_summaries):
+        observed = observed_routers[node]
+        assert observed["accepted"] == summary.accepted_flit_count
+        assert observed["forwarded"] == summary.forwarded_flit_count
+        assert observed["istall"] == summary.input_stall_cycles
+        assert observed["ostall"] == summary.output_stall_cycles
+        assert observed["contention"] == summary.arbitration_contention_cycles
+        assert observed["maxocc"] == summary.max_input_occupancy
+        assert observed["local"] == summary.route_flit_count[PORT_LOCAL]
+        assert observed["east"] == summary.route_flit_count[PORT_EAST]
+        assert observed["south"] == summary.route_flit_count[PORT_SOUTH]
+
+
+def test_multiflow_mesh_preserves_conservation_order_and_fairness() -> None:
+    flows = _multiflow_mesh_flows()
+    ready = _multiflow_mesh_ready()
+    scheduled = [scheduled for flow in flows for scheduled in packetize_traffic_flow(flow)]
+    result = simulate_scheduled_flits(scheduled, endpoint_out_ready_schedule=ready, max_cycles=256)
+
+    assert result.endpoint_injected_flit_count == len(scheduled)
+    assert len(result.deliveries) == len(scheduled)
+
+    by_label: dict[str, list[MeshDelivery]] = {}
+    for delivery in result.deliveries:
+        by_label.setdefault(delivery.flit.label, []).append(delivery)
+
+    assert set(by_label) == {flow.name for flow in flows}
+    for deliveries in by_label.values():
+        assert [delivery.flit.fragment for delivery in deliveries] == list(range(8))
+
+    first_sixteen_tags = {delivery.flit.tag for delivery in result.deliveries[:16]}
+    assert len(first_sixteen_tags) >= 2
+    assert any(summary.arbitration_contention_cycles > 0 for summary in result.router_summaries)


### PR DESCRIPTION
## Summary

- replace the single-flow mesh shortcut with a cycle-by-cycle 4x4 multi-flow model using deterministic XY routing, four VCs, finite router FIFOs, endpoint backpressure, and fair arbitration
- correlate a contended multi-source trace and router counters against the concrete mesh RTL
- map all eight declared Llama7B score32 waves (128 tiles) onto explicit cluster, shared-SRAM-home, and root endpoints
- prove ordered packet streams and non-overlapping lifetime reuse of concrete 8-bit tags
- preserve explicit boundaries for HBM/DRAM, SRAM floorplanning, root-finalizer timing, and source-descriptor/producer-control implementation

## Key result

The full default trace drains 92,128 flits / 11,576 packets in 37,374 cycles. It covers all 128 tiles, observes contention, and proves reused-tag separation with a minimum 12,721-cycle gap. This is an on-chip routed-service result, not a full token-latency claim.

## Validation

- `pytest -q tests/test_noc_segmented_mesh.py tests/test_llm_decoder_attention_score32_noc_phase2_schedule.py`: 9 passed
- git diff --check: clean
