### PR TITLE
control_plane: reconcile source for assigned L2 items

### DIFF
--- a/control_plane/control_plane/services/source_reconciler.py
+++ b/control_plane/control_plane/services/source_reconciler.py
@@ -16,7 +16,7 @@ from typing import NoReturn
 
 from sqlalchemy.orm import Session
 
-from control_plane.models.enums import FlowName, LeaseStatus, WorkItemState
+from control_plane.models.enums import LeaseStatus, WorkItemState
 from control_plane.models.worker_leases import WorkerLease
 from control_plane.models.work_items import WorkItem
 from control_plane.services.lease_service import upsert_worker_machine, worker_capabilities_for_filter
@@ -375,17 +375,6 @@ def _source_relation(repo_root: Path, required_sha: str, head_sha: str | None = 
     return "mismatch"
 
 
-def _machine_matches_item(*, capability_filter: dict[str, object] | None, work_item: WorkItem) -> bool:
-    effective = dict(capability_filter or {})
-    platform = str(effective.get("platform") or "").strip()
-    flow = str(effective.get("flow") or "").strip()
-    if platform and work_item.platform != platform:
-        return False
-    if flow and work_item.flow != FlowName(flow):
-        return False
-    return True
-
-
 def next_source_required_item(
     session: Session,
     *,
@@ -408,8 +397,6 @@ def next_source_required_item(
         role=machine_role,
         slot_capacity=slot_capacity,
     )
-    effective_filter = dict(machine.capabilities or {})
-    effective_filter.update(capability_filter or {})
     query = (
         session.query(WorkItem)
         .filter(WorkItem.state == WorkItemState.READY)
@@ -418,10 +405,11 @@ def next_source_required_item(
         .order_by(WorkItem.priority.desc(), WorkItem.created_at.asc(), WorkItem.item_id.asc())
     )
     for item in query.all():
-        if str(item.source_commit or "").strip() and _machine_matches_item(
-            capability_filter=effective_filter,
-            work_item=item,
-        ):
+        # Dispatcher assignment is authoritative. Reapplying the worker's
+        # platform/flow filter here can hide assigned Layer-2 items whose
+        # planning platform is intentionally "unknown", preventing the source
+        # update required before either execution or a later eligibility check.
+        if str(item.source_commit or "").strip():
             session.commit()
             return item
     session.commit()

--- a/control_plane/control_plane/tests/test_source_reconciler.py
+++ b/control_plane/control_plane/tests/test_source_reconciler.py
@@ -103,6 +103,59 @@ def test_next_source_required_item_persists_capability_filter() -> None:
         assert machine.capabilities["flow"] == "openroad"
 
 
+def test_next_source_required_item_honors_assignment_when_l2_platform_is_unknown() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    create_all(engine)
+    with Session(engine) as session:
+        task = TaskRequest(
+            request_key="queue:assigned_l2_unknown_platform",
+            source="test",
+            requested_by="tester",
+            title="assigned L2 source item",
+            description="requires newer source",
+            layer="layer2",
+            flow="openroad",
+            priority=1,
+            request_payload={"item_id": "assigned_l2_unknown_platform"},
+        )
+        session.add(task)
+        session.flush()
+        session.add(
+            WorkItem(
+                work_item_key="queue:assigned_l2_unknown_platform",
+                task_request_id=task.id,
+                item_id="assigned_l2_unknown_platform",
+                layer="layer2",
+                flow="openroad",
+                platform="unknown",
+                task_type="l2_campaign",
+                state=WorkItemState.READY,
+                priority=1,
+                source_commit="1" * 40,
+                assigned_machine_key="machine-1",
+                input_manifest={},
+                command_manifest=[],
+                expected_outputs=[],
+                acceptance_rules=[],
+            )
+        )
+        session.commit()
+
+        selected = next_source_required_item(
+            session,
+            machine_key="machine-1",
+            hostname=None,
+            executor_kind="docker",
+            machine_role="evaluator",
+            slot_capacity=1,
+            capabilities=None,
+            capability_filter={"platform": "nangate45", "flow": "openroad"},
+        )
+
+        assert selected is not None
+        assert selected.item_id == "assigned_l2_unknown_platform"
+
+
 def test_reconcile_service_repo_recovers_stale_git_index_lock(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     repo_root.mkdir()


### PR DESCRIPTION
## Summary

- treat an existing READY machine assignment as authoritative during pre-lease source reconciliation
- stop reapplying platform/flow capability filters after assignment
- cover assigned Layer-2 items with `platform=unknown` on a Nangate45 evaluator

## Root cause

The remote workload retry was already assigned and READY, but its Layer-2 planning platform is `unknown`. `next_source_required_item()` re-applied the evaluator capability filter (`platform=nangate45`) and skipped it, so the worker reported `no_work` forever instead of fetching the required newer source.

## Validation

- source reconciler + worker daemon suites: 31 passed
- git diff --check: clean
