### PR TITLE
Add strict NoC Phase 2 L2 dispatch

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5184,6 +5184,93 @@ def _decoder_attention_kv_onchip_service_schedule_evidence(
     }
 
 
+def _decoder_attention_score32_noc_phase2_schedule_evidence(
+    *,
+    item_id: str,
+    proposal_id: str | None,
+    proposal_path: str | None,
+) -> dict[str, Any]:
+    expected_item_id = "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1"
+    expected_proposal_id = "prop_l2_decoder_attention_score32_noc_phase2_schedule_v1"
+    expected_proposal_path = f"docs/proposals/{expected_proposal_id}/proposal.json"
+    if item_id != expected_item_id:
+        raise Layer2TaskGenerationError("score32 NoC Phase 2 only permits the exact workload-complete item")
+    if str(proposal_id or "").strip() != expected_proposal_id:
+        raise Layer2TaskGenerationError("score32 NoC Phase 2 proposal_id mismatch")
+    if str(proposal_path or "").strip() != expected_proposal_path:
+        raise Layer2TaskGenerationError("score32 NoC Phase 2 proposal_path mismatch")
+
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    source = (
+        f"{base}/decoder_attention_score32_exact_reduction_recost__"
+        "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1.json"
+    )
+    measured_costs = (
+        "runs/campaigns/npu/l1_measured_costs/"
+        "llama7b_attention_local_costs_all_measured_endpoint_v1.json"
+    )
+    out = f"{base}/decoder_attention_score32_noc_phase2_schedule__{item_id}.json"
+    report = f"{base}/decoder_attention_score32_noc_phase2_schedule__{item_id}.md"
+    command = _bounded_launcher_command(
+        memory_high="2G",
+        memory_max="4G",
+        cpu_quota="200%",
+        tasks_max=128,
+        runtime_max_sec=300,
+        child_command=[
+            "python3",
+            "npu/eval/measure_llm_decoder_attention_score32_noc_phase2_schedule.py",
+            "--repo-root",
+            ".",
+            "--source-json",
+            source,
+            "--measured-l1-costs",
+            measured_costs,
+            "--out",
+            out,
+            "--report",
+            report,
+        ],
+    )
+    return {
+        "inputs": {
+            "attention_score32_noc_phase2_source_recost": source,
+            "attention_score32_noc_phase2_measured_l1_costs": measured_costs,
+            "attention_score32_noc_phase2_schedule_out": out,
+            "attention_score32_noc_phase2_schedule_report": report,
+            "attention_score32_noc_phase2_scope": (
+                "Route all eight declared waves and all 128 Llama7B score32 tiles through the "
+                "cycle-level 4x4 segmented mesh model. Require finite router FIFOs, endpoint "
+                "backpressure, deterministic XY routing, four VCs, and collision-free 8-bit tag "
+                "reuse. Keep HBM/DRAM, SRAM floorplanning, root-finalizer compute, and source "
+                "descriptor/control storage explicit as remaining abstractions."
+            ),
+        },
+        "commands": [{"name": "measure_attention_score32_noc_phase2_full_schedule", "run": command}],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+        "worker_resources": {
+            "exclusive_worker": True,
+            "memory_high": "2G",
+            "memory_max": "4G",
+            "cpu_quota": "200%",
+            "tasks_max": 128,
+            "outer_timeout_seconds": 300,
+            "stall_timeout_seconds": 180,
+        },
+        "acceptance": [
+            "Require coverage=workload_complete with simulated_wave_count=declared_tile_waves=8",
+            "Require simulated_tiles=tile_count=128 and delivered_flit_count=scheduled_flit_count",
+            "Require collision_free_reuse_proven=true for concrete 8-bit tags",
+            "Require routed contention, endpoint stall, and top-link counts in the output",
+            "Do not pass --wave-limit in the workload-complete command",
+            "Preserve all on-chip and HBM/DRAM remaining-abstraction disclosures",
+            "Write exactly one JSON and one Markdown report",
+            "Run python3 scripts/validate_runs.py --skip_eval_queue before pushing",
+        ],
+    }
+
+
 def _decoder_attention_kv_endpoint_full_onchip_service_schedule_evidence(
     *,
     item_id: str,
@@ -12057,6 +12144,7 @@ def _build_payload(
         "decoder_attention_kv_endpoint_sram_noc_full_search_schedule",
         "decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_schedule",
         "decoder_attention_kv_onchip_service_schedule",
+        "decoder_attention_score32_noc_phase2_schedule",
         "decoder_attention_kv_endpoint_full_onchip_service_schedule",
         "decoder_attention_kv_endpoint_ready_valid_service",
         "decoder_attention_kv_endpoint_router_sram_composition",
@@ -12278,6 +12366,12 @@ def _build_payload(
             )
         elif abstraction_layer_name == "decoder_attention_kv_onchip_service_schedule":
             decoder_evidence = _decoder_attention_kv_onchip_service_schedule_evidence(item_id=item_id)
+        elif abstraction_layer_name == "decoder_attention_score32_noc_phase2_schedule":
+            decoder_evidence = _decoder_attention_score32_noc_phase2_schedule_evidence(
+                item_id=item_id,
+                proposal_id=proposal_id,
+                proposal_path=proposal_path,
+            )
         elif abstraction_layer_name == "decoder_attention_kv_endpoint_full_onchip_service_schedule":
             decoder_evidence = _decoder_attention_kv_endpoint_full_onchip_service_schedule_evidence(
                 item_id=item_id,

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -14550,6 +14550,122 @@ def test_generate_l2_campaign_task_adds_onchip_service_schedule_evidence() -> No
             )
 
 
+def test_generate_l2_campaign_task_adds_score32_noc_phase2_full_schedule_evidence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                _make_l2_request(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_score32_noc_phase2_schedule_v1",
+                    proposal_path=(
+                        "docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/"
+                        "proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_score32_noc_phase2_schedule",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            commands = work_item.task_request.request_payload["task"]["commands"]
+            command_names = [command["name"] for command in commands]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            expected_outputs = work_item.expected_outputs
+            run = commands[0]["run"]
+
+            assert command_names == [
+                "measure_attention_score32_noc_phase2_full_schedule",
+                "validate_runs",
+            ]
+            assert "control_plane/scripts/run_bounded_command.py" in run
+            assert "--memory-high 2G" in run
+            assert "--memory-max 4G" in run
+            assert "--cpu-quota 200%" in run
+            assert "--tasks-max 128" in run
+            assert "--runtime-max-sec 300" in run
+            assert "measure_llm_decoder_attention_score32_noc_phase2_schedule.py" in run
+            assert "decoder_attention_score32_exact_reduction_recost__" in run
+            assert "llama7b_attention_local_costs_all_measured_endpoint_v1.json" in run
+            assert "--wave-limit" not in run
+            assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
+            assert expected_outputs == [
+                (
+                    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                    "decoder_attention_score32_noc_phase2_schedule__"
+                    "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1.json"
+                ),
+                (
+                    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+                    "decoder_attention_score32_noc_phase2_schedule__"
+                    "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1.md"
+                ),
+            ]
+            expected_worker_resources = {
+                "exclusive_worker": True,
+                "memory_high": "2G",
+                "memory_max": "4G",
+                "cpu_quota": "200%",
+                "tasks_max": 128,
+                "outer_timeout_seconds": 300,
+                "stall_timeout_seconds": 180,
+            }
+            assert work_item.input_manifest["worker_resources"] == expected_worker_resources
+            assert (
+                work_item.task_request.request_payload["task"]["inputs"]["worker_resources"]
+                == expected_worker_resources
+            )
+            acceptance = work_item.task_request.request_payload["task"]["acceptance"]
+            assert any("declared_tile_waves=8" in entry for entry in acceptance)
+            assert any("simulated_tiles=tile_count=128" in entry for entry in acceptance)
+            assert any("collision_free_reuse_proven=true" in entry for entry in acceptance)
+
+
+def test_generate_l2_campaign_task_rejects_noncanonical_score32_noc_phase2_item() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session, pytest.raises(
+            Layer2TaskGenerationError,
+            match="only permits the exact workload-complete item",
+        ):
+            generate_l2_campaign_task(
+                session,
+                _make_l2_request(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r2",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_score32_noc_phase2_schedule_v1",
+                    proposal_path=(
+                        "docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/"
+                        "proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_score32_noc_phase2_schedule",
+                    evaluation_mode="frontier_detail",
+                    run_physical=False,
+                ),
+            )
+
+
 def test_generate_l2_campaign_task_adds_endpoint_full_onchip_service_schedule_evidence() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/evaluation_requests.json
@@ -1,7 +1,7 @@
 {
   "proposal_id": "prop_l2_decoder_attention_score32_noc_phase2_schedule_v1",
-  "source_commit_note": "Replace with the merged commit that adds the Phase 2 multi-flow segmented-mesh simulator, the score32 schedule materializer, focused tests, and this proposal before dispatch.",
-  "items": [
+  "source_commit_note": "Merge-pending: dispatch only from the clean merge commit containing the strict L2 generator contract and these finalized paths.",
+  "requested_items": [
     {
       "item_id": "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1",
       "task_type": "l2_campaign",
@@ -10,9 +10,14 @@
       "abstraction_layer": "decoder_attention_score32_noc_phase2_schedule",
       "cost_class": "low",
       "comparison_role": "closure_detail",
+      "campaign_path": "runs/campaigns/npu/e2e_eval_llm_attention_tail_stress_v1/campaign.json",
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_schedule__l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_schedule__l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1.md"
+      ],
       "requires_merged_inputs": true,
-      "requires_materialized_refs": false,
-      "acceptance_notes": "Do not insert a DB task from this patch. This request is checked in only so the evaluator can dispatch it later from a merged source. The default command should run the full declared workload; an explicit lightweight bounded dispatch may pass --wave-limit 1 when only a quick routed spot-check is desired. Every invocation must preserve the no-HBM/DRAM claim.",
+      "requires_materialized_refs": true,
+      "acceptance_notes": "Do not insert a DB task from this patch. Generate it only after merge using the strict two-pass source-identity workflow. The canonical command must run all eight waves and 128 tiles and must not pass --wave-limit. Every invocation must preserve the explicit HBM/DRAM and on-chip storage abstraction disclosures.",
       "expected_result": {
         "direction": "iterate",
         "reason": "Use the routed service summary to decide whether the next score32 composed rerank can replace the old NoC scalar or still needs a tighter SRAM-placement adapter."

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/proposal.json
@@ -42,8 +42,13 @@
       "abstraction_layer": "decoder_attention_score32_noc_phase2_schedule",
       "cost_class": "low",
       "comparison_role": "closure_detail",
+      "campaign_path": "runs/campaigns/npu/e2e_eval_llm_attention_tail_stress_v1/campaign.json",
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_schedule__l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_schedule__l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1.md"
+      ],
       "requires_merged_inputs": true,
-      "requires_materialized_refs": false,
+      "requires_materialized_refs": true,
       "expected_result": {
         "direction": "iterate",
         "reason": "Use the routed service summary to decide whether the next score32 composed rerank can replace the old NoC scalar or still needs a tighter SRAM-placement adapter."


### PR DESCRIPTION
## Summary
- add a strict, exact-item L2 generator path for the workload-complete score32 NoC Phase 2 schedule
- require all 8 waves / 128 tiles, bounded remote resources, and explicit remaining-abstraction disclosures
- finalize proposal campaign/output materialization metadata without inserting a DB item

## Tests
- `PYTHONPATH=control_plane python3 -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -k score32_noc_phase2`
- `python3 -m pytest -q tests/test_noc_segmented_mesh.py tests/test_llm_decoder_attention_score32_noc_phase2_schedule.py`
- `git diff --check origin/master...HEAD`