### PR TITLE
Finalize segmented router physical dispatch

### DIFF
--- a/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/analysis_report.md
+++ b/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/analysis_report.md
@@ -1,0 +1,27 @@
+# Analysis Report
+
+## Candidate
+- `proposal_id`: `prop_l1_segmented_xy_mesh_noc_phase1_v1`
+- `candidate_id`: `l1_segmented_xy_mesh_noc_phase1_v1`
+
+## Evaluations Consumed
+- Pending remote Nangate45 evaluation from the exact finalized source commit.
+
+## Baseline Comparison
+- Legacy comparison: separately measured synthetic 4-port router and FIFO
+  primitives.
+- Candidate: the exact five-port router with four per-input VCs and depth-4
+  buffering used by the merged 4x4 mesh RTL/model.
+
+## Result
+- Pending. No measured area, timing, or power claim is made before the result
+  artifacts merge.
+
+## Failures and Caveats
+- This item is a single-router macro anchor, not aggregate 4x4 placement.
+- Vectorless power will not close workload-specific NoC activity energy.
+- SRAM endpoints and external memory are not part of this block.
+
+## Recommendation
+- Measure the primitive remotely, consume it in the Phase 2 schedule recost,
+  then evaluate whether aggregate 4x4 placement is required to bound wire cost.

--- a/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/evaluation_gate.md
@@ -1,0 +1,8 @@
+# Evaluation Gate
+
+- status: approved
+- approved_by: user
+- approved_utc: 2026-08-11T00:00:00Z
+- allowed_evaluations:
+  - `l1_segmented_xy_mesh_noc_phase1_v1`
+- note: Run on the remote evaluator; preserve the single-router primitive scope.

--- a/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/evaluation_requests.json
@@ -1,18 +1,31 @@
 {
   "proposal_id": "prop_l1_segmented_xy_mesh_noc_phase1_v1",
-  "source_commit": "",
+  "source_commit": "b61e9afcdb7a5da2c7c72200e6483eb9aebeb349",
   "requested_items": [
     {
       "item_id": "l1_segmented_xy_mesh_noc_phase1_v1",
       "task_type": "l1_sweep",
-      "objective": "Measure the concrete segmented five-port router primitive for the Phase 1 NoC embodiment.",
+      "objective": "Measure Nangate45 PPA for the concrete 256-bit, 4-VC, depth-4 five-port router used by the 4x4 Phase 2 mesh model.",
       "evaluation_mode": "ppa",
       "abstraction_layer": "architecture_block",
       "config_paths": [
         "runs/designs/noc/l1_noc_segmented_xy_router_p5_w256_vc4_d4_wrapper/config_l1_noc_segmented_xy_router_p5_w256_vc4_d4.json"
       ],
       "sweep_path": "runs/campaigns/noc/l1_segmented_xy_mesh_router/sweeps/nangate45_macro_frontier.json",
-      "status": "proposed"
+      "expected_outputs": [
+        "runs/designs/noc/l1_noc_segmented_xy_router_p5_w256_vc4_d4_wrapper/metrics.csv"
+      ],
+      "status": "pending",
+      "comparison_role": "segmented_xy_router_primitive_anchor",
+      "paired_baseline_item_id": "",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_segmented_xy_router_primitive",
+        "reason": "Replace scaled legacy router/FIFO cost with the exact five-port Phase 1 router primitive before aggregate mesh recost."
+      },
+      "acceptance_notes": "Accept only physically completed hierarchical rows. Record this as a single-router primitive anchor, not aggregate 4x4 mesh PPA or SRAM/HBM evidence."
     }
   ]
 }

--- a/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/promotion_decision.json
+++ b/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/promotion_decision.json
@@ -1,0 +1,9 @@
+{
+  "proposal_id": "prop_l1_segmented_xy_mesh_noc_phase1_v1",
+  "candidate_id": "",
+  "decision": "pending",
+  "reason": "The dedicated segmented-router physical result has not materialized yet.",
+  "evidence_refs": [],
+  "next_action": "Run and merge l1_segmented_xy_mesh_noc_phase1_v1, then recost the full-workload Phase 2 schedule with the measured primitive.",
+  "requires_human_approval": true
+}

--- a/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/promotion_gate.md
+++ b/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/promotion_gate.md
@@ -1,0 +1,7 @@
+# Promotion Gate
+
+- status: pending
+- approved_by:
+- approved_utc:
+- action: Accept a timing-feasible hierarchical router row as a primitive anchor.
+- note: Do not promote it as aggregate 4x4 mesh PPA or workload activity signoff.

--- a/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/promotion_result.json
+++ b/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l1_segmented_xy_mesh_noc_phase1_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/proposal.json
+++ b/docs/proposals/prop_l1_segmented_xy_mesh_noc_phase1_v1/proposal.json
@@ -25,5 +25,29 @@
     "The Phase 1 PPA artifact is a single-router wrapper, not the physical aggregate 4x4 mesh.",
     "The mesh model remains deterministic XY and does not include adaptive routing or workload-specific traffic shaping.",
     "End-to-end Llama7B scheduling over the mesh still needs explicit producer/consumer traffic mapping."
-  ]
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l1_segmented_xy_mesh_noc_phase1_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the concrete 256-bit, 4-VC, depth-4 five-port router used by the 4x4 Phase 2 mesh model.",
+      "evaluation_mode": "ppa",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "segmented_xy_router_primitive_anchor",
+      "config_paths": [
+        "runs/designs/noc/l1_noc_segmented_xy_router_p5_w256_vc4_d4_wrapper/config_l1_noc_segmented_xy_router_p5_w256_vc4_d4.json"
+      ],
+      "sweep_path": "runs/campaigns/noc/l1_segmented_xy_mesh_router/sweeps/nangate45_macro_frontier.json",
+      "expected_outputs": [
+        "runs/designs/noc/l1_noc_segmented_xy_router_p5_w256_vc4_d4_wrapper/metrics.csv"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_segmented_xy_router_primitive",
+        "reason": "Replace scaled legacy router/FIFO cost with the exact five-port Phase 1 router primitive before aggregate mesh recost."
+      }
+    }
+  ],
+  "created_utc": "2026-08-11T10:15:10.770452Z"
 }


### PR DESCRIPTION
## Summary
- finalize the strict first-pass proposal metadata for the concrete five-port segmented router PPA item
- distinguish the measured single-router primitive from aggregate 4x4 placement and workload activity
- record exact config, sweep, output, approval, and promotion gates without inserting a DB item

## Validation
- generated the router wrapper and compiled it with `iverilog`
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`