### PR TITLE
Correct NoC Phase 2 clock domains

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5190,7 +5190,7 @@ def _decoder_attention_score32_noc_phase2_schedule_evidence(
     proposal_id: str | None,
     proposal_path: str | None,
 ) -> dict[str, Any]:
-    expected_item_id = "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1"
+    expected_item_id = "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1"
     expected_proposal_id = "prop_l2_decoder_attention_score32_noc_phase2_schedule_v1"
     expected_proposal_path = f"docs/proposals/{expected_proposal_id}/proposal.json"
     if item_id != expected_item_id:
@@ -5226,6 +5226,8 @@ def _decoder_attention_score32_noc_phase2_schedule_evidence(
             source,
             "--measured-l1-costs",
             measured_costs,
+            "--noc-clock-ns",
+            "1.0",
             "--out",
             out,
             "--report",
@@ -5242,8 +5244,10 @@ def _decoder_attention_score32_noc_phase2_schedule_evidence(
                 "Route all eight declared waves and all 128 Llama7B score32 tiles through the "
                 "cycle-level 4x4 segmented mesh model. Require finite router FIFOs, endpoint "
                 "backpressure, deterministic XY routing, four VCs, and collision-free 8-bit tag "
-                "reuse. Keep HBM/DRAM, SRAM floorplanning, root-finalizer compute, and source "
-                "descriptor/control storage explicit as remaining abstractions."
+                "reuse. Convert source compute cycles to an explicit 1ns NoC target clock before "
+                "routing. Keep measured NoC-clock substitution, HBM/DRAM, SRAM floorplanning, "
+                "root-finalizer compute, and source descriptor/control storage explicit as "
+                "remaining abstractions."
             ),
         },
         "commands": [{"name": "measure_attention_score32_noc_phase2_full_schedule", "run": command}],
@@ -5262,6 +5266,9 @@ def _decoder_attention_score32_noc_phase2_schedule_evidence(
             "Require coverage=workload_complete with simulated_wave_count=declared_tile_waves=8",
             "Require simulated_tiles=tile_count=128 and delivered_flit_count=scheduled_flit_count",
             "Require collision_free_reuse_proven=true for concrete 8-bit tags",
+            "Require version=2 and explicit compute_clock_ns/noc_clock_ns release conversion",
+            "Require every NoC release cycle to equal ceil(compute_cycles * compute_clock_ns / noc_clock_ns)",
+            "Record NoC drain time against the source compute-layer wall-time envelope without claiming root-finalizer closure",
             "Require routed contention, endpoint stall, and top-link counts in the output",
             "Do not pass --wave-limit in the workload-complete command",
             "Preserve all on-chip and HBM/DRAM remaining-abstraction disclosures",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -14565,7 +14565,7 @@ def test_generate_l2_campaign_task_adds_score32_noc_phase2_full_schedule_evidenc
                 _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
-                    item_id="l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1",
+                    item_id="l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1",
                     requested_by="@tester",
                     source_commit=source_commit,
                     proposal_id="prop_l2_decoder_attention_score32_noc_phase2_schedule_v1",
@@ -14599,18 +14599,19 @@ def test_generate_l2_campaign_task_adds_score32_noc_phase2_full_schedule_evidenc
             assert "measure_llm_decoder_attention_score32_noc_phase2_schedule.py" in run
             assert "decoder_attention_score32_exact_reduction_recost__" in run
             assert "llama7b_attention_local_costs_all_measured_endpoint_v1.json" in run
+            assert "--noc-clock-ns 1.0" in run
             assert "--wave-limit" not in run
             assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
             assert expected_outputs == [
                 (
                     "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                     "decoder_attention_score32_noc_phase2_schedule__"
-                    "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1.json"
+                    "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1.json"
                 ),
                 (
                     "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                     "decoder_attention_score32_noc_phase2_schedule__"
-                    "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1.md"
+                    "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1.md"
                 ),
             ]
             expected_worker_resources = {
@@ -14631,6 +14632,7 @@ def test_generate_l2_campaign_task_adds_score32_noc_phase2_full_schedule_evidenc
             assert any("declared_tile_waves=8" in entry for entry in acceptance)
             assert any("simulated_tiles=tile_count=128" in entry for entry in acceptance)
             assert any("collision_free_reuse_proven=true" in entry for entry in acceptance)
+            assert any("compute_clock_ns/noc_clock_ns" in entry for entry in acceptance)
 
 
 def test_generate_l2_campaign_task_rejects_noncanonical_score32_noc_phase2_item() -> None:
@@ -14651,7 +14653,7 @@ def test_generate_l2_campaign_task_rejects_noncanonical_score32_noc_phase2_item(
                 _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
-                    item_id="l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r2",
+                    item_id="l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1",
                     requested_by="@tester",
                     source_commit=source_commit,
                     proposal_id="prop_l2_decoder_attention_score32_noc_phase2_schedule_v1",

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/README.md
@@ -5,5 +5,11 @@ This proposal introduces a Phase 2 score32 NoC schedule report that:
 - consumes the existing Llama7B score32 recost artifact and measured L1 cost profile
 - materializes an explicit static 4x4 mesh mapping for shared-SRAM and root-reduction traffic
 - uses the cycle-by-cycle multi-flow segmented mesh model instead of a one-flow bandwidth scalar
+- converts compute-wrapper release cycles into absolute NoC cycles using explicit
+  clock periods before routing
 
 The checked-in report generator now defaults to the full declared workload. A lightweight bounded run is still available, but only when `--wave-limit` is passed explicitly. The requested L2 job stays intentionally lightweight, with no HBM/DRAM timing claim and no DB insertion from this patch.
+
+The original unrun v1 queue item is superseded: it treated compute cycles as
+NoC cycles. The immutable `_r1` retry uses a 1ns target NoC clock and retains
+measured-router-clock substitution as a required follow-on.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/analysis_report.md
@@ -2,7 +2,7 @@
 
 ## Candidate
 - `proposal_id`: `prop_l2_decoder_attention_score32_noc_phase2_schedule_v1`
-- `candidate_id`: `l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1`
+- `candidate_id`: `l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1`
 
 ## Evaluations Consumed
 - Pending remote execution from the exact finalized source commit.
@@ -15,6 +15,9 @@
 ## Result
 - Pending. No architectural promotion or rerank is permitted before the result
   artifact is merged and its full-workload assertions pass.
+- The unrun v1 item is superseded because it interpreted compute-wrapper cycles
+  directly as NoC cycles and therefore represented a saturation stress trace,
+  not a physically timed producer-coupled schedule.
 
 ## Failures and Caveats
 - HBM/DRAM timing and controller behavior remain abstract.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/design_brief.md
@@ -17,6 +17,9 @@ flit conservation, or 8-bit tag lifetime safety.
 - One evidence-only item covering all 128 tiles in all eight declared waves.
 - Deterministic XY routing, four VCs, finite router FIFOs, and endpoint stalls.
 - Checked-in exact-reduction traffic and measured L1 endpoint-cost inputs.
+- Explicit conversion from the measured `48.6509 ns` compute-wrapper domain to
+  a 1ns target NoC domain; the measured five-port router clock remains a
+  follow-on substitution.
 - No dependency on the historically failed recost DB record; materialized repo
   references are required instead.
 - HBM/DRAM, measured SRAM placement, root-finalizer timing, and producer

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/evaluation_gate.md
@@ -4,5 +4,5 @@
 - approved_by: user
 - approved_utc: 2026-08-11T00:00:00Z
 - allowed_evaluations:
-  - `l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1`
-- note: Run remotely from the exact finalized commit with no `--wave-limit`.
+  - `l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1`
+- note: Run the clock-corrected retry remotely from the exact finalized commit with no `--wave-limit`; v1 is superseded.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/evaluation_requests.json
@@ -24,7 +24,34 @@
       },
       "paired_baseline_item_id": "",
       "depends_on_item_ids": [],
-      "status": "pending"
+      "status": "superseded",
+      "superseded_by_item_id": "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1",
+      "notes": "Superseded before dispatch: compute-wrapper cycles were incorrectly interpreted as NoC cycles. No result from this item may be used for recost or ranking."
+    },
+    {
+      "item_id": "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1",
+      "task_type": "l2_campaign",
+      "objective": "Materialize the clock-corrected complete 8-wave, 128-tile score32 schedule through the concrete 4x4 segmented mesh model.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_noc_phase2_schedule",
+      "cost_class": "low",
+      "comparison_role": "closure_detail",
+      "campaign_path": "runs/campaigns/npu/e2e_eval_llm_attention_tail_stress_v1/campaign.json",
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_schedule__l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_schedule__l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1.md"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "acceptance_notes": "Generate only after merge using the strict two-pass source-identity workflow. Run all eight waves and 128 tiles with no --wave-limit. Require version=2, explicit compute/NoC clocks, exact release-cycle conversion, and all remaining abstraction disclosures.",
+      "expected_result": {
+        "direction": "iterate",
+        "reason": "Use clock-corrected routed service evidence to replace the old NoC scalar or identify the next measured-clock/SRAM-placement adapter."
+      },
+      "paired_baseline_item_id": "",
+      "depends_on_item_ids": [],
+      "status": "pending",
+      "supersedes_item_id": "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1"
     }
   ],
   "source_commit": "8657c26f8c3ba3d6aa361a0a74d12d665cb13113"

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/implementation_summary.md
@@ -9,23 +9,36 @@
   schedule.
 - Added bounded remote resources, exact outputs, proposal linkage, and explicit
   remaining-abstraction acceptance checks.
-- Did not alter router RTL, the simulator, source traffic quantities, or HBM.
+- Corrected compute-to-NoC clock conversion after the unrun v1 contract was
+  found to interpret `48.6509 ns` compute-wrapper cycles as router cycles.
+- Added idle fast-forward that preserves absolute cycle timestamps, allowing
+  physically spaced releases without storing hundreds of thousands of empty
+  traces.
+- Did not alter router RTL, source traffic quantities, or HBM.
 
 ## Files Changed
 - `control_plane/control_plane/services/l2_task_generator.py`
 - `control_plane/control_plane/tests/test_l2_task_generator.py`
+- `npu/sim/perf/noc_segmented_mesh.py`
+- `npu/eval/measure_llm_decoder_attention_score32_noc_phase2_schedule.py`
+- `tests/test_noc_segmented_mesh.py`
+- `tests/test_llm_decoder_attention_score32_noc_phase2_schedule.py`
 - this proposal workspace
 
 ## Local Validation
 - Focused L2 generator tests: 2 passed.
-- NoC simulator/materializer tests: 9 passed.
+- NoC simulator/materializer tests cover absolute clock conversion and idle
+  fast-forward equivalence in addition to routing and tag safety.
 - `python3 scripts/validate_runs.py --skip_eval_queue`: passed.
 - `git diff --check`: passed.
 
 ## Evaluation Request
-- One low-cost evidence-only remote L2 item.
+- One immutable low-cost evidence-only remote L2 retry; the unrun v1 item is
+  superseded and must not be consumed.
 - Compare routed service evidence against the prior scalar NoC assumption.
 
 ## Risks
 - The result cannot close HBM/DRAM, physical SRAM placement, root-finalizer
   compute, or producer descriptor/control storage.
+- The explicit 1ns NoC target remains an assumption until the segmented-router
+  physical item supplies a measured clock.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/promotion_decision.json
@@ -4,6 +4,6 @@
   "decision": "pending",
   "reason": "The workload-complete remote result has not materialized yet.",
   "evidence_refs": [],
-  "next_action": "Run and merge l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1, then rerank or add the SRAM-placement adapter.",
+  "next_action": "Run and merge l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1, substitute the measured router clock, then rerank or add the SRAM-placement adapter.",
   "requires_human_approval": true
 }

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/proposal.json
@@ -30,29 +30,37 @@
     "the static shared-SRAM home mapping is still an adapter, not a measured SRAM placement",
     "full on-chip routed schedule evidence must not be promoted into a full HBM-backed latency claim",
     "release queues are logical zero-copy source descriptors backed by retained SRAM data; their control/storage implementation is not measured here",
-    "command/control cadence remains inherited from the checked-in recost artifact"
+    "command/control cadence remains inherited from the checked-in recost artifact",
+    "the explicit 1ns NoC target must be replaced by the measured five-port router clock before final recost"
   ],
   "needs_mapper_change": false,
   "required_evaluations": [
     {
-      "item_id": "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1",
+      "item_id": "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1",
       "task_type": "l2_campaign",
-      "objective": "Run the score32 segmented-mesh Phase 2 schedule materializer and record routed drain cycles, contention, and explicit assumptions, defaulting to the full declared workload unless a bounded wave limit is passed explicitly.",
+      "objective": "Run the clock-corrected score32 segmented-mesh Phase 2 schedule materializer and record routed drain time, contention, and explicit assumptions for the full workload.",
       "evaluation_mode": "frontier_detail",
       "abstraction_layer": "decoder_attention_score32_noc_phase2_schedule",
       "cost_class": "low",
       "comparison_role": "closure_detail",
       "campaign_path": "runs/campaigns/npu/e2e_eval_llm_attention_tail_stress_v1/campaign.json",
       "expected_outputs": [
-        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_schedule__l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1.json",
-        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_schedule__l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1.md"
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_schedule__l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_schedule__l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1.md"
       ],
       "requires_merged_inputs": true,
       "requires_materialized_refs": true,
       "expected_result": {
         "direction": "iterate",
-        "reason": "Use the routed service summary to decide whether the next score32 composed rerank can replace the old NoC scalar or still needs a tighter SRAM-placement adapter."
-      }
+        "reason": "Use clock-corrected routed service evidence to decide whether the next score32 composed rerank can replace the old NoC scalar or still needs a measured-clock/SRAM-placement adapter."
+      },
+      "supersedes_item_id": "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1"
+    }
+  ],
+  "superseded_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1",
+      "reason": "Compute-wrapper cycles were interpreted directly as NoC cycles; the unrun item is invalid for physical schedule conclusions."
     }
   ],
   "baseline_refs": [

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/quality_gate.md
@@ -15,6 +15,10 @@ The result will replace a scalar NoC assumption in later architecture costing.
 - coverage: `workload_complete`, 8 waves, and 128 tiles
 - conservation: delivered flits equal scheduled flits
 - tag safety: collision-free 8-bit reuse is proven
+- clock domains: compute releases are converted to absolute NoC cycles with
+  `ceil(compute_cycles * compute_clock_ns / noc_clock_ns)`
+- fast-forward: accelerated and unaccelerated simulations preserve absolute
+  delivery cycles
 - disclosure: all remaining storage, finalizer, and HBM abstractions are listed
 
 ## Local Commands

--- a/npu/eval/measure_llm_decoder_attention_score32_noc_phase2_schedule.py
+++ b/npu/eval/measure_llm_decoder_attention_score32_noc_phase2_schedule.py
@@ -62,6 +62,14 @@ def _ceil_div(numerator: int | float, denominator: int | float) -> int:
     return int(math.ceil(float(numerator) / float(denominator)))
 
 
+def _cycles_between_domains(cycles: int, *, source_clock_ns: float, destination_clock_ns: float) -> int:
+    if cycles < 0:
+        raise ValueError("cycle count must be non-negative")
+    if source_clock_ns <= 0.0 or destination_clock_ns <= 0.0:
+        raise ValueError("clock periods must be positive")
+    return _ceil_div(cycles * source_clock_ns, destination_clock_ns)
+
+
 def _int_list(value: str) -> list[int]:
     items = [int(item.strip()) for item in value.split(",") if item.strip()]
     if not items:
@@ -393,6 +401,8 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "cross_tile_reduction_payload_bytes",
             "tile_attention_cycles",
             "qkv_cycles",
+            "layer_cycles",
+            "measured_dual_stream_composed_clock_ns",
             "noc_hops",
             "measured_l1_profile",
         ],
@@ -451,6 +461,17 @@ def build_report(args: argparse.Namespace) -> JsonDict:
 
     qkv_cycles = int(source_row["qkv_cycles"])
     tile_attention_cycles = int(source_row["tile_attention_cycles"])
+    compute_layer_cycles = int(source_row["layer_cycles"])
+    compute_clock_ns = float(
+        args.compute_clock_ns
+        if args.compute_clock_ns is not None
+        else source_row["measured_dual_stream_composed_clock_ns"]
+    )
+    noc_clock_ns = float(args.noc_clock_ns)
+    if compute_clock_ns <= 0.0:
+        raise ValueError("compute_clock_ns must be positive")
+    if noc_clock_ns <= 0.0:
+        raise ValueError("noc_clock_ns must be positive")
     reduction_payload_bytes = int(source_row["partial_reduction_payload_bytes"])
 
     packet_specs: list[PacketSpec] = []
@@ -459,11 +480,29 @@ def build_report(args: argparse.Namespace) -> JsonDict:
     remote_shared_hops: list[int] = []
     remote_reduction_hops: list[int] = []
     packet_seed_counter = 0
+    wave_start_compute_cycles: list[int] = []
+    wave_start_noc_cycles: list[int] = []
+    reduction_release_compute_cycles: list[int] = []
+    reduction_release_noc_cycles: list[int] = []
 
     for wave in range(wave_count):
         wave_tiles = min(active_clusters, max(0, tile_count - wave * active_clusters))
-        wave_start = qkv_cycles + (wave * tile_attention_cycles)
-        reduction_release = wave_start + tile_attention_cycles
+        wave_start_compute = qkv_cycles + (wave * tile_attention_cycles)
+        reduction_release_compute = wave_start_compute + tile_attention_cycles
+        wave_start = _cycles_between_domains(
+            wave_start_compute,
+            source_clock_ns=compute_clock_ns,
+            destination_clock_ns=noc_clock_ns,
+        )
+        reduction_release = _cycles_between_domains(
+            reduction_release_compute,
+            source_clock_ns=compute_clock_ns,
+            destination_clock_ns=noc_clock_ns,
+        )
+        wave_start_compute_cycles.append(wave_start_compute)
+        wave_start_noc_cycles.append(wave_start)
+        reduction_release_compute_cycles.append(reduction_release_compute)
+        reduction_release_noc_cycles.append(reduction_release)
         for cluster_index in range(wave_tiles):
             compute_endpoint = cluster_endpoints[cluster_index]
             home_endpoint = _home_endpoint(
@@ -510,7 +549,11 @@ def build_report(args: argparse.Namespace) -> JsonDict:
 
     traffic_flows = _packetize_specs_with_wide_tags(packet_specs)
     scheduled_flits = [scheduled for flow in traffic_flows for scheduled in packetize_traffic_flow(flow)]
-    mesh_result = simulate_scheduled_flits(scheduled_flits, max_cycles=args.max_cycles)
+    mesh_result = simulate_scheduled_flits(
+        scheduled_flits,
+        max_cycles=args.max_cycles,
+        fast_forward_idle=True,
+    )
     flow_names = {spec.flow_name for spec in packet_specs}
     if not flow_names:
         raise ValueError("Phase 2 schedule produced no remote NoC traffic")
@@ -548,9 +591,11 @@ def build_report(args: argparse.Namespace) -> JsonDict:
     total_reduction_remote_bytes = sum(
         spec.payload_bytes for spec in packet_specs if spec.flow_name.startswith("reduction_")
     )
+    compute_layer_time_ns = compute_layer_cycles * compute_clock_ns
+    noc_drain_time_ns = mesh_result.cycles * noc_clock_ns
 
     payload = {
-        "version": 1,
+        "version": 2,
         "model": "llama7b_proxy",
         "profile": "decoder_attention_score32_noc_phase2_schedule",
         "source_artifacts": {
@@ -573,6 +618,10 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "shared_byte_share": float(source_row["shared_byte_share"]),
             "declared_cross_tile_reduction_cycles": int(source_row["cross_tile_reduction_cycles"]),
             "declared_noc_hops": int(source_row["noc_hops"]),
+            "compute_clock_ns": compute_clock_ns,
+            "noc_clock_ns": noc_clock_ns,
+            "compute_layer_cycles": compute_layer_cycles,
+            "compute_layer_time_ns": compute_layer_time_ns,
             "topology": source_row.get("topology"),
             "scheduler_policy": source_row.get("scheduler_policy"),
             "reduction_strategy": source_row.get("reduction_strategy"),
@@ -602,12 +651,23 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "shared_vc": int(args.shared_vc),
             "reduction_vc": int(args.reduction_vc),
             "requested_wave_limit": requested_wave_limit,
-            "qkv_cycles_before_wave0": qkv_cycles,
-            "tile_attention_cycles_per_wave": tile_attention_cycles,
-            "reduction_release_offset_cycles": tile_attention_cycles,
+            "compute_qkv_cycles_before_wave0": qkv_cycles,
+            "compute_tile_attention_cycles_per_wave": tile_attention_cycles,
+            "compute_reduction_release_offset_cycles": tile_attention_cycles,
+            "compute_clock_ns": compute_clock_ns,
+            "noc_clock_ns": noc_clock_ns,
+            "compute_to_noc_clock_ratio": compute_clock_ns / noc_clock_ns,
+            "wave_start_compute_cycles": wave_start_compute_cycles,
+            "wave_start_noc_cycles": wave_start_noc_cycles,
+            "reduction_release_compute_cycles": reduction_release_compute_cycles,
+            "reduction_release_noc_cycles": reduction_release_noc_cycles,
+            "release_conversion": "ceil(compute_cycles * compute_clock_ns / noc_clock_ns)",
         },
         "simulation": {
             "cycles_to_drain": mesh_result.cycles,
+            "drain_time_ns": noc_drain_time_ns,
+            "drain_minus_compute_layer_time_ns": noc_drain_time_ns - compute_layer_time_ns,
+            "drain_within_source_compute_layer_envelope": noc_drain_time_ns <= compute_layer_time_ns,
             "scheduled_flit_count": len(scheduled_flits),
             "scheduled_packet_count": len(packet_specs),
             "endpoint_injected_flit_count": mesh_result.endpoint_injected_flit_count,
@@ -675,14 +735,15 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "Tile-to-cluster assignment is static wave-major round robin over the named cluster endpoints.",
             "Shared SRAM homes use a deterministic rotating stride/offset mapping chosen only from explicit 4x4 permutations to approximate the declared hop envelope while keeping load balanced.",
             "The root endpoint is explicit and fixed; root-finalizer output remains local to that endpoint.",
-            "Wave start and reduction release times are derived from the checked-in score32 recost quantities qkv_cycles and tile_attention_cycles only.",
+            "Wave start and reduction release times are derived from checked-in score32 compute cycles and converted to absolute NoC cycles using the explicit compute and NoC clock periods.",
             "HBM/DRAM timing is intentionally excluded; no remote traffic or timing claim is made for HBM service.",
             "Each packet carries up to packet_payload_bytes of payload and is segmented into 256-bit flits with no extra header flit modeled.",
             "The performance model does not perform packet reassembly; the checked artifact therefore fails closed unless 8-bit tag reuse is provably non-overlapping for each (source, destination, vc) tuple over packet lifetime intervals.",
             "Per-endpoint release queues are logical zero-copy descriptors over payloads retained in source SRAM or reducer state, not physically costed flit FIFOs; endpoint packetizer/control storage remains outside this result.",
         ],
         "remaining_abstractions": [
-            "The schedule uses static wave timing from checked-in recost quantities and does not yet prove end-to-end command/control RTL cadence.",
+            "The schedule uses clock-corrected static wave timing from checked-in recost quantities and does not yet prove end-to-end command/control RTL cadence.",
+            "The NoC clock is an explicit evaluation assumption until the exact five-port segmented-router physical result is merged and substituted.",
             "The source-descriptor queues and producer backpressure/control needed to retain payloads until injection are not yet embodied or physically measured.",
             "Shared SRAM home placement is deterministic and explicit, but still a topology adapter rather than a measured SRAM floorplan.",
             "HBM/DRAM service and controller timing remain intentionally out of scope.",
@@ -704,6 +765,8 @@ def write_report(payload: JsonDict, report: Path) -> None:
         f"- coverage: `{payload['source_contract']['coverage']}`",
         f"- declared waves: `{payload['source_contract']['declared_tile_waves']}`",
         f"- simulated waves: `{payload['source_contract']['simulated_wave_count']}`",
+        f"- compute clock: `{payload['source_contract']['compute_clock_ns']} ns`",
+        f"- NoC clock: `{payload['source_contract']['noc_clock_ns']} ns`",
         "",
         "## Mapping",
         "",
@@ -723,6 +786,9 @@ def write_report(payload: JsonDict, report: Path) -> None:
         "## Routed Result",
         "",
         f"- drain cycles: `{payload['simulation']['cycles_to_drain']}`",
+        f"- drain time: `{payload['simulation']['drain_time_ns']} ns`",
+        f"- source compute-layer envelope: `{payload['source_contract']['compute_layer_time_ns']} ns`",
+        f"- drain within source compute-layer envelope: `{payload['simulation']['drain_within_source_compute_layer_envelope']}`",
         f"- scheduled packets: `{payload['simulation']['scheduled_packet_count']}`",
         f"- scheduled flits: `{payload['simulation']['scheduled_flit_count']}`",
         f"- contention cycles: `{payload['simulation']['router_contention_cycles']}`",
@@ -767,7 +833,9 @@ def main() -> int:
     parser.add_argument("--root-endpoint", type=int, default=15)
     parser.add_argument("--shared-vc", type=int, default=0)
     parser.add_argument("--reduction-vc", type=int, default=1)
-    parser.add_argument("--max-cycles", type=int, default=200000)
+    parser.add_argument("--compute-clock-ns", type=float, default=None)
+    parser.add_argument("--noc-clock-ns", type=float, default=1.0)
+    parser.add_argument("--max-cycles", type=int, default=1000000)
     args = parser.parse_args()
 
     payload = build_report(args)

--- a/npu/sim/perf/noc_segmented_mesh.py
+++ b/npu/sim/perf/noc_segmented_mesh.py
@@ -499,6 +499,7 @@ def simulate_scheduled_flits(
     fifo_depth: int = DEFAULT_FIFO_DEPTH,
     vc_count: int = VIRTUAL_CHANNELS,
     max_cycles: int = 100000,
+    fast_forward_idle: bool = False,
 ) -> MeshSimulationResult:
     ordered = sorted(scheduled_flits, key=lambda item: (item.release_cycle, item.flit.source, item.flit.tag, item.flit.fragment))
     release_queues: list[deque[ScheduledFlit]] = [deque() for _ in range(ENDPOINTS)]
@@ -520,7 +521,17 @@ def simulate_scheduled_flits(
     endpoint_input_stall_cycles = [0] * ENDPOINTS
     endpoint_injected_flit_count = 0
 
-    for cycle in range(max_cycles):
+    cycle = 0
+    while cycle < max_cycles:
+        if (
+            fast_forward_idle
+            and future
+            and future[0].release_cycle > cycle
+            and all(not queue for queue in release_queues)
+            and all(state.idle() for state in states)
+        ):
+            cycle = future[0].release_cycle
+
         while future and future[0].release_cycle <= cycle:
             released = future.popleft()
             release_queues[released.flit.source].append(released)
@@ -634,6 +645,8 @@ def simulate_scheduled_flits(
                 endpoint_injected_flit_count=endpoint_injected_flit_count,
                 endpoint_input_stall_cycles=tuple(endpoint_input_stall_cycles),
             )
+
+        cycle += 1
 
     raise RuntimeError("mesh model did not drain within max_cycles")
 

--- a/tests/test_llm_decoder_attention_score32_noc_phase2_schedule.py
+++ b/tests/test_llm_decoder_attention_score32_noc_phase2_schedule.py
@@ -25,7 +25,9 @@ def _args(**overrides: object) -> argparse.Namespace:
         "root_endpoint": 15,
         "shared_vc": 0,
         "reduction_vc": 1,
-        "max_cycles": 200000,
+        "compute_clock_ns": None,
+        "noc_clock_ns": 1.0,
+        "max_cycles": 1000000,
     }
     values.update(overrides)
     return argparse.Namespace(**values)
@@ -35,12 +37,24 @@ def test_score32_noc_phase2_default_report_covers_full_declared_workload() -> No
     report = build_report(_args())
 
     assert report["profile"] == "decoder_attention_score32_noc_phase2_schedule"
+    assert report["version"] == 2
     assert report["source_contract"]["coverage"] == "workload_complete"
     assert report["source_contract"]["simulated_wave_count"] == report["source_contract"]["declared_tile_waves"]
     assert report["traffic_quantities"]["simulated_tiles"] == report["traffic_quantities"]["tile_count"]
     assert report["flow_summary"]["remote_shared_flow_count"] > 0
     assert report["flow_summary"]["remote_reduction_flow_count"] > 0
     assert report["simulation"]["delivered_flit_count"] == report["simulation"]["scheduled_flit_count"]
+    assert report["source_contract"]["compute_clock_ns"] == pytest.approx(48.6509)
+    assert report["source_contract"]["noc_clock_ns"] == pytest.approx(1.0)
+    assert report["schedule_parameters"]["wave_start_compute_cycles"][0] == 192
+    assert report["schedule_parameters"]["wave_start_noc_cycles"][0] == 9341
+    assert report["schedule_parameters"]["wave_start_noc_cycles"][1] == 57311
+    assert report["simulation"]["drain_time_ns"] == pytest.approx(
+        report["simulation"]["cycles_to_drain"]
+    )
+    assert report["source_contract"]["compute_layer_time_ns"] == pytest.approx(8664 * 48.6509)
+    assert report["simulation"]["drain_within_source_compute_layer_envelope"] is True
+    assert report["simulation"]["drain_minus_compute_layer_time_ns"] < 0.0
     assert report["simulation"]["router_contention_cycles"] > 0
     assert report["tag_semantics"]["collision_free_reuse_proven"] is True
     assert report["tag_semantics"]["ordered_tuple_stream_proven"] is True
@@ -70,6 +84,18 @@ def test_score32_noc_phase2_explicit_wave_limit_is_bounded() -> None:
     assert report["source_contract"]["simulated_wave_count"] == 1
     assert report["traffic_quantities"]["simulated_tiles"] == report["source_contract"]["active_clusters"]
     assert report["schedule_parameters"]["requested_wave_limit"] == 1
+
+
+def test_score32_noc_phase2_converts_absolute_release_times_between_clock_domains() -> None:
+    report = build_report(_args(wave_limit=1, compute_clock_ns=10.0, noc_clock_ns=4.0))
+
+    schedule = report["schedule_parameters"]
+    assert schedule["compute_to_noc_clock_ratio"] == pytest.approx(2.5)
+    assert schedule["wave_start_compute_cycles"] == [192]
+    assert schedule["wave_start_noc_cycles"] == [480]
+    assert schedule["reduction_release_compute_cycles"] == [1178]
+    assert schedule["reduction_release_noc_cycles"] == [2945]
+    assert schedule["release_conversion"] == "ceil(compute_cycles * compute_clock_ns / noc_clock_ns)"
 
 
 def test_score32_noc_phase2_proves_nonoverlapping_8bit_tag_reuse() -> None:

--- a/tests/test_noc_segmented_mesh.py
+++ b/tests/test_noc_segmented_mesh.py
@@ -913,3 +913,21 @@ def test_multiflow_mesh_preserves_conservation_order_and_fairness() -> None:
     first_sixteen_tags = {delivery.flit.tag for delivery in result.deliveries[:16]}
     assert len(first_sixteen_tags) >= 2
     assert any(summary.arbitration_contention_cycles > 0 for summary in result.router_summaries)
+
+
+def test_mesh_idle_fast_forward_preserves_absolute_delivery_cycles() -> None:
+    flows = [
+        TrafficFlow(name="early", source=0, destination=1, payload_bytes=32, vc=0, release_cycle=0),
+        TrafficFlow(name="late", source=0, destination=1, payload_bytes=32, vc=0, release_cycle=1000),
+    ]
+    scheduled = [item for flow in flows for item in packetize_traffic_flow(flow)]
+
+    normal = simulate_scheduled_flits(scheduled, max_cycles=1100)
+    accelerated = simulate_scheduled_flits(scheduled, max_cycles=1100, fast_forward_idle=True)
+
+    assert accelerated.cycles == normal.cycles
+    assert [delivery.cycle for delivery in accelerated.deliveries] == [
+        delivery.cycle for delivery in normal.deliveries
+    ]
+    assert len(accelerated.traces) < len(normal.traces)
+    assert accelerated.endpoint_injected_flit_count == normal.endpoint_injected_flit_count


### PR DESCRIPTION
## Summary
- convert score32 compute-wrapper release cycles into explicit NoC cycles before multi-flow routing
- add idle fast-forward that preserves absolute timestamps so physically spaced full-workload schedules remain bounded
- supersede the unrun v1 contract and prepare an immutable `_r1` L2 retry at a disclosed 1ns NoC target
- report NoC drain wall time against the source compute-layer envelope without claiming measured router clock, SRAM placement, root-finalizer, or HBM closure

## Corrected result
- compute clock: 48.6509ns
- NoC target clock: 1.0ns
- routed drain: 397004 cycles / 397004ns
- source compute-layer envelope: 421511.3976ns
- all 92128 flits delivered; heavy within-wave contention remains

## Tests
- `python3 -m pytest -q tests/test_llm_decoder_attention_score32_noc_phase2_schedule.py tests/test_noc_segmented_mesh.py` (11 passed)
- `PYTHONPATH=control_plane python3 -m pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -k score32_noc_phase2` (2 passed)
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`