### PR TITLE
Add measured-router-clock NoC reroute wrapper

### DIFF
--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_measured_router_clock_reroute_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_measured_router_clock_reroute_v1/README.md
@@ -1,0 +1,5 @@
+# Proposal Overview
+
+Rerun the complete corrected score32 Phase 2 mesh schedule after converting
+release times to the measured segmented-router clock. This is a routing-model
+closure step, not aggregate mesh physical signoff.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_measured_router_clock_reroute_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_measured_router_clock_reroute_v1/design_brief.md
@@ -1,0 +1,10 @@
+# Design Brief
+
+- Consume only `l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1`.
+- Consume only the exact `p5/w256/vc4/d4` timing-feasible router promotion.
+- Rerun all eight waves and 128 tiles at the primitive critical-path clock and
+  at `max(1 ns, critical_path_ns)`.
+- Recompute release cycles and contention; never scale the old absolute 1 ns
+  cycle timeline.
+- Treat the primitive-clock case as diagnostic when it is faster than 1 ns and
+  the no-faster-than-source case as the conservative schedule bound.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_measured_router_clock_reroute_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_measured_router_clock_reroute_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_noc_phase2_measured_router_clock_reroute_v1",
+  "source_commit": "TBD",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_noc_phase2_measured_router_clock_reroute_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Rerun the complete corrected score32 mesh schedule at measured router clock bounds.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_noc_phase2_measured_router_clock_reroute",
+      "status": "pending_after_dependencies_merge",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1",
+        "l1_segmented_xy_mesh_noc_phase1_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_measured_router_clock_reroute__l2_decoder_attention_score32_noc_phase2_measured_router_clock_reroute_llama7b_v1.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_measured_router_clock_reroute__l2_decoder_attention_score32_noc_phase2_measured_router_clock_reroute_llama7b_v1.md"
+      ],
+      "acceptance_notes": "Require exact 8-wave/128-tile coverage and complete flit delivery in both clock cases. Keep aggregate mesh PPA, workload-matched router power, SRAM placement, HBM/DRAM, and root-finalizer compute explicit. Do not dispatch before both dependencies merge."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_measured_router_clock_reroute_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_measured_router_clock_reroute_v1/implementation_summary.md
@@ -1,0 +1,6 @@
+# Implementation Summary
+
+The wrapper reuses the existing Phase 2 simulator and the fail-closed measured
+router validator. It runs fresh release conversion and mesh routing for the raw
+primitive clock and conservative effective clock, deduplicating equal cases.
+It emits compact schedule summaries and does not alter DB state or rankings.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_measured_router_clock_reroute_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_measured_router_clock_reroute_v1/proposal.json
@@ -1,0 +1,40 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_noc_phase2_measured_router_clock_reroute_v1",
+  "created_utc": "2026-08-11T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Measured-router-clock reroute for the corrected score32 NoC schedule",
+  "hypothesis": "Fresh release conversion and mesh routing at measured router clock bounds can replace the no-reroute timing upper bound without claiming aggregate physical closure.",
+  "direct_comparison": {
+    "primary_question": "How does the complete 8-wave/128-tile route change after measured-clock release conversion?",
+    "include": [
+      "exact corrected Phase 2 retry",
+      "exact segmented-router promotion",
+      "primitive-critical-path diagnostic reroute",
+      "conservative no-faster-than-source reroute"
+    ],
+    "exclude": [
+      "aggregate mesh physical signoff",
+      "workload-matched router power",
+      "SRAM or HBM closure",
+      "ranking changes"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1",
+        "l1_segmented_xy_mesh_noc_phase1_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_schedule__l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1.json",
+    "control_plane/shadow_exports/l1_promotions/l1_segmented_xy_mesh_noc_phase1_v1.json"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_measured_router_clock_reroute_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_measured_router_clock_reroute_v1/quality_gate.md
@@ -1,0 +1,9 @@
+# Quality Gate
+
+- Exact canonical dependency identities are required.
+- Both reroutes must remain workload-complete with eight waves, 128 tiles, and
+  every scheduled flit delivered.
+- The output must state that the old absolute 1 ns timeline was not reused.
+- The primitive-clock case cannot be promoted as aggregate mesh clock closure.
+- Run
+  `python3 -m pytest -q tests/test_reroute_llm_decoder_attention_score32_noc_phase2_measured_router_clock.py`.

--- a/npu/eval/reroute_llm_decoder_attention_score32_noc_phase2_measured_router_clock.py
+++ b/npu/eval/reroute_llm_decoder_attention_score32_noc_phase2_measured_router_clock.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Rerun the complete score32 mesh schedule at measured router clock bounds."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from npu.eval import measure_llm_decoder_attention_score32_noc_phase2_schedule as phase2_schedule  # noqa: E402
+from npu.eval.audit_llm_decoder_attention_score32_noc_phase2_measured_router_closure import (  # noqa: E402
+    _load_json,
+    _validate_phase1_router_promotion,
+    _validate_phase2_schedule,
+)
+
+JsonDict = dict[str, Any]
+
+DEFAULT_BASELINE_SCHEDULE = Path(
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+    "decoder_attention_score32_noc_phase2_schedule__"
+    "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1.json"
+)
+DEFAULT_ROUTER_PROMOTION = Path(
+    "control_plane/shadow_exports/l1_promotions/l1_segmented_xy_mesh_noc_phase1_v1.json"
+)
+
+
+def _schedule_args(args: argparse.Namespace, *, noc_clock_ns: float) -> argparse.Namespace:
+    return argparse.Namespace(
+        repo_root=args.repo_root,
+        source_json=args.source_json,
+        measured_l1_costs=args.measured_l1_costs,
+        out=args.out,
+        report=args.report,
+        wave_limit=None,
+        packet_payload_bytes=256,
+        cluster_endpoints=None,
+        root_endpoint=15,
+        shared_vc=0,
+        reduction_vc=1,
+        compute_clock_ns=None,
+        noc_clock_ns=noc_clock_ns,
+        max_cycles=args.max_cycles,
+    )
+
+
+def _compact_schedule(payload: JsonDict) -> JsonDict:
+    if payload.get("version") != 2 or payload.get("profile") != "decoder_attention_score32_noc_phase2_schedule":
+        raise ValueError("rerouted schedule must preserve the Phase 2 v2 profile")
+    source = payload.get("source_contract")
+    traffic = payload.get("traffic_quantities")
+    simulation = payload.get("simulation")
+    parameters = payload.get("schedule_parameters")
+    if not all(isinstance(item, dict) for item in (source, traffic, simulation, parameters)):
+        raise ValueError("rerouted schedule is missing required sections")
+    if source.get("coverage") != "workload_complete":
+        raise ValueError("rerouted schedule must remain workload_complete")
+    if source.get("declared_tile_waves") != 8 or source.get("simulated_wave_count") != 8:
+        raise ValueError("rerouted schedule must cover exactly eight waves")
+    if traffic.get("tile_count") != 128 or traffic.get("simulated_tiles") != 128:
+        raise ValueError("rerouted schedule must cover exactly 128 tiles")
+    if simulation.get("scheduled_flit_count") != simulation.get("delivered_flit_count"):
+        raise ValueError("rerouted schedule must deliver every scheduled flit")
+    return {
+        "noc_clock_ns": source["noc_clock_ns"],
+        "compute_clock_ns": source["compute_clock_ns"],
+        "compute_layer_time_ns": source["compute_layer_time_ns"],
+        "cycles_to_drain": simulation["cycles_to_drain"],
+        "drain_time_ns": simulation["drain_time_ns"],
+        "drain_within_source_compute_layer_envelope": simulation[
+            "drain_within_source_compute_layer_envelope"
+        ],
+        "drain_minus_compute_layer_time_ns": simulation["drain_minus_compute_layer_time_ns"],
+        "scheduled_packet_count": simulation["scheduled_packet_count"],
+        "scheduled_flit_count": simulation["scheduled_flit_count"],
+        "delivered_flit_count": simulation["delivered_flit_count"],
+        "router_contention_cycles": simulation["router_contention_cycles"],
+        "endpoint_input_stall_cycles_total": simulation["endpoint_input_stall_cycles_total"],
+        "wave_start_noc_cycles": parameters["wave_start_noc_cycles"],
+        "reduction_release_noc_cycles": parameters["reduction_release_noc_cycles"],
+        "release_conversion": parameters["release_conversion"],
+    }
+
+
+def build_report(args: argparse.Namespace) -> JsonDict:
+    repo_root = args.repo_root.resolve()
+    baseline_path = repo_root / args.baseline_schedule_json
+    router_path = repo_root / args.router_promotion_json
+    baseline_payload = _load_json(baseline_path)
+    baseline = _validate_phase2_schedule(baseline_payload, source_path=baseline_path)
+    router = _validate_phase1_router_promotion(_load_json(router_path))
+
+    source_clock_ns = float(baseline["source_contract"]["noc_clock_ns"])
+    measured_clock_ns = float(router["router_metric"]["critical_path_ns"])
+    conservative_clock_ns = max(source_clock_ns, measured_clock_ns)
+
+    requested_cases = [
+        ("primitive_critical_path_diagnostic", measured_clock_ns),
+        ("conservative_no_faster_than_source", conservative_clock_ns),
+    ]
+    schedules_by_clock: dict[float, JsonDict] = {}
+    cases: list[JsonDict] = []
+    baseline_drain_ns = float(baseline["simulation"]["drain_time_ns"])
+    for case_name, clock_ns in requested_cases:
+        if clock_ns not in schedules_by_clock:
+            schedules_by_clock[clock_ns] = _compact_schedule(
+                phase2_schedule.build_report(_schedule_args(args, noc_clock_ns=clock_ns))
+            )
+        schedule = schedules_by_clock[clock_ns]
+        cases.append(
+            {
+                "case": case_name,
+                "promotion_status": (
+                    "diagnostic_primitive_clock_not_aggregate_mesh_closure"
+                    if case_name == "primitive_critical_path_diagnostic" and clock_ns < source_clock_ns
+                    else "conservative_schedule_bound"
+                ),
+                "schedule": schedule,
+                "drain_time_delta_ns_vs_source_1ns_schedule": float(schedule["drain_time_ns"])
+                - baseline_drain_ns,
+            }
+        )
+
+    return {
+        "version": 1,
+        "model": "llama7b_proxy",
+        "profile": "decoder_attention_score32_noc_phase2_measured_router_clock_reroute",
+        "decision": "score32_noc_phase2_measured_router_clock_reroute_recorded",
+        "source_items": {
+            "baseline_schedule": baseline["item_id"],
+            "router_primitive": router["item_id"],
+        },
+        "clock_contract": {
+            "source_schedule_noc_clock_ns": source_clock_ns,
+            "measured_router_critical_path_ns": measured_clock_ns,
+            "conservative_effective_clock_ns": conservative_clock_ns,
+            "release_conversion_and_mesh_routing_rerun": True,
+            "absolute_1ns_cycle_timeline_reused": False,
+        },
+        "cases": cases,
+        "area_power_scope": {
+            "aggregate_mesh_physical_closure": "not_claimed",
+            "router_power_activity_match": "not_measured",
+        },
+        "remaining_abstractions": [
+            "Aggregate 4x4 mesh links, repeaters, placement congestion, and clock-tree effects remain unmeasured.",
+            "Router dynamic power remains activity dependent until workload-matched switching evidence is measured.",
+            "Endpoint packetizers, descriptor/source-retention control, and endpoint/shared SRAM placement remain unmeasured.",
+            "HBM/DRAM timing, controller implementation, and vendor current signoff remain external envelopes.",
+            "Root-finalizer internal compute after root ingress remains outside this routing result.",
+        ],
+    }
+
+
+def write_report(payload: JsonDict, path: Path) -> None:
+    lines = [
+        "# Llama7B Score32 Measured-Router-Clock Reroute",
+        "",
+        f"- source NoC clock ns: `{payload['clock_contract']['source_schedule_noc_clock_ns']}`",
+        f"- measured router critical path ns: `{payload['clock_contract']['measured_router_critical_path_ns']}`",
+        f"- conservative effective clock ns: `{payload['clock_contract']['conservative_effective_clock_ns']}`",
+        "- release conversion and mesh routing rerun: `true`",
+        "",
+        "## Cases",
+        "",
+    ]
+    for case in payload["cases"]:
+        schedule = case["schedule"]
+        lines.extend(
+            [
+                f"### {case['case']}",
+                "",
+                f"- promotion status: `{case['promotion_status']}`",
+                f"- NoC clock ns: `{schedule['noc_clock_ns']}`",
+                f"- drain cycles: `{schedule['cycles_to_drain']}`",
+                f"- drain time ns: `{schedule['drain_time_ns']}`",
+                f"- within compute envelope: `{schedule['drain_within_source_compute_layer_envelope']}`",
+                "",
+            ]
+        )
+    lines.extend(["## Remaining Abstractions", ""])
+    lines.extend(f"- {item}" for item in payload["remaining_abstractions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--source-json", type=Path, default=phase2_schedule.DEFAULT_SOURCE_JSON)
+    parser.add_argument("--measured-l1-costs", type=Path, default=phase2_schedule.DEFAULT_MEASURED_L1_COSTS)
+    parser.add_argument("--baseline-schedule-json", type=Path, default=DEFAULT_BASELINE_SCHEDULE)
+    parser.add_argument("--router-promotion-json", type=Path, default=DEFAULT_ROUTER_PROMOTION)
+    parser.add_argument("--max-cycles", type=int, default=1000000)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--report", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_report(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_report(payload, args.report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_reroute_llm_decoder_attention_score32_noc_phase2_measured_router_clock.py
+++ b/tests/test_reroute_llm_decoder_attention_score32_noc_phase2_measured_router_clock.py
@@ -1,0 +1,168 @@
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from npu.eval import reroute_llm_decoder_attention_score32_noc_phase2_measured_router_clock as reroute
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _baseline() -> dict:
+    return {
+        "version": 2,
+        "profile": "decoder_attention_score32_noc_phase2_schedule",
+        "source_contract": {
+            "coverage": "workload_complete",
+            "active_clusters": 8,
+            "cluster_count": 16,
+            "declared_tile_waves": 8,
+            "simulated_wave_count": 8,
+            "compute_clock_ns": 48.6509,
+            "noc_clock_ns": 1.0,
+            "compute_layer_time_ns": 421511.3976,
+        },
+        "mapping": {"cluster_endpoints": list(range(8)), "root_endpoint": 15},
+        "traffic_quantities": {
+            "tile_count": 128,
+            "simulated_tiles": 128,
+            "shared_tile_payload_bytes": 8192,
+            "partial_reduction_payload_bytes": 1024,
+        },
+        "schedule_parameters": {
+            "wave_start_compute_cycles": [192] * 8,
+            "wave_start_noc_cycles": [9341] * 8,
+            "reduction_release_compute_cycles": [1178] * 8,
+            "reduction_release_noc_cycles": [57311] * 8,
+            "compute_to_noc_clock_ratio": 48.6509,
+            "release_conversion": "ceil(compute_cycles * compute_clock_ns / noc_clock_ns)",
+        },
+        "simulation": {
+            "cycles_to_drain": 397004,
+            "drain_time_ns": 397004.0,
+            "drain_within_source_compute_layer_envelope": True,
+            "drain_minus_compute_layer_time_ns": -24507.3976,
+            "scheduled_packet_count": 512,
+            "scheduled_flit_count": 92128,
+            "delivered_flit_count": 92128,
+            "router_contention_cycles": 36747,
+            "endpoint_input_stall_cycles_total": 319772,
+        },
+    }
+
+
+def _router(critical_path_ns: float) -> dict:
+    return {
+        "item_id": "l1_segmented_xy_mesh_noc_phase1_v1",
+        "task_type": "l1_sweep",
+        "evaluation_record": {"physical_metrics_present": True, "timing_feasible": True},
+        "proposals": [
+            {
+                "metrics_ref": {
+                    "metrics_csv": "runs/designs/noc/l1_noc_segmented_xy_router_p5_w256_vc4_d4_wrapper/metrics.csv"
+                },
+                "metric_summary": {
+                    "critical_path_ns": critical_path_ns,
+                    "die_area": 12000.0,
+                    "total_power_mw": 0.4,
+                },
+            }
+        ],
+    }
+
+
+def _rerouted(clock_ns: float) -> dict:
+    cycles = int(round(397004.0 / clock_ns))
+    drain_ns = cycles * clock_ns
+    return {
+        "version": 2,
+        "profile": "decoder_attention_score32_noc_phase2_schedule",
+        "source_contract": {
+            "coverage": "workload_complete",
+            "declared_tile_waves": 8,
+            "simulated_wave_count": 8,
+            "compute_clock_ns": 48.6509,
+            "noc_clock_ns": clock_ns,
+            "compute_layer_time_ns": 421511.3976,
+        },
+        "traffic_quantities": {"tile_count": 128, "simulated_tiles": 128},
+        "schedule_parameters": {
+            "wave_start_noc_cycles": [1] * 8,
+            "reduction_release_noc_cycles": [2] * 8,
+            "release_conversion": "ceil(compute_cycles * compute_clock_ns / noc_clock_ns)",
+        },
+        "simulation": {
+            "cycles_to_drain": cycles,
+            "drain_time_ns": drain_ns,
+            "drain_within_source_compute_layer_envelope": drain_ns <= 421511.3976,
+            "drain_minus_compute_layer_time_ns": drain_ns - 421511.3976,
+            "scheduled_packet_count": 512,
+            "scheduled_flit_count": 92128,
+            "delivered_flit_count": 92128,
+            "router_contention_cycles": 100,
+            "endpoint_input_stall_cycles_total": 200,
+        },
+    }
+
+
+def _args(root: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        repo_root=root,
+        source_json=Path("source.json"),
+        measured_l1_costs=Path("costs.json"),
+        baseline_schedule_json=reroute.DEFAULT_BASELINE_SCHEDULE,
+        router_promotion_json=reroute.DEFAULT_ROUTER_PROMOTION,
+        max_cycles=1000000,
+        out=root / "out.json",
+        report=root / "out.md",
+    )
+
+
+def test_reroute_records_raw_and_conservative_clocks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write(tmp_path / reroute.DEFAULT_BASELINE_SCHEDULE, _baseline())
+    _write(tmp_path / reroute.DEFAULT_ROUTER_PROMOTION, _router(0.8))
+    called: list[float] = []
+
+    def fake_build(args: argparse.Namespace) -> dict:
+        called.append(args.noc_clock_ns)
+        return _rerouted(args.noc_clock_ns)
+
+    monkeypatch.setattr(reroute.phase2_schedule, "build_report", fake_build)
+    report = reroute.build_report(_args(tmp_path))
+
+    assert called == [0.8, 1.0]
+    assert report["clock_contract"]["absolute_1ns_cycle_timeline_reused"] is False
+    assert report["cases"][0]["promotion_status"] == "diagnostic_primitive_clock_not_aggregate_mesh_closure"
+    assert report["cases"][1]["promotion_status"] == "conservative_schedule_bound"
+    assert report["cases"][1]["schedule"]["noc_clock_ns"] == pytest.approx(1.0)
+
+
+def test_reroute_deduplicates_equal_slow_clock_cases(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write(tmp_path / reroute.DEFAULT_BASELINE_SCHEDULE, _baseline())
+    _write(tmp_path / reroute.DEFAULT_ROUTER_PROMOTION, _router(1.4))
+    called: list[float] = []
+
+    def fake_build(args: argparse.Namespace) -> dict:
+        called.append(args.noc_clock_ns)
+        return _rerouted(args.noc_clock_ns)
+
+    monkeypatch.setattr(reroute.phase2_schedule, "build_report", fake_build)
+    report = reroute.build_report(_args(tmp_path))
+
+    assert called == [1.4]
+    assert all(case["schedule"]["noc_clock_ns"] == pytest.approx(1.4) for case in report["cases"])
+    assert all(case["promotion_status"] == "conservative_schedule_bound" for case in report["cases"])
+
+
+def test_reroute_rejects_noncanonical_baseline_item(tmp_path: Path) -> None:
+    args = _args(tmp_path)
+    args.baseline_schedule_json = Path("wrong.json")
+    _write(tmp_path / args.baseline_schedule_json, _baseline())
+    _write(tmp_path / reroute.DEFAULT_ROUTER_PROMOTION, _router(1.0))
+
+    with pytest.raises(ValueError, match="phase2 item_id"):
+        reroute.build_report(args)


### PR DESCRIPTION
## Summary
- reuse the validated Phase 2 scheduler to rerun all 8 waves and 128 tiles after measured-clock release conversion
- emit a raw primitive-critical-path diagnostic case and a conservative `max(1ns, critical_path)` case
- deduplicate equal clock cases and require complete flit delivery
- explicitly reject reuse of the old absolute 1ns cycle timeline
- retain aggregate mesh PPA, workload-matched router power, SRAM placement, HBM/DRAM, and root-finalizer compute as open abstractions

## Validation
- `python3 -m pytest -q tests/test_reroute_llm_decoder_attention_score32_noc_phase2_measured_router_clock.py tests/test_audit_llm_decoder_attention_score32_noc_phase2_measured_router_closure.py` (9 passed)
- `python3 scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`

No DB/task-generator wiring, dispatch, or ranking changes are included. Full execution remains dependency-gated on the two remote outputs.