### PR TITLE
Allow assigned unknown-platform items to lease

### DIFF
--- a/control_plane/control_plane/services/scheduler.py
+++ b/control_plane/control_plane/services/scheduler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from sqlalchemy import case
+from sqlalchemy import case, or_
 from sqlalchemy.orm import Session
 
 from control_plane.models.enums import FlowName, LeaseStatus, WorkItemState
@@ -132,7 +132,17 @@ def select_next_work_item(
     if machine_key:
         query = query.filter(WorkItem.assigned_machine_key == machine_key)
     if effective.get("platform"):
-        query = query.filter(WorkItem.platform == effective["platform"])
+        if machine_key:
+            # An explicit dispatcher assignment is authoritative for Layer-2
+            # planning items whose platform is intentionally unresolved.
+            query = query.filter(
+                or_(
+                    WorkItem.platform == effective["platform"],
+                    WorkItem.platform == "unknown",
+                )
+            )
+        else:
+            query = query.filter(WorkItem.platform == effective["platform"])
     if effective.get("flow"):
         query = query.filter(WorkItem.flow == FlowName(effective["flow"]))
 

--- a/control_plane/control_plane/tests/test_leases.py
+++ b/control_plane/control_plane/tests/test_leases.py
@@ -109,6 +109,44 @@ def test_acquire_next_lease_selects_matching_highest_priority_item() -> None:
         assert lease.status == LeaseStatus.ACTIVE
 
 
+def test_acquire_next_lease_accepts_assigned_unknown_planning_platform() -> None:
+    with make_session() as session:
+        _, item_b = seed_ready_items(session)
+        from control_plane.services.lease_service import upsert_worker_machine
+
+        item_b.platform = "unknown"
+        session.commit()
+        upsert_worker_machine(session, machine_key="machine-1")
+        assign_work_item(session, item_id=item_b.item_id, machine_key="machine-1")
+
+        result = acquire_next_lease(
+            session,
+            machine_key="machine-1",
+            capabilities={"platform": "nangate45", "flow": "openroad"},
+            lease_seconds=900,
+        )
+
+        assert result.item_id == item_b.item_id
+        assert item_b.state == WorkItemState.LEASED
+
+
+def test_acquire_next_lease_rejects_assigned_concrete_platform_mismatch() -> None:
+    with make_session() as session:
+        item_a, _ = seed_ready_items(session)
+        from control_plane.services.lease_service import upsert_worker_machine
+
+        upsert_worker_machine(session, machine_key="machine-1")
+        assign_work_item(session, item_id=item_a.item_id, machine_key="machine-1")
+
+        with pytest.raises(NoEligibleWorkItem, match="no eligible work item"):
+            acquire_next_lease(
+                session,
+                machine_key="machine-1",
+                capabilities={"platform": "nangate45", "flow": "openroad"},
+                lease_seconds=900,
+            )
+
+
 def test_acquire_next_lease_blocks_parallel_work_behind_exclusive_block_sweep() -> None:
     with make_session() as session:
         _, item_b = seed_ready_items(session)


### PR DESCRIPTION
## Summary
- treat `platform=unknown` as a planning wildcard only for explicitly assigned work
- retain exact platform filtering for concrete platform values
- preserve flow filtering and machine assignment constraints
- add regressions for accepted unknown and rejected concrete mismatch

## Root cause
PR 1619 made assignment authoritative during source reconciliation, but lease selection still filtered the assigned L2 item (`platform=unknown`) against the worker (`platform=nangate45`). The refreshed worker therefore remained at `no_work`.

## Validation
- `PYTHONPATH=control_plane python3 -m pytest -q control_plane/control_plane/tests/test_leases.py control_plane/control_plane/tests/test_source_reconciler.py` (19 passed)
- live rollback-only `select_next_work_item` probe selects `l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1`
- `git diff --check`