### PR TITLE
Fix workload correspondence decision artifact

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -703,6 +703,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "decode_score_multivalue_service_finalized_cdc_lane_probe_report",
     ),
     (
+        "exact_partial_c1_workload_correspondence_out",
+        "exact_partial_c1_workload_correspondence_report",
+    ),
+    (
         "decode_score_multivalue_service_exact_partial_physical_recost_out",
         "decode_score_multivalue_service_exact_partial_physical_recost_report",
     ),

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -354,6 +354,29 @@ def test_decoder_evidence_paths_recognizes_exact_partial_physical_recost(
     }
 
 
+def test_decoder_evidence_paths_recognizes_exact_partial_c1_workload_correspondence(
+    tmp_path: Path,
+) -> None:
+    evidence_rel = "runs/datasets/demo/exact_partial_c1_workload_correspondence.json"
+    _write(tmp_path / evidence_rel, "{}\n")
+    work_item = SimpleNamespace(
+        input_manifest={
+            "decoder_contract": {
+                "exact_partial_c1_workload_correspondence_out": evidence_rel,
+            }
+        }
+    )
+
+    evidence_ref, source_refs = _decoder_evidence_paths(
+        repo_root=tmp_path, work_item=work_item
+    )
+
+    assert evidence_ref == evidence_rel
+    assert source_refs == {
+        "decoder_exact_partial_c1_workload_correspondence_out": evidence_rel,
+    }
+
+
 @pytest.mark.parametrize(
     "prefix",
     [


### PR DESCRIPTION
## Summary
- recognize the exact-partial c1 workload-correspondence output as L2 decoder evidence
- allow the succeeded run to emit its required decision proposal
- cover the exact generated contract key with a regression test

## Validation
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/pytest -q control_plane/control_plane/tests/test_l2_result_consumer.py`
- 128 passed