### PR TITLE
Transport workload correspondence evidence

### DIFF
--- a/control_plane/control_plane/artifact_policy.py
+++ b/control_plane/control_plane/artifact_policy.py
@@ -31,6 +31,7 @@ _ALLOWED_DATASET_PREFIXES = {
     "decoder_attention_decode_score_multivalue_service_",
     "decoder_attention_decode_score_multivalue_gqa_group_",
     "decoder_attention_decode_score_multivalue_gqa_folded_lane_",
+    "decoder_attention_exact_partial_",
     "decoder_attention_mixed_int8_",
     "decoder_attention_noc_profile__",
     "decoder_attention_operational_component_frontier__",

--- a/control_plane/control_plane/tests/test_artifact_stage.py
+++ b/control_plane/control_plane/tests/test_artifact_stage.py
@@ -104,6 +104,29 @@ def test_collect_expected_output_artifacts_includes_attention_kv_dataset(tmp_pat
     assert all("inline_utf8" in artifact.metadata for artifact in artifacts)
 
 
+def test_collect_expected_output_artifacts_includes_exact_partial_workload_correspondence(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    json_rel = (
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_exact_partial_c1_workload_correspondence__"
+        "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1.json"
+    )
+    _write_json(repo_root / json_rel, {"passed": True})
+
+    artifacts = collect_expected_output_artifacts(
+        repo_root=str(repo_root),
+        expected_outputs=[json_rel],
+    )
+
+    assert [artifact.path for artifact in artifacts] == [json_rel]
+    assert artifacts[0].kind == "expected_output"
+    assert artifacts[0].metadata["transport_policy"] == "inline_text_evidence"
+    assert "inline_utf8" in artifacts[0].metadata
+
+
 def test_collect_expected_output_artifacts_includes_operational_component_frontier(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- allow exact-partial workload-correspondence dataset JSON through remote expected-output transport
- preserve it inline for dev-side completion processing
- test the exact generated output path

## Validation
- `PYTHONPATH=control_plane /workspaces/RTLGen/control_plane/.venv/bin/pytest -q control_plane/control_plane/tests/test_artifact_stage.py control_plane/control_plane/tests/test_l2_result_consumer.py`
- 136 passed