### PR TITLE
Make finalized CDC backpressure check deterministic

### DIFF
--- a/npu/eval/probe_attention_decode_score_multivalue_service_finalized_cdc.py
+++ b/npu/eval/probe_attention_decode_score_multivalue_service_finalized_cdc.py
@@ -291,11 +291,11 @@ module tb;
   reg blocked_output_valid;
   reg stable_output_seen;
   reg summary_done;
+  reg directed_stall_armed;
+  reg [1:0] directed_stall_remaining;
   reg [376:0] blocked_output;
 
-  assign out_ready = temporal_rst_n &&
-      (((temporal_cycle % 13) != 2) && ((temporal_cycle % 13) != 3) &&
-       ((temporal_cycle % 13) != 4) && ((temporal_cycle % 13) != 9));
+  assign out_ready = temporal_rst_n && (directed_stall_remaining == 0);
 
   {top_name} dut (
       .service_clk(service_clk),
@@ -446,8 +446,17 @@ module tb;
       stable_output_seen <= 1'b0;
       blocked_output <= 377'd0;
       summary_done <= 1'b0;
+      directed_stall_armed <= 1'b1;
+      directed_stall_remaining <= 2'd0;
     end else begin
       temporal_cycle <= temporal_cycle + 1;
+      if (directed_stall_remaining != 0) begin
+        if (out_valid)
+          directed_stall_remaining <= directed_stall_remaining - 1'b1;
+      end else if (directed_stall_armed && out_valid && out_ready) begin
+        directed_stall_armed <= 1'b0;
+        directed_stall_remaining <= 2'd3;
+      end
       if (out_valid && !out_ready) begin
         if (!blocked_output_valid) begin
           blocked_output_valid <= 1'b1;

--- a/tests/test_probe_attention_decode_score_multivalue_service_finalized_cdc.py
+++ b/tests/test_probe_attention_decode_score_multivalue_service_finalized_cdc.py
@@ -27,3 +27,24 @@ def test_real_c1_two_window_full_context_finalization() -> None:
     assert report["summary"]["finalizer_accepted"] == 16
     assert report["summary"]["finalizer_completed"] == 16
     assert report["summary"]["protocol_error"] == 0
+
+
+@pytest.mark.parametrize("divider_lanes", [1, 2, 4, 8])
+def test_finalized_cdc_campaign_configuration_exercises_directed_backpressure(
+    divider_lanes: int,
+) -> None:
+    if not (shutil.which("iverilog") and shutil.which("vvp")):
+        pytest.skip("iverilog/vvp unavailable")
+
+    report = build_report(
+        service_period_ns=10.0,
+        temporal_period_ns=12.0,
+        divider_lanes=divider_lanes,
+        temporal_state_backend="sram",
+        service_value_memory_backend="macro_banked_4x16x64x32",
+    )
+
+    assert report["passed"] is True
+    assert report["observed_rows"] == report["expected_rows"]
+    assert report["summary"]["stable"] == 1
+    assert report["summary"]["protocol_error"] == 0


### PR DESCRIPTION
## Summary
- replace phase-dependent periodic output stalls with a directed three-cycle backpressure check
- preserve bitwise output stability verification
- cover all divider lanes under the exact 10 ns/12 ns SRAM and macro-banked campaign configuration

## Diagnosis
Lane 4 produced exact values and counters with zero protocol errors, but the periodic stall phase never held an output for two cycles, leaving `stable_output_seen=0`.

## Validation
- full four-lane campaign passes
- `pytest -q tests/test_probe_attention_decode_score_multivalue_service_finalized_cdc.py tests/test_run_attention_decode_score_multivalue_service_finalized_cdc_lane_campaign.py`
- 13 passed