### PR TITLE
Revise exact partial recost dependencies

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -8148,12 +8148,12 @@ def _decoder_attention_decode_score_multivalue_service_exact_partial_physical_re
 ) -> dict[str, Any]:
     expected_item_id = (
         "l2_decoder_attention_decode_score_multivalue_service_"
-        "exact_partial_physical_recost_10ns_12ns_v1_r1"
+        "exact_partial_physical_recost_10ns_12ns_v1_r2"
     )
     if str(item_id).strip() != expected_item_id:
         raise Layer2TaskGenerationError(
-            "exact-partial physical recost only permits the immutable _r1 retry item; "
-            "the blocked v1 item must remain untouched"
+            "exact-partial physical recost only permits the immutable _r2 retry item; "
+            "the blocked v1 and failed-dependency r1 items must remain untouched"
         )
     expected_proposal_id = (
         "prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1"
@@ -8167,7 +8167,7 @@ def _decoder_attention_decode_score_multivalue_service_exact_partial_physical_re
         "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
         (
             "l2_decoder_attention_decode_score_multivalue_service_"
-            "finalized_cdc_lane_probe_10ns_12ns_v1_r1"
+            "finalized_cdc_lane_probe_10ns_12ns_v1_r2"
         ),
         "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1",
     ]

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -10292,7 +10292,7 @@ def test_generate_l2_campaign_task_adds_exact_partial_physical_recost_consumer()
         create_all(engine)
         item_id = (
             "l2_decoder_attention_decode_score_multivalue_service_"
-            "exact_partial_physical_recost_10ns_12ns_v1_r1"
+            "exact_partial_physical_recost_10ns_12ns_v1_r2"
         )
         proposal_id = (
             "prop_l2_decoder_attention_decode_score_multivalue_service_"
@@ -10303,7 +10303,7 @@ def test_generate_l2_campaign_task_adds_exact_partial_physical_recost_consumer()
             "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
             (
                 "l2_decoder_attention_decode_score_multivalue_service_"
-                "finalized_cdc_lane_probe_10ns_12ns_v1_r1"
+                "finalized_cdc_lane_probe_10ns_12ns_v1_r2"
             ),
             "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1",
         ]
@@ -10360,17 +10360,17 @@ def test_generate_l2_campaign_task_adds_exact_partial_physical_recost_consumer()
                 "decode_score_multivalue_service_exact_partial_physical_recost_functional_dependency_item_id"
             ] == (
                 "l2_decoder_attention_decode_score_multivalue_service_"
-                "finalized_cdc_lane_probe_10ns_12ns_v1_r1"
+                "finalized_cdc_lane_probe_10ns_12ns_v1_r2"
             )
             assert decoder_inputs[
                 "decode_score_multivalue_service_exact_partial_physical_recost_workload_dependency_item_id"
             ] == "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1"
             assert decoder_inputs[
                 "decode_score_multivalue_service_exact_partial_physical_recost_out"
-            ].endswith("_v1_r1.json")
+            ].endswith("_v1_r2.json")
             assert decoder_inputs[
                 "decode_score_multivalue_service_exact_partial_physical_recost_csv_out"
-            ].endswith("_v1_r1.csv")
+            ].endswith("_v1_r2.csv")
             assert payload["developer_loop"]["dependencies"] == {
                 "item_ids": dependencies,
                 "requires_merged_inputs": True,
@@ -10401,7 +10401,7 @@ def test_exact_partial_physical_recost_consumer_rejects_missing_dependency() -> 
                     campaign_path=campaign_path,
                     item_id=(
                         "l2_decoder_attention_decode_score_multivalue_service_"
-                        "exact_partial_physical_recost_10ns_12ns_v1_r1"
+                        "exact_partial_physical_recost_10ns_12ns_v1_r2"
                     ),
                     proposal_id=(
                         "prop_l2_decoder_attention_decode_score_multivalue_service_"
@@ -10439,14 +10439,14 @@ def test_exact_partial_physical_recost_consumer_rejects_obsolete_v1_item_id() ->
             "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
             (
                 "l2_decoder_attention_decode_score_multivalue_service_"
-                "finalized_cdc_lane_probe_10ns_12ns_v1_r1"
+                "finalized_cdc_lane_probe_10ns_12ns_v1_r2"
             ),
             "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1",
         ]
 
         with Session(engine) as session, pytest.raises(
             Layer2TaskGenerationError,
-            match="blocked v1 item must remain untouched",
+            match="blocked v1 and failed-dependency r1 items must remain untouched",
         ):
             generate_l2_campaign_task(
                 session,

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/evaluation_requests.json
@@ -3,7 +3,7 @@
   "source_commit_note": "Historical v1 remains blocked and must stay untouched. After merge and after all three corrected dependency outputs are materialized, generate only the fresh _r1 DB item from a clean exact-source worktree at the merge commit with proposal updates disabled so source_requirement.required_sha pins the merged aggregate driver and corrected dependency consumer wiring. Do not dispatch this preparation branch.",
   "requested_items": [
     {
-      "item_id": "l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r1",
+      "item_id": "l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r2",
       "task_type": "l2_campaign",
       "title": "Exact-partial composed-service 10 ns / 12 ns physical recost retry",
       "objective": "Record one fail-closed aggregate report and four-row CSV for divider_lanes 1, 2, 4, and 8 using the corrected functional and workload retry materializations.",
@@ -14,7 +14,7 @@
       "cost_class": "lightweight",
       "depends_on_item_ids": [
         "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
-        "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r1",
+        "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r2",
         "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1"
       ],
       "requires_merged_inputs": true,
@@ -26,8 +26,8 @@
         "preserve_blocked_item_id": "l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1"
       },
       "expected_outputs": [
-        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost__l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r1.json",
-        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost__l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r1.csv"
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost__l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r2.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost__l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r2.csv"
       ],
       "acceptance_notes": "Fail closed unless all three exact dependency items are satisfied and all four lane-matched 12 ns temporal bundles, hashed finalized-CDC retry probe summaries, and the passing 131k Llama7B workload-correspondence retry report are materialized. Require four rows ordered [1,2,4,8], source-domain single-FIFO accounting from the 10 ns row, the 12 ns destination diagnostic row, preserved overlap/serial timing bounds, conservative affine workload projections, and bounded provisional energy provenance. Emit no per-lane recost files.",
       "notes": "Queue only from merged origin/master after corrected dependency materialization. Generate the _r1 item only; preserve the blocked v1 item/history without mutation or requeue."

--- a/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/proposal.json
@@ -37,7 +37,7 @@
   },
   "required_evaluations": [
     {
-      "item_id": "l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r1",
+      "item_id": "l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r2",
       "task_type": "l2_campaign",
       "objective": "Record the fail-closed four-lane exact-partial composed-service physical recost retry at the selected 10 ns / 12 ns domain pair using the corrected functional and workload materializations.",
       "evaluation_mode": "frontier_detail",
@@ -45,7 +45,7 @@
       "comparison_role": "lane_matched_composed_physical_recost",
       "depends_on_item_ids": [
         "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
-        "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r1",
+        "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r2",
         "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1"
       ],
       "requires_merged_inputs": true,
@@ -56,7 +56,7 @@
         "preserve_blocked_item_id": "l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1",
         "corrected_dependency_item_ids": [
           "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
-          "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r1",
+          "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r2",
           "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1"
         ]
       },

--- a/npu/eval/run_attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign.py
+++ b/npu/eval/run_attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign.py
@@ -27,12 +27,12 @@ AuditRunner = Callable[..., JsonDict]
 _CAMPAIGN_MODEL = "attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign_v1"
 _SUMMARY_MODEL = "attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign_summary_v1"
 _AUDIT_MODEL = "decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1"
-_CAMPAIGN_ID = "attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r1"
+_CAMPAIGN_ID = "attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r2"
 _PROPOSAL_ID = "prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1"
 _PROPOSAL_PATH = f"docs/proposals/{_PROPOSAL_ID}/proposal.json"
 _PHYSICAL_DEPENDENCY = "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1"
 _FUNCTIONAL_DEPENDENCY = (
-    "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r1"
+    "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r2"
 )
 _WORKLOAD_DEPENDENCY = (
     "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1"

--- a/runs/campaigns/npu/attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/campaign.json
+++ b/runs/campaigns/npu/attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/campaign.json
@@ -1,13 +1,13 @@
 {
   "model": "attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign_v1",
-  "campaign_id": "attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r1",
+  "campaign_id": "attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r2",
   "proposal_ref": {
     "proposal_id": "prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1",
     "proposal_path": "docs/proposals/prop_l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/proposal.json"
   },
   "depends_on_item_ids": [
     "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
-    "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r1",
+    "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r2",
     "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1"
   ],
   "fixed_inputs": {
@@ -27,7 +27,7 @@
       "config_json": "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_destination_domain_physical/config.json",
       "macro_manifest_json": "runs/designs/npu_blocks/attention_exact_partial_async_fifo_d4_destination_domain_physical/macro_manifest.json"
     },
-    "functional_probe_summary_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r1/campaign_summary.json",
+    "functional_probe_summary_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r2/campaign_summary.json",
     "workload_correspondence_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_exact_partial_c1_workload_correspondence__l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1.json"
   },
   "points": [
@@ -37,7 +37,7 @@
       "temporal_metrics_csv": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l1/metrics.csv",
       "temporal_config_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l1/config.json",
       "temporal_macro_manifest_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l1/macro_manifest.json",
-      "functional_probe_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r1/lane1.json"
+      "functional_probe_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r2/lane1.json"
     },
     {
       "divider_lanes": 2,
@@ -45,7 +45,7 @@
       "temporal_metrics_csv": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l2/metrics.csv",
       "temporal_config_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l2/config.json",
       "temporal_macro_manifest_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l2/macro_manifest.json",
-      "functional_probe_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r1/lane2.json"
+      "functional_probe_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r2/lane2.json"
     },
     {
       "divider_lanes": 4,
@@ -53,7 +53,7 @@
       "temporal_metrics_csv": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l4/metrics.csv",
       "temporal_config_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l4/config.json",
       "temporal_macro_manifest_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l4/macro_manifest.json",
-      "functional_probe_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r1/lane4.json"
+      "functional_probe_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r2/lane4.json"
     },
     {
       "divider_lanes": 8,
@@ -61,14 +61,14 @@
       "temporal_metrics_csv": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l8/metrics.csv",
       "temporal_config_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l8/config.json",
       "temporal_macro_manifest_json": "runs/designs/npu_blocks/attention_score32_exact_partial_temporal_finalizer_physical_l8/macro_manifest.json",
-      "functional_probe_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r1/lane8.json"
+      "functional_probe_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe__l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r2/lane8.json"
     }
   ],
   "outputs": {
     "campaign_dir": "runs/campaigns/npu/attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/results",
     "results_csv": "runs/campaigns/npu/attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/results/results.csv",
     "report_md": "runs/campaigns/npu/attention_decode_score_multivalue_service_exact_partial_physical_recost_v1/results/report.md",
-    "report_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost__l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r1.json",
-    "rows_csv": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost__l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r1.csv"
+    "report_json": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost__l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r2.json",
+    "rows_csv": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost__l2_decoder_attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r2.csv"
   }
 }

--- a/tests/test_run_attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign.py
+++ b/tests/test_run_attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign.py
@@ -154,25 +154,25 @@ def test_committed_campaign_contract_requires_exact_dependencies() -> None:
     validated = _validate_campaign(campaign)
 
     assert validated["campaign_id"] == (
-        "attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r1"
+        "attention_decode_score_multivalue_service_exact_partial_physical_recost_10ns_12ns_v1_r2"
     )
     assert [point["divider_lanes"] for point in validated["points"]] == [1, 2, 4, 8]
     assert validated["depends_on_item_ids"] == [
         "l1_decoder_attention_exact_partial_temporal_finalizer_bounded_12ns_physical_v1_r1",
-        "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r1",
+        "l2_decoder_attention_decode_score_multivalue_service_finalized_cdc_lane_probe_10ns_12ns_v1_r2",
         "l2_decoder_attention_exact_partial_c1_workload_correspondence_llama7b_v1_r1",
     ]
     assert validated["fixed_inputs"]["functional_probe_summary_json"].endswith(
-        "_finalized_cdc_lane_probe_10ns_12ns_v1_r1/campaign_summary.json"
+        "_finalized_cdc_lane_probe_10ns_12ns_v1_r2/campaign_summary.json"
     )
     assert validated["fixed_inputs"]["workload_correspondence_json"].endswith(
         "_exact_partial_c1_workload_correspondence_llama7b_v1_r1.json"
     )
     assert validated["outputs"]["report_json"].endswith(
-        "_exact_partial_physical_recost_10ns_12ns_v1_r1.json"
+        "_exact_partial_physical_recost_10ns_12ns_v1_r2.json"
     )
     assert validated["outputs"]["rows_csv"].endswith(
-        "_exact_partial_physical_recost_10ns_12ns_v1_r1.csv"
+        "_exact_partial_physical_recost_10ns_12ns_v1_r2.csv"
     )
 
     campaign["depends_on_item_ids"].pop()


### PR DESCRIPTION
## Summary
- define immutable physical-recost retry `_r2`
- consume the successful finalized-CDC lane probe `_r2` instead of failed `_r1`
- revise campaign IDs, output paths, proposal request, generator guards, and audit tests together
- retain the merged temporal-finalizer and workload-correspondence `_r1` dependencies

## Validation
- `pytest -q control_plane/control_plane/tests/test_l2_task_generator.py -k exact_partial_physical_recost tests/test_run_attention_decode_score_multivalue_service_exact_partial_physical_recost_campaign.py tests/test_audit_attention_decode_score_multivalue_service_exact_partial_physical_recost.py`
- 24 passed