### PR TITLE
Fix devcontainer rebuild bootstrap

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -215,6 +215,7 @@ RUN chown root:root /usr/local/sbin/rtlgen-container-init && \
     visudo -cf /etc/sudoers.d/rtlgen-container-init
 
 ENV HOME=/home/${USERNAME}
+ENV PATH="/home/${USERNAME}/.local/bin:${PATH}"
 USER ${USERNAME}
 
 # Set the working directory

--- a/.devcontainer/control_plane_service_ctl.sh
+++ b/.devcontainer/control_plane_service_ctl.sh
@@ -105,6 +105,7 @@ case "${ACTION}" in
     if ! kill -0 "$(cat "${PID_FILE}")" 2>/dev/null; then
       rm -f "${PID_FILE}"
       echo "failed to start ${SERVICE}; see ${LOG_FILE}" >&2
+      _tail_log 40 >&2
       exit 1
     fi
     echo "started ${SERVICE}: pid=$(cat "${PID_FILE}") log=${LOG_FILE}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,8 @@
 {
-  "name": "Ubuntu22-orfs",
+    "name": "Ubuntu22-orfs",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/RTLGen,type=bind",
+    "workspaceFolder": "/workspaces/RTLGen",
+
   "build": {
     "dockerfile": "Dockerfile",
     "context": ".."
@@ -23,9 +26,12 @@
     "RTLCP_SUBMIT": "${localEnv:RTLCP_SUBMIT}",
     "RTLCP_AUTOSTART_WORKER_DAEMON": "${localEnv:RTLCP_AUTOSTART_WORKER_DAEMON}",
     "RTLCP_AUTOSTART_API": "${localEnv:RTLCP_AUTOSTART_API}",
+    "RTLCP_REPO_SLUG": "yhmtmt/RTLGen",
+    "VENV_PATH": "/home/rtlgen/.venvs/rtlgen-control-plane",
     "RTLCP_HOST": "0.0.0.0",
     "RTLCP_PORT": "8080"
   },
+  "postCreateCommand": "/workspaces/RTLGen/control_plane/scripts/bootstrap_venv.sh /home/rtlgen/.venvs/rtlgen-control-plane",
   "postStartCommand": "/workspaces/RTLGen/.devcontainer/post_start.sh",
   "settings": {
     "terminal.integrated.defaultProfile.linux": "bash"

--- a/.devcontainer/start_control_plane_services.sh
+++ b/.devcontainer/start_control_plane_services.sh
@@ -56,6 +56,11 @@ case "${ROLE}" in
   server)
     echo "Developer/server role is not an execution node; worker/completion stay disabled unless started explicitly"
     echo "Skipping completion loop autostart for server role"
+    if [[ "${AUTOSTART_API:-1}" == "1" ]]; then
+      /workspaces/RTLGen/.devcontainer/control_plane_service_ctl.sh start api
+    else
+      echo "Skipping control-plane API autostart for server role"
+    fi
     if [[ "${AUTOSTART_RESOLVER:-1}" == "1" ]]; then
       /workspaces/RTLGen/.devcontainer/control_plane_service_ctl.sh start resolver
     else

--- a/docs/operations/devcontainer_uid_ownership.md
+++ b/docs/operations/devcontainer_uid_ownership.md
@@ -8,6 +8,31 @@ The host Codex directory is mounted at `/home/rtlgen/.codex`. Do not mount it at
 `/root/.codex` or run Codex as root: bind-mount ownership is numeric, so either
 choice recreates host-inaccessible files.
 
+The control-plane virtual environment is created as `rtlgen` under
+`/home/rtlgen/.venvs/rtlgen-control-plane` by `postCreateCommand`. Keeping it
+outside the bind-mounted checkout avoids host/container Python ABI and file
+ownership conflicts. Rebuilding the container recreates this environment before
+the resolver is started by `postStartCommand`.
+
+The devcontainer also sets `RTLCP_REPO_SLUG=yhmtmt/RTLGen` explicitly. Use an
+independent clone as the folder opened by the devcontainer. Do not open a host
+linked worktree by itself: its `.git` file normally refers to the primary
+checkout through an absolute host path that is not mounted in the container,
+which leaves all Git commands unusable. The fixed workspace mount maps the
+independent checkout to `/workspaces/RTLGen` regardless of its host directory
+name.
+
+`scripts/install-codex-cli.sh` installs the Codex CLI into
+`/home/rtlgen/.local/bin` without sudo. This directory is included in the image
+PATH. When the mounted Codex plugin provides `codex-code-mode-host`, the script
+also links that executable into the same directory. Installing developer CLI
+tools must not require a root password or write to `/usr/local/bin` at runtime.
+
+For the developer/server role, post-start launches the API before the resolver.
+The API initializes a fresh local database schema, after which the resolver can
+poll without racing missing tables. Set `RTLCP_AUTOSTART_API=0` only when the
+dashboard and API are deliberately hosted elsewhere.
+
 ## Privileged initialization
 
 Only `/usr/local/sbin/rtlgen-container-init`, copied into the image and owned by

--- a/scripts/install-codex-cli.sh
+++ b/scripts/install-codex-cli.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Install the Codex CLI native binary on Ubuntu 22.04 (inside a container).
-# This does NOT use Node.js or npm.
+# Install the Codex CLI native binary without root privileges.
+# The devcontainer image already provides wget, tar, and CA certificates.
 
-SUDO=""
-if [ "$(id -u)" -ne 0 ]; then
-  SUDO="sudo"
-fi
+INSTALL_DIR="${CODEX_INSTALL_DIR:-${HOME}/.local/bin}"
 
-echo "[codex] Installing dependencies (curl, ca-certificates)..."
-$SUDO apt-get update -y
-$SUDO apt-get install -y curl ca-certificates
+for dependency in wget tar; do
+  if ! command -v "${dependency}" >/dev/null 2>&1; then
+    echo "[codex] Missing dependency: ${dependency}" >&2
+    echo "[codex] Install it in the image, then rebuild the devcontainer." >&2
+    exit 1
+  fi
+done
 
 ARCH="$(uname -m)"
 case "$ARCH" in
@@ -28,24 +29,35 @@ case "$ARCH" in
 esac
 
 TMP_DIR="$(mktemp -d)"
-cd "$TMP_DIR"
+trap 'rm -rf "${TMP_DIR}"' EXIT
 
 echo "[codex] Downloading latest Codex CLI binary for $ARCH..."
-curl -L "https://github.com/openai/codex/releases/latest/download/${CODEx_ASSET}.tar.gz" \
-  -o codex.tar.gz
+wget -q \
+  "https://github.com/openai/codex/releases/latest/download/${CODEx_ASSET}.tar.gz" \
+  -O "${TMP_DIR}/codex.tar.gz"
 
 echo "[codex] Extracting..."
-tar -xzf codex.tar.gz
+tar -xzf "${TMP_DIR}/codex.tar.gz" -C "${TMP_DIR}"
 
 # The tar contains a single binary named like codex-x86_64-unknown-linux-musl
-echo "[codex] Installing to /usr/local/bin/codex ..."
-$SUDO mv "$CODEx_ASSET" /usr/local/bin/codex
-$SUDO chmod +x /usr/local/bin/codex
+echo "[codex] Installing to ${INSTALL_DIR}/codex ..."
+mkdir -p "${INSTALL_DIR}"
+install -m 0755 "${TMP_DIR}/${CODEx_ASSET}" "${INSTALL_DIR}/codex"
 
-cd /
-rm -rf "$TMP_DIR"
+CODE_MODE_HOST_SOURCE="${CODEX_CODE_MODE_HOST_SOURCE:-${HOME}/.codex/plugins/.plugin-appserver/codex-code-mode-host}"
+CODE_MODE_HOST_TARGET="${INSTALL_DIR}/codex-code-mode-host"
+if [[ -x "${CODE_MODE_HOST_SOURCE}" ]]; then
+  if [[ -L "${CODE_MODE_HOST_TARGET}" ]]; then
+    ln -sfn "${CODE_MODE_HOST_SOURCE}" "${CODE_MODE_HOST_TARGET}"
+  elif [[ ! -e "${CODE_MODE_HOST_TARGET}" ]]; then
+    ln -s "${CODE_MODE_HOST_SOURCE}" "${CODE_MODE_HOST_TARGET}"
+  fi
+  echo "[codex] Code-mode host available at ${CODE_MODE_HOST_TARGET}"
+else
+  echo "[codex] Code-mode host plugin is not installed; CLI-only use remains available." >&2
+fi
 
 echo "[codex] Verifying installation..."
-codex --version
+"${INSTALL_DIR}/codex" --version
 
 echo "[codex] Done. You can now run 'codex' inside this container."

--- a/tests/test_devcontainer_user_contract.py
+++ b/tests/test_devcontainer_user_contract.py
@@ -11,6 +11,16 @@ def test_devcontainer_runs_as_uid_remapped_non_root_user() -> None:
 
     assert config["remoteUser"] == "rtlgen"
     assert config["updateRemoteUserUID"] is True
+    assert config["workspaceMount"] == (
+        "source=${localWorkspaceFolder},target=/workspaces/RTLGen,type=bind"
+    )
+    assert config["workspaceFolder"] == "/workspaces/RTLGen"
+    assert config["containerEnv"]["RTLCP_REPO_SLUG"] == "yhmtmt/RTLGen"
+    assert config["containerEnv"]["VENV_PATH"] == "/home/rtlgen/.venvs/rtlgen-control-plane"
+    assert config["postCreateCommand"] == (
+        "/workspaces/RTLGen/control_plane/scripts/bootstrap_venv.sh "
+        "/home/rtlgen/.venvs/rtlgen-control-plane"
+    )
     assert config["postStartCommand"] == "/workspaces/RTLGen/.devcontainer/post_start.sh"
     assert config["mounts"] == [
         "source=${localEnv:HOME}/.codex,target=/home/rtlgen/.codex,type=bind"
@@ -22,6 +32,7 @@ def test_dockerfile_grants_only_image_owned_init_helper() -> None:
 
     assert "USER ${USERNAME}" in dockerfile
     assert "ENV HOME=/home/${USERNAME}" in dockerfile
+    assert 'ENV PATH="/home/${USERNAME}/.local/bin:${PATH}"' in dockerfile
     assert "COPY .devcontainer/rtlgen-container-init /usr/local/sbin/rtlgen-container-init" in dockerfile
     assert "NOPASSWD: /usr/local/sbin/rtlgen-container-init" in dockerfile
     assert "NOPASSWD: ALL" not in dockerfile
@@ -44,3 +55,36 @@ def test_post_start_rejects_root_and_uses_noninteractive_sudo() -> None:
 
     assert '[[ "$(id -u)" == "0" ]]' in post_start
     assert "sudo -n /usr/local/sbin/rtlgen-container-init prepare" in post_start
+
+
+def test_service_start_failure_prints_the_service_log() -> None:
+    service_ctl = (DEVCONTAINER / "control_plane_service_ctl.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'echo "failed to start ${SERVICE}; see ${LOG_FILE}" >&2' in service_ctl
+    assert "_tail_log 40 >&2" in service_ctl
+
+
+def test_codex_installer_is_unprivileged_and_user_local() -> None:
+    installer = (REPO_ROOT / "scripts/install-codex-cli.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert "sudo" not in installer
+    assert 'INSTALL_DIR="${CODEX_INSTALL_DIR:-${HOME}/.local/bin}"' in installer
+    assert 'install -m 0755' in installer
+    assert "${HOME}/.codex/plugins/.plugin-appserver/codex-code-mode-host" in installer
+    assert 'CODE_MODE_HOST_TARGET="${INSTALL_DIR}/codex-code-mode-host"' in installer
+
+
+def test_server_starts_api_before_resolver() -> None:
+    startup = (DEVCONTAINER / "start_control_plane_services.sh").read_text(
+        encoding="utf-8"
+    )
+    server_case = startup.rsplit("  server)", maxsplit=1)[1].split(
+        "    ;;", maxsplit=1
+    )[0]
+
+    assert '${AUTOSTART_API:-1}' in server_case
+    assert server_case.index("start api") < server_case.index("start resolver")


### PR DESCRIPTION
## Summary
- keep the checkout at /workspaces/RTLGen with a user-local control-plane venv and CLI PATH
- expose the mounted Codex code-mode host after CLI installation
- start the developer API before the resolver so fresh databases receive their schema
- document independent-clone and UID ownership requirements
- print service logs immediately when daemon startup fails

## Verification
- bash syntax checks for modified shell scripts
- devcontainer JSON parse
- pytest -q tests/test_devcontainer_user_contract.py (7 passed)
- git diff --check