### PR TITLE
Fix migration smoke with external control-plane venv

### DIFF
--- a/control_plane/control_plane/migrations/versions/0003_expand_work_item_state_enum_width.py
+++ b/control_plane/control_plane/migrations/versions/0003_expand_work_item_state_enum_width.py
@@ -29,15 +29,15 @@ work_item_state_enum = sa.Enum(
 
 
 def upgrade() -> None:
-    op.alter_column(
-        "work_items",
-        "state",
-        existing_type=sa.String(length=15),
-        type_=work_item_state_enum,
-        existing_nullable=False,
-        existing_server_default="draft",
-        postgresql_using="state::varchar(32)",
-    )
+    with op.batch_alter_table("work_items") as batch_op:
+        batch_op.alter_column(
+            "state",
+            existing_type=sa.String(length=15),
+            type_=work_item_state_enum,
+            existing_nullable=False,
+            existing_server_default="draft",
+            postgresql_using="state::varchar(32)",
+        )
 
 
 def downgrade() -> None:
@@ -57,12 +57,12 @@ def downgrade() -> None:
         length=15,
     )
     op.execute("UPDATE work_items SET state = 'ready' WHERE state = 'dispatch_pending'")
-    op.alter_column(
-        "work_items",
-        "state",
-        existing_type=work_item_state_enum,
-        type_=legacy_state_enum,
-        existing_nullable=False,
-        existing_server_default="draft",
-        postgresql_using="state::varchar(15)",
-    )
+    with op.batch_alter_table("work_items") as batch_op:
+        batch_op.alter_column(
+            "state",
+            existing_type=work_item_state_enum,
+            type_=legacy_state_enum,
+            existing_nullable=False,
+            existing_server_default="draft",
+            postgresql_using="state::varchar(15)",
+        )

--- a/control_plane/control_plane/migrations/versions/0004_trial_metadata.py
+++ b/control_plane/control_plane/migrations/versions/0004_trial_metadata.py
@@ -14,8 +14,22 @@ depends_on = None
 json_type = sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql")
 
 
+def _json_object_default() -> sa.TextClause:
+    if op.get_bind().dialect.name == "postgresql":
+        return sa.text("'{}'::jsonb")
+    return sa.text("'{}'")
+
+
 def upgrade() -> None:
-    op.add_column("work_items", sa.Column("trial_policy_json", json_type, nullable=False, server_default=sa.text("'{}'::jsonb")))
+    op.add_column(
+        "work_items",
+        sa.Column(
+            "trial_policy_json",
+            json_type,
+            nullable=False,
+            server_default=_json_object_default(),
+        ),
+    )
     op.add_column("runs", sa.Column("trial_index", sa.Integer(), nullable=True))
     op.add_column("runs", sa.Column("seed", sa.Integer(), nullable=True))
     op.add_column("runs", sa.Column("trial_group_key", sa.String(length=255), nullable=True))

--- a/control_plane/control_plane/migrations/versions/0005_resolver_cases.py
+++ b/control_plane/control_plane/migrations/versions/0005_resolver_cases.py
@@ -14,6 +14,12 @@ depends_on = None
 json_type = sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql")
 
 
+def _json_object_default() -> sa.TextClause:
+    if op.get_bind().dialect.name == "postgresql":
+        return sa.text("'{}'::jsonb")
+    return sa.text("'{}'")
+
+
 def upgrade() -> None:
     op.create_table(
         "resolver_cases",
@@ -31,8 +37,8 @@ def upgrade() -> None:
         sa.Column("machine_key", sa.String(length=255), nullable=True),
         sa.Column("source_commit", sa.String(length=64), nullable=True),
         sa.Column("repo_root", sa.Text(), nullable=True),
-        sa.Column("evidence_json", json_type, nullable=False, server_default=sa.text("'{}'::jsonb")),
-        sa.Column("resolution_json", json_type, nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("evidence_json", json_type, nullable=False, server_default=_json_object_default()),
+        sa.Column("resolution_json", json_type, nullable=False, server_default=_json_object_default()),
         sa.Column("attempt_count", sa.Integer(), nullable=False, server_default="0"),
         sa.Column("max_attempts", sa.Integer(), nullable=False, server_default="3"),
         sa.Column("last_evidence_hash", sa.String(length=64), nullable=True),
@@ -63,7 +69,7 @@ def upgrade() -> None:
         sa.Column("source", sa.String(length=32), nullable=False),
         sa.Column("kind", sa.String(length=64), nullable=False),
         sa.Column("summary", sa.Text(), nullable=False),
-        sa.Column("payload_json", json_type, nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("payload_json", json_type, nullable=False, server_default=_json_object_default()),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
         sa.ForeignKeyConstraint(["case_id"], ["resolver_cases.id"], name=op.f("fk_resolver_observations_case_id_resolver_cases")),
         sa.PrimaryKeyConstraint("id", name=op.f("pk_resolver_observations")),
@@ -93,8 +99,8 @@ def upgrade() -> None:
         sa.Column("evidence_hash", sa.String(length=64), nullable=True),
         sa.Column("failure_hash", sa.String(length=64), nullable=True),
         sa.Column("idempotency_key", sa.String(length=255), nullable=False),
-        sa.Column("request_json", json_type, nullable=False, server_default=sa.text("'{}'::jsonb")),
-        sa.Column("result_json", json_type, nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("request_json", json_type, nullable=False, server_default=_json_object_default()),
+        sa.Column("result_json", json_type, nullable=False, server_default=_json_object_default()),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
         sa.ForeignKeyConstraint(["case_id"], ["resolver_cases.id"], name=op.f("fk_resolver_actions_case_id_resolver_cases")),
         sa.PrimaryKeyConstraint("id", name=op.f("pk_resolver_actions")),

--- a/control_plane/scripts/bootstrap_venv.sh
+++ b/control_plane/scripts/bootstrap_venv.sh
@@ -20,5 +20,5 @@ activate with:
   source "$VENV_DIR/bin/activate"
 
 next recommended step:
-  "$ROOT_DIR/scripts/migrate_smoke.sh"
+  VENV_PATH="$VENV_DIR" "$ROOT_DIR/scripts/migrate_smoke.sh"
 EOF

--- a/control_plane/scripts/ensure_postgres_db.sh
+++ b/control_plane/scripts/ensure_postgres_db.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-VENV_DIR=${RTLCP_VENV_DIR:-"$ROOT_DIR/.venv"}
+VENV_DIR=${RTLCP_VENV_DIR:-${VENV_PATH:-"$ROOT_DIR/.venv"}}
 
 if [[ ! -x "$VENV_DIR/bin/python" ]]; then
   echo "missing virtualenv at $VENV_DIR; run $ROOT_DIR/scripts/bootstrap_venv.sh first" >&2

--- a/control_plane/scripts/migrate_postgres.sh
+++ b/control_plane/scripts/migrate_postgres.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-VENV_DIR=${RTLCP_VENV_DIR:-"$ROOT_DIR/.venv"}
+VENV_DIR=${RTLCP_VENV_DIR:-${VENV_PATH:-"$ROOT_DIR/.venv"}}
 
 if [[ ! -x "$VENV_DIR/bin/python" ]]; then
   echo "missing virtualenv at $VENV_DIR; run $ROOT_DIR/scripts/bootstrap_venv.sh first" >&2

--- a/control_plane/scripts/migrate_smoke.sh
+++ b/control_plane/scripts/migrate_smoke.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-VENV_DIR=${RTLCP_VENV_DIR:-"$ROOT_DIR/.venv"}
+VENV_DIR=${RTLCP_VENV_DIR:-${VENV_PATH:-"$ROOT_DIR/.venv"}}
 DB_PATH=${RTLCP_SMOKE_DB_PATH:-/tmp/rtlgen-control-plane-phase1.db}
 DB_URL=${RTLCP_DATABASE_URL:-"sqlite+pysqlite:///$DB_PATH"}
 

--- a/tests/test_devcontainer_user_contract.py
+++ b/tests/test_devcontainer_user_contract.py
@@ -88,3 +88,18 @@ def test_server_starts_api_before_resolver() -> None:
 
     assert '${AUTOSTART_API:-1}' in server_case
     assert server_case.index("start api") < server_case.index("start resolver")
+
+
+def test_migration_scripts_honor_external_devcontainer_venv() -> None:
+    scripts = REPO_ROOT / "control_plane" / "scripts"
+
+    for script_name in (
+        "migrate_smoke.sh",
+        "migrate_postgres.sh",
+        "ensure_postgres_db.sh",
+    ):
+        script = (scripts / script_name).read_text(encoding="utf-8")
+        assert 'VENV_DIR=${RTLCP_VENV_DIR:-${VENV_PATH:-"$ROOT_DIR/.venv"}}' in script
+
+    bootstrap = (scripts / "bootstrap_venv.sh").read_text(encoding="utf-8")
+    assert 'VENV_PATH="$VENV_DIR" "$ROOT_DIR/scripts/migrate_smoke.sh"' in bootstrap


### PR DESCRIPTION
## Summary
- resolve migration venvs from RTLCP_VENV_DIR, then VENV_PATH, before the legacy workspace fallback
- make bootstrap recommend the smoke command with the exact venv it created
- make migrations 0003-0005 executable on SQLite while preserving PostgreSQL DDL
- prevent devcontainer bootstrap from requiring or creating control_plane/.venv

## Verification
- shell syntax checks
- pytest -q tests/test_devcontainer_user_contract.py: 8 passed
- complete migrate_smoke.sh chain on fresh SQLite using /home/rtlgen/.venvs/rtlgen-control-plane
- offline PostgreSQL migration generation through head, including VARCHAR(32) USING cast and JSONB defaults
- confirmed control_plane/.venv was not created

A fresh PostgreSQL execution database could not be created because the local application role intentionally lacks CREATEDB.