### PR TITLE
fix devcontainer workspace ownership bootstrap

### DIFF
--- a/.devcontainer/rtlgen-container-init
+++ b/.devcontainer/rtlgen-container-init
@@ -21,6 +21,13 @@ require_value() {
 
 prepare_paths() {
   local path
+  if [[ -L /workspaces ]]; then
+    echo "Refusing symlink at privileged directory: /workspaces" >&2
+    exit 2
+  fi
+  install -d -o "${RTLGEN_USER}" -g "${RTLGEN_GROUP}" -m 0755 /workspaces
+  chown "${RTLGEN_USER}:${RTLGEN_GROUP}" /workspaces
+
   for path in /tmp/rtlgen-control-plane /workspaces/rtlgen-eval-clean; do
     if [[ -L "${path}" ]]; then
       echo "Refusing symlink at privileged directory: ${path}" >&2

--- a/tests/test_devcontainer_user_contract.py
+++ b/tests/test_devcontainer_user_contract.py
@@ -50,6 +50,23 @@ def test_privileged_helper_does_not_execute_workspace_scripts() -> None:
     assert "^[0-9A-Fa-f:.]+/[0-9]+$" in helper
 
 
+def test_privileged_helper_rejects_symlinked_workspaces_parent() -> None:
+    helper = (DEVCONTAINER / "rtlgen-container-init").read_text(encoding="utf-8")
+
+    assert "[[ -L /workspaces ]]" in helper
+    assert "Refusing symlink at privileged directory: /workspaces" in helper
+    assert helper.index("[[ -L /workspaces ]]") < helper.index("install -d")
+
+
+def test_privileged_helper_owns_workspaces_non_recursively() -> None:
+    helper = (DEVCONTAINER / "rtlgen-container-init").read_text(encoding="utf-8")
+
+    assert 'install -d -o "${RTLGEN_USER}" -g "${RTLGEN_GROUP}" -m 0755 /workspaces' in helper
+    assert 'chown "${RTLGEN_USER}:${RTLGEN_GROUP}" /workspaces' in helper
+    assert 'chown -R' not in helper
+    assert 'chown "${RTLGEN_USER}:${RTLGEN_GROUP}" /workspaces/' not in helper
+
+
 def test_post_start_rejects_root_and_uses_noninteractive_sudo() -> None:
     post_start = (DEVCONTAINER / "post_start.sh").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- Ensure `/workspaces` is a real directory during devcontainer bootstrap.
- Refuse a symlink at `/workspaces` before changing ownership.
- Create and chown `/workspaces` for the remapped `rtlgen` user/group before preparing evaluator runtime paths.

## Context

This follows the evaluator rebuild contract in issue #1653. The non-root evaluator session is now using the independent `/workspaces/RTLGen` checkout, with daemons running from that checkout rather than the linked evaluator worktree.

## Verification

- `bash -n /workspaces/RTLGen/.devcontainer/rtlgen-container-init`
- `bash -n /workspaces/RTLGen/.devcontainer/control_plane_service_ctl.sh`
- `VENV_PATH=/home/rtlgen/.venvs/rtlgen-control-plane env -u RTLCP_DATABASE_URL /workspaces/RTLGen/control_plane/scripts/migrate_smoke.sh`
- Issue 1653 verification block passed for non-root identity, `.codex` ownership, absent legacy venv, Codex host symlink, and running worker/completions/api/resolver services.
