### PR TITLE
Fix non-root OpenROAD runtime ownership

### DIFF
--- a/.devcontainer/rtlgen-container-init
+++ b/.devcontainer/rtlgen-container-init
@@ -36,6 +36,21 @@ prepare_paths() {
     install -d -o "${RTLGEN_USER}" -g "${RTLGEN_GROUP}" -m 0755 "${path}"
     chown "${RTLGEN_USER}:${RTLGEN_GROUP}" "${path}"
   done
+
+  for path in \
+    /orfs/flow/designs/src \
+    /orfs/flow/designs/nangate45 \
+    /orfs/flow/logs \
+    /orfs/flow/objects \
+    /orfs/flow/reports \
+    /orfs/flow/results; do
+    if [[ -L "${path}" ]]; then
+      echo "Refusing symlink at privileged directory: ${path}" >&2
+      exit 2
+    fi
+    install -d -o "${RTLGEN_USER}" -g "${RTLGEN_GROUP}" -m 0755 "${path}"
+    chown "${RTLGEN_USER}:${RTLGEN_GROUP}" "${path}"
+  done
 }
 
 initialize_postgres() {

--- a/docs/operations/devcontainer_uid_ownership.md
+++ b/docs/operations/devcontainer_uid_ownership.md
@@ -39,11 +39,16 @@ Only `/usr/local/sbin/rtlgen-container-init`, copied into the image and owned by
 root, may run passwordlessly through sudo. It has two validated operations:
 
 - `prepare`: create the control-plane runtime and evaluator service-checkout
-  directories for `rtlgen`.
+  directories for `rtlgen`. It also prepares only the writable OpenROAD runtime
+  roots used by generation and flow execution: `designs/src`,
+  `designs/nangate45`, `logs`, `objects`, `reports`, and `results` under
+  `/orfs/flow`.
 - `postgres`: initialize the local PostgreSQL service for the server role.
 
 The helper does not execute files from the writable workspace. API, resolver,
-worker, completion, Git, and Codex processes remain unprivileged.
+worker, completion, Git, Codex, RTL generation, and OpenROAD processes remain
+unprivileged. Ownership changes are non-recursive; OpenROAD tools, platform
+files, and scripts remain root-owned image content.
 
 ## One-time host repair
 

--- a/tests/test_devcontainer_user_contract.py
+++ b/tests/test_devcontainer_user_contract.py
@@ -67,6 +67,24 @@ def test_privileged_helper_owns_workspaces_non_recursively() -> None:
     assert 'chown "${RTLGEN_USER}:${RTLGEN_GROUP}" /workspaces/' not in helper
 
 
+def test_privileged_helper_prepares_only_orfs_runtime_roots() -> None:
+    helper = (DEVCONTAINER / "rtlgen-container-init").read_text(encoding="utf-8")
+    expected_paths = (
+        "/orfs/flow/designs/src",
+        "/orfs/flow/designs/nangate45",
+        "/orfs/flow/logs",
+        "/orfs/flow/objects",
+        "/orfs/flow/reports",
+        "/orfs/flow/results",
+    )
+
+    for path in expected_paths:
+        assert path in helper
+    assert "/orfs/flow/platforms" not in helper
+    assert "/orfs/flow/scripts" not in helper
+    assert "chown -R" not in helper
+
+
 def test_post_start_rejects_root_and_uses_noninteractive_sudo() -> None:
     post_start = (DEVCONTAINER / "post_start.sh").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- prepare only the ORFS runtime roots written by RTL generation and OpenROAD
- keep ownership changes non-recursive and reject symlinked privileged targets
- preserve root ownership for tools, platform collateral, and flow scripts
- document and test the non-root physical-flow contract

## Root cause
The first post-UID-migration physical job, `l1_segmented_xy_mesh_noc_phase1_v1`, built RTLGen successfully but failed before OpenROAD because `generate_design.py` could not move generated RTL into root-owned `/orfs/flow/designs/src`. See issue #1656.

## Verification
- `bash -n .devcontainer/rtlgen-container-init`
- `pytest -q tests/test_devcontainer_user_contract.py` (11 passed)
- `git diff --check`
- reproduced the failed job in an isolated worktree and confirmed `PermissionError: /orfs/flow/designs/src/...`

This helper is image-owned, so evaluator rollout requires rebuilding the devcontainer before retrying the failed physical job.