### PR TITLE
fix: consume score32 NoC Phase 2 schedule evidence

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -587,6 +587,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_score32_exact_reduction_recost_report",
     ),
     (
+        "attention_score32_noc_phase2_schedule_out",
+        "attention_score32_noc_phase2_schedule_report",
+    ),
+    (
         "attention_score32_folded_global_exact_reduction_recost_out",
         "attention_score32_folded_global_exact_reduction_recost_report",
     ),
@@ -830,6 +834,42 @@ def _decoder_quality_brief(evidence_payload: dict[str, Any]) -> dict[str, Any]:
     ):
         if key in evidence_payload:
             brief[key] = evidence_payload[key]
+    if (
+        evidence_payload.get("model") == "llama7b_proxy"
+        and evidence_payload.get("profile") == "decoder_attention_score32_noc_phase2_schedule"
+    ):
+        source_contract = dict(evidence_payload.get("source_contract") or {})
+        simulation = dict(evidence_payload.get("simulation") or {})
+        tag_semantics = dict(evidence_payload.get("tag_semantics") or {})
+        brief["schedule_summary"] = {
+            key: source_contract[key]
+            for key in (
+                "simulated_wave_count",
+                "tile_count",
+                "compute_layer_time_ns",
+                "noc_clock_ns",
+            )
+            if key in source_contract
+        }
+        brief["schedule_summary"].update(
+            {
+                key: simulation[key]
+                for key in (
+                    "cycles_to_drain",
+                    "drain_time_ns",
+                    "drain_within_source_compute_layer_envelope",
+                    "scheduled_packet_count",
+                    "scheduled_flit_count",
+                    "router_contention_cycles",
+                    "endpoint_input_stall_cycles_total",
+                )
+                if key in simulation
+            }
+        )
+        if "collision_free_reuse_proven" in tag_semantics:
+            brief["schedule_summary"]["collision_free_reuse_proven"] = tag_semantics[
+                "collision_free_reuse_proven"
+            ]
     return brief
 
 
@@ -999,6 +1039,45 @@ def _decoder_recommendation_override(
 
 def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, Any]) -> tuple[str, str]:
     model = str(evidence_payload.get("model", "")).strip()
+    if (
+        model == "llama7b_proxy"
+        and str(evidence_payload.get("profile", "")).strip()
+        == "decoder_attention_score32_noc_phase2_schedule"
+    ):
+        simulation = dict(evidence_payload.get("simulation") or {})
+        source_contract = dict(evidence_payload.get("source_contract") or {})
+        tag_semantics = dict(evidence_payload.get("tag_semantics") or {})
+        outcome = "score32_noc_phase2_schedule_recorded"
+        parts = [
+            f"Decoder score32 NoC Phase 2 schedule evidence recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for key in (
+            "simulated_wave_count",
+            "tile_count",
+            "compute_layer_time_ns",
+            "noc_clock_ns",
+        ):
+            if key in source_contract:
+                parts.append(f"{key}={source_contract.get(key)}")
+        for key in (
+            "cycles_to_drain",
+            "drain_time_ns",
+            "drain_within_source_compute_layer_envelope",
+            "scheduled_packet_count",
+            "scheduled_flit_count",
+            "router_contention_cycles",
+            "endpoint_input_stall_cycles_total",
+        ):
+            if key in simulation:
+                parts.append(f"{key}={simulation.get(key)}")
+        if "collision_free_reuse_proven" in tag_semantics:
+            parts.append(
+                "collision_free_reuse_proven="
+                f"{tag_semantics.get('collision_free_reuse_proven')}"
+            )
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+
     if evidence_payload.get("estimator") == "attention_pwl_recip_lut_boundary_v1":
         outcome = str(evidence_payload.get("decision") or "attention_pwl_recip_lut_boundary_recorded")
         parts = [

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -180,6 +180,174 @@ def test_decoder_evidence_paths_recognizes_operational_component_frontier(tmp_pa
     }
 
 
+def test_decoder_evidence_paths_recognizes_score32_noc_phase2_schedule(tmp_path: Path) -> None:
+    evidence_rel = "runs/datasets/demo/score32_noc_phase2_schedule.json"
+    report_rel = "runs/datasets/demo/score32_noc_phase2_schedule.md"
+    _write(tmp_path / evidence_rel, "{}\n")
+    _write(tmp_path / report_rel, "# Score32 NoC Phase 2 schedule\n")
+    work_item = SimpleNamespace(
+        input_manifest={
+            "decoder_contract": {
+                "attention_score32_noc_phase2_schedule_out": evidence_rel,
+                "attention_score32_noc_phase2_schedule_report": report_rel,
+            }
+        }
+    )
+
+    evidence_ref, source_refs = _decoder_evidence_paths(
+        repo_root=tmp_path,
+        work_item=work_item,
+    )
+
+    assert evidence_ref == evidence_rel
+    assert source_refs == {
+        "decoder_attention_score32_noc_phase2_schedule_out": evidence_rel,
+        "decoder_attention_score32_noc_phase2_schedule_report": report_rel,
+    }
+
+
+def test_decoder_evidence_summary_recognizes_score32_noc_phase2_schedule() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/score32_noc_phase2_schedule.json",
+        evidence_payload={
+            "model": "llama7b_proxy",
+            "profile": "decoder_attention_score32_noc_phase2_schedule",
+            "source_contract": {
+                "simulated_wave_count": 8,
+                "tile_count": 128,
+                "compute_layer_time_ns": 421511.3976,
+                "noc_clock_ns": 1.0,
+            },
+            "simulation": {
+                "cycles_to_drain": 397004,
+                "drain_time_ns": 397004.0,
+                "drain_within_source_compute_layer_envelope": True,
+                "scheduled_packet_count": 11576,
+                "scheduled_flit_count": 92128,
+                "router_contention_cycles": 36747,
+                "endpoint_input_stall_cycles_total": 319772,
+            },
+            "tag_semantics": {"collision_free_reuse_proven": True},
+        },
+    )
+
+    assert outcome == "score32_noc_phase2_schedule_recorded"
+    assert "cycles_to_drain=397004" in summary
+    assert "collision_free_reuse_proven=True" in summary
+
+
+def test_consume_l2_result_score32_noc_phase2_schedule_without_campaign_outputs(tmp_path: Path) -> None:
+    evidence_rel = "runs/datasets/demo/score32_noc_phase2_schedule.json"
+    report_rel = "runs/datasets/demo/score32_noc_phase2_schedule.md"
+    _write(
+        tmp_path / evidence_rel,
+        json.dumps(
+            {
+                "model": "llama7b_proxy",
+                "profile": "decoder_attention_score32_noc_phase2_schedule",
+                "source_contract": {
+                    "simulated_wave_count": 8,
+                    "tile_count": 128,
+                    "compute_layer_time_ns": 421511.3976,
+                    "noc_clock_ns": 1.0,
+                },
+                "simulation": {
+                    "cycles_to_drain": 397004,
+                    "drain_time_ns": 397004.0,
+                    "drain_within_source_compute_layer_envelope": True,
+                },
+                "tag_semantics": {
+                    "collision_free_reuse_proven": True,
+                    "tuple_summaries": [{"source": 0, "destination": 15}],
+                },
+                "remaining_abstractions": ["measured router clock substitution"],
+            }
+        )
+        + "\n",
+    )
+    _write(tmp_path / report_rel, "# Score32 NoC Phase 2 schedule\n")
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    create_all(engine)
+
+    item_id = "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1"
+    with Session(engine) as session:
+        task_request = TaskRequest(
+            request_key=f"l2_campaign:{item_id}",
+            source="test",
+            requested_by="@tester",
+            title="Layer2 score32 NoC Phase 2 schedule",
+            description="Route the complete score32 workload through the segmented mesh.",
+            layer=LayerName.LAYER2,
+            flow=FlowName.OPENROAD,
+            priority=1,
+            request_payload={
+                "item_id": item_id,
+                "developer_loop": {
+                    "evaluation": {"mode": "frontier_detail"},
+                    "comparison": {"role": "closure_detail"},
+                    "abstraction": {"layer": "decoder_attention_score32_noc_phase2_schedule"},
+                },
+            },
+            source_commit="deadbeef",
+        )
+        session.add(task_request)
+        session.flush()
+        work_item = WorkItem(
+            work_item_key=f"l2_campaign:{item_id}",
+            task_request_id=task_request.id,
+            item_id=item_id,
+            layer=LayerName.LAYER2,
+            flow=FlowName.OPENROAD,
+            platform="nangate45",
+            task_type="l2_campaign",
+            state=WorkItemState.ARTIFACT_SYNC,
+            priority=1,
+            source_mode="src_verilog",
+            input_manifest={
+                "decoder_contract": {
+                    "attention_score32_noc_phase2_schedule_out": evidence_rel,
+                    "attention_score32_noc_phase2_schedule_report": report_rel,
+                }
+            },
+            command_manifest=[],
+            expected_outputs=[evidence_rel, report_rel],
+            acceptance_rules=[],
+            source_commit="deadbeef",
+        )
+        session.add(work_item)
+        session.flush()
+        session.add(
+            Run(
+                run_key=f"{item_id}_run_1",
+                work_item_id=work_item.id,
+                attempt=1,
+                executor_type=ExecutorType.INTERNAL_WORKER,
+                status=RunStatus.SUCCEEDED,
+                started_at=utcnow(),
+                completed_at=utcnow(),
+                checkout_commit="deadbeef",
+                result_summary="2/2 commands succeeded",
+                result_payload={"queue_result": {"status": "ok"}},
+            )
+        )
+        session.commit()
+
+        result = consume_l2_result(
+            session,
+            Layer2ConsumeRequest(repo_root=str(tmp_path), item_id=item_id),
+        )
+
+        assert result.recommended_arch_id == "decoder_attention_score32_noc_phase2_schedule"
+        assert result.recommended_macro_mode == "evidence_only"
+        decision_path = tmp_path / "control_plane" / "shadow_exports" / "l2_decisions" / f"{item_id}.json"
+        decision = json.loads(decision_path.read_text(encoding="utf-8"))
+        assert decision["proposal_assessment"]["outcome"] == "score32_noc_phase2_schedule_recorded"
+        assert decision["source_refs"]["decoder_attention_score32_noc_phase2_schedule_out"] == evidence_rel
+        assert decision["decoder_quality"]["schedule_summary"]["cycles_to_drain"] == 397004
+        assert "tuple_summaries" not in decision["decoder_quality"]["schedule_summary"]
+        assert "best_point_json" not in decision["source_refs"]
+
+
 def test_decoder_evidence_paths_recognizes_decode_score_tile_equivalence(tmp_path: Path) -> None:
     evidence_rel = "runs/datasets/demo/decode_score_tile_equivalence.json"
     report_rel = "runs/datasets/demo/decode_score_tile_equivalence.md"


### PR DESCRIPTION
## Summary
- classify the score32 segmented-mesh Phase 2 JSON/Markdown pair as decoder evidence
- preserve routed schedule, tag, traffic, and clock details in the review payload
- avoid incorrectly requiring campaign `best_point.json`, `summary.csv`, and `results.csv`

## Root cause
The remote evaluation itself completed successfully, but automatic completion failed with:

```
expected output not found for suffix /best_point.json: l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1
```

The task deliberately emits one evidence JSON and one Markdown report, so it must use the evidence-only consumer path.

## Verification
- `python3 -m pytest -q control_plane/control_plane/tests/test_l2_result_consumer.py` (`131 passed`)
- `python3 scripts/validate_runs.py --skip_eval_queue`

Relates to #1658.
