### PR TITLE
fix(noc): register mesh credits and compose endpoints

### DIFF
--- a/docs/architecture/llama7b_attention_abstraction_closure_plan.md
+++ b/docs/architecture/llama7b_attention_abstraction_closure_plan.md
@@ -244,6 +244,19 @@ evidence gaps:
   performance model. The prepared L1 item
   `l1_noc_sram_packet_endpoint_phase2_v1` must measure endpoint PPA/service
   before the Phase 2 reroute can remove the endpoint-control cost abstraction.
+- Composition: `noc_sram_packet_mesh4x4` connects sixteen finite endpoints to
+  all sixteen routers with explicit scheduler descriptors, source SRAM reads,
+  destination SRAM writes, completion, and protocol-error boundaries. The
+  composed test proves simultaneous multihop packets and exact data/address
+  delivery. Endpoint receive logic now rejects a flit whose destination does
+  not name the local endpoint.
+- Credit timing: the original router FIFO allowed a full queue's input ready
+  to depend on a same-cycle downstream pop. Across bidirectional links this
+  formed a combinational ready fixpoint. FIFO credits now depend only on
+  registered occupancy, and the performance model uses the same one-cycle
+  full-queue recovery rule. Router, aggregate-mesh, and endpoint PPA items must
+  use a merge commit containing this correction; the earlier queued source
+  hashes are not valid final physical anchors.
 - The original NoC Phase 2 item is superseded without a usable result. It
   interpreted compute-wrapper cycles as NoC cycles. The retry converts every
   release timestamp with

--- a/docs/proposals/prop_l1_noc_sram_packet_endpoint_phase2_v1/design_brief.md
+++ b/docs/proposals/prop_l1_noc_sram_packet_endpoint_phase2_v1/design_brief.md
@@ -8,7 +8,7 @@
 - Eight receive contexts keyed by `(source, VC, tag)`.
 - Direct fragment writes to destination SRAM and buffered packet completion.
 - Sticky protocol checking for invalid descriptors, duplicate live keys,
-  missing contexts, fragment order, and `last` consistency.
+  missing contexts, wrong destination, fragment order, and `last` consistency.
 
 ## Physical Harness
 
@@ -18,6 +18,8 @@
 - Apply SRAM-read, SRAM-write, and completion backpressure.
 - Observe TX metadata, payloads, RX addresses/data, completion metadata,
   issued/completed counts, and protocol status through a compact boundary.
+- Retain the local-destination comparator through a four-bit destination probe
+  instead of tying it to a synthesis-removable constant.
 
 ## Exclusions
 

--- a/docs/proposals/prop_l1_noc_sram_packet_endpoint_phase2_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_noc_sram_packet_endpoint_phase2_v1/evaluation_requests.json
@@ -25,7 +25,7 @@
         "direction": "measure_phase2_sram_packet_endpoint",
         "reason": "Replace uncosted logical source descriptors and packetizer/control storage with concrete finite RTL PPA."
       },
-      "acceptance_notes": "Require exact packet metadata correspondence, stable ready/valid behavior, direct RX SRAM addresses, completion safety, protocol_error=0, and retained configured queue/context structures. Treat measured PPA as endpoint-control-plus-compact-harness evidence, not SRAM macro, router, aggregate mesh, or workload-activity evidence."
+      "acceptance_notes": "Require exact packet metadata correspondence, local-destination validation, stable ready/valid behavior, direct RX SRAM addresses, completion safety, protocol_error=0, and retained configured queue/context structures. Treat measured PPA as endpoint-control-plus-compact-harness evidence, not SRAM macro, router, aggregate mesh, or workload-activity evidence."
     }
   ]
 }

--- a/docs/proposals/prop_l1_noc_sram_packet_endpoint_phase2_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_noc_sram_packet_endpoint_phase2_v1/quality_gate.md
@@ -6,6 +6,8 @@
 - RTL TX metadata exactly matches `packetize_traffic_flow` for one- through
   eight-fragment packets.
 - RX accepts interleaved packet contexts and writes exact fragment addresses.
+- RX consumes a misrouted flit without an SRAM write and raises the sticky
+  protocol error.
 - Completion backpressure cannot release a receive context early.
 - Valid bounded traffic finishes with `protocol_error=0`.
 - Generated compact harness compiles, runs, and retains live issued/completed

--- a/docs/proposals/prop_l1_segmented_xy_mesh4x4_aggregate_ppa_v1/design_brief.md
+++ b/docs/proposals/prop_l1_segmented_xy_mesh4x4_aggregate_ppa_v1/design_brief.md
@@ -6,6 +6,9 @@
 - Generate full-width endpoint traffic internally to avoid exposing over 8,000 payload pins.
 - Rotate each destination by an odd stride, cycle every VC, and vary every sink-ready signal.
 - Register a distinct 16-bit payload slice plus metadata at each endpoint. Across 16 endpoints, all 256 payload bit positions remain observable without a global XOR or 16:1 mux path.
+- Use registered-occupancy input credits so no downstream-ready path crosses
+  multiple routers combinationally. A full FIFO exposes renewed credit one
+  cycle after its first resumed pop.
 
 ## Accounting
 - Included: mesh routers, FIFOs, links, endpoint source state, compact observation registers, placement wiring, and clock distribution.

--- a/npu/docs/noc_sram_packet_endpoint_contract.md
+++ b/npu/docs/noc_sram_packet_endpoint_contract.md
@@ -21,6 +21,8 @@ control abstraction between cluster SRAM and the 256-bit segmented mesh.
 - Each valid fragment is written directly to `base + fragment * 32` bytes.
 - Contexts accept interleaved packets with different keys and enforce ordered
   fragments and a consistent `last` bit independently.
+- Every received flit must name the local endpoint as its destination; a
+  misrouted flit is consumed without an SRAM write and raises the sticky error.
 - A context is released only when its last SRAM write is accepted and packet
   completion can be retained.
 - Missing contexts, duplicate live keys, invalid counts, fragment-order errors,

--- a/npu/docs/noc_sram_packet_mesh4x4_contract.md
+++ b/npu/docs/noc_sram_packet_mesh4x4_contract.md
@@ -1,0 +1,46 @@
+# SRAM Packet Mesh Composition Contract
+
+`noc_sram_packet_mesh4x4` is the exact functional boundary between sixteen
+descriptor-driven SRAM endpoints and the 4x4 segmented NoC.
+
+## Included RTL
+
+- Sixteen `noc_sram_packet_endpoint` instances.
+- Sixteen five-port deterministic-XY routers.
+- Four virtual channels and four entries per input/VC FIFO.
+- All 24 bidirectional neighbor connections.
+- Full 256-bit payload, source, destination, VC, tag, fragment, and `last`
+  transport.
+- Direct receive SRAM writes, packet completion, and per-endpoint protocol
+  errors.
+- Registered-occupancy FIFO credits; no router-to-router combinational ready
+  path exists.
+
+## External Contracts
+
+- The command scheduler must install receive descriptors before releasing the
+  matching transmit descriptors.
+- Source SRAM returns one in-order response for each accepted read request.
+- Destination SRAM accepts each write only on ready/valid handshake.
+- SRAM arrays and bitcells are external; their address, data, and flow-control
+  boundaries are explicit rather than modeled as zero-cost storage.
+- HBM/DRAM and its controller remain outside the chip-level RTL scope.
+
+## Backpressure Semantics
+
+FIFO input readiness depends only on registered occupancy. A non-full FIFO can
+accept and pop in the same cycle at one flit/cycle. A full FIFO that resumes
+after downstream blockage first releases one entry, then advertises credit on
+the following cycle. The performance model uses the same rule; it no longer
+solves a combinational ready fixpoint across the mesh.
+
+## Current Evidence
+
+The end-to-end test concurrently transfers an eight-flit packet from endpoint
+0 to 15 and a three-flit packet from endpoint 3 to 12. It checks exact source
+SRAM data, multihop delivery, destination-specific write addresses, completion
+metadata, backpressure, and zero protocol errors. Structural synthesis checks
+the complete sixteen-endpoint/sixteen-router hierarchy.
+
+This is functional composition evidence. Aggregate physical placement and
+workload-matched switching activity remain separate gates.

--- a/npu/sim/perf/noc_segmented_mesh.py
+++ b/npu/sim/perf/noc_segmented_mesh.py
@@ -233,11 +233,12 @@ class _RouterState:
     def _occupancy(self) -> int:
         return sum(len(queue) for queue in self.queues)
 
-    def _input_ready(self, port: int, vc: int, will_pop: set[int]) -> bool:
+    def _input_ready(self, port: int, vc: int) -> bool:
         queue = self.queues[self._input_index(port, vc)]
-        if len(queue) < self.fifo_depth:
-            return True
-        return self._input_index(port, vc) in will_pop
+        # Match the RTL's registered-occupancy credit boundary. A full FIFO
+        # does not expose a combinational path from downstream ready to its
+        # upstream sender, even when one entry will be popped this cycle.
+        return len(queue) < self.fifo_depth
 
     def idle(self) -> bool:
         return self._occupancy() == 0 and all(flit is None for flit in self.out_holding)
@@ -277,7 +278,7 @@ class _RouterState:
         for port in range(PORTS):
             item = inputs[port]
             vc = 0 if item.flit is None else item.flit.vc
-            port_ready = self._input_ready(port, vc, will_pop)
+            port_ready = self._input_ready(port, vc)
             ready.append(port_ready)
             if item.valid and not port_ready:
                 input_stall = True
@@ -557,26 +558,26 @@ def simulate_scheduled_flits(
         for node in range(ENDPOINTS):
             out_ready[node][PORT_LOCAL] = endpoint_out_ready[node]
 
-        plans: list[RouterPlan] = []
-        for _ in range(ENDPOINTS * PORTS * 2):
-            plans = []
-            for node in range(ENDPOINTS):
-                plans.append(states[node].compute_plan(router_inputs[node], out_ready[node]))
-            updated = [[False] * PORTS for _ in range(ENDPOINTS)]
-            for node in range(ENDPOINTS):
-                updated[node][PORT_LOCAL] = endpoint_out_ready[node]
-                for port in (PORT_NORTH, PORT_SOUTH, PORT_EAST, PORT_WEST):
-                    neighbor = _neighbor(node, port)
-                    if neighbor is None:
-                        updated[node][port] = True
-                        continue
-                    downstream_node, downstream_port = neighbor
-                    updated[node][port] = plans[downstream_node].ready[downstream_port]
-            if updated == out_ready:
-                break
-            out_ready = updated
-        else:
-            raise RuntimeError("mesh ready/valid fixpoint did not converge")
+        # Input credit is a function of registered FIFO occupancy only. First
+        # sample those credits, then calculate link readiness and the final
+        # arbitration plan. No network-wide combinational fixpoint is needed.
+        credit_plans = [
+            states[node].compute_plan(router_inputs[node], [False] * PORTS)
+            for node in range(ENDPOINTS)
+        ]
+        for node in range(ENDPOINTS):
+            out_ready[node][PORT_LOCAL] = endpoint_out_ready[node]
+            for port in (PORT_NORTH, PORT_SOUTH, PORT_EAST, PORT_WEST):
+                neighbor = _neighbor(node, port)
+                if neighbor is None:
+                    out_ready[node][port] = True
+                    continue
+                downstream_node, downstream_port = neighbor
+                out_ready[node][port] = credit_plans[downstream_node].ready[downstream_port]
+        plans = [
+            states[node].compute_plan(router_inputs[node], out_ready[node])
+            for node in range(ENDPOINTS)
+        ]
 
         cycle_router_traces: list[RouterCycleTrace] = []
         cycle_injected: list[tuple[int, ModelFlit]] = []

--- a/npu/sim/rtl/noc_ready_valid_fifo.sv
+++ b/npu/sim/rtl/noc_ready_valid_fifo.sv
@@ -19,7 +19,8 @@ module noc_ready_valid_fifo #(
   output wire [COUNT_W-1:0] occupancy,
   output reg [COUNT_W-1:0] max_occupancy
 );
-  localparam [COUNT_W-1:0] DEPTH_VALUE = DEPTH;
+  localparam integer PTR_W = (DEPTH <= 1) ? 1 : $clog2(DEPTH);
+  localparam [COUNT_W-1:0] DEPTH_VALUE = COUNT_W'(DEPTH);
 
   reg [WIDTH-1:0] mem [0:DEPTH-1];
   reg [COUNT_W-1:0] count;
@@ -27,8 +28,11 @@ module noc_ready_valid_fifo #(
 
   wire out_valid_int = (count != {COUNT_W{1'b0}});
   wire out_fire = out_valid_int && out_ready;
-  wire in_ready_int = (count < DEPTH_VALUE) || out_fire;
+  // Readiness depends only on registered occupancy. This deliberately avoids
+  // propagating downstream ready through every router in a mesh cycle.
+  wire in_ready_int = count < DEPTH_VALUE;
   wire in_fire = in_valid && in_ready_int;
+  wire [PTR_W-1:0] count_index = count[PTR_W-1:0];
 
   assign in_ready = in_ready_int;
   assign out_valid = out_valid_int;
@@ -42,7 +46,7 @@ module noc_ready_valid_fifo #(
     end else begin
       case ({in_fire, out_fire})
         2'b10: begin
-          mem[count] <= in_data;
+          mem[count_index] <= in_data;
           count <= count + {{(COUNT_W-1){1'b0}}, 1'b1};
           if ((count + {{(COUNT_W-1){1'b0}}, 1'b1}) > max_occupancy) begin
             max_occupancy <= count + {{(COUNT_W-1){1'b0}}, 1'b1};
@@ -65,7 +69,7 @@ module noc_ready_valid_fifo #(
           if (count == {{(COUNT_W-1){1'b0}}, 1'b1}) begin
             mem[0] <= in_data;
           end else begin
-            mem[count - {{(COUNT_W-1){1'b0}}, 1'b1}] <= in_data;
+            mem[count_index - 1'b1] <= in_data;
           end
         end
         default: begin

--- a/npu/sim/rtl/noc_sram_packet_endpoint.sv
+++ b/npu/sim/rtl/noc_sram_packet_endpoint.sv
@@ -57,6 +57,7 @@ module noc_sram_packet_endpoint #(
   input wire rx_flit_valid,
   output wire rx_flit_ready,
   input wire [ENDPOINT_W-1:0] rx_flit_source,
+  input wire [ENDPOINT_W-1:0] rx_flit_destination,
   input wire [VC_W-1:0] rx_flit_vc,
   input wire [TAG_W-1:0] rx_flit_tag,
   input wire [FRAGMENT_W-1:0] rx_flit_fragment,
@@ -213,7 +214,9 @@ module noc_sram_packet_endpoint #(
     (rx_desc_flit_count != {FLIT_COUNT_W{1'b0}}) &&
     (rx_desc_flit_count <= MAX_FLIT_COUNT);
   wire rx_desc_push = rx_desc_valid && rx_desc_ready;
-  wire rx_flit_protocol_valid = rx_match_found && rx_fragment_valid && rx_last_valid;
+  wire rx_destination_valid = rx_flit_destination == LOCAL_ENDPOINT_ID[ENDPOINT_W-1:0];
+  wire rx_flit_protocol_valid =
+    rx_destination_valid && rx_match_found && rx_fragment_valid && rx_last_valid;
   wire rx_completion_space = !rx_completion_valid_r || rx_completion_ready;
   wire rx_flit_fire = rx_flit_valid && rx_flit_ready;
   wire rx_packet_complete = rx_flit_protocol_valid && rx_flit_last;

--- a/npu/sim/rtl/noc_sram_packet_mesh4x4.sv
+++ b/npu/sim/rtl/noc_sram_packet_mesh4x4.sv
@@ -1,0 +1,207 @@
+`timescale 1ns/1ps
+
+// Exact composition boundary for sixteen SRAM packet endpoints and the
+// deterministic-XY 4x4 segmented mesh. SRAM arrays and descriptor scheduling
+// remain outside this module, but every transfer between them is explicit.
+module noc_sram_packet_mesh4x4 #(
+  parameter integer DATA_W = 256,
+  parameter integer ENDPOINT_W = 4,
+  parameter integer VC_W = 2,
+  parameter integer VC_COUNT = 4,
+  parameter integer TAG_W = 8,
+  parameter integer FRAGMENT_W = 3,
+  parameter integer ADDR_W = 24,
+  parameter integer FLIT_COUNT_W = 4,
+  parameter integer TX_DESC_DEPTH = 4,
+  parameter integer TX_OUTSTANDING = 8,
+  parameter integer RX_CONTEXTS = 8,
+  parameter integer ROUTER_FIFO_DEPTH = 4,
+  parameter integer COUNTER_W = 32
+) (
+  input wire clk,
+  input wire rst_n,
+
+  input wire [15:0] tx_desc_valid,
+  output wire [15:0] tx_desc_ready,
+  input wire [16*ENDPOINT_W-1:0] tx_desc_destination,
+  input wire [16*VC_W-1:0] tx_desc_vc,
+  input wire [16*TAG_W-1:0] tx_desc_tag,
+  input wire [16*ADDR_W-1:0] tx_desc_base_addr,
+  input wire [16*FLIT_COUNT_W-1:0] tx_desc_flit_count,
+
+  output wire [15:0] tx_mem_req_valid,
+  input wire [15:0] tx_mem_req_ready,
+  output wire [16*ADDR_W-1:0] tx_mem_req_addr,
+  input wire [15:0] tx_mem_rsp_valid,
+  output wire [15:0] tx_mem_rsp_ready,
+  input wire [16*DATA_W-1:0] tx_mem_rsp_data,
+
+  input wire [15:0] rx_desc_valid,
+  output wire [15:0] rx_desc_ready,
+  input wire [16*ENDPOINT_W-1:0] rx_desc_source,
+  input wire [16*VC_W-1:0] rx_desc_vc,
+  input wire [16*TAG_W-1:0] rx_desc_tag,
+  input wire [16*ADDR_W-1:0] rx_desc_base_addr,
+  input wire [16*FLIT_COUNT_W-1:0] rx_desc_flit_count,
+
+  output wire [15:0] rx_mem_write_valid,
+  input wire [15:0] rx_mem_write_ready,
+  output wire [16*ADDR_W-1:0] rx_mem_write_addr,
+  output wire [16*DATA_W-1:0] rx_mem_write_data,
+
+  output wire [15:0] rx_completion_valid,
+  input wire [15:0] rx_completion_ready,
+  output wire [16*ENDPOINT_W-1:0] rx_completion_source,
+  output wire [16*VC_W-1:0] rx_completion_vc,
+  output wire [16*TAG_W-1:0] rx_completion_tag,
+  output wire [15:0] endpoint_protocol_error,
+
+  output wire [16*COUNTER_W-1:0] router_accepted_flit_count,
+  output wire [16*COUNTER_W-1:0] router_forwarded_flit_count,
+  output wire [16*COUNTER_W-1:0] router_input_stall_cycles,
+  output wire [16*COUNTER_W-1:0] router_output_stall_cycles,
+  output wire [16*COUNTER_W-1:0] router_contention_cycles,
+  output wire [16*COUNTER_W-1:0] router_current_input_occupancy,
+  output wire [16*COUNTER_W-1:0] router_max_input_occupancy,
+  output wire [16*5*COUNTER_W-1:0] router_route_flit_count
+);
+  localparam integer NODES = 16;
+
+  wire [NODES-1:0] mesh_in_valid;
+  wire [NODES-1:0] mesh_in_ready;
+  wire [NODES*ENDPOINT_W-1:0] mesh_in_destination;
+  wire [NODES*ENDPOINT_W-1:0] mesh_in_source;
+  wire [NODES*TAG_W-1:0] mesh_in_tag;
+  wire [NODES*FRAGMENT_W-1:0] mesh_in_fragment;
+  wire [NODES-1:0] mesh_in_last;
+  wire [NODES*VC_W-1:0] mesh_in_vc;
+  wire [NODES*DATA_W-1:0] mesh_in_data;
+
+  wire [NODES-1:0] mesh_out_valid;
+  wire [NODES-1:0] mesh_out_ready;
+  wire [NODES*ENDPOINT_W-1:0] mesh_out_destination;
+  wire [NODES*ENDPOINT_W-1:0] mesh_out_source;
+  wire [NODES*TAG_W-1:0] mesh_out_tag;
+  wire [NODES*FRAGMENT_W-1:0] mesh_out_fragment;
+  wire [NODES-1:0] mesh_out_last;
+  wire [NODES*VC_W-1:0] mesh_out_vc;
+  wire [NODES*DATA_W-1:0] mesh_out_data;
+
+  genvar node_g;
+  generate
+    for (node_g = 0; node_g < NODES; node_g = node_g + 1) begin : gen_endpoints
+      noc_sram_packet_endpoint #(
+        .DATA_W(DATA_W),
+        .ENDPOINT_W(ENDPOINT_W),
+        .VC_W(VC_W),
+        .TAG_W(TAG_W),
+        .FRAGMENT_W(FRAGMENT_W),
+        .ADDR_W(ADDR_W),
+        .FLIT_COUNT_W(FLIT_COUNT_W),
+        .TX_DESC_DEPTH(TX_DESC_DEPTH),
+        .TX_OUTSTANDING(TX_OUTSTANDING),
+        .RX_CONTEXTS(RX_CONTEXTS),
+        .LOCAL_ENDPOINT_ID(node_g)
+      ) endpoint (
+        .clk(clk),
+        .rst_n(rst_n),
+        .tx_desc_valid(tx_desc_valid[node_g]),
+        .tx_desc_ready(tx_desc_ready[node_g]),
+        .tx_desc_destination(tx_desc_destination[(node_g*ENDPOINT_W) +: ENDPOINT_W]),
+        .tx_desc_vc(tx_desc_vc[(node_g*VC_W) +: VC_W]),
+        .tx_desc_tag(tx_desc_tag[(node_g*TAG_W) +: TAG_W]),
+        .tx_desc_base_addr(tx_desc_base_addr[(node_g*ADDR_W) +: ADDR_W]),
+        .tx_desc_flit_count(tx_desc_flit_count[(node_g*FLIT_COUNT_W) +: FLIT_COUNT_W]),
+        .tx_mem_req_valid(tx_mem_req_valid[node_g]),
+        .tx_mem_req_ready(tx_mem_req_ready[node_g]),
+        .tx_mem_req_addr(tx_mem_req_addr[(node_g*ADDR_W) +: ADDR_W]),
+        .tx_mem_rsp_valid(tx_mem_rsp_valid[node_g]),
+        .tx_mem_rsp_ready(tx_mem_rsp_ready[node_g]),
+        .tx_mem_rsp_data(tx_mem_rsp_data[(node_g*DATA_W) +: DATA_W]),
+        .tx_flit_valid(mesh_in_valid[node_g]),
+        .tx_flit_ready(mesh_in_ready[node_g]),
+        .tx_flit_source(mesh_in_source[(node_g*ENDPOINT_W) +: ENDPOINT_W]),
+        .tx_flit_destination(mesh_in_destination[(node_g*ENDPOINT_W) +: ENDPOINT_W]),
+        .tx_flit_vc(mesh_in_vc[(node_g*VC_W) +: VC_W]),
+        .tx_flit_tag(mesh_in_tag[(node_g*TAG_W) +: TAG_W]),
+        .tx_flit_fragment(mesh_in_fragment[(node_g*FRAGMENT_W) +: FRAGMENT_W]),
+        .tx_flit_last(mesh_in_last[node_g]),
+        .tx_flit_data(mesh_in_data[(node_g*DATA_W) +: DATA_W]),
+        .rx_desc_valid(rx_desc_valid[node_g]),
+        .rx_desc_ready(rx_desc_ready[node_g]),
+        .rx_desc_source(rx_desc_source[(node_g*ENDPOINT_W) +: ENDPOINT_W]),
+        .rx_desc_vc(rx_desc_vc[(node_g*VC_W) +: VC_W]),
+        .rx_desc_tag(rx_desc_tag[(node_g*TAG_W) +: TAG_W]),
+        .rx_desc_base_addr(rx_desc_base_addr[(node_g*ADDR_W) +: ADDR_W]),
+        .rx_desc_flit_count(rx_desc_flit_count[(node_g*FLIT_COUNT_W) +: FLIT_COUNT_W]),
+        .rx_flit_valid(mesh_out_valid[node_g]),
+        .rx_flit_ready(mesh_out_ready[node_g]),
+        .rx_flit_source(mesh_out_source[(node_g*ENDPOINT_W) +: ENDPOINT_W]),
+        .rx_flit_destination(mesh_out_destination[(node_g*ENDPOINT_W) +: ENDPOINT_W]),
+        .rx_flit_vc(mesh_out_vc[(node_g*VC_W) +: VC_W]),
+        .rx_flit_tag(mesh_out_tag[(node_g*TAG_W) +: TAG_W]),
+        .rx_flit_fragment(mesh_out_fragment[(node_g*FRAGMENT_W) +: FRAGMENT_W]),
+        .rx_flit_last(mesh_out_last[node_g]),
+        .rx_flit_data(mesh_out_data[(node_g*DATA_W) +: DATA_W]),
+        .rx_mem_write_valid(rx_mem_write_valid[node_g]),
+        .rx_mem_write_ready(rx_mem_write_ready[node_g]),
+        .rx_mem_write_addr(rx_mem_write_addr[(node_g*ADDR_W) +: ADDR_W]),
+        .rx_mem_write_data(rx_mem_write_data[(node_g*DATA_W) +: DATA_W]),
+        .rx_completion_valid(rx_completion_valid[node_g]),
+        .rx_completion_ready(rx_completion_ready[node_g]),
+        .rx_completion_source(rx_completion_source[(node_g*ENDPOINT_W) +: ENDPOINT_W]),
+        .rx_completion_vc(rx_completion_vc[(node_g*VC_W) +: VC_W]),
+        .rx_completion_tag(rx_completion_tag[(node_g*TAG_W) +: TAG_W]),
+        .protocol_error(endpoint_protocol_error[node_g])
+      );
+    end
+  endgenerate
+
+  noc_segmented_mesh4x4 #(
+    .DATA_W(DATA_W),
+    .TAG_W(TAG_W),
+    .FRAGMENT_W(FRAGMENT_W),
+    .VC_W(VC_W),
+    .VC_COUNT(VC_COUNT),
+    .FIFO_DEPTH(ROUTER_FIFO_DEPTH),
+    .COUNTER_W(COUNTER_W)
+  ) mesh (
+    .clk(clk),
+    .rst_n(rst_n),
+    .endpoint_in_valid(mesh_in_valid),
+    .endpoint_in_ready(mesh_in_ready),
+    .endpoint_in_dest(mesh_in_destination),
+    .endpoint_in_source(mesh_in_source),
+    .endpoint_in_tag(mesh_in_tag),
+    .endpoint_in_fragment(mesh_in_fragment),
+    .endpoint_in_last(mesh_in_last),
+    .endpoint_in_vc(mesh_in_vc),
+    .endpoint_in_data(mesh_in_data),
+    .endpoint_out_valid(mesh_out_valid),
+    .endpoint_out_ready(mesh_out_ready),
+    .endpoint_out_dest(mesh_out_destination),
+    .endpoint_out_source(mesh_out_source),
+    .endpoint_out_tag(mesh_out_tag),
+    .endpoint_out_fragment(mesh_out_fragment),
+    .endpoint_out_last(mesh_out_last),
+    .endpoint_out_vc(mesh_out_vc),
+    .endpoint_out_data(mesh_out_data),
+    .router_accepted_flit_count(router_accepted_flit_count),
+    .router_forwarded_flit_count(router_forwarded_flit_count),
+    .router_input_stall_cycles(router_input_stall_cycles),
+    .router_output_stall_cycles(router_output_stall_cycles),
+    .router_contention_cycles(router_contention_cycles),
+    .router_current_input_occupancy(router_current_input_occupancy),
+    .router_max_input_occupancy(router_max_input_occupancy),
+    .router_route_flit_count(router_route_flit_count)
+  );
+
+`ifndef SYNTHESIS
+  initial begin
+    if (DATA_W != 256 || ENDPOINT_W != 4 || VC_COUNT != 4 || VC_W != 2) begin
+      $error("noc_sram_packet_mesh4x4 must match the 4x4 segmented-mesh contract");
+      $finish(1);
+    end
+  end
+`endif
+endmodule

--- a/scripts/generate_design.py
+++ b/scripts/generate_design.py
@@ -1471,6 +1471,7 @@ def _emit_l1_sram_packet_endpoint(module_name, design):
 module {module_name}(
   input clk,
   input rst_n,
+  input [{dest_bits-1}:0] rx_destination_probe,
   output [{flit_bits-1}:0] observed_flit,
   output [{counter_bits-1}:0] issued_packet_count,
   output [{counter_bits-1}:0] completed_packet_count,
@@ -1598,7 +1599,8 @@ module {module_name}(
     .rx_desc_tag(next_tag), .rx_desc_base_addr(next_rx_base),
     .rx_desc_flit_count(next_flit_count),
     .rx_flit_valid(tx_flit_valid), .rx_flit_ready(rx_flit_ready),
-    .rx_flit_source(tx_flit_source), .rx_flit_vc(tx_flit_vc),
+    .rx_flit_source(tx_flit_source), .rx_flit_destination(rx_destination_probe),
+    .rx_flit_vc(tx_flit_vc),
     .rx_flit_tag(tx_flit_tag), .rx_flit_fragment(tx_flit_fragment),
     .rx_flit_last(tx_flit_last), .rx_flit_data(tx_flit_data),
     .rx_mem_write_valid(rx_mem_write_valid), .rx_mem_write_ready(rx_mem_write_ready),
@@ -2464,6 +2466,7 @@ endmodule
 module {wrapper_name}(
   input clk,
   input rst_n,
+  input [{design['dest_bits']-1}:0] rx_destination_probe,
   output [{flit_bits-1}:0] observed_flit,
   output [{counter_bits-1}:0] issued_packet_count,
   output [{counter_bits-1}:0] completed_packet_count,
@@ -2473,6 +2476,7 @@ module {wrapper_name}(
   {module_name} dut (
     .clk(clk),
     .rst_n(rst_n),
+    .rx_destination_probe(rx_destination_probe),
     .observed_flit(observed_flit),
     .issued_packet_count(issued_packet_count),
     .completed_packet_count(completed_packet_count),

--- a/tests/noc_sram_packet_endpoint_tb.sv
+++ b/tests/noc_sram_packet_endpoint_tb.sv
@@ -41,6 +41,7 @@ module noc_sram_packet_endpoint_tb;
   reg rx_flit_valid = 1'b0;
   wire rx_flit_ready;
   reg [3:0] rx_flit_source = 0;
+  reg [3:0] rx_flit_destination = 2;
   reg [1:0] rx_flit_vc = 0;
   reg [7:0] rx_flit_tag = 0;
   reg [2:0] rx_flit_fragment = 0;
@@ -94,7 +95,8 @@ module noc_sram_packet_endpoint_tb;
     .rx_desc_tag(rx_desc_tag), .rx_desc_base_addr(rx_desc_base_addr),
     .rx_desc_flit_count(rx_desc_flit_count),
     .rx_flit_valid(rx_flit_valid), .rx_flit_ready(rx_flit_ready),
-    .rx_flit_source(rx_flit_source), .rx_flit_vc(rx_flit_vc),
+    .rx_flit_source(rx_flit_source), .rx_flit_destination(rx_flit_destination),
+    .rx_flit_vc(rx_flit_vc),
     .rx_flit_tag(rx_flit_tag), .rx_flit_fragment(rx_flit_fragment),
     .rx_flit_last(rx_flit_last), .rx_flit_data(rx_flit_data),
     .rx_mem_write_valid(rx_mem_write_valid),
@@ -317,10 +319,12 @@ module noc_sram_packet_endpoint_tb;
     if (request_count !== 10 || write_count !== 5 || protocol_error)
       $fatal(1, "wrong final counts or protocol_error");
 
-    // An unmatched packet must be consumed to avoid deadlock and reported.
+    // A misrouted packet must be consumed without a write and reported.
+    send_rx_descriptor(15, 3, 8'hee, 16'h0900, 1);
+    rx_flit_destination = 3;
     send_rx_flit(15, 3, 8'hee, 0, 1, 32'hdeadbeef);
     if (!protocol_error)
-      $fatal(1, "unmatched RX packet did not set protocol_error");
+      $fatal(1, "misrouted RX packet did not set protocol_error");
 
     $display("PASS noc_sram_packet_endpoint requests=%0d tx=%0d writes=%0d completions=%0d",
              request_count, tx_count, write_count, completion_count);

--- a/tests/noc_sram_packet_mesh4x4_tb.sv
+++ b/tests/noc_sram_packet_mesh4x4_tb.sv
@@ -1,0 +1,231 @@
+`timescale 1ns/1ps
+
+module noc_sram_packet_mesh4x4_tb;
+  localparam integer DATA_W = 256;
+  localparam integer ADDR_W = 16;
+
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  integer cycle = 0;
+  integer endpoint_i;
+
+  reg [15:0] tx_desc_valid = 0;
+  wire [15:0] tx_desc_ready;
+  reg [63:0] tx_desc_destination = 0;
+  reg [31:0] tx_desc_vc = 0;
+  reg [127:0] tx_desc_tag = 0;
+  reg [16*ADDR_W-1:0] tx_desc_base_addr = 0;
+  reg [63:0] tx_desc_flit_count = 0;
+  wire [15:0] tx_mem_req_valid;
+  reg [15:0] tx_mem_req_ready = 16'hffff;
+  wire [16*ADDR_W-1:0] tx_mem_req_addr;
+  reg [15:0] tx_mem_rsp_valid = 0;
+  wire [15:0] tx_mem_rsp_ready;
+  reg [16*DATA_W-1:0] tx_mem_rsp_data = 0;
+
+  reg [15:0] rx_desc_valid = 0;
+  wire [15:0] rx_desc_ready;
+  reg [63:0] rx_desc_source = 0;
+  reg [31:0] rx_desc_vc = 0;
+  reg [127:0] rx_desc_tag = 0;
+  reg [16*ADDR_W-1:0] rx_desc_base_addr = 0;
+  reg [63:0] rx_desc_flit_count = 0;
+  wire [15:0] rx_mem_write_valid;
+  reg [15:0] rx_mem_write_ready = 16'hffff;
+  wire [16*ADDR_W-1:0] rx_mem_write_addr;
+  wire [16*DATA_W-1:0] rx_mem_write_data;
+  wire [15:0] rx_completion_valid;
+  reg [15:0] rx_completion_ready = 0;
+  wire [63:0] rx_completion_source;
+  wire [31:0] rx_completion_vc;
+  wire [127:0] rx_completion_tag;
+  wire [15:0] endpoint_protocol_error;
+
+  integer source0_requests = 0;
+  integer source3_requests = 0;
+  integer destination12_writes = 0;
+  integer destination15_writes = 0;
+  reg completion12 = 1'b0;
+  reg completion15 = 1'b0;
+
+  noc_sram_packet_mesh4x4 #(
+    .ADDR_W(ADDR_W)
+  ) dut (
+    .clk(clk), .rst_n(rst_n),
+    .tx_desc_valid(tx_desc_valid), .tx_desc_ready(tx_desc_ready),
+    .tx_desc_destination(tx_desc_destination), .tx_desc_vc(tx_desc_vc),
+    .tx_desc_tag(tx_desc_tag), .tx_desc_base_addr(tx_desc_base_addr),
+    .tx_desc_flit_count(tx_desc_flit_count),
+    .tx_mem_req_valid(tx_mem_req_valid), .tx_mem_req_ready(tx_mem_req_ready),
+    .tx_mem_req_addr(tx_mem_req_addr), .tx_mem_rsp_valid(tx_mem_rsp_valid),
+    .tx_mem_rsp_ready(tx_mem_rsp_ready), .tx_mem_rsp_data(tx_mem_rsp_data),
+    .rx_desc_valid(rx_desc_valid), .rx_desc_ready(rx_desc_ready),
+    .rx_desc_source(rx_desc_source), .rx_desc_vc(rx_desc_vc),
+    .rx_desc_tag(rx_desc_tag), .rx_desc_base_addr(rx_desc_base_addr),
+    .rx_desc_flit_count(rx_desc_flit_count),
+    .rx_mem_write_valid(rx_mem_write_valid),
+    .rx_mem_write_ready(rx_mem_write_ready),
+    .rx_mem_write_addr(rx_mem_write_addr),
+    .rx_mem_write_data(rx_mem_write_data),
+    .rx_completion_valid(rx_completion_valid),
+    .rx_completion_ready(rx_completion_ready),
+    .rx_completion_source(rx_completion_source),
+    .rx_completion_vc(rx_completion_vc),
+    .rx_completion_tag(rx_completion_tag),
+    .endpoint_protocol_error(endpoint_protocol_error),
+    .router_accepted_flit_count(), .router_forwarded_flit_count(),
+    .router_input_stall_cycles(), .router_output_stall_cycles(),
+    .router_contention_cycles(), .router_current_input_occupancy(),
+    .router_max_input_occupancy(), .router_route_flit_count()
+  );
+
+  always #5 clk = ~clk;
+
+  function [DATA_W-1:0] memory_data;
+    input [3:0] source;
+    input [ADDR_W-1:0] address;
+    begin
+      memory_data = {{(DATA_W-36){1'b0}}, source, 16'hcafe, address};
+    end
+  endfunction
+
+  task install_receive_descriptors;
+    begin
+      @(negedge clk);
+      rx_desc_source[(12*4) +: 4] = 4'd3;
+      rx_desc_vc[(12*2) +: 2] = 2'd2;
+      rx_desc_tag[(12*8) +: 8] = 8'h32;
+      rx_desc_base_addr[(12*ADDR_W) +: ADDR_W] = 16'h1200;
+      rx_desc_flit_count[(12*4) +: 4] = 4'd3;
+      rx_desc_source[(15*4) +: 4] = 4'd0;
+      rx_desc_vc[(15*2) +: 2] = 2'd1;
+      rx_desc_tag[(15*8) +: 8] = 8'h08;
+      rx_desc_base_addr[(15*ADDR_W) +: ADDR_W] = 16'h1800;
+      rx_desc_flit_count[(15*4) +: 4] = 4'd8;
+      rx_desc_valid = 16'h9000;
+      @(posedge clk);
+      while ((rx_desc_ready & 16'h9000) != 16'h9000) @(posedge clk);
+      @(negedge clk);
+      rx_desc_valid = 0;
+    end
+  endtask
+
+  task install_transmit_descriptors;
+    begin
+      @(negedge clk);
+      tx_desc_destination[(0*4) +: 4] = 4'd15;
+      tx_desc_vc[(0*2) +: 2] = 2'd1;
+      tx_desc_tag[(0*8) +: 8] = 8'h08;
+      tx_desc_base_addr[(0*ADDR_W) +: ADDR_W] = 16'h0100;
+      tx_desc_flit_count[(0*4) +: 4] = 4'd8;
+      tx_desc_destination[(3*4) +: 4] = 4'd12;
+      tx_desc_vc[(3*2) +: 2] = 2'd2;
+      tx_desc_tag[(3*8) +: 8] = 8'h32;
+      tx_desc_base_addr[(3*ADDR_W) +: ADDR_W] = 16'h0300;
+      tx_desc_flit_count[(3*4) +: 4] = 4'd3;
+      tx_desc_valid = 16'h0009;
+      @(posedge clk);
+      while ((tx_desc_ready & 16'h0009) != 16'h0009) @(posedge clk);
+      @(negedge clk);
+      tx_desc_valid = 0;
+    end
+  endtask
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      cycle <= 0;
+      tx_mem_rsp_valid <= 0;
+      tx_mem_rsp_data <= 0;
+      source0_requests <= 0;
+      source3_requests <= 0;
+    end else begin
+      cycle <= cycle + 1;
+      tx_mem_req_ready <= 16'hffff;
+      for (endpoint_i = 0; endpoint_i < 16; endpoint_i = endpoint_i + 1) begin
+        if (tx_mem_req_valid[endpoint_i] && tx_mem_req_ready[endpoint_i]) begin
+          tx_mem_rsp_valid[endpoint_i] <= 1'b1;
+          tx_mem_rsp_data[(endpoint_i*DATA_W) +: DATA_W] <= memory_data(
+            endpoint_i[3:0], tx_mem_req_addr[(endpoint_i*ADDR_W) +: ADDR_W]);
+          if (endpoint_i == 0)
+            source0_requests <= source0_requests + 1;
+          else if (endpoint_i == 3)
+            source3_requests <= source3_requests + 1;
+          else
+            $fatal(1, "unexpected memory request from endpoint %0d", endpoint_i);
+        end else if (tx_mem_rsp_valid[endpoint_i] && tx_mem_rsp_ready[endpoint_i]) begin
+          tx_mem_rsp_valid[endpoint_i] <= 1'b0;
+        end
+      end
+    end
+  end
+
+  always @(posedge clk) begin
+    if (rst_n) begin
+      rx_mem_write_ready <= 16'hffff;
+      if ((cycle % 5) == 2)
+        rx_mem_write_ready[15] <= 1'b0;
+      if ((cycle % 7) == 3)
+        rx_mem_write_ready[12] <= 1'b0;
+
+      if (rx_mem_write_valid[12] && rx_mem_write_ready[12]) begin
+        if (rx_mem_write_addr[(12*ADDR_W) +: ADDR_W] !==
+            (16'h1200 + destination12_writes * 32))
+          $fatal(1, "wrong destination-12 write address");
+        if (rx_mem_write_data[(12*DATA_W) +: DATA_W] !==
+            memory_data(4'd3, 16'h0300 + destination12_writes * 32))
+          $fatal(1, "wrong destination-12 write data");
+        destination12_writes <= destination12_writes + 1;
+      end
+      if (rx_mem_write_valid[15] && rx_mem_write_ready[15]) begin
+        if (rx_mem_write_addr[(15*ADDR_W) +: ADDR_W] !==
+            (16'h1800 + destination15_writes * 32))
+          $fatal(1, "wrong destination-15 write address");
+        if (rx_mem_write_data[(15*DATA_W) +: DATA_W] !==
+            memory_data(4'd0, 16'h0100 + destination15_writes * 32))
+          $fatal(1, "wrong destination-15 write data");
+        destination15_writes <= destination15_writes + 1;
+      end
+
+      if (rx_completion_valid[12] && rx_completion_ready[12]) begin
+        if (rx_completion_source[(12*4) +: 4] !== 3 ||
+            rx_completion_vc[(12*2) +: 2] !== 2 ||
+            rx_completion_tag[(12*8) +: 8] !== 8'h32)
+          $fatal(1, "wrong destination-12 completion");
+        completion12 <= 1'b1;
+      end
+      if (rx_completion_valid[15] && rx_completion_ready[15]) begin
+        if (rx_completion_source[(15*4) +: 4] !== 0 ||
+            rx_completion_vc[(15*2) +: 2] !== 1 ||
+            rx_completion_tag[(15*8) +: 8] !== 8'h08)
+          $fatal(1, "wrong destination-15 completion");
+        completion15 <= 1'b1;
+      end
+
+      if (endpoint_protocol_error != 0)
+        $fatal(1, "endpoint protocol error: %h", endpoint_protocol_error);
+    end
+  end
+
+  initial begin
+    #500000;
+    $fatal(1, "simulation timeout");
+  end
+
+  initial begin
+    repeat (3) @(negedge clk);
+    rst_n = 1'b1;
+    install_receive_descriptors();
+    install_transmit_descriptors();
+    repeat (8) @(negedge clk);
+    rx_completion_ready = 16'h9000;
+    while (!completion12 || !completion15) @(negedge clk);
+    repeat (3) @(negedge clk);
+    if (source0_requests != 8 || source3_requests != 3 ||
+        destination12_writes != 3 || destination15_writes != 8)
+      $fatal(1, "wrong final request/write counts");
+    $display("PASS noc_sram_packet_mesh4x4 req0=%0d req3=%0d write12=%0d write15=%0d cycles=%0d",
+      source0_requests, source3_requests,
+      destination12_writes, destination15_writes, cycle);
+    $finish;
+  end
+endmodule

--- a/tests/test_noc_sram_packet_endpoint.py
+++ b/tests/test_noc_sram_packet_endpoint.py
@@ -118,6 +118,7 @@ def test_noc_sram_packet_endpoint_ppa_harness_is_compact_live_and_compiles(
     assert design["primitive"] == "sram_packet_endpoint"
     generated = _emit_l1_sram_packet_endpoint(design["module_name"], design)
     assert "output [255:0] observed_flit" in generated
+    assert "input [3:0] rx_destination_probe" in generated
     assert "output [31:0] issued_packet_count" in generated
     assert ".TX_DESC_DEPTH(4)" in generated
     assert ".TX_OUTSTANDING(8)" in generated
@@ -135,13 +136,15 @@ def test_noc_sram_packet_endpoint_ppa_harness_is_compact_live_and_compiles(
 module tb_endpoint_ppa;
   reg clk = 1'b0;
   reg rst_n = 1'b0;
+  reg [3:0] rx_destination_probe = 4'd2;
   wire [255:0] observed_flit;
   wire [31:0] issued_packet_count;
   wire [31:0] completed_packet_count;
   wire protocol_error;
   always #1 clk = ~clk;
   {design['wrapper_name']} dut (
-    .clk(clk), .rst_n(rst_n), .observed_flit(observed_flit),
+    .clk(clk), .rst_n(rst_n),
+    .rx_destination_probe(rx_destination_probe), .observed_flit(observed_flit),
     .issued_packet_count(issued_packet_count),
     .completed_packet_count(completed_packet_count),
     .protocol_error(protocol_error)

--- a/tests/test_noc_sram_packet_mesh4x4.py
+++ b/tests/test_noc_sram_packet_mesh4x4.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RTL_SOURCES = [
+    REPO_ROOT / "npu/sim/rtl/noc_ready_valid_fifo.sv",
+    REPO_ROOT / "npu/sim/rtl/noc_segmented_mesh_router.sv",
+    REPO_ROOT / "npu/sim/rtl/noc_segmented_mesh4x4.sv",
+    REPO_ROOT / "npu/sim/rtl/noc_sram_packet_endpoint.sv",
+    REPO_ROOT / "npu/sim/rtl/noc_sram_packet_mesh4x4.sv",
+]
+TB = REPO_ROOT / "tests/noc_sram_packet_mesh4x4_tb.sv"
+
+
+def _tool(name: str) -> str | None:
+    return shutil.which(name) or (
+        f"/oss-cad-suite/bin/{name}"
+        if Path(f"/oss-cad-suite/bin/{name}").exists()
+        else None
+    )
+
+
+@pytest.mark.skipif(
+    _tool("iverilog") is None or _tool("vvp") is None,
+    reason="iverilog/vvp unavailable",
+)
+def test_noc_sram_packet_mesh4x4_end_to_end(tmp_path: Path) -> None:
+    sim = tmp_path / "noc_sram_packet_mesh4x4_sim"
+    subprocess.run(
+        [
+            str(_tool("iverilog")),
+            "-g2012",
+            "-s",
+            "noc_sram_packet_mesh4x4_tb",
+            "-o",
+            str(sim),
+            *[str(path) for path in RTL_SOURCES],
+            str(TB),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    result = subprocess.run(
+        [str(_tool("vvp")), str(sim)],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert (
+        "PASS noc_sram_packet_mesh4x4 req0=8 req3=3 write12=3 write15=8"
+        in result.stdout
+    )
+
+
+@pytest.mark.skipif(_tool("yosys") is None, reason="yosys unavailable")
+def test_noc_sram_packet_mesh4x4_synthesis_hierarchy(tmp_path: Path) -> None:
+    script = tmp_path / "mesh.ys"
+    script.write_text(
+        "\n".join(
+            [
+                f"read_verilog -DSYNTHESIS -sv {' '.join(str(path) for path in RTL_SOURCES)}",
+                "hierarchy -check -top noc_sram_packet_mesh4x4",
+                "proc",
+                "check",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    subprocess.run(
+        [str(_tool("yosys")), "-q", "-s", str(script)],
+        check=True,
+        cwd=REPO_ROOT,
+        timeout=60,
+    )
+
+
+@pytest.mark.skipif(_tool("verilator") is None, reason="verilator unavailable")
+def test_noc_sram_packet_mesh4x4_has_no_combinational_ready_cycle() -> None:
+    result = subprocess.run(
+        [
+            str(_tool("verilator")),
+            "--lint-only",
+            "-Wall",
+            "-Wno-fatal",
+            "--top-module",
+            "noc_sram_packet_mesh4x4",
+            *[str(path) for path in RTL_SOURCES],
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    diagnostics = result.stdout + result.stderr
+    assert "UNOPTFLAT" not in diagnostics
+
+
+@pytest.mark.skipif(
+    _tool("iverilog") is None or _tool("vvp") is None,
+    reason="iverilog/vvp unavailable",
+)
+def test_noc_fifo_full_credit_recovers_one_cycle_later(tmp_path: Path) -> None:
+    tb = tmp_path / "tb_registered_credit.sv"
+    tb.write_text(
+        """
+module tb_registered_credit;
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  reg in_valid = 1'b0;
+  wire in_ready;
+  reg [7:0] in_data = 0;
+  wire out_valid;
+  reg out_ready = 1'b0;
+  wire [7:0] out_data;
+  wire [1:0] occupancy;
+  always #5 clk = ~clk;
+  noc_ready_valid_fifo #(.WIDTH(8), .DEPTH(2)) dut (
+    .clk(clk), .rst_n(rst_n),
+    .in_valid(in_valid), .in_ready(in_ready), .in_data(in_data),
+    .out_valid(out_valid), .out_ready(out_ready), .out_data(out_data),
+    .occupancy(occupancy), .max_occupancy()
+  );
+  initial begin
+    repeat (2) @(posedge clk);
+    @(negedge clk); rst_n = 1'b1; in_valid = 1'b1; in_data = 8'h11;
+    @(posedge clk); #1;
+    @(negedge clk); in_data = 8'h22;
+    @(posedge clk); #1;
+    if (occupancy != 2 || in_ready || out_data != 8'h11)
+      $fatal(1, "FIFO did not reach full state");
+    @(negedge clk); out_ready = 1'b1; in_data = 8'h33;
+    #1;
+    if (in_ready)
+      $fatal(1, "full FIFO leaked combinational downstream ready");
+    @(posedge clk); #1;
+    if (occupancy != 1 || !in_ready || out_data != 8'h22)
+      $fatal(1, "credit did not return after registered pop");
+    @(posedge clk); #1;
+    if (occupancy != 1 || out_data != 8'h33)
+      $fatal(1, "simultaneous non-full push/pop failed");
+    @(negedge clk); in_valid = 1'b0;
+    @(posedge clk); #1;
+    if (occupancy != 0 || out_valid)
+      $fatal(1, "FIFO did not drain");
+    $display("PASS registered occupancy credit");
+    $finish;
+  end
+endmodule
+""",
+        encoding="utf-8",
+    )
+    sim = tmp_path / "registered_credit.vvp"
+    subprocess.run(
+        [
+            str(_tool("iverilog")),
+            "-g2012",
+            "-s",
+            "tb_registered_credit",
+            "-o",
+            str(sim),
+            str(RTL_SOURCES[0]),
+            str(tb),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    result = subprocess.run(
+        [str(_tool("vvp")), str(sim)],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert "PASS registered occupancy credit" in result.stdout


### PR DESCRIPTION
## Summary
- remove the network-wide combinational ready fixpoint by making FIFO credit depend only on registered occupancy and update the cycle model to the same deterministic two-pass rule
- validate routed destination IDs at SRAM endpoints and keep that comparator live in the compact PPA harness
- add the exact sixteen-endpoint plus sixteen-router functional composition with explicit descriptor, source-SRAM, destination-SRAM, completion, and protocol boundaries
- add simultaneous multihop end-to-end data/address tests, full-hierarchy synthesis, one-cycle full-credit recovery, and an enforced no-`UNOPTFLAT` lint gate

## Physical impact
Pending router, endpoint, and aggregate-mesh PPA items must be repinned to this merge commit before dispatch. Earlier sources contain either the combinational ready cycle or a synthesis-removable destination comparator and are not valid final anchors.

## Verification
- focused NoC/endpoint/Phase-2 gate: 17 passed, 1 evaluator-filesystem-only test deselected
- composition gate: 4 passed
- `python scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`