### PR TITLE
feat(noc): add composed endpoint mesh PPA harness

### DIFF
--- a/docs/architecture/llama7b_attention_abstraction_closure_plan.md
+++ b/docs/architecture/llama7b_attention_abstraction_closure_plan.md
@@ -250,6 +250,14 @@ evidence gaps:
   composed test proves simultaneous multihop packets and exact data/address
   delivery. Endpoint receive logic now rejects a flit whose destination does
   not name the local endpoint.
+- Physical composition: the prepared
+  `l1_noc_sram_packet_mesh4x4_composed_ppa_v1` item places the complete
+  endpoint/mesh hierarchy at the same initial floorplan envelope as the
+  aggregate mesh. Its checked-in harness installs collision-free descriptors,
+  exercises one- through eight-flit packets and all VCs, applies finite SRAM
+  and completion backpressure, and rotates local observation across all 256
+  payload bits. It remains dependency-gated behind router, endpoint, and
+  aggregate-mesh anchors and is not workload-activity or SRAM-macro evidence.
 - Credit timing: the original router FIFO allowed a full queue's input ready
   to depend on a same-cycle downstream pop. Across bidirectional links this
   formed a combinational ready fixpoint. FIFO credits now depend only on

--- a/docs/proposals/prop_l1_noc_sram_packet_mesh4x4_composed_ppa_v1/README.md
+++ b/docs/proposals/prop_l1_noc_sram_packet_mesh4x4_composed_ppa_v1/README.md
@@ -1,0 +1,8 @@
+# Composed SRAM Endpoint Mesh PPA
+
+This proposal measures the exact sixteen-endpoint plus sixteen-router 4x4
+composition after its endpoint, router, and aggregate-mesh anchors merge.
+
+It is a compact-boundary on-chip control/fabric feasibility point. It does not
+include SRAM bitcells, HBM/DRAM, producer/reducer arithmetic, or
+workload-matched switching activity.

--- a/docs/proposals/prop_l1_noc_sram_packet_mesh4x4_composed_ppa_v1/design_brief.md
+++ b/docs/proposals/prop_l1_noc_sram_packet_mesh4x4_composed_ppa_v1/design_brief.md
@@ -1,0 +1,27 @@
+# Design Brief
+
+## Included Structure
+
+- Sixteen descriptor-driven SRAM packet endpoints.
+- Sixteen five-port, four-VC, depth-four deterministic-XY routers.
+- All 24 bidirectional 256-bit neighbor links.
+- Registered-occupancy FIFO credits with no network-wide ready fixpoint.
+- Collision-free descriptor installation and packet release control.
+- One bounded in-order source-SRAM response slot per endpoint.
+- Destination-SRAM write and completion backpressure.
+- Packet lengths 1..8, all VCs, all sources, and an odd-stride destination
+  permutation.
+
+## Compact Observability
+
+Each destination captures a local 16-bit payload slice. The selected slice
+rotates by epoch, so every one of the 256 transported payload bits remains
+structurally observable without a global 4096-bit port or XOR timing path.
+Packet counters, endpoint-valid bits, and aggregate protocol error are exposed.
+
+## Comparison
+
+Use the same 3.2 mm square die/core envelope, 45 percent placement density,
+and 2.0 ns target as the aggregate-mesh feasibility point. Report absolute PPA
+and the disclosed delta from aggregate mesh plus separately measured endpoint
+anchors. Do not interpret vectorless power as Llama7B traffic energy.

--- a/docs/proposals/prop_l1_noc_sram_packet_mesh4x4_composed_ppa_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l1_noc_sram_packet_mesh4x4_composed_ppa_v1/evaluation_gate.md
@@ -1,0 +1,12 @@
+# Evaluation Gate
+
+- Dispatch only after corrected router, endpoint, and aggregate-mesh results
+  merge and materialize.
+- Use the exact merge commit containing the registered-credit composition and
+  physical harness.
+- Run the one-point 2.0 ns, 3.2 mm square, 45 percent density hierarchical
+  feasibility configuration first.
+- Accept a completed physical row or an explicit bounded flow/runtime failure.
+- Audit retention of sixteen routers, sixteen endpoints, every VC FIFO, dynamic
+  destination checks, and rotating payload observation.
+- Report harness registers/control separately where synthesis reports permit.

--- a/docs/proposals/prop_l1_noc_sram_packet_mesh4x4_composed_ppa_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_noc_sram_packet_mesh4x4_composed_ppa_v1/evaluation_requests.json
@@ -1,0 +1,35 @@
+{
+  "proposal_id": "prop_l1_noc_sram_packet_mesh4x4_composed_ppa_v1",
+  "source_commit": "TBD",
+  "requested_items": [
+    {
+      "item_id": "l1_noc_sram_packet_mesh4x4_composed_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure first-pass Nangate45 physical feasibility for the complete descriptor-driven endpoint/mesh composition.",
+      "evaluation_mode": "ppa",
+      "abstraction_layer": "architecture_block",
+      "config_paths": [
+        "runs/designs/noc/l1_noc_sram_packet_mesh4x4_w256_vc4_d4_td4_to8_rx8_wrapper/config_l1_noc_sram_packet_mesh4x4_w256_vc4_d4_td4_to8_rx8.json"
+      ],
+      "sweep_path": "runs/campaigns/noc/l1_sram_packet_mesh4x4/sweeps/nangate45_composed_feasibility.json",
+      "expected_outputs": [
+        "runs/designs/noc/l1_noc_sram_packet_mesh4x4_w256_vc4_d4_td4_to8_rx8_wrapper/metrics.csv"
+      ],
+      "status": "pending_after_dependencies_merge",
+      "comparison_role": "composed_sram_endpoint_mesh_physical_anchor",
+      "paired_baseline_item_id": "l1_segmented_xy_mesh4x4_aggregate_ppa_v1",
+      "depends_on_item_ids": [
+        "l1_segmented_xy_mesh_noc_phase1_v1",
+        "l1_noc_sram_packet_endpoint_phase2_v1",
+        "l1_segmented_xy_mesh4x4_aggregate_ppa_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_composed_endpoint_mesh_physical_overhead",
+        "reason": "Replace additive endpoint/router composition with an aggregate placed control/fabric anchor at a matched floorplan envelope."
+      },
+      "acceptance_notes": "Require all sixteen endpoints and routers retained, no combinational ready cycle, valid descriptor-before-release behavior, rotating full-payload observability, and a completed row or explicit bounded failure. Report harness overhead and do not claim SRAM macro, workload-activity, or HBM/DRAM closure."
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_noc_sram_packet_mesh4x4_composed_ppa_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_noc_sram_packet_mesh4x4_composed_ppa_v1/implementation_summary.md
@@ -1,0 +1,8 @@
+# Implementation Summary
+
+- Added `noc_sram_packet_mesh4x4_ppa_harness`.
+- Added collision-free all-endpoint descriptor epochs and finite SRAM response
+  boundaries.
+- Added rotating local payload observation across all 256 bits.
+- Added continuous progress/protocol simulation coverage.
+- Added `sram_packet_mesh4x4` generator, config, wrapper, and one-point sweep.

--- a/docs/proposals/prop_l1_noc_sram_packet_mesh4x4_composed_ppa_v1/promotion_gate.md
+++ b/docs/proposals/prop_l1_noc_sram_packet_mesh4x4_composed_ppa_v1/promotion_gate.md
@@ -1,0 +1,9 @@
+# Promotion Gate
+
+- status: pending
+- Require the router, endpoint, and aggregate-mesh dependencies to be merged.
+- Require at least one physically completed row before using this as a composed
+  timing/area/power anchor.
+- Preserve SRAM-macro, workload-activity, and HBM/DRAM exclusions explicitly.
+- If physical feasibility fails, retain the result as a bounded architecture
+  limit and split the composition only with an explicit hierarchical plan.

--- a/docs/proposals/prop_l1_noc_sram_packet_mesh4x4_composed_ppa_v1/proposal.json
+++ b/docs/proposals/prop_l1_noc_sram_packet_mesh4x4_composed_ppa_v1/proposal.json
@@ -1,0 +1,62 @@
+{
+  "proposal_id": "prop_l1_noc_sram_packet_mesh4x4_composed_ppa_v1",
+  "created_utc": "2026-08-14T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "abstraction_layer": "architecture_block",
+  "title": "Place the composed SRAM packet endpoints and 4x4 segmented mesh",
+  "hypothesis": "The exact sixteen-endpoint, sixteen-router registered-credit composition can be physically bounded at the same floorplan envelope as the aggregate mesh, replacing linear endpoint-plus-router composition with a placed control/fabric anchor.",
+  "direct_comparison": {
+    "primary_question": "What physical overhead appears when finite packet endpoints, SRAM boundary handshakes, and the complete segmented mesh are placed together?",
+    "include": [
+      "sixteen finite SRAM packet endpoints",
+      "sixteen exact segmented routers and links",
+      "registered FIFO credits",
+      "descriptor installation and packet release control",
+      "bounded SRAM response/write/completion handshakes",
+      "compact rotating full-payload observability"
+    ],
+    "exclude": [
+      "SRAM bitcells and macros",
+      "producer/reducer arithmetic",
+      "HBM/DRAM and controller",
+      "workload-matched switching activity"
+    ]
+  },
+  "expected_benefit": [
+    "replace additive endpoint/router area and timing assumptions with aggregate placement evidence",
+    "measure endpoint-to-router timing and congestion interactions",
+    "bound the remaining on-chip communication composition term before Llama7B reranking"
+  ],
+  "risks": [
+    "the source/observation scheduler harness adds disclosed area and registers",
+    "the full hierarchy may cross the known Yosys/OpenROAD runtime boundary",
+    "vectorless power is not workload energy",
+    "SRAM macro placement remains external"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l1_noc_sram_packet_mesh4x4_composed_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure first-pass Nangate45 physical feasibility for the complete descriptor-driven endpoint/mesh composition.",
+      "evaluation_mode": "ppa",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "composed_sram_endpoint_mesh_physical_anchor",
+      "depends_on_item_ids": [
+        "l1_segmented_xy_mesh_noc_phase1_v1",
+        "l1_noc_sram_packet_endpoint_phase2_v1",
+        "l1_segmented_xy_mesh4x4_aggregate_ppa_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "config_paths": [
+        "runs/designs/noc/l1_noc_sram_packet_mesh4x4_w256_vc4_d4_td4_to8_rx8_wrapper/config_l1_noc_sram_packet_mesh4x4_w256_vc4_d4_td4_to8_rx8.json"
+      ],
+      "sweep_path": "runs/campaigns/noc/l1_sram_packet_mesh4x4/sweeps/nangate45_composed_feasibility.json",
+      "expected_outputs": [
+        "runs/designs/noc/l1_noc_sram_packet_mesh4x4_w256_vc4_d4_td4_to8_rx8_wrapper/metrics.csv"
+      ]
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_noc_sram_packet_mesh4x4_composed_ppa_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_noc_sram_packet_mesh4x4_composed_ppa_v1/quality_gate.md
@@ -1,0 +1,11 @@
+# Quality Gate
+
+- The exact checked-in endpoint/mesh composition is instantiated.
+- All sixteen endpoints issue and complete packets under SRAM and completion
+  backpressure.
+- Every packet key is installed at its destination before source release.
+- Packet lengths 1..8 and all four VCs make progress.
+- Every endpoint and all 256 payload bit positions remain observable.
+- `protocol_error` stays zero during valid generated traffic.
+- Verilator reports no `UNOPTFLAT` combinational ready cycle.
+- Generated hierarchy compiles from the exact run config.

--- a/npu/sim/rtl/noc_sram_packet_mesh4x4_ppa_harness.sv
+++ b/npu/sim/rtl/noc_sram_packet_mesh4x4_ppa_harness.sv
@@ -1,0 +1,352 @@
+`timescale 1ns/1ps
+
+// Compact-boundary physical harness for the exact endpoint/mesh composition.
+// It generates collision-free descriptor epochs and finite SRAM handshakes.
+// SRAM bitcells and workload-derived activity are intentionally not modeled.
+module noc_sram_packet_mesh4x4_ppa_harness #(
+  parameter integer DATA_W = 256,
+  parameter integer ADDR_W = 24,
+  parameter integer COUNTER_W = 32,
+  parameter integer TX_DESC_DEPTH = 4,
+  parameter integer TX_OUTSTANDING = 8,
+  parameter integer RX_CONTEXTS = 8,
+  parameter integer ROUTER_FIFO_DEPTH = 4
+) (
+  input wire clk,
+  input wire rst_n,
+  output wire [15:0] observed_valid,
+  output wire [DATA_W-1:0] observed_flit,
+  output wire [COUNTER_W-1:0] issued_packet_count,
+  output wire [COUNTER_W-1:0] completed_packet_count,
+  output wire protocol_error
+);
+  localparam integer NODES = 16;
+  localparam integer ENDPOINT_W = 4;
+  localparam integer VC_W = 2;
+  localparam integer TAG_W = 8;
+  localparam integer FLIT_COUNT_W = 4;
+  localparam integer OBSERVE_SLICE_W = DATA_W / NODES;
+  localparam [1:0] INSTALL_RX = 2'd0;
+  localparam [1:0] INSTALL_TX = 2'd1;
+  localparam [1:0] RUN_PACKETS = 2'd2;
+
+  reg [1:0] setup_state;
+  reg [7:0] epoch;
+  reg [15:0] descriptor_pending;
+  reg [15:0] completion_seen;
+  reg [COUNTER_W-1:0] issued_count_q;
+  reg [COUNTER_W-1:0] completed_count_q;
+  reg [COUNTER_W-1:0] cycle_count_q;
+
+  reg [16*ENDPOINT_W-1:0] tx_desc_destination;
+  reg [16*VC_W-1:0] tx_desc_vc;
+  reg [16*TAG_W-1:0] tx_desc_tag;
+  reg [16*ADDR_W-1:0] tx_desc_base_addr;
+  reg [16*FLIT_COUNT_W-1:0] tx_desc_flit_count;
+  wire [15:0] tx_desc_valid =
+    (setup_state == INSTALL_TX) ? descriptor_pending : 16'h0000;
+  wire [15:0] tx_desc_ready;
+
+  reg [16*ENDPOINT_W-1:0] rx_desc_source;
+  reg [16*VC_W-1:0] rx_desc_vc;
+  reg [16*TAG_W-1:0] rx_desc_tag;
+  reg [16*ADDR_W-1:0] rx_desc_base_addr;
+  reg [16*FLIT_COUNT_W-1:0] rx_desc_flit_count;
+  wire [15:0] rx_desc_valid =
+    (setup_state == INSTALL_RX) ? descriptor_pending : 16'h0000;
+  wire [15:0] rx_desc_ready;
+
+  wire [15:0] tx_mem_req_valid;
+  reg [15:0] tx_mem_req_ready;
+  wire [16*ADDR_W-1:0] tx_mem_req_addr;
+  reg [15:0] tx_mem_rsp_valid;
+  wire [15:0] tx_mem_rsp_ready;
+  reg [16*DATA_W-1:0] tx_mem_rsp_data;
+  reg [DATA_W-1:0] source_data_state [0:NODES-1];
+
+  wire [15:0] rx_mem_write_valid;
+  reg [15:0] rx_mem_write_ready;
+  wire [16*ADDR_W-1:0] rx_mem_write_addr;
+  wire [16*DATA_W-1:0] rx_mem_write_data;
+  wire [15:0] rx_completion_valid;
+  reg [15:0] rx_completion_ready;
+  wire [16*ENDPOINT_W-1:0] rx_completion_source;
+  wire [16*VC_W-1:0] rx_completion_vc;
+  wire [16*TAG_W-1:0] rx_completion_tag;
+  wire [15:0] endpoint_protocol_error;
+
+  wire [16*COUNTER_W-1:0] router_accepted_flit_count;
+  wire [16*COUNTER_W-1:0] router_forwarded_flit_count;
+  wire [16*COUNTER_W-1:0] router_input_stall_cycles;
+  wire [16*COUNTER_W-1:0] router_output_stall_cycles;
+  wire [16*COUNTER_W-1:0] router_contention_cycles;
+  wire [16*COUNTER_W-1:0] router_current_input_occupancy;
+  wire [16*COUNTER_W-1:0] router_max_input_occupancy;
+  wire [16*5*COUNTER_W-1:0] router_route_flit_count;
+
+  reg [15:0] observed_valid_q;
+  reg [DATA_W-1:0] observed_q;
+  integer node_i;
+
+  function [ENDPOINT_W-1:0] destination_for_source;
+    input [ENDPOINT_W-1:0] source;
+    begin
+      destination_for_source = source + 4'd5;
+    end
+  endfunction
+
+  function [ENDPOINT_W-1:0] source_for_destination;
+    input [ENDPOINT_W-1:0] destination;
+    begin
+      source_for_destination = destination + 4'd11;
+    end
+  endfunction
+
+  function [FLIT_COUNT_W-1:0] count_for_source;
+    input [ENDPOINT_W-1:0] source;
+    begin
+      count_for_source =
+        {1'b0, (source[2:0] ^ {3{source[3]}})} + 1'b1;
+    end
+  endfunction
+
+  function [VC_W-1:0] vc_for_source;
+    input [ENDPOINT_W-1:0] source;
+    begin
+      vc_for_source = source[1:0] ^ source[3:2];
+    end
+  endfunction
+
+  function [TAG_W-1:0] tag_for_source;
+    input [ENDPOINT_W-1:0] source;
+    begin
+      tag_for_source = {epoch[3:0], source};
+    end
+  endfunction
+
+  function [ADDR_W-1:0] tx_base_for_source;
+    input [ENDPOINT_W-1:0] source;
+    begin
+      tx_base_for_source =
+        ({{(ADDR_W-ENDPOINT_W){1'b0}}, source} << 12) |
+        ({{(ADDR_W-8){1'b0}}, epoch} << 4);
+    end
+  endfunction
+
+  function [ADDR_W-1:0] rx_base_for_destination;
+    input [ENDPOINT_W-1:0] destination;
+    begin
+      rx_base_for_destination =
+        ({{(ADDR_W-1){1'b0}}, 1'b1} << (ADDR_W - 1)) |
+        ({{(ADDR_W-ENDPOINT_W){1'b0}}, destination} << 12) |
+        ({{(ADDR_W-8){1'b0}}, epoch} << 4);
+    end
+  endfunction
+
+  function [DATA_W-1:0] advance_data;
+    input [DATA_W-1:0] value;
+    begin
+      advance_data = {
+        value[DATA_W-2:0],
+        value[DATA_W-1] ^ value[(DATA_W/2)-1] ^ value[21] ^ value[5] ^ value[0]
+      };
+    end
+  endfunction
+
+  function [5:0] popcount16;
+    input [15:0] value;
+    integer bit_i;
+    begin
+      popcount16 = 0;
+      for (bit_i = 0; bit_i < 16; bit_i = bit_i + 1)
+        popcount16 = popcount16 + {{5{1'b0}}, value[bit_i]};
+    end
+  endfunction
+
+  assign observed_valid = observed_valid_q;
+  assign observed_flit = observed_q;
+  assign issued_packet_count = issued_count_q;
+  assign completed_packet_count = completed_count_q;
+  assign protocol_error = |endpoint_protocol_error;
+
+  always @(*) begin
+    tx_desc_destination = 0;
+    tx_desc_vc = 0;
+    tx_desc_tag = 0;
+    tx_desc_base_addr = 0;
+    tx_desc_flit_count = 0;
+    rx_desc_source = 0;
+    rx_desc_vc = 0;
+    rx_desc_tag = 0;
+    rx_desc_base_addr = 0;
+    rx_desc_flit_count = 0;
+    tx_mem_req_ready = 0;
+    rx_mem_write_ready = 0;
+    rx_completion_ready = 0;
+    for (node_i = 0; node_i < NODES; node_i = node_i + 1) begin
+      tx_desc_destination[(node_i*ENDPOINT_W) +: ENDPOINT_W] =
+        destination_for_source(node_i[ENDPOINT_W-1:0]);
+      tx_desc_vc[(node_i*VC_W) +: VC_W] =
+        vc_for_source(node_i[ENDPOINT_W-1:0]);
+      tx_desc_tag[(node_i*TAG_W) +: TAG_W] =
+        tag_for_source(node_i[ENDPOINT_W-1:0]);
+      tx_desc_base_addr[(node_i*ADDR_W) +: ADDR_W] =
+        tx_base_for_source(node_i[ENDPOINT_W-1:0]);
+      tx_desc_flit_count[(node_i*FLIT_COUNT_W) +: FLIT_COUNT_W] =
+        count_for_source(node_i[ENDPOINT_W-1:0]);
+
+      rx_desc_source[(node_i*ENDPOINT_W) +: ENDPOINT_W] =
+        source_for_destination(node_i[ENDPOINT_W-1:0]);
+      rx_desc_vc[(node_i*VC_W) +: VC_W] =
+        vc_for_source(source_for_destination(node_i[ENDPOINT_W-1:0]));
+      rx_desc_tag[(node_i*TAG_W) +: TAG_W] =
+        tag_for_source(source_for_destination(node_i[ENDPOINT_W-1:0]));
+      rx_desc_base_addr[(node_i*ADDR_W) +: ADDR_W] =
+        rx_base_for_destination(node_i[ENDPOINT_W-1:0]);
+      rx_desc_flit_count[(node_i*FLIT_COUNT_W) +: FLIT_COUNT_W] =
+        count_for_source(source_for_destination(node_i[ENDPOINT_W-1:0]));
+
+      tx_mem_req_ready[node_i] =
+        (!tx_mem_rsp_valid[node_i] || tx_mem_rsp_ready[node_i]) &&
+        (cycle_count_q[2:0] != node_i[2:0]);
+      rx_mem_write_ready[node_i] =
+        cycle_count_q[2:0] != (node_i[2:0] ^ 3'b101);
+      rx_completion_ready[node_i] =
+        cycle_count_q[3:1] != node_i[2:0];
+    end
+  end
+
+  noc_sram_packet_mesh4x4 #(
+    .DATA_W(DATA_W),
+    .ADDR_W(ADDR_W),
+    .TX_DESC_DEPTH(TX_DESC_DEPTH),
+    .TX_OUTSTANDING(TX_OUTSTANDING),
+    .RX_CONTEXTS(RX_CONTEXTS),
+    .ROUTER_FIFO_DEPTH(ROUTER_FIFO_DEPTH),
+    .COUNTER_W(COUNTER_W)
+  ) composition (
+    .clk(clk), .rst_n(rst_n),
+    .tx_desc_valid(tx_desc_valid), .tx_desc_ready(tx_desc_ready),
+    .tx_desc_destination(tx_desc_destination), .tx_desc_vc(tx_desc_vc),
+    .tx_desc_tag(tx_desc_tag), .tx_desc_base_addr(tx_desc_base_addr),
+    .tx_desc_flit_count(tx_desc_flit_count),
+    .tx_mem_req_valid(tx_mem_req_valid), .tx_mem_req_ready(tx_mem_req_ready),
+    .tx_mem_req_addr(tx_mem_req_addr), .tx_mem_rsp_valid(tx_mem_rsp_valid),
+    .tx_mem_rsp_ready(tx_mem_rsp_ready), .tx_mem_rsp_data(tx_mem_rsp_data),
+    .rx_desc_valid(rx_desc_valid), .rx_desc_ready(rx_desc_ready),
+    .rx_desc_source(rx_desc_source), .rx_desc_vc(rx_desc_vc),
+    .rx_desc_tag(rx_desc_tag), .rx_desc_base_addr(rx_desc_base_addr),
+    .rx_desc_flit_count(rx_desc_flit_count),
+    .rx_mem_write_valid(rx_mem_write_valid), .rx_mem_write_ready(rx_mem_write_ready),
+    .rx_mem_write_addr(rx_mem_write_addr), .rx_mem_write_data(rx_mem_write_data),
+    .rx_completion_valid(rx_completion_valid),
+    .rx_completion_ready(rx_completion_ready),
+    .rx_completion_source(rx_completion_source),
+    .rx_completion_vc(rx_completion_vc),
+    .rx_completion_tag(rx_completion_tag),
+    .endpoint_protocol_error(endpoint_protocol_error),
+    .router_accepted_flit_count(router_accepted_flit_count),
+    .router_forwarded_flit_count(router_forwarded_flit_count),
+    .router_input_stall_cycles(router_input_stall_cycles),
+    .router_output_stall_cycles(router_output_stall_cycles),
+    .router_contention_cycles(router_contention_cycles),
+    .router_current_input_occupancy(router_current_input_occupancy),
+    .router_max_input_occupancy(router_max_input_occupancy),
+    .router_route_flit_count(router_route_flit_count)
+  );
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      setup_state <= INSTALL_RX;
+      epoch <= 0;
+      descriptor_pending <= 16'hffff;
+      completion_seen <= 0;
+      issued_count_q <= 0;
+      completed_count_q <= 0;
+      cycle_count_q <= 0;
+      tx_mem_rsp_valid <= 0;
+      tx_mem_rsp_data <= 0;
+      observed_valid_q <= 0;
+      observed_q <= 0;
+      for (node_i = 0; node_i < NODES; node_i = node_i + 1)
+        source_data_state[node_i] <= {{(DATA_W-5){1'b0}}, node_i[3:0], 1'b1};
+    end else begin
+      cycle_count_q <= cycle_count_q + 1'b1;
+      observed_valid_q <= rx_mem_write_valid & rx_mem_write_ready;
+
+      issued_count_q <= issued_count_q +
+        {{(COUNTER_W-6){1'b0}}, popcount16(tx_desc_valid & tx_desc_ready)};
+      completed_count_q <= completed_count_q +
+        {{(COUNTER_W-6){1'b0}},
+         popcount16(rx_completion_valid & rx_completion_ready)};
+
+      case (setup_state)
+        INSTALL_RX: begin
+          descriptor_pending <= descriptor_pending & ~rx_desc_ready;
+          if ((descriptor_pending & ~rx_desc_ready) == 0) begin
+            descriptor_pending <= 16'hffff;
+            setup_state <= INSTALL_TX;
+          end
+        end
+        INSTALL_TX: begin
+          descriptor_pending <= descriptor_pending & ~tx_desc_ready;
+          if ((descriptor_pending & ~tx_desc_ready) == 0) begin
+            descriptor_pending <= 0;
+            completion_seen <= 0;
+            setup_state <= RUN_PACKETS;
+          end
+        end
+        default: begin
+          completion_seen <= completion_seen |
+            (rx_completion_valid & rx_completion_ready);
+          if ((completion_seen |
+               (rx_completion_valid & rx_completion_ready)) == 16'hffff) begin
+            epoch <= epoch + 1'b1;
+            descriptor_pending <= 16'hffff;
+            completion_seen <= 0;
+            setup_state <= INSTALL_RX;
+          end
+        end
+      endcase
+
+      for (node_i = 0; node_i < NODES; node_i = node_i + 1) begin
+        if (tx_mem_req_valid[node_i] && tx_mem_req_ready[node_i]) begin
+          tx_mem_rsp_valid[node_i] <= 1'b1;
+          tx_mem_rsp_data[(node_i*DATA_W) +: DATA_W] <=
+            advance_data(source_data_state[node_i]) ^
+            {{(DATA_W-ADDR_W){1'b0}},
+             tx_mem_req_addr[(node_i*ADDR_W) +: ADDR_W]};
+          source_data_state[node_i] <= advance_data(source_data_state[node_i]);
+        end else if (tx_mem_rsp_valid[node_i] && tx_mem_rsp_ready[node_i]) begin
+          tx_mem_rsp_valid[node_i] <= 1'b0;
+        end
+
+        if ((rx_mem_write_valid[node_i] && rx_mem_write_ready[node_i]) ||
+            (rx_completion_valid[node_i] && rx_completion_ready[node_i])) begin
+          observed_q[(node_i*OBSERVE_SLICE_W) +: OBSERVE_SLICE_W] <=
+            ((rx_mem_write_valid[node_i] && rx_mem_write_ready[node_i]) ?
+              (rx_mem_write_data[
+                 (node_i*DATA_W) + (epoch[3:0]*OBSERVE_SLICE_W) +: OBSERVE_SLICE_W
+               ] ^ rx_mem_write_addr[(node_i*ADDR_W) +: OBSERVE_SLICE_W]) :
+              observed_q[(node_i*OBSERVE_SLICE_W) +: OBSERVE_SLICE_W]) ^
+            ((rx_completion_valid[node_i] && rx_completion_ready[node_i]) ?
+              {2'b0,
+               rx_completion_source[(node_i*ENDPOINT_W) +: ENDPOINT_W],
+               rx_completion_vc[(node_i*VC_W) +: VC_W],
+               rx_completion_tag[(node_i*TAG_W) +: TAG_W]} :
+              {OBSERVE_SLICE_W{1'b0}});
+        end
+      end
+    end
+  end
+
+`ifndef SYNTHESIS
+  initial begin
+    if (DATA_W != 256 || DATA_W % NODES != 0 || ADDR_W < OBSERVE_SLICE_W ||
+        COUNTER_W < 6 || OBSERVE_SLICE_W != 16) begin
+      $error("noc_sram_packet_mesh4x4_ppa_harness parameter contract violated");
+      $finish(1);
+    end
+  end
+`endif
+endmodule

--- a/runs/campaigns/noc/l1_sram_packet_mesh4x4/sweeps/nangate45_composed_feasibility.json
+++ b/runs/campaigns/noc/l1_sram_packet_mesh4x4/sweeps/nangate45_composed_feasibility.json
@@ -1,0 +1,11 @@
+{
+  "tag_prefix": "l1_sram_packet_mesh4x4_nangate45_composed_feasibility",
+  "flow_params": {
+    "CLOCK_PERIOD": [2.0],
+    "DIE_AREA": ["0 0 3200 3200"],
+    "CORE_AREA": ["50 50 3150 3150"],
+    "PLACE_DENSITY": [0.45],
+    "SYNTH_HIERARCHICAL": [1],
+    "SYNTH_KEEP_MODULES": ["noc_sram_packet_endpoint noc_segmented_mesh_router noc_ready_valid_fifo"]
+  }
+}

--- a/runs/designs/noc/l1_noc_sram_packet_mesh4x4_w256_vc4_d4_td4_to8_rx8_wrapper/config_l1_noc_sram_packet_mesh4x4_w256_vc4_d4_td4_to8_rx8.json
+++ b/runs/designs/noc/l1_noc_sram_packet_mesh4x4_w256_vc4_d4_td4_to8_rx8_wrapper/config_l1_noc_sram_packet_mesh4x4_w256_vc4_d4_td4_to8_rx8.json
@@ -1,0 +1,37 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "flit",
+      "dimensions": 1,
+      "bit_width": 256,
+      "signed": false,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "l1_memory_noc_primitive",
+      "module_name": "l1_noc_sram_packet_mesh4x4_w256_vc4_d4_td4_to8_rx8",
+      "operand": "flit",
+      "options": {
+        "primitive": "sram_packet_mesh4x4",
+        "flit_bits": 256,
+        "depth": 4,
+        "ports": 5,
+        "banks": 4,
+        "vc_count": 4,
+        "dest_bits": 4,
+        "source_bits": 4,
+        "tag_bits": 8,
+        "fragment_bits": 3,
+        "addr_bits": 24,
+        "flit_count_bits": 4,
+        "tx_desc_depth": 4,
+        "tx_outstanding": 8,
+        "rx_contexts": 8,
+        "counter_bits": 32
+      }
+    }
+  ]
+}

--- a/scripts/generate_design.py
+++ b/scripts/generate_design.py
@@ -450,10 +450,11 @@ def identify_design(config):
             "segmented_router",
             "segmented_mesh4x4",
             "sram_packet_endpoint",
+            "sram_packet_mesh4x4",
         ):
             raise ValueError(
                 "l1_memory_noc_primitive primitive must be fifo, router, endpoint, segmented_router, "
-                "segmented_mesh4x4, or sram_packet_endpoint"
+                "segmented_mesh4x4, sram_packet_endpoint, or sram_packet_mesh4x4"
             )
         if flit_bits <= 0:
             raise ValueError("l1_memory_noc_primitive flit_bits must be positive")
@@ -481,7 +482,7 @@ def identify_design(config):
             raise ValueError("l1_memory_noc_primitive segmented_router requires five ports")
         if primitive == "segmented_router" and flit_bits < 4:
             raise ValueError("l1_memory_noc_primitive segmented_router requires at least four flit bits")
-        if primitive == "segmented_mesh4x4":
+        if primitive in ("segmented_mesh4x4", "sram_packet_mesh4x4"):
             if ports != 5:
                 raise ValueError("l1_memory_noc_primitive segmented_mesh4x4 requires five-port routers")
             if vc_count != 4:
@@ -501,7 +502,7 @@ def identify_design(config):
                 raise ValueError(
                     "l1_memory_noc_primitive segmented_mesh4x4 observation slice is narrower than metadata"
                 )
-        if primitive == "sram_packet_endpoint":
+        if primitive in ("sram_packet_endpoint", "sram_packet_mesh4x4"):
             if flit_bits != 256:
                 raise ValueError("l1_memory_noc_primitive sram_packet_endpoint requires 256-bit flits")
             if vc_count != 4 or dest_bits != 4 or source_bits != 4:
@@ -958,6 +959,21 @@ def generate_l1_memory_noc_design(src_dir, design):
             )
     elif design["primitive"] == "sram_packet_endpoint":
         text = _emit_l1_sram_packet_endpoint(module_name, design)
+    elif design["primitive"] == "sram_packet_mesh4x4":
+        text = _emit_l1_sram_packet_mesh4x4(module_name, design)
+        for filename in (
+            "noc_ready_valid_fifo.sv",
+            "noc_segmented_mesh_router.sv",
+            "noc_segmented_mesh4x4.sv",
+            "noc_sram_packet_endpoint.sv",
+            "noc_sram_packet_mesh4x4.sv",
+            "noc_sram_packet_mesh4x4_ppa_harness.sv",
+        ):
+            rtl_path = repo_root / "npu" / "sim" / "rtl" / filename
+            Path(src_dir, Path(filename).with_suffix(".v")).write_text(
+                rtl_path.read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
     else:
         text = _emit_l1_endpoint(module_name, design)
     Path(src_dir, f"{module_name}.v").write_text(text, encoding="utf-8")
@@ -1645,6 +1661,40 @@ module {module_name}(
 endmodule
 """
     return endpoint_rtl + top
+
+
+def _emit_l1_sram_packet_mesh4x4(module_name, design):
+    return f"""
+`timescale 1ns/1ps
+
+module {module_name}(
+  input clk,
+  input rst_n,
+  output [15:0] observed_valid,
+  output [{design['flit_bits']-1}:0] observed_flit,
+  output [{design['counter_bits']-1}:0] issued_packet_count,
+  output [{design['counter_bits']-1}:0] completed_packet_count,
+  output protocol_error
+);
+  noc_sram_packet_mesh4x4_ppa_harness #(
+    .DATA_W({design['flit_bits']}),
+    .ADDR_W({design['addr_bits']}),
+    .COUNTER_W({design['counter_bits']}),
+    .TX_DESC_DEPTH({design['tx_desc_depth']}),
+    .TX_OUTSTANDING({design['tx_outstanding']}),
+    .RX_CONTEXTS({design['rx_contexts']}),
+    .ROUTER_FIFO_DEPTH({design['depth']})
+  ) harness (
+    .clk(clk),
+    .rst_n(rst_n),
+    .observed_valid(observed_valid),
+    .observed_flit(observed_flit),
+    .issued_packet_count(issued_packet_count),
+    .completed_packet_count(completed_packet_count),
+    .protocol_error(protocol_error)
+  );
+endmodule
+"""
 
 
 def _emit_l1_endpoint(module_name, design):
@@ -2477,6 +2527,30 @@ module {wrapper_name}(
     .clk(clk),
     .rst_n(rst_n),
     .rx_destination_probe(rx_destination_probe),
+    .observed_flit(observed_flit),
+    .issued_packet_count(issued_packet_count),
+    .completed_packet_count(completed_packet_count),
+    .protocol_error(protocol_error)
+  );
+
+endmodule
+"""
+        elif design["primitive"] == "sram_packet_mesh4x4":
+            wrapper_content = f"""
+module {wrapper_name}(
+  input clk,
+  input rst_n,
+  output [15:0] observed_valid,
+  output [{flit_bits-1}:0] observed_flit,
+  output [{counter_bits-1}:0] issued_packet_count,
+  output [{counter_bits-1}:0] completed_packet_count,
+  output protocol_error
+);
+
+  {module_name} dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .observed_valid(observed_valid),
     .observed_flit(observed_flit),
     .issued_packet_count(issued_packet_count),
     .completed_packet_count(completed_packet_count),

--- a/tests/test_noc_sram_packet_mesh4x4.py
+++ b/tests/test_noc_sram_packet_mesh4x4.py
@@ -1,12 +1,23 @@
 from __future__ import annotations
 
+import json
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.generate_design import (  # noqa: E402
+    generate_l1_memory_noc_design,
+    generate_wrapper,
+    identify_design,
+)
+
 RTL_SOURCES = [
     REPO_ROOT / "npu/sim/rtl/noc_ready_valid_fifo.sv",
     REPO_ROOT / "npu/sim/rtl/noc_segmented_mesh_router.sv",
@@ -15,6 +26,12 @@ RTL_SOURCES = [
     REPO_ROOT / "npu/sim/rtl/noc_sram_packet_mesh4x4.sv",
 ]
 TB = REPO_ROOT / "tests/noc_sram_packet_mesh4x4_tb.sv"
+HARNESS = REPO_ROOT / "npu/sim/rtl/noc_sram_packet_mesh4x4_ppa_harness.sv"
+PPA_CONFIG = (
+    REPO_ROOT
+    / "runs/designs/noc/l1_noc_sram_packet_mesh4x4_w256_vc4_d4_td4_to8_rx8_wrapper"
+    / "config_l1_noc_sram_packet_mesh4x4_w256_vc4_d4_td4_to8_rx8.json"
+)
 
 
 def _tool(name: str) -> str | None:
@@ -185,3 +202,126 @@ endmodule
         timeout=10,
     )
     assert "PASS registered occupancy credit" in result.stdout
+
+
+@pytest.mark.skipif(
+    _tool("iverilog") is None or _tool("vvp") is None,
+    reason="iverilog/vvp unavailable",
+)
+def test_noc_sram_packet_mesh4x4_ppa_harness_makes_progress(tmp_path: Path) -> None:
+    tb = tmp_path / "tb_composed_ppa.sv"
+    tb.write_text(
+        """
+module tb_composed_ppa;
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  wire [15:0] observed_valid;
+  wire [255:0] observed_flit;
+  wire [31:0] issued_packet_count;
+  wire [31:0] completed_packet_count;
+  wire protocol_error;
+  reg [15:0] observed_nodes = 0;
+  reg [255:0] observed_bits = 0;
+  integer cycle;
+  always #1 clk = ~clk;
+  noc_sram_packet_mesh4x4_ppa_harness dut (
+    .clk(clk), .rst_n(rst_n),
+    .observed_valid(observed_valid), .observed_flit(observed_flit),
+    .issued_packet_count(issued_packet_count),
+    .completed_packet_count(completed_packet_count),
+    .protocol_error(protocol_error)
+  );
+  initial begin
+    repeat (3) @(posedge clk);
+    rst_n = 1'b1;
+    for (cycle = 0; cycle < 4096; cycle = cycle + 1) begin
+      @(posedge clk);
+      if (^observed_flit === 1'bx)
+        $fatal(1, "unknown compact observation");
+      if (protocol_error)
+        $fatal(1, "composed harness protocol error endpoints=%h state=%0d epoch=%0d",
+          dut.endpoint_protocol_error, dut.setup_state, dut.epoch);
+      observed_nodes = observed_nodes | observed_valid;
+      observed_bits = observed_bits | observed_flit;
+    end
+    if (issued_packet_count < 128 || completed_packet_count < 112)
+      $fatal(1, "insufficient packet progress");
+    if (observed_nodes != 16'hffff || observed_bits == 0)
+      $fatal(1, "incomplete endpoint observation");
+    $display("PASS composed_ppa issued=%0d completed=%0d observed=%h",
+      issued_packet_count, completed_packet_count, observed_nodes);
+    $finish;
+  end
+endmodule
+""",
+        encoding="utf-8",
+    )
+    sim = tmp_path / "composed_ppa.vvp"
+    subprocess.run(
+        [
+            str(_tool("iverilog")),
+            "-g2012",
+            "-s",
+            "tb_composed_ppa",
+            "-o",
+            str(sim),
+            *[str(path) for path in RTL_SOURCES],
+            str(HARNESS),
+            str(tb),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    result = subprocess.run(
+        [str(_tool("vvp")), str(sim)],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert "PASS composed_ppa" in result.stdout
+
+
+def test_noc_sram_packet_mesh4x4_generator_emits_exact_hierarchy(
+    tmp_path: Path,
+) -> None:
+    config = json.loads(PPA_CONFIG.read_text(encoding="utf-8"))
+    design = identify_design(config)
+    assert design["primitive"] == "sram_packet_mesh4x4"
+    generate_l1_memory_noc_design(str(tmp_path), design)
+    generate_wrapper(config, str(tmp_path), design)
+
+    expected_sources = {
+        "noc_ready_valid_fifo.v",
+        "noc_segmented_mesh_router.v",
+        "noc_segmented_mesh4x4.v",
+        "noc_sram_packet_endpoint.v",
+        "noc_sram_packet_mesh4x4.v",
+        "noc_sram_packet_mesh4x4_ppa_harness.v",
+        f"{design['module_name']}.v",
+        f"{design['wrapper_name']}.v",
+    }
+    assert expected_sources <= {path.name for path in tmp_path.glob("*.v")}
+
+    iverilog = _tool("iverilog")
+    if iverilog is None:
+        pytest.skip("iverilog unavailable")
+    subprocess.run(
+        [
+            iverilog,
+            "-g2012",
+            "-s",
+            design["wrapper_name"],
+            "-t",
+            "null",
+            *[str(path) for path in sorted(tmp_path.glob("*.v"))],
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )


### PR DESCRIPTION
## Summary
- add a compact physical harness around the exact sixteen-endpoint/sixteen-router registered-credit composition
- install collision-free receive descriptors before release, exercise packet lengths 1–8 and every VC, and model finite source-read, destination-write, and completion backpressure
- rotate local observation slices by epoch so every transported payload bit remains live without a global 4096-bit boundary or XOR timing path
- add the `sram_packet_mesh4x4` generator/config path, a matched 3.2 mm-square one-point Nangate45 feasibility sweep, and strict proposal/dependency linkage

## Scope
This is composed on-chip control/fabric PPA evidence. SRAM bitcells/macros, producer/reducer arithmetic, HBM/DRAM, and workload-matched switching activity remain excluded. The item is dependency-gated behind corrected router, endpoint, and aggregate-mesh results.

## Verification
- endpoint/composition/router regression: 16 passed, 1 evaluator-filesystem-only test deselected
- 4096-cycle all-endpoint harness progress with zero protocol errors
- generated exact hierarchy compiles from the checked-in run config
- no Verilator `UNOPTFLAT` ready cycle
- `python scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`