### PR TITLE
Add composed mesh Llama7B reroute closure

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -591,6 +591,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_score32_noc_phase2_schedule_report",
     ),
     (
+        "attention_score32_noc_phase2_composed_mesh_reroute_out",
+        "attention_score32_noc_phase2_composed_mesh_reroute_report",
+    ),
+    (
         "attention_score32_folded_global_exact_reduction_recost_out",
         "attention_score32_folded_global_exact_reduction_recost_report",
     ),
@@ -814,6 +818,9 @@ def _decoder_quality_brief(evidence_payload: dict[str, Any]) -> dict[str, Any]:
         "remaining_abstractions",
         "closure_flags",
         "closure_diagnosis",
+        "clock_contract",
+        "schedule",
+        "physical_accounting",
         "boundary_evidence",
         "composition_quantities",
         "measured_primitives",

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5457,6 +5457,107 @@ def _decoder_attention_score32_noc_phase2_measured_router_clock_reroute_evidence
     }
 
 
+def _decoder_attention_score32_noc_phase2_composed_mesh_reroute_evidence(
+    *,
+    item_id: str,
+    depends_on_item_ids: list[str] | None,
+    proposal_id: str | None,
+    proposal_path: str | None,
+) -> dict[str, Any]:
+    expected_item_id = "l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_llama7b_v1"
+    expected_proposal_id = "prop_l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_v1"
+    if item_id != expected_item_id:
+        raise Layer2TaskGenerationError("score32 composed-mesh reroute only permits the exact item")
+    if str(proposal_id or "").strip() != expected_proposal_id:
+        raise Layer2TaskGenerationError("score32 composed-mesh reroute proposal_id mismatch")
+    if str(proposal_path or "").strip() != f"docs/proposals/{expected_proposal_id}/proposal.json":
+        raise Layer2TaskGenerationError("score32 composed-mesh reroute proposal_path mismatch")
+    expected_dependencies = [
+        "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1",
+        "l1_noc_sram_packet_mesh4x4_composed_ppa_v1",
+    ]
+    if list(depends_on_item_ids or []) != expected_dependencies:
+        raise Layer2TaskGenerationError(
+            "score32 composed-mesh reroute requires the corrected schedule and composed PPA dependencies"
+        )
+
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    source = (
+        f"{base}/decoder_attention_score32_exact_reduction_recost__"
+        "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1.json"
+    )
+    measured_costs = (
+        "runs/campaigns/npu/l1_measured_costs/"
+        "llama7b_attention_local_costs_all_measured_endpoint_v1.json"
+    )
+    schedule = (
+        f"{base}/decoder_attention_score32_noc_phase2_schedule__"
+        "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1.json"
+    )
+    composed = (
+        "control_plane/shadow_exports/l1_promotions/"
+        "l1_noc_sram_packet_mesh4x4_composed_ppa_v1.json"
+    )
+    out = f"{base}/decoder_attention_score32_noc_phase2_composed_mesh_reroute__{item_id}.json"
+    report = f"{base}/decoder_attention_score32_noc_phase2_composed_mesh_reroute__{item_id}.md"
+    command = _bounded_launcher_command(
+        memory_high="2G",
+        memory_max="4G",
+        cpu_quota="200%",
+        tasks_max=128,
+        runtime_max_sec=600,
+        child_command=[
+            "python3",
+            "npu/eval/reroute_llm_decoder_attention_score32_noc_phase2_composed_mesh.py",
+            "--repo-root",
+            ".",
+            "--source-json",
+            source,
+            "--measured-l1-costs",
+            measured_costs,
+            "--baseline-schedule-json",
+            schedule,
+            "--composed-promotion-json",
+            composed,
+            "--out",
+            out,
+            "--report",
+            report,
+        ],
+    )
+    return {
+        "inputs": {
+            "attention_score32_noc_phase2_source_recost": source,
+            "attention_score32_noc_phase2_measured_l1_costs": measured_costs,
+            "attention_score32_noc_phase2_corrected_schedule": schedule,
+            "attention_score32_noc_phase2_composed_mesh_promotion": composed,
+            "attention_score32_noc_phase2_composed_mesh_reroute_out": out,
+            "attention_score32_noc_phase2_composed_mesh_reroute_report": report,
+        },
+        "commands": [{"name": "reroute_attention_score32_noc_at_composed_mesh_clock", "run": command}],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+        "worker_resources": {
+            "exclusive_worker": True,
+            "memory_high": "2G",
+            "memory_max": "4G",
+            "cpu_quota": "200%",
+            "tasks_max": 128,
+            "outer_timeout_seconds": 600,
+            "stall_timeout_seconds": 300,
+        },
+        "acceptance": [
+            "Require the exact workload-complete 8-wave/128-tile corrected schedule",
+            "Require timing-feasible PPA for the exact sixteen-endpoint/sixteen-router composed wrapper",
+            "Rerun release conversion and routing at max(source clock, composed critical path)",
+            "Require delivered_flit_count=scheduled_flit_count",
+            "Account the aggregate placed footprint and vectorless power without summing primitives",
+            "Label SRAM bitcells, workload-matched switching, HBM/DRAM, and producer/reducer arithmetic explicitly",
+            "Write exactly one JSON and one Markdown report",
+        ],
+    }
+
+
 def _decoder_attention_kv_endpoint_full_onchip_service_schedule_evidence(
     *,
     item_id: str,
@@ -12333,6 +12434,7 @@ def _build_payload(
         "decoder_attention_score32_noc_phase2_schedule",
         "decoder_attention_score32_noc_phase2_measured_router_closure",
         "decoder_attention_score32_noc_phase2_measured_router_clock_reroute",
+        "decoder_attention_score32_noc_phase2_composed_mesh_reroute",
         "decoder_attention_kv_endpoint_full_onchip_service_schedule",
         "decoder_attention_kv_endpoint_ready_valid_service",
         "decoder_attention_kv_endpoint_router_sram_composition",
@@ -12569,6 +12671,13 @@ def _build_payload(
             )
         elif abstraction_layer_name == "decoder_attention_score32_noc_phase2_measured_router_clock_reroute":
             decoder_evidence = _decoder_attention_score32_noc_phase2_measured_router_clock_reroute_evidence(
+                item_id=item_id,
+                depends_on_item_ids=depends_on_item_ids,
+                proposal_id=proposal_id,
+                proposal_path=proposal_path,
+            )
+        elif abstraction_layer_name == "decoder_attention_score32_noc_phase2_composed_mesh_reroute":
+            decoder_evidence = _decoder_attention_score32_noc_phase2_composed_mesh_reroute_evidence(
                 item_id=item_id,
                 depends_on_item_ids=depends_on_item_ids,
                 proposal_id=proposal_id,

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -206,6 +206,29 @@ def test_decoder_evidence_paths_recognizes_score32_noc_phase2_schedule(tmp_path:
     }
 
 
+def test_decoder_evidence_paths_recognizes_score32_noc_composed_mesh_reroute(tmp_path: Path) -> None:
+    evidence_rel = "runs/datasets/demo/score32_noc_composed_mesh_reroute.json"
+    report_rel = "runs/datasets/demo/score32_noc_composed_mesh_reroute.md"
+    _write(tmp_path / evidence_rel, "{}\n")
+    _write(tmp_path / report_rel, "# Score32 NoC composed mesh reroute\n")
+    work_item = SimpleNamespace(
+        input_manifest={
+            "decoder_contract": {
+                "attention_score32_noc_phase2_composed_mesh_reroute_out": evidence_rel,
+                "attention_score32_noc_phase2_composed_mesh_reroute_report": report_rel,
+            }
+        }
+    )
+
+    evidence_ref, source_refs = _decoder_evidence_paths(repo_root=tmp_path, work_item=work_item)
+
+    assert evidence_ref == evidence_rel
+    assert source_refs == {
+        "decoder_attention_score32_noc_phase2_composed_mesh_reroute_out": evidence_rel,
+        "decoder_attention_score32_noc_phase2_composed_mesh_reroute_report": report_rel,
+    }
+
+
 def test_decoder_evidence_summary_recognizes_score32_noc_phase2_schedule() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/score32_noc_phase2_schedule.json",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -14767,6 +14767,57 @@ def test_generate_l2_campaign_task_adds_score32_noc_measured_router_clock_rerout
             assert work_item.input_manifest["worker_resources"]["outer_timeout_seconds"] == 600
 
 
+def test_generate_l2_campaign_task_adds_score32_noc_composed_mesh_reroute() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        dependencies = [
+            "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1",
+            "l1_noc_sram_packet_mesh4x4_composed_ppa_v1",
+        ]
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                _make_l2_request(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_v1",
+                    proposal_path=(
+                        "docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_v1/"
+                        "proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_score32_noc_phase2_composed_mesh_reroute",
+                    evaluation_mode="frontier_detail",
+                    depends_on_item_ids=dependencies,
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            run = work_item.command_manifest[0]["run"]
+            assert work_item.state == WorkItemState.BLOCKED
+            assert work_item.task_request.request_payload["developer_loop"]["dependencies"]["item_ids"] == dependencies
+            assert "reroute_llm_decoder_attention_score32_noc_phase2_composed_mesh.py" in run
+            assert "--composed-promotion-json" in run
+            assert "l1_noc_sram_packet_mesh4x4_composed_ppa_v1.json" in run
+            assert "--runtime-max-sec 600" in run
+            assert work_item.input_manifest["worker_resources"]["exclusive_worker"] is True
+            assert work_item.expected_outputs[0].endswith(
+                "decoder_attention_score32_noc_phase2_composed_mesh_reroute__"
+                "l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_llama7b_v1.json"
+            )
+
+
 def test_score32_noc_closure_rejects_inexact_dependencies() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/architecture/llama7b_attention_abstraction_closure_plan.md
+++ b/docs/architecture/llama7b_attention_abstraction_closure_plan.md
@@ -258,6 +258,12 @@ evidence gaps:
   and completion backpressure, and rotates local observation across all 256
   payload bits. It remains dependency-gated behind router, endpoint, and
   aggregate-mesh anchors and is not workload-activity or SRAM-macro evidence.
+- Composed schedule substitution: the prepared
+  `l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_llama7b_v1`
+  item waits for the corrected workload schedule and composed endpoint/mesh
+  promotion. It reruns all eight waves and 128 tiles at the conservative
+  composed clock, replaces primitive area/power sums with aggregate placed
+  evidence, and keeps SRAM macros plus workload-matched activity explicit.
 - Credit timing: the original router FIFO allowed a full queue's input ready
   to depend on a same-cycle downstream pop. Across bidirectional links this
   formed a combinational ready fixpoint. FIFO credits now depend only on

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_v1/README.md
@@ -1,0 +1,6 @@
+# Composed Endpoint/Mesh Reroute
+
+This proposal consumes the workload-complete score32 Phase 2 schedule and the
+placed sixteen-endpoint/sixteen-router promotion. It reruns the full traffic
+schedule at the conservative composed clock and records aggregate physical
+accounting without treating SRAM macros or vectorless power as closed.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_v1/design_brief.md
@@ -1,0 +1,6 @@
+# Design Brief
+
+The consumer validates the canonical schedule and exact composed promotion,
+uses `max(source_clock, composed_critical_path)` because SRAM macro timing is
+outside the wrapper, reruns all eight waves and 128 tiles, and records the
+placed footprint, vectorless power, and diagnostic drain energy.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_v1",
+  "source_commit": "TBD",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Reroute and recost the complete score32 Phase 2 workload using composed endpoint/mesh PPA.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_noc_phase2_composed_mesh_reroute",
+      "status": "pending_after_dependencies_merge",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1",
+        "l1_noc_sram_packet_mesh4x4_composed_ppa_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_composed_mesh_reroute__l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_llama7b_v1.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_composed_mesh_reroute__l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_llama7b_v1.md"
+      ],
+      "acceptance_notes": "Require complete flit delivery after fresh rerouting at the conservative composed clock. Use aggregate placed PPA without primitive summation and keep SRAM macros, workload activity, HBM/DRAM, and arithmetic blocks explicit."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_v1/implementation_summary.md
@@ -1,0 +1,6 @@
+# Implementation Summary
+
+Prepared dependency-gated evaluator support includes canonical promotion
+validation, conservative composed-clock selection, a fresh full-workload
+reroute, aggregate physical accounting, and evidence-only result consumption.
+The job remains blocked until both source promotions merge.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_v1/proposal.json
@@ -1,0 +1,40 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_v1",
+  "created_utc": "2026-08-15T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Bind composed endpoint/mesh PPA to the complete score32 NoC schedule",
+  "hypothesis": "Fresh full-workload routing at the measured composed endpoint/mesh clock can replace primitive sums with aggregate timing, footprint, wiring, congestion, and vectorless-power evidence.",
+  "direct_comparison": {
+    "primary_question": "Does the corrected 8-wave/128-tile Llama7B schedule remain inside its compute envelope after substituting aggregate composed-mesh PPA?",
+    "include": [
+      "exact corrected Phase 2 workload schedule",
+      "sixteen-endpoint and sixteen-router composed promotion",
+      "fresh release conversion and routing",
+      "aggregate placed footprint and vectorless power"
+    ],
+    "exclude": [
+      "SRAM bitcells and macro placement",
+      "workload-derived switching activity",
+      "HBM/DRAM controller implementation",
+      "producer, reducer, and root-finalizer arithmetic"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1",
+        "l1_noc_sram_packet_mesh4x4_composed_ppa_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_schedule__l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1.json",
+    "control_plane/shadow_exports/l1_promotions/l1_noc_sram_packet_mesh4x4_composed_ppa_v1.json"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_composed_mesh_reroute_v1/quality_gate.md
@@ -1,0 +1,6 @@
+# Quality Gate
+
+- The corrected workload-complete schedule and exact composed promotion are mandatory.
+- Every scheduled flit must be delivered after fresh release conversion and routing.
+- Aggregate PPA must come from the composed wrapper, not a primitive sum.
+- SRAM macro, activity, HBM/DRAM, and arithmetic exclusions remain explicit.

--- a/npu/eval/reroute_llm_decoder_attention_score32_noc_phase2_composed_mesh.py
+++ b/npu/eval/reroute_llm_decoder_attention_score32_noc_phase2_composed_mesh.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Reroute score32 Phase 2 traffic using measured composed endpoint/mesh PPA."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from npu.eval import measure_llm_decoder_attention_score32_noc_phase2_schedule as phase2_schedule  # noqa: E402
+from npu.eval.audit_llm_decoder_attention_score32_noc_phase2_measured_router_closure import (  # noqa: E402
+    _as_positive_float,
+    _load_json,
+    _validate_phase2_schedule,
+)
+from npu.eval.reroute_llm_decoder_attention_score32_noc_phase2_measured_router_clock import (  # noqa: E402
+    _compact_schedule,
+    _schedule_args,
+)
+
+JsonDict = dict[str, Any]
+
+DEFAULT_BASELINE_SCHEDULE = Path(
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+    "decoder_attention_score32_noc_phase2_schedule__"
+    "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1.json"
+)
+DEFAULT_COMPOSED_PROMOTION = Path(
+    "control_plane/shadow_exports/l1_promotions/"
+    "l1_noc_sram_packet_mesh4x4_composed_ppa_v1.json"
+)
+_EXPECTED_COMPOSED_ITEM_ID = "l1_noc_sram_packet_mesh4x4_composed_ppa_v1"
+_EXPECTED_DESIGN_TOKEN = "noc_sram_packet_mesh4x4"
+
+
+def _validate_composed_promotion(payload: JsonDict) -> JsonDict:
+    if payload.get("item_id") != _EXPECTED_COMPOSED_ITEM_ID:
+        raise ValueError("composed promotion item_id mismatch")
+    if payload.get("task_type") != "l1_sweep":
+        raise ValueError("composed promotion task_type must be l1_sweep")
+    record = payload.get("evaluation_record")
+    proposals = payload.get("proposals")
+    if not isinstance(record, dict) or not bool(record.get("physical_metrics_present")):
+        raise ValueError("composed promotion must provide physical metrics")
+    if record.get("timing_feasible") is False:
+        raise ValueError("composed promotion is not timing-feasible")
+    if not isinstance(proposals, list):
+        raise ValueError("composed promotion is missing proposals")
+
+    candidates: list[JsonDict] = []
+    for proposal in proposals:
+        if not isinstance(proposal, dict):
+            continue
+        ref = proposal.get("metrics_ref")
+        summary = proposal.get("metric_summary")
+        if not isinstance(ref, dict) or not isinstance(summary, dict):
+            continue
+        identity = " ".join(
+            str(ref.get(key) or "") for key in ("design", "metrics_csv", "result_path")
+        )
+        if _EXPECTED_DESIGN_TOKEN not in identity:
+            continue
+        candidates.append(
+            {
+                "metrics_csv": str(ref.get("metrics_csv") or ""),
+                "param_hash": str(ref.get("param_hash") or ""),
+                "tag": str(ref.get("tag") or ""),
+                "result_path": str(ref.get("result_path") or ""),
+                "critical_path_ns": _as_positive_float(
+                    summary.get("critical_path_ns"), "composed critical_path_ns"
+                ),
+                "footprint_um2": _as_positive_float(summary.get("die_area"), "composed die_area"),
+                "vectorless_power_mw": _as_positive_float(
+                    summary.get("total_power_mw"), "composed total_power_mw"
+                ),
+            }
+        )
+    if not candidates:
+        raise ValueError("composed promotion does not contain the expected endpoint/mesh design")
+    return min(
+        candidates,
+        key=lambda item: (
+            item["critical_path_ns"],
+            item["footprint_um2"],
+            item["vectorless_power_mw"],
+        ),
+    )
+
+
+def build_report(args: argparse.Namespace) -> JsonDict:
+    repo_root = args.repo_root.resolve()
+    baseline_path = repo_root / args.baseline_schedule_json
+    baseline = _validate_phase2_schedule(_load_json(baseline_path), source_path=baseline_path)
+    composed = _validate_composed_promotion(_load_json(repo_root / args.composed_promotion_json))
+
+    source_clock_ns = float(baseline["source_contract"]["noc_clock_ns"])
+    measured_clock_ns = float(composed["critical_path_ns"])
+    effective_clock_ns = max(source_clock_ns, measured_clock_ns)
+    schedule = _compact_schedule(
+        phase2_schedule.build_report(_schedule_args(args, noc_clock_ns=effective_clock_ns))
+    )
+    if schedule["scheduled_flit_count"] != schedule["delivered_flit_count"]:
+        raise ValueError("composed-clock reroute did not deliver every scheduled flit")
+
+    drain_time_ns = float(schedule["drain_time_ns"])
+    vectorless_energy_mj = composed["vectorless_power_mw"] * drain_time_ns / 1.0e9
+    return {
+        "version": 1,
+        "model": "llama7b_proxy",
+        "profile": "decoder_attention_score32_noc_phase2_composed_mesh_reroute",
+        "decision": "score32_noc_phase2_composed_mesh_reroute_recorded",
+        "diagnosis": {
+            "decision": "score32_noc_phase2_composed_mesh_reroute_recorded",
+            "workload_complete": True,
+            "within_compute_envelope": bool(schedule["drain_within_source_compute_layer_envelope"]),
+            "remaining_onchip_communication_abstraction": "sram_macro_placement_and_activity_only",
+        },
+        "source_items": {
+            "baseline_schedule": baseline["item_id"],
+            "composed_endpoint_mesh": _EXPECTED_COMPOSED_ITEM_ID,
+        },
+        "clock_contract": {
+            "source_schedule_noc_clock_ns": source_clock_ns,
+            "measured_composed_logic_critical_path_ns": measured_clock_ns,
+            "effective_noc_clock_ns": effective_clock_ns,
+            "source_clock_floor_reason": (
+                "The composed wrapper excludes SRAM bitcell/macro timing and workload-matched service; "
+                "a faster logic result alone does not justify reducing the existing 1ns schedule floor."
+            ),
+            "release_conversion_and_mesh_routing_rerun": True,
+            "absolute_source_cycle_timeline_reused": False,
+        },
+        "schedule": schedule,
+        "physical_accounting": {
+            **composed,
+            "scope": "placed_16_endpoint_16_router_control_fabric_with_bounded_harness",
+            "footprint_status": "floorplan_envelope_includes_harness_not_cell_area",
+            "power_status": "vectorless_not_workload_matched",
+            "vectorless_drain_energy_mj": vectorless_energy_mj,
+            "energy_status": "diagnostic_vectorless_power_times_rerouted_drain_time",
+        },
+        "closure_flags": {
+            "all_16_endpoints_and_routers_physically_anchored_together": True,
+            "fresh_full_workload_reroute": True,
+            "aggregate_wiring_and_congestion_included": True,
+            "sram_bitcells_included": False,
+            "workload_matched_switching_power": False,
+            "hbm_dram_included": False,
+        },
+        "remaining_abstractions": [
+            "SRAM bitcells/macros, macro placement, and macro access energy are outside the composed RTL wrapper.",
+            "The OpenROAD power estimate is vectorless rather than driven by the measured Phase 2 toggle trace.",
+            "HBM/DRAM timing, controller implementation, and vendor current signoff remain external envelopes.",
+            "Producer, reducer arithmetic, and root-finalizer compute are measured by separate compatible "
+            "anchors, not this NoC wrapper.",
+        ],
+    }
+
+
+def write_report(payload: JsonDict, path: Path) -> None:
+    schedule = payload["schedule"]
+    physical = payload["physical_accounting"]
+    lines = [
+        "# Llama7B Score32 Composed Endpoint/Mesh Reroute",
+        "",
+        "- measured composed critical path ns: "
+        f"`{payload['clock_contract']['measured_composed_logic_critical_path_ns']}`",
+        f"- effective NoC clock ns: `{payload['clock_contract']['effective_noc_clock_ns']}`",
+        f"- drain time ns: `{schedule['drain_time_ns']}`",
+        f"- within compute envelope: `{str(schedule['drain_within_source_compute_layer_envelope']).lower()}`",
+        f"- composed footprint um2: `{physical['footprint_um2']}`",
+        f"- vectorless power mW: `{physical['vectorless_power_mw']}`",
+        f"- diagnostic vectorless drain energy mJ: `{physical['vectorless_drain_energy_mj']}`",
+        "",
+        "## Remaining Abstractions",
+        "",
+        *(f"- {item}" for item in payload["remaining_abstractions"]),
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--source-json", type=Path, default=phase2_schedule.DEFAULT_SOURCE_JSON)
+    parser.add_argument("--measured-l1-costs", type=Path, default=phase2_schedule.DEFAULT_MEASURED_L1_COSTS)
+    parser.add_argument("--baseline-schedule-json", type=Path, default=DEFAULT_BASELINE_SCHEDULE)
+    parser.add_argument("--composed-promotion-json", type=Path, default=DEFAULT_COMPOSED_PROMOTION)
+    parser.add_argument("--max-cycles", type=int, default=1000000)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--report", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_report(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_report(payload, args.report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_reroute_llm_decoder_attention_score32_noc_phase2_composed_mesh.py
+++ b/tests/test_reroute_llm_decoder_attention_score32_noc_phase2_composed_mesh.py
@@ -1,0 +1,116 @@
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from npu.eval import reroute_llm_decoder_attention_score32_noc_phase2_composed_mesh as reroute
+from tests.test_reroute_llm_decoder_attention_score32_noc_phase2_measured_router_clock import (
+    _baseline,
+    _rerouted,
+)
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _composed(
+    *,
+    critical_path_ns: float = 1.4,
+    design: str = "l1_noc_sram_packet_mesh4x4_composed_ppa_harness_wrapper",
+) -> dict:
+    return {
+        "item_id": "l1_noc_sram_packet_mesh4x4_composed_ppa_v1",
+        "task_type": "l1_sweep",
+        "evaluation_record": {"physical_metrics_present": True, "timing_feasible": True},
+        "proposals": [
+            {
+                "metrics_ref": {
+                    "design": design,
+                    "metrics_csv": f"runs/designs/noc/{design}/metrics.csv",
+                    "param_hash": "abcd1234",
+                },
+                "metric_summary": {
+                    "critical_path_ns": critical_path_ns,
+                    "die_area": 10_240_000.0,
+                    "total_power_mw": 12.5,
+                },
+            }
+        ],
+    }
+
+
+def _args(root: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        repo_root=root,
+        source_json=Path("source.json"),
+        measured_l1_costs=Path("costs.json"),
+        baseline_schedule_json=reroute.DEFAULT_BASELINE_SCHEDULE,
+        composed_promotion_json=reroute.DEFAULT_COMPOSED_PROMOTION,
+        max_cycles=1_000_000,
+        out=root / "out.json",
+        report=root / "out.md",
+    )
+
+
+def test_composed_mesh_reroutes_full_schedule_and_accounts_aggregate_ppa(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write(tmp_path / reroute.DEFAULT_BASELINE_SCHEDULE, _baseline())
+    _write(tmp_path / reroute.DEFAULT_COMPOSED_PROMOTION, _composed(critical_path_ns=1.4))
+    called: list[float] = []
+
+    def fake_build(args: argparse.Namespace) -> dict:
+        called.append(args.noc_clock_ns)
+        return _rerouted(args.noc_clock_ns)
+
+    monkeypatch.setattr(reroute.phase2_schedule, "build_report", fake_build)
+    report = reroute.build_report(_args(tmp_path))
+
+    assert called == [1.4]
+    assert report["profile"] == "decoder_attention_score32_noc_phase2_composed_mesh_reroute"
+    assert report["schedule"]["scheduled_flit_count"] == report["schedule"]["delivered_flit_count"]
+    assert report["physical_accounting"]["footprint_um2"] == pytest.approx(10_240_000.0)
+    assert report["physical_accounting"]["vectorless_drain_energy_mj"] == pytest.approx(
+        12.5 * report["schedule"]["drain_time_ns"] / 1.0e9
+    )
+    assert report["closure_flags"]["aggregate_wiring_and_congestion_included"] is True
+    assert report["closure_flags"]["sram_bitcells_included"] is False
+
+
+def test_composed_mesh_keeps_source_clock_floor_when_logic_is_faster(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write(tmp_path / reroute.DEFAULT_BASELINE_SCHEDULE, _baseline())
+    _write(tmp_path / reroute.DEFAULT_COMPOSED_PROMOTION, _composed(critical_path_ns=0.7))
+    called: list[float] = []
+
+    def fake_build(args: argparse.Namespace) -> dict:
+        called.append(args.noc_clock_ns)
+        return _rerouted(args.noc_clock_ns)
+
+    monkeypatch.setattr(reroute.phase2_schedule, "build_report", fake_build)
+    report = reroute.build_report(_args(tmp_path))
+
+    assert called == [1.0]
+    assert report["clock_contract"]["effective_noc_clock_ns"] == pytest.approx(1.0)
+
+
+def test_composed_mesh_rejects_wrong_physical_design(tmp_path: Path) -> None:
+    _write(tmp_path / reroute.DEFAULT_BASELINE_SCHEDULE, _baseline())
+    _write(tmp_path / reroute.DEFAULT_COMPOSED_PROMOTION, _composed(design="unrelated_router"))
+
+    with pytest.raises(ValueError, match="expected endpoint/mesh design"):
+        reroute.build_report(_args(tmp_path))
+
+
+def test_composed_mesh_rejects_noncanonical_promotion_item(tmp_path: Path) -> None:
+    _write(tmp_path / reroute.DEFAULT_BASELINE_SCHEDULE, _baseline())
+    promotion = _composed()
+    promotion["item_id"] = "wrong"
+    _write(tmp_path / reroute.DEFAULT_COMPOSED_PROMOTION, promotion)
+
+    with pytest.raises(ValueError, match="item_id mismatch"):
+        reroute.build_report(_args(tmp_path))


### PR DESCRIPTION
## Summary

- add a dependency-gated Llama7B score32 consumer for the measured composed 16-endpoint/16-router mesh
- rerun all eight waves and 128 tiles at `max(source clock, composed critical path)` instead of reusing the 1 ns cycle timeline
- account aggregate placed footprint, wiring/congestion, vectorless power, and diagnostic drain energy without summing primitives
- keep SRAM macros, workload-matched activity, HBM/DRAM, and producer/reducer arithmetic explicit
- register the JSON/Markdown pair as evidence-only output so completion does not require campaign CSV artifacts

## Why

The existing follow-ons stop at a single-router component bound. After the composed endpoint/mesh PPA job merges, no consumer currently substitutes that aggregate evidence into the complete Llama7B schedule. This change prepares that closure step and prevents another `ARTIFACT_SYNC` failure caused by treating an evidence-only job as a ranked campaign.

## Validation

- `23 passed` across new and adjacent score32 NoC tests
- broad L2 generator/result-consumer run: `408 passed, 1 unrelated existing failure`
- `python scripts/validate_runs.py --skip_eval_queue`: passed
- `git diff --check`: passed

The unrelated broad-suite failure is `test_service_activity_power_request_manifests_remain_dependency_gated`; current master has `...service_c1_activity_power...v1_r3` in that proposal manifest while the test expects `...v1`.
