### PR TITLE
Model concrete NoC tags independently of schedule order

### DIFF
--- a/npu/eval/measure_llm_decoder_attention_score32_noc_phase2_schedule.py
+++ b/npu/eval/measure_llm_decoder_attention_score32_noc_phase2_schedule.py
@@ -109,9 +109,13 @@ def _build_packet_specs(
     return specs
 
 
-def _packetize_specs_with_wide_tags(specs: list[PacketSpec]) -> list[TrafficFlow]:
+def _packetize_specs_with_concrete_tags(specs: list[PacketSpec]) -> list[TrafficFlow]:
     flows: list[TrafficFlow] = []
+    tuple_sequence: Counter[tuple[int, int, int]] = Counter()
     for ordinal, spec in enumerate(specs):
+        key = (spec.source, spec.destination, spec.vc)
+        wire_tag = tuple_sequence[key] % 256
+        tuple_sequence[key] += 1
         flows.append(
             TrafficFlow(
                 name=spec.label,
@@ -121,8 +125,9 @@ def _packetize_specs_with_wide_tags(specs: list[PacketSpec]) -> list[TrafficFlow
                 vc=spec.vc,
                 release_cycle=spec.release_cycle,
                 packet_payload_bytes=spec.payload_bytes,
-                tag_base=ordinal,
+                tag_base=wire_tag,
                 data_seed=spec.data_seed,
+                schedule_order=ordinal,
             )
         )
     return flows
@@ -547,7 +552,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
                     packet_specs.extend(new_specs)
                     packet_seed_counter += len(new_specs)
 
-    traffic_flows = _packetize_specs_with_wide_tags(packet_specs)
+    traffic_flows = _packetize_specs_with_concrete_tags(packet_specs)
     scheduled_flits = [scheduled for flow in traffic_flows for scheduled in packetize_traffic_flow(flow)]
     mesh_result = simulate_scheduled_flits(
         scheduled_flits,
@@ -708,9 +713,11 @@ def build_report(args: argparse.Namespace) -> JsonDict:
         "tag_semantics": {
             "tag_width_bits": 8,
             "assignment_scope": "per (source, destination, vc) ordered packet stream",
+            "concrete_wire_tags_simulated": True,
+            "schedule_order_is_independent_of_wire_tag": True,
             "collision_free_reuse_proven": True,
             "collision_free_reuse_invariant": "Concrete low_tag = tuple packet sequence index mod 256. For every reused (source, destination, vc, low_tag), the next packet's first injection cycle is strictly greater than the prior packet's last delivery cycle; same-cycle reuse is treated as ambiguous and rejected.",
-            "packet_identity_modeled_by_simulator": "source, destination, vc, label, packet-local fragment index, and last bit; 8-bit wire tags are audited after routing because the performance model does not perform packet reassembly or claim standalone reassembly correctness.",
+            "packet_identity_modeled_by_simulator": "source, destination, vc, concrete 8-bit wire tag, schedule order, label, packet-local fragment index, and last bit; schedule order is explicit and cannot be perturbed by modulo-256 tag reuse.",
             "ordered_tuple_stream_proven": True,
             "ordered_tuple_stream_summary": tuple_stream_proof["tuple_summaries"],
             "ordered_tuple_stream_max_packet_flits": tuple_stream_proof["max_packet_flits"],

--- a/npu/sim/perf/noc_segmented_mesh.py
+++ b/npu/sim/perf/noc_segmented_mesh.py
@@ -108,6 +108,8 @@ class Flow:
 class ScheduledFlit:
     release_cycle: int
     flit: ModelFlit
+    schedule_order: int = 0
+    packet_order: int = 0
 
 
 @dataclass(frozen=True)
@@ -121,6 +123,7 @@ class TrafficFlow:
     packet_payload_bytes: int = CONCEPTUAL_LINK_BITS // 8
     tag_base: int = 0
     data_seed: int = 0
+    schedule_order: int = 0
 
 
 @dataclass(frozen=True)
@@ -457,14 +460,15 @@ def packetize_traffic_flow(flow: TrafficFlow) -> tuple[ScheduledFlit, ...]:
             raise ValueError(
                 "traffic flow packetization exceeds the eight-fragment tagged packet envelope"
             )
-        # The performance model keeps a wide synthetic packet sequence tag so
-        # packet ordering cannot be perturbed by 8-bit wraparound. Concrete
-        # 8-bit tag reuse is audited separately by higher-level reports.
-        tag = flow.tag_base + packet_index
+        # Producer order is simulator metadata, independent of the concrete
+        # eight-bit tag carried by the modeled wire protocol.
+        tag = (flow.tag_base + packet_index) & 0xFF
         for fragment in range(flit_count):
             scheduled.append(
                 ScheduledFlit(
                     release_cycle=flow.release_cycle,
+                    schedule_order=flow.schedule_order,
+                    packet_order=packet_index,
                     flit=ModelFlit(
                         source=flow.source,
                         destination=flow.destination,
@@ -502,7 +506,16 @@ def simulate_scheduled_flits(
     max_cycles: int = 100000,
     fast_forward_idle: bool = False,
 ) -> MeshSimulationResult:
-    ordered = sorted(scheduled_flits, key=lambda item: (item.release_cycle, item.flit.source, item.flit.tag, item.flit.fragment))
+    ordered = sorted(
+        scheduled_flits,
+        key=lambda item: (
+            item.release_cycle,
+            item.flit.source,
+            item.schedule_order,
+            item.packet_order,
+            item.flit.fragment,
+        ),
+    )
     release_queues: list[deque[ScheduledFlit]] = [deque() for _ in range(ENDPOINTS)]
     future = deque(ordered)
     states = [
@@ -699,7 +712,7 @@ def simulate_mesh(
 def simulate(flows: Iterable[Flow], *, max_cycles: int = 10000) -> dict[str, object]:
     flow_list = list(flows)
     scheduled: list[ScheduledFlit] = []
-    for flow in flow_list:
+    for flow_order, flow in enumerate(flow_list):
         if flow.flits <= 0:
             raise ValueError("flow flits must be positive")
         if flow.flits % FLITS_PER_CONCEPTUAL_TRANSFER != 0:
@@ -714,6 +727,8 @@ def simulate(flows: Iterable[Flow], *, max_cycles: int = 10000) -> dict[str, obj
                 scheduled.append(
                     ScheduledFlit(
                         release_cycle=flow.release_cycle,
+                        schedule_order=flow_order,
+                        packet_order=packet_index,
                         flit=ModelFlit(
                             source=flow.source,
                             destination=flow.destination,

--- a/tests/test_llm_decoder_attention_score32_noc_phase2_schedule.py
+++ b/tests/test_llm_decoder_attention_score32_noc_phase2_schedule.py
@@ -57,6 +57,8 @@ def test_score32_noc_phase2_default_report_covers_full_declared_workload() -> No
     assert report["simulation"]["drain_minus_compute_layer_time_ns"] < 0.0
     assert report["simulation"]["router_contention_cycles"] > 0
     assert report["tag_semantics"]["collision_free_reuse_proven"] is True
+    assert report["tag_semantics"]["concrete_wire_tags_simulated"] is True
+    assert report["tag_semantics"]["schedule_order_is_independent_of_wire_tag"] is True
     assert report["tag_semantics"]["ordered_tuple_stream_proven"] is True
     assert report["tag_semantics"]["max_packets_per_tuple"] > 256
     assert any(

--- a/tests/test_noc_segmented_mesh.py
+++ b/tests/test_noc_segmented_mesh.py
@@ -1027,3 +1027,80 @@ def test_mesh_idle_fast_forward_preserves_absolute_delivery_cycles() -> None:
     ]
     assert len(accelerated.traces) < len(normal.traces)
     assert accelerated.endpoint_injected_flit_count == normal.endpoint_injected_flit_count
+
+
+def test_mesh_schedule_order_is_independent_of_wrapped_wire_tag() -> None:
+    flows = [
+        TrafficFlow(
+            name="before_wrap",
+            source=0,
+            destination=1,
+            payload_bytes=32,
+            vc=0,
+            release_cycle=0,
+            tag_base=255,
+            schedule_order=10,
+        ),
+        TrafficFlow(
+            name="after_wrap",
+            source=0,
+            destination=1,
+            payload_bytes=32,
+            vc=0,
+            release_cycle=0,
+            tag_base=0,
+            schedule_order=11,
+        ),
+    ]
+    scheduled = [item for flow in flows for item in packetize_traffic_flow(flow)]
+
+    result = simulate_scheduled_flits(scheduled, max_cycles=32)
+
+    assert [delivery.flit.label for delivery in result.deliveries] == [
+        "before_wrap",
+        "after_wrap",
+    ]
+    assert [delivery.flit.tag for delivery in result.deliveries] == [255, 0]
+
+
+def test_mesh_flow_and_packet_order_remain_distinct_across_tag_wrap() -> None:
+    flows = [
+        TrafficFlow(
+            name="multi_packet",
+            source=0,
+            destination=1,
+            payload_bytes=64,
+            packet_payload_bytes=32,
+            vc=0,
+            release_cycle=0,
+            tag_base=255,
+            schedule_order=10,
+        ),
+        TrafficFlow(
+            name="following_flow",
+            source=0,
+            destination=1,
+            payload_bytes=32,
+            packet_payload_bytes=32,
+            vc=0,
+            release_cycle=0,
+            tag_base=1,
+            schedule_order=11,
+        ),
+    ]
+    scheduled = [item for flow in flows for item in packetize_traffic_flow(flow)]
+
+    assert [(item.flit.tag, item.schedule_order, item.packet_order) for item in scheduled] == [
+        (255, 10, 0),
+        (0, 10, 1),
+        (1, 11, 0),
+    ]
+
+    result = simulate_scheduled_flits(scheduled, max_cycles=32)
+
+    assert [delivery.flit.label for delivery in result.deliveries] == [
+        "multi_packet",
+        "multi_packet",
+        "following_flow",
+    ]
+    assert [delivery.flit.tag for delivery in result.deliveries] == [255, 0, 1]


### PR DESCRIPTION
## Summary

- simulate the Phase-2 NoC workload with the RTL wire protocol's concrete modulo-256 tags
- carry producer flow and packet order as simulator-only metadata instead of deriving injection order from tags
- add wraparound and multi-packet ordering regressions
- disclose concrete-tag simulation in the Phase-2 evidence report

## Root cause

The Phase-2 performance schedule assigned an unbounded packet ordinal to `ModelFlit.tag` and used that tag as an injection sort key. RTL carries only an 8-bit tag, so the schedule result did not directly model the protocol at tag wrap.

## Validation

- `python -m pytest -q tests/test_noc_segmented_mesh.py -k "not segmented_router_wrapper_generates_and_compiles"` (9 passed, 1 deselected; the deselected compile test requires the rebuilt non-root ORFS image)
- `python -m pytest -q tests/test_llm_decoder_attention_score32_noc_phase2_schedule.py tests/test_noc_sram_packet_endpoint.py tests/test_noc_sram_packet_mesh4x4.py` (14 passed)
- `python scripts/validate_runs.py --skip_eval_queue`
- full Phase-2 replay remains 397,004 cycles, 11,576 packets, 92,128 flits, 36,762 contention cycles, and 320,240 endpoint stall cycles