### PR TITLE
Add workload-complete endpoint mesh RTL equivalence

### DIFF
--- a/.github/workflows/npu-golden-sim.yml
+++ b/.github/workflows/npu-golden-sim.yml
@@ -53,6 +53,7 @@ jobs:
             libgtest-dev \
             ca-certificates \
             wget
+          python3 -m pip install pytest
 
       - name: Install OR-Tools C++ runtime
         run: |
@@ -94,6 +95,13 @@ jobs:
 
       - name: Run mapper split regression tests
         run: python3 tests/test_mapper_split.py
+
+      - name: Run endpoint mesh equivalence tests
+        run: |
+          python3 -m pytest -q \
+            tests/test_noc_sram_packet_mesh_perf.py \
+            tests/test_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py \
+            tests/test_llm_decoder_attention_score32_noc_phase2_schedule.py
 
       - name: Run NPU golden simulation
         run: bash npu/sim/run_golden.sh

--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -595,6 +595,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_score32_noc_phase2_composed_mesh_reroute_report",
     ),
     (
+        "attention_score32_noc_phase2_endpoint_rtl_equivalence_out",
+        "attention_score32_noc_phase2_endpoint_rtl_equivalence_report",
+    ),
+    (
         "attention_score32_folded_global_exact_reduction_recost_out",
         "attention_score32_folded_global_exact_reduction_recost_report",
     ),

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5558,6 +5558,100 @@ def _decoder_attention_score32_noc_phase2_composed_mesh_reroute_evidence(
     }
 
 
+def _decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_evidence(
+    *,
+    item_id: str,
+    depends_on_item_ids: list[str] | None,
+    proposal_id: str | None,
+    proposal_path: str | None,
+) -> dict[str, Any]:
+    expected_item_id = (
+        "l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_llama7b_v1"
+    )
+    expected_proposal_id = (
+        "prop_l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_v1"
+    )
+    if item_id != expected_item_id:
+        raise Layer2TaskGenerationError("score32 endpoint/RTL equivalence only permits the exact item")
+    if str(proposal_id or "").strip() != expected_proposal_id:
+        raise Layer2TaskGenerationError("score32 endpoint/RTL equivalence proposal_id mismatch")
+    if str(proposal_path or "").strip() != f"docs/proposals/{expected_proposal_id}/proposal.json":
+        raise Layer2TaskGenerationError("score32 endpoint/RTL equivalence proposal_path mismatch")
+    if list(depends_on_item_ids or []):
+        raise Layer2TaskGenerationError(
+            "score32 endpoint/RTL equivalence regenerates its source schedule and has no item dependency"
+        )
+
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    source = (
+        f"{base}/decoder_attention_score32_exact_reduction_recost__"
+        "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1.json"
+    )
+    measured_costs = (
+        "runs/campaigns/npu/l1_measured_costs/"
+        "llama7b_attention_local_costs_all_measured_endpoint_v1.json"
+    )
+    out = f"{base}/decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence__{item_id}.json"
+    report = f"{base}/decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence__{item_id}.md"
+    command = _bounded_launcher_command(
+        memory_high="4G",
+        memory_max="6G",
+        cpu_quota="200%",
+        tasks_max=128,
+        runtime_max_sec=3600,
+        child_command=[
+            "python3",
+            "npu/eval/verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py",
+            "--repo-root",
+            ".",
+            "--source-json",
+            source,
+            "--measured-l1-costs",
+            measured_costs,
+            "--wall-timeout-seconds",
+            "2400",
+            "--out",
+            out,
+            "--report",
+            report,
+        ],
+    )
+    return {
+        "inputs": {
+            "attention_score32_noc_phase2_source_recost": source,
+            "attention_score32_noc_phase2_measured_l1_costs": measured_costs,
+            "attention_score32_noc_phase2_endpoint_rtl_equivalence_out": out,
+            "attention_score32_noc_phase2_endpoint_rtl_equivalence_report": report,
+        },
+        "commands": [
+            {
+                "name": "verify_attention_score32_noc_phase2_endpoint_rtl_equivalence",
+                "run": command,
+            }
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+        "worker_resources": {
+            "exclusive_worker": True,
+            "memory_high": "4G",
+            "memory_max": "6G",
+            "cpu_quota": "200%",
+            "tasks_max": 128,
+            "outer_timeout_seconds": 3900,
+            "stall_timeout_seconds": 1200,
+        },
+        "acceptance": [
+            "Replay all eight waves and every generated packet through finite endpoint and composed-mesh RTL",
+            "Install every receive descriptor before releasing its paired transmit descriptor",
+            "Use one-cycle in-order source SRAM responses, four-entry TX descriptor FIFOs, eight outstanding reads, and eight RX contexts",
+            "Require exact performance/RTL agreement for packets, flits, drain cycles, contention, stalls, and occupancy",
+            "Require zero endpoint protocol errors and concrete 8-bit wire tags",
+            "Keep SRAM bitcells, synthesized command scheduler, workload activity power, and HBM/DRAM explicit",
+            "Write exactly one JSON and one Markdown report",
+        ],
+    }
+
+
 def _decoder_attention_kv_endpoint_full_onchip_service_schedule_evidence(
     *,
     item_id: str,
@@ -12435,6 +12529,7 @@ def _build_payload(
         "decoder_attention_score32_noc_phase2_measured_router_closure",
         "decoder_attention_score32_noc_phase2_measured_router_clock_reroute",
         "decoder_attention_score32_noc_phase2_composed_mesh_reroute",
+        "decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence",
         "decoder_attention_kv_endpoint_full_onchip_service_schedule",
         "decoder_attention_kv_endpoint_ready_valid_service",
         "decoder_attention_kv_endpoint_router_sram_composition",
@@ -12678,6 +12773,13 @@ def _build_payload(
             )
         elif abstraction_layer_name == "decoder_attention_score32_noc_phase2_composed_mesh_reroute":
             decoder_evidence = _decoder_attention_score32_noc_phase2_composed_mesh_reroute_evidence(
+                item_id=item_id,
+                depends_on_item_ids=depends_on_item_ids,
+                proposal_id=proposal_id,
+                proposal_path=proposal_path,
+            )
+        elif abstraction_layer_name == "decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence":
+            decoder_evidence = _decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_evidence(
                 item_id=item_id,
                 depends_on_item_ids=depends_on_item_ids,
                 proposal_id=proposal_id,

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -14818,6 +14818,60 @@ def test_generate_l2_campaign_task_adds_score32_noc_composed_mesh_reroute() -> N
             )
 
 
+def test_generate_l2_campaign_task_adds_score32_endpoint_rtl_equivalence() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                _make_l2_request(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=(
+                        "l2_decoder_attention_score32_noc_phase2_"
+                        "endpoint_rtl_equivalence_llama7b_v1"
+                    ),
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id=(
+                        "prop_l2_decoder_attention_score32_noc_phase2_"
+                        "endpoint_rtl_equivalence_v1"
+                    ),
+                    proposal_path=(
+                        "docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_"
+                        "endpoint_rtl_equivalence_v1/proposal.json"
+                    ),
+                    abstraction_layer=(
+                        "decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    depends_on_item_ids=[],
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            run = work_item.command_manifest[0]["run"]
+            assert work_item.state == WorkItemState.DISPATCH_PENDING
+            assert "verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py" in run
+            assert "--runtime-max-sec 3600" in run
+            assert "--memory-high 4G" in run
+            assert "--memory-max 6G" in run
+            assert "--wall-timeout-seconds 2400" in run
+            assert work_item.input_manifest["worker_resources"]["exclusive_worker"] is True
+            assert work_item.input_manifest["worker_resources"]["stall_timeout_seconds"] == 1200
+            assert work_item.expected_outputs[0].endswith(
+                "decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence__"
+                "l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_llama7b_v1.json"
+            )
+
+
 def test_score32_noc_closure_rejects_inexact_dependencies() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_v1/README.md
@@ -1,0 +1,9 @@
+# Score32 Phase-2 Endpoint/RTL Equivalence
+
+- `proposal_id`: `prop_l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_v1`
+- scope: replay the complete Llama7B Phase-2 packet schedule through finite SRAM endpoints and the exact 4x4 mesh RTL
+- output: one JSON evidence file and one Markdown report
+
+This closes the logical zero-copy release-queue shortcut. The paired scheduler
+installs an RX context before releasing TX, obeys finite endpoint queues, and
+compares cycle and router counters against an endpoint-aware performance model.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_v1/design_brief.md
@@ -1,0 +1,19 @@
+# Design Brief
+
+The canonical Phase-2 packet list is converted to concrete descriptors with
+8-bit tags. Sixteen destination queues install receive contexts in static
+release order; sixteen source queues release transmit descriptors only after
+the matching receive handshake. Source SRAM provides one in-order response per
+cycle and destination SRAM accepts one write per cycle.
+
+The same descriptor list runs through:
+
+1. `npu.sim.perf.noc_sram_packet_mesh`, including finite queues and registered mesh credits.
+2. `noc_sram_packet_mesh4x4`, including all sixteen endpoints and routers.
+
+Packets, flits, drain cycles, aggregate contention, aggregate input stalls, and
+maximum occupancy must agree exactly. Every destination write checks address
+and payload identity, and every completion checks source, VC, and tag.
+
+SRAM bitcells, a synthesized command scheduler, HBM/DRAM, and activity-derived
+power remain outside this functional equivalence boundary.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_v1/evaluation_gate.md
@@ -1,0 +1,9 @@
+# Evaluation Gate
+
+- Use all eight declared waves; do not pass `--wave-limit`.
+- Require every paired RX descriptor to handshake before TX release.
+- Require concrete modulo-256 tags and zero endpoint protocol errors.
+- Require all 11,576 canonical packets and 92,128 canonical flits unless the corrected source schedule changes at the required commit.
+- Require exact performance/RTL agreement for packets, flits, drain cycles, contention, input stalls, and maximum occupancy.
+- Enforce the bounded worker resource and timeout contract.
+- Produce only the declared JSON and Markdown artifacts.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_v1/evaluation_requests.json
@@ -1,0 +1,23 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_v1",
+  "source_commit": "TBD",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Prove workload-complete equivalence between the finite endpoint-aware performance model and composed endpoint/mesh RTL.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence",
+      "comparison_role": "closure_detail",
+      "status": "pending_after_merge",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": false,
+      "requires_materialized_refs": false,
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence__l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_llama7b_v1.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence__l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_llama7b_v1.md"
+      ],
+      "acceptance_notes": "Replay all eight waves through finite descriptor queues, one-cycle SRAM responses, eight RX contexts, and the exact composed mesh RTL. Require exact counter equivalence and keep physical SRAM, scheduler PPA, activity power, and HBM/DRAM explicit."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_v1/implementation_summary.md
@@ -1,0 +1,12 @@
+# Implementation Summary
+
+- Added a finite endpoint/scheduler cycle model around the registered-credit mesh.
+- Added a compact runtime workload manifest for the exact composed RTL.
+- Added direct SRAM write-data, address, completion, and protocol checks.
+- Added exact performance/RTL comparison for six schedule and router observables.
+- Added bounded evidence-only remote task generation and result consumption.
+
+The two-packet RTL/performance gate passes locally. A one-wave performance replay
+completed 1,583 packets and 12,604 flits in 61,414 cycles, 199 cycles beyond the
+logical release-queue model. The workload-complete RTL result is intentionally
+left to the remote evaluator.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_v1/promotion_gate.md
@@ -1,0 +1,14 @@
+# Promotion Gate
+
+Promotion requires the merged remote JSON and Markdown artifacts with:
+
+- `coverage=workload_complete`
+- all packet/flit equivalence flags true
+- exact cycle and router counter agreement
+- zero endpoint protocol errors
+- finite queue/context parameters recorded
+- remaining physical abstractions preserved
+
+Passing this gate permits replacing the logical release-queue timing with the
+finite endpoint cadence in the next composed PPA rerank. It does not promote
+SRAM, scheduler, activity power, or HBM/DRAM closure.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_v1/proposal.json
@@ -1,0 +1,39 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_v1",
+  "created_utc": "2026-08-16T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "equivalence",
+  "title": "Workload-complete finite endpoint and mesh RTL equivalence",
+  "hypothesis": "Finite descriptor queues, SRAM handshakes, receive contexts, and paired scheduling can replay the complete score32 Phase-2 traffic with exact agreement between the performance model and composed RTL while quantifying the latency hidden by logical release queues.",
+  "direct_comparison": {
+    "primary_question": "What drain-time and congestion change appears when the complete Llama7B Phase-2 schedule is constrained by embodied endpoint control and checked against RTL?",
+    "include": [
+      "all eight waves and every canonical packet",
+      "paired RX-before-TX descriptor scheduling",
+      "finite TX descriptor and outstanding-read limits",
+      "finite RX contexts and completion retirement",
+      "one-cycle source SRAM responses and direct destination writes",
+      "all sixteen endpoints and deterministic-XY routers"
+    ],
+    "exclude": [
+      "SRAM bitcells and macro floorplanning",
+      "synthesized command-scheduler PPA",
+      "workload-derived switching power",
+      "HBM/DRAM controller implementation"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": false,
+      "requires_materialized_refs": false
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exact_reduction_recost__l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1.json",
+    "npu/sim/rtl/noc_sram_packet_mesh4x4.sv"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_v1/quality_gate.md
@@ -1,0 +1,14 @@
+# Quality Gate
+
+Run:
+
+```sh
+python3 -m pytest -q \
+  tests/test_noc_sram_packet_mesh_perf.py \
+  tests/test_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py \
+  tests/test_llm_decoder_attention_score32_noc_phase2_schedule.py
+```
+
+Also require the focused L2 generator test, result-consumer tests, run
+validation, and `git diff --check`. The remote command must remain bounded and
+must not emit per-flit traces as declared artifacts.

--- a/npu/docs/noc_sram_packet_mesh4x4_contract.md
+++ b/npu/docs/noc_sram_packet_mesh4x4_contract.md
@@ -44,3 +44,12 @@ the complete sixteen-endpoint/sixteen-router hierarchy.
 
 This is functional composition evidence. Aggregate physical placement and
 workload-matched switching activity remain separate gates.
+
+The workload replay extension uses compact runtime descriptor memories to
+exercise the same hierarchy without embedding a packet list in generated RTL.
+Its paired scheduler installs each receive context before transmit release,
+serves one-cycle in-order source SRAM responses, verifies every destination
+write and completion, and compares drain/congestion counters with
+`npu.sim.perf.noc_sram_packet_mesh`. A local eight-source contention gate proves
+exact counters with full RX-context occupancy; the workload-complete Llama7B
+replay remains a bounded remote evaluation gate.

--- a/npu/eval/measure_llm_decoder_attention_score32_noc_phase2_schedule.py
+++ b/npu/eval/measure_llm_decoder_attention_score32_noc_phase2_schedule.py
@@ -381,7 +381,11 @@ def _home_endpoint(cluster_endpoints: list[int], *, cluster_index: int, wave: in
     return cluster_endpoints[(cluster_index + offset + ((wave + 1) * stride)) % len(cluster_endpoints)]
 
 
-def build_report(args: argparse.Namespace) -> JsonDict:
+def build_report(
+    args: argparse.Namespace,
+    *,
+    packet_spec_output: list[PacketSpec] | None = None,
+) -> JsonDict:
     repo_root = args.repo_root.resolve()
     source_json = repo_root / args.source_json
     costs_json = repo_root / args.measured_l1_costs
@@ -551,6 +555,9 @@ def build_report(args: argparse.Namespace) -> JsonDict:
                     )
                     packet_specs.extend(new_specs)
                     packet_seed_counter += len(new_specs)
+
+    if packet_spec_output is not None:
+        packet_spec_output.extend(packet_specs)
 
     traffic_flows = _packetize_specs_with_concrete_tags(packet_specs)
     scheduled_flits = [scheduled for flow in traffic_flows for scheduled in packetize_traffic_flow(flow)]

--- a/npu/eval/verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py
+++ b/npu/eval/verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py
@@ -216,10 +216,16 @@ def run_rtl_replay(
             str(repo_root / RTL_TB),
         ],
         cwd=repo_root,
-        check=True,
+        check=False,
         capture_output=True,
         text=True,
     )
+    if compile_result.returncode != 0:
+        raise RuntimeError(
+            "endpoint mesh RTL compilation failed\n"
+            f"stdout:\n{compile_result.stdout}\n"
+            f"stderr:\n{compile_result.stderr}"
+        )
     expected_flits = sum(packet.flit_count for packet in packets)
     command = [
         _tool("vvp"),

--- a/npu/eval/verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py
+++ b/npu/eval/verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""Replay the Llama7B Phase-2 packet schedule through endpoint plus mesh RTL."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from npu.eval.measure_llm_decoder_attention_score32_noc_phase2_schedule import (  # noqa: E402
+    DEFAULT_MEASURED_L1_COSTS,
+    DEFAULT_SOURCE_JSON,
+    PacketSpec,
+    _packetize_specs_with_concrete_tags,
+    build_report,
+)
+from npu.sim.perf.noc_sram_packet_mesh import (  # noqa: E402
+    PacketDescriptor,
+    simulate_packet_mesh,
+)
+
+JsonDict = dict[str, Any]
+MAX_PACKETS = 12000
+RTL_SOURCES = (
+    Path("npu/sim/rtl/noc_ready_valid_fifo.sv"),
+    Path("npu/sim/rtl/noc_segmented_mesh_router.sv"),
+    Path("npu/sim/rtl/noc_segmented_mesh4x4.sv"),
+    Path("npu/sim/rtl/noc_sram_packet_endpoint.sv"),
+    Path("npu/sim/rtl/noc_sram_packet_mesh4x4.sv"),
+)
+RTL_TB = Path("tests/noc_sram_packet_mesh4x4_workload_tb.sv")
+PASS_RE = re.compile(
+    r"PASS workload packets=(?P<packets>\d+) flits=(?P<flits>\d+) "
+    r"cycles=(?P<cycles>\d+) contention=(?P<contention>\d+) "
+    r"input_stalls=(?P<input_stalls>\d+) max_occupancy=(?P<max_occupancy>\d+)"
+)
+
+
+@dataclass(frozen=True)
+class WorkloadPacket:
+    packet_id: int
+    schedule_order: int
+    release_cycle: int
+    source: int
+    destination: int
+    vc: int
+    tag: int
+    flit_count: int
+    label: str
+
+
+@dataclass(frozen=True)
+class WorkloadMemoryPaths:
+    descriptors: Path
+    source_order: Path
+    destination_order: Path
+    source_meta: Path
+    destination_meta: Path
+
+
+def _tool(name: str) -> str:
+    candidate = shutil.which(name)
+    if candidate:
+        return candidate
+    bundled = Path("/oss-cad-suite/bin") / name
+    if bundled.exists():
+        return str(bundled)
+    raise RuntimeError(f"required RTL simulation tool is unavailable: {name}")
+
+
+def _flit_count(payload_bytes: int) -> int:
+    return (payload_bytes + 31) // 32
+
+
+def descriptors_from_packet_specs(packet_specs: list[PacketSpec]) -> list[WorkloadPacket]:
+    flows = _packetize_specs_with_concrete_tags(packet_specs)
+    if len(flows) != len(packet_specs):
+        raise ValueError("packet specification and concrete-tag flow counts differ")
+    if len(flows) > MAX_PACKETS:
+        raise ValueError(f"workload has {len(flows)} packets; RTL replay limit is {MAX_PACKETS}")
+    packets: list[WorkloadPacket] = []
+    for packet_id, (spec, flow) in enumerate(zip(packet_specs, flows, strict=True)):
+        flit_count = _flit_count(spec.payload_bytes)
+        if not 1 <= flit_count <= 8:
+            raise ValueError(f"packet {spec.label} has unsupported flit count {flit_count}")
+        packets.append(
+            WorkloadPacket(
+                packet_id=packet_id,
+                schedule_order=flow.schedule_order,
+                release_cycle=spec.release_cycle,
+                source=spec.source,
+                destination=spec.destination,
+                vc=spec.vc,
+                tag=flow.tag_base & 0xFF,
+                flit_count=flit_count,
+                label=spec.label,
+            )
+        )
+    return packets
+
+
+def _write_hex_lines(path: Path, values: Iterable[int], width: int) -> None:
+    path.write_text(
+        "".join(f"{value:0{width}x}\n" for value in values),
+        encoding="ascii",
+    )
+
+
+def _queue_order_and_meta(
+    packets: list[WorkloadPacket],
+    *,
+    endpoint_field: str,
+) -> tuple[list[int], list[int]]:
+    order: list[int] = []
+    meta: list[int] = []
+    for endpoint in range(16):
+        endpoint_packets = sorted(
+            (
+                packet
+                for packet in packets
+                if int(getattr(packet, endpoint_field)) == endpoint
+            ),
+            key=lambda packet: (packet.release_cycle, packet.schedule_order),
+        )
+        offset = len(order)
+        count = len(endpoint_packets)
+        if offset > 0xFFFF or count > 0xFFFF:
+            raise ValueError("workload queue metadata exceeds 16-bit fields")
+        order.extend(packet.packet_id for packet in endpoint_packets)
+        meta.append((count << 16) | offset)
+    if len(order) != len(packets) or sorted(order) != list(range(len(packets))):
+        raise ValueError(f"{endpoint_field} queue order is not a packet permutation")
+    return order, meta
+
+
+def write_workload_memories(
+    packets: list[WorkloadPacket],
+    output_dir: Path,
+) -> WorkloadMemoryPaths:
+    if not packets:
+        raise ValueError("RTL workload must contain at least one packet")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    descriptors = output_dir / "descriptors.mem"
+    source_order_path = output_dir / "source_order.mem"
+    destination_order_path = output_dir / "destination_order.mem"
+    source_meta_path = output_dir / "source_meta.mem"
+    destination_meta_path = output_dir / "destination_meta.mem"
+
+    words: list[int] = []
+    for expected_id, packet in enumerate(packets):
+        if packet.packet_id != expected_id:
+            raise ValueError("packet IDs must be dense and array ordered")
+        if not 0 <= packet.release_cycle <= 0xFFFFFFFF:
+            raise ValueError(f"packet {packet.label} release cycle exceeds 32 bits")
+        if not 0 <= packet.source < 16 or not 0 <= packet.destination < 16:
+            raise ValueError(f"packet {packet.label} endpoint is outside the 4x4 mesh")
+        if not 0 <= packet.vc < 4 or not 0 <= packet.tag < 256:
+            raise ValueError(f"packet {packet.label} VC/tag is outside the wire contract")
+        word = packet.release_cycle
+        word |= packet.source << 32
+        word |= packet.destination << 36
+        word |= packet.vc << 40
+        word |= packet.tag << 42
+        word |= packet.flit_count << 50
+        words.append(word)
+    _write_hex_lines(descriptors, words, 24)
+
+    source_order, source_meta = _queue_order_and_meta(packets, endpoint_field="source")
+    destination_order, destination_meta = _queue_order_and_meta(
+        packets, endpoint_field="destination"
+    )
+    _write_hex_lines(source_order_path, source_order, 4)
+    _write_hex_lines(destination_order_path, destination_order, 4)
+    _write_hex_lines(source_meta_path, source_meta, 8)
+    _write_hex_lines(destination_meta_path, destination_meta, 8)
+    return WorkloadMemoryPaths(
+        descriptors=descriptors,
+        source_order=source_order_path,
+        destination_order=destination_order_path,
+        source_meta=source_meta_path,
+        destination_meta=destination_meta_path,
+    )
+
+
+def run_rtl_replay(
+    *,
+    repo_root: Path,
+    packets: list[WorkloadPacket],
+    work_dir: Path,
+    timeout_cycles: int,
+    wall_timeout_seconds: int,
+) -> JsonDict:
+    memories = write_workload_memories(packets, work_dir)
+    simulator = work_dir / "phase2_endpoint_mesh.vvp"
+    compile_result = subprocess.run(
+        [
+            _tool("iverilog"),
+            "-g2012",
+            "-s",
+            "noc_sram_packet_mesh4x4_workload_tb",
+            "-o",
+            str(simulator),
+            *[str(repo_root / path) for path in RTL_SOURCES],
+            str(repo_root / RTL_TB),
+        ],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    expected_flits = sum(packet.flit_count for packet in packets)
+    command = [
+        _tool("vvp"),
+        str(simulator),
+        f"+PACKET_COUNT={len(packets)}",
+        f"+EXPECTED_FLITS={expected_flits}",
+        f"+TIMEOUT_CYCLES={timeout_cycles}",
+        f"+DESC_MEM={memories.descriptors}",
+        f"+SRC_ORDER_MEM={memories.source_order}",
+        f"+DST_ORDER_MEM={memories.destination_order}",
+        f"+SRC_META_MEM={memories.source_meta}",
+        f"+DST_META_MEM={memories.destination_meta}",
+    ]
+    process = subprocess.Popen(
+        command,
+        cwd=repo_root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    stdout_lines: list[str] = []
+    stderr_lines: list[str] = []
+
+    def _drain(stream: Any, lines: list[str], *, destination: Any) -> None:
+        for line in stream:
+            lines.append(line)
+            print(line, end="", file=destination, flush=True)
+
+    stdout_thread = threading.Thread(
+        target=_drain,
+        args=(process.stdout, stdout_lines),
+        kwargs={"destination": sys.stdout},
+        daemon=True,
+    )
+    stderr_thread = threading.Thread(
+        target=_drain,
+        args=(process.stderr, stderr_lines),
+        kwargs={"destination": sys.stderr},
+        daemon=True,
+    )
+    stdout_thread.start()
+    stderr_thread.start()
+    try:
+        return_code = process.wait(timeout=wall_timeout_seconds)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
+        raise
+    finally:
+        stdout_thread.join(timeout=10)
+        stderr_thread.join(timeout=10)
+    simulation_stdout = "".join(stdout_lines)
+    simulation_stderr = "".join(stderr_lines)
+    if return_code != 0:
+        raise subprocess.CalledProcessError(
+            return_code,
+            command,
+            output=simulation_stdout,
+            stderr=simulation_stderr,
+        )
+    match = PASS_RE.search(simulation_stdout)
+    if match is None:
+        raise ValueError(f"RTL replay did not emit its PASS record:\n{simulation_stdout}")
+    counters = {key: int(value) for key, value in match.groupdict().items()}
+    if counters["packets"] != len(packets) or counters["flits"] != expected_flits:
+        raise ValueError(f"RTL replay count mismatch: {counters}")
+    return {
+        "counters": counters,
+        "compile_stdout": compile_result.stdout,
+        "compile_stderr": compile_result.stderr,
+        "simulation_stdout": simulation_stdout,
+        "simulation_stderr": simulation_stderr,
+    }
+
+
+def run_performance_replay(
+    packets: list[WorkloadPacket],
+    *,
+    max_cycles: int,
+) -> JsonDict:
+    result = simulate_packet_mesh(
+        [
+            PacketDescriptor(
+                source=packet.source,
+                destination=packet.destination,
+                vc=packet.vc,
+                tag=packet.tag,
+                flit_count=packet.flit_count,
+                tx_base_addr=packet.packet_id << 8,
+                rx_base_addr=packet.packet_id << 8,
+                release_cycle=packet.release_cycle,
+                schedule_order=packet.schedule_order,
+                data_seed=packet.packet_id,
+                packet_id=packet.label,
+            )
+            for packet in packets
+        ],
+        max_cycles=max_cycles,
+    )
+    counters = {
+        "packets": len(result.completions),
+        "flits": len(result.destination_memory_writes),
+        "cycles": result.cycles,
+        "contention": sum(
+            router.arbitration_contention_cycles for router in result.router_summaries
+        ),
+        "input_stalls": sum(router.input_stall_cycles for router in result.router_summaries),
+        "max_occupancy": max(
+            (router.max_input_occupancy for router in result.router_summaries),
+            default=0,
+        ),
+        "max_rx_context_occupancy_per_endpoint": result.max_rx_context_occupancy,
+        "rx_descriptor_handshakes": len(result.rx_descriptor_handshakes),
+        "tx_descriptor_handshakes": len(result.tx_descriptor_handshakes),
+        "source_memory_requests": len(result.source_memory_requests),
+        "source_memory_responses": len(result.source_memory_responses),
+        "protocol_errors": list(result.protocol_errors),
+    }
+    expected_flits = sum(packet.flit_count for packet in packets)
+    required_counts = {
+        "packets": len(packets),
+        "flits": expected_flits,
+        "rx_descriptor_handshakes": len(packets),
+        "tx_descriptor_handshakes": len(packets),
+        "source_memory_requests": expected_flits,
+        "source_memory_responses": expected_flits,
+    }
+    mismatches = {
+        key: {"expected": expected, "observed": counters[key]}
+        for key, expected in required_counts.items()
+        if counters[key] != expected
+    }
+    if mismatches or counters["protocol_errors"]:
+        raise ValueError(
+            "endpoint-aware performance replay failed: "
+            f"count_mismatches={mismatches}, protocol_errors={counters['protocol_errors']}"
+        )
+    return counters
+
+
+def _schedule_args(args: argparse.Namespace) -> argparse.Namespace:
+    return argparse.Namespace(
+        repo_root=args.repo_root,
+        source_json=args.source_json,
+        measured_l1_costs=args.measured_l1_costs,
+        wave_limit=args.wave_limit,
+        packet_payload_bytes=256,
+        cluster_endpoints=None,
+        root_endpoint=15,
+        shared_vc=0,
+        reduction_vc=1,
+        compute_clock_ns=None,
+        noc_clock_ns=args.noc_clock_ns,
+        max_cycles=args.schedule_max_cycles,
+    )
+
+
+def build_and_run(args: argparse.Namespace) -> JsonDict:
+    packet_specs: list[PacketSpec] = []
+    schedule = build_report(_schedule_args(args), packet_spec_output=packet_specs)
+    packets = descriptors_from_packet_specs(packet_specs)
+    performance = run_performance_replay(packets, max_cycles=args.rtl_timeout_cycles)
+    with tempfile.TemporaryDirectory(prefix="rtlgen-phase2-endpoint-rtl-") as temporary:
+        replay = run_rtl_replay(
+            repo_root=args.repo_root.resolve(),
+            packets=packets,
+            work_dir=Path(temporary),
+            timeout_cycles=args.rtl_timeout_cycles,
+            wall_timeout_seconds=args.wall_timeout_seconds,
+        )
+    counters = replay["counters"]
+    compared_fields = ("packets", "flits", "cycles", "contention", "input_stalls", "max_occupancy")
+    mismatches = {
+        field: {"performance": performance[field], "rtl": counters[field]}
+        for field in compared_fields
+        if performance[field] != counters[field]
+    }
+    if mismatches:
+        raise ValueError(f"endpoint-aware performance/RTL mismatch: {mismatches}")
+    return {
+        "profile": "decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence",
+        "version": 1,
+        "coverage": schedule["source_contract"]["coverage"],
+        "source_schedule": {
+            "packet_count": schedule["simulation"]["scheduled_packet_count"],
+            "flit_count": schedule["simulation"]["scheduled_flit_count"],
+            "logical_release_queue_cycles_to_drain": schedule["simulation"]["cycles_to_drain"],
+        },
+        "rtl_replay": counters,
+        "endpoint_aware_performance_replay": performance,
+        "endpoint_cadence_delta_cycles": (
+            counters["cycles"] - schedule["simulation"]["cycles_to_drain"]
+        ),
+        "equivalence": {
+            "all_packets_completed": counters["packets"] == len(packets),
+            "all_flits_written": counters["flits"] == sum(packet.flit_count for packet in packets),
+            "rx_descriptor_precedes_tx_enforced": True,
+            "source_sram_response_latency_cycles": 1,
+            "rx_contexts_per_endpoint": 8,
+            "tx_descriptor_depth": 4,
+            "tx_outstanding_limit": 8,
+            "wire_tag_width_bits": 8,
+            "cycle_and_router_counter_match": True,
+        },
+        "remaining_abstractions": [
+            "SRAM arrays are transaction-accurate one-cycle ports; bitcells and macro placement remain external.",
+            "The command scheduler is embodied by the deterministic paired-descriptor testbench driver, not yet synthesized RTL.",
+            "HBM/DRAM and its controller remain intentionally outside the design boundary.",
+            "Workload-matched switching power requires a separate activity-capture run.",
+        ],
+    }
+
+
+def write_report(payload: JsonDict, path: Path) -> None:
+    source = payload["source_schedule"]
+    rtl = payload["rtl_replay"]
+    performance = payload["endpoint_aware_performance_replay"]
+    lines = [
+        "# Llama7B Phase-2 Endpoint/RTL Equivalence",
+        "",
+        f"- coverage: `{payload['coverage']}`",
+        f"- packets/flits: `{rtl['packets']}` / `{rtl['flits']}`",
+        f"- logical release-queue drain: `{source['logical_release_queue_cycles_to_drain']}` cycles",
+        f"- finite endpoint/RTL drain: `{rtl['cycles']}` cycles",
+        f"- endpoint cadence delta: `{payload['endpoint_cadence_delta_cycles']}` cycles",
+        f"- router contention/input stalls: `{rtl['contention']}` / `{rtl['input_stalls']}`",
+        f"- maximum router occupancy: `{rtl['max_occupancy']}`",
+        f"- maximum RX contexts used per endpoint: `{performance['max_rx_context_occupancy_per_endpoint']}`",
+        "- cycle and router counter equivalence: `true`",
+        "",
+        "## Remaining Abstractions",
+        "",
+    ]
+    lines.extend(f"- {item}" for item in payload["remaining_abstractions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--source-json", type=Path, default=DEFAULT_SOURCE_JSON)
+    parser.add_argument("--measured-l1-costs", type=Path, default=DEFAULT_MEASURED_L1_COSTS)
+    parser.add_argument("--wave-limit", type=int, default=None)
+    parser.add_argument("--noc-clock-ns", type=float, default=1.0)
+    parser.add_argument("--schedule-max-cycles", type=int, default=1000000)
+    parser.add_argument("--rtl-timeout-cycles", type=int, default=2000000)
+    parser.add_argument("--wall-timeout-seconds", type=int, default=1800)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--report", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_and_run(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_report(payload, args.report)
+    print(json.dumps(payload["rtl_replay"], sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/sim/perf/noc_sram_packet_mesh.py
+++ b/npu/sim/perf/noc_sram_packet_mesh.py
@@ -1,0 +1,793 @@
+"""Cycle model for the descriptor-driven SRAM packet mesh.
+
+This module models the control boundary of ``noc_sram_packet_mesh4x4``.  The
+router and registered-credit behavior are supplied by
+``noc_segmented_mesh``; this file adds the endpoint descriptor, SRAM, and
+receive-context timing around that mesh.
+
+The model deliberately keeps the packet payload in a deterministic read
+function.  It records the same metadata that crosses the RTL boundary, which
+is sufficient for scheduling and later full Phase-2 replay without allocating
+packet-sized registers.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Callable, Iterable, Mapping, Sequence
+
+from npu.sim.perf.noc_segmented_mesh import (
+    ENDPOINTS,
+    PORT_EAST,
+    PORT_LOCAL,
+    PORT_NORTH,
+    PORT_SOUTH,
+    PORT_WEST,
+    VIRTUAL_CHANNELS,
+    MeshCycleTrace,
+    MeshDelivery,
+    MeshLinkTransfer,
+    ModelFlit,
+    RouterCycleInput,
+    RouterSimulationResult,
+    _RouterState,
+    _neighbor,
+    coordinates,
+)
+
+TX_DESC_DEPTH = 4
+TX_OUTSTANDING = 8
+RX_CONTEXTS = 8
+MAX_PACKET_FLITS = 8
+FLIT_BYTES = 32
+
+
+@dataclass(frozen=True)
+class PacketDescriptor:
+    """One paired packet transfer described at both endpoint boundaries."""
+
+    source: int
+    destination: int
+    vc: int
+    tag: int
+    flit_count: int
+    tx_base_addr: int = 0
+    rx_base_addr: int = 0
+    release_cycle: int = 0
+    schedule_order: int = 0
+    data_seed: int = 0
+    packet_id: str = ""
+
+    def __post_init__(self) -> None:
+        if not 0 <= self.source < ENDPOINTS:
+            raise ValueError("source must be in [0, 15]")
+        if not 0 <= self.destination < ENDPOINTS:
+            raise ValueError("destination must be in [0, 15]")
+        if not 0 <= self.vc < VIRTUAL_CHANNELS:
+            raise ValueError("vc must be in [0, 3]")
+        if not 0 <= self.tag < 256:
+            raise ValueError("tag must be an 8-bit concrete wire value")
+        if not 1 <= self.flit_count <= MAX_PACKET_FLITS:
+            raise ValueError("flit_count must be in [1, 8]")
+        if self.release_cycle < 0:
+            raise ValueError("release_cycle must be non-negative")
+        if self.schedule_order < 0:
+            raise ValueError("schedule_order must be non-negative")
+
+    @property
+    def key(self) -> tuple[int, int, int]:
+        """The RX lookup key used by the RTL: ``(source, vc, tag)``."""
+
+        return self.source, self.vc, self.tag
+
+
+@dataclass(frozen=True)
+class DescriptorHandshake:
+    cycle: int
+    endpoint: int
+    direction: str
+    packet_index: int
+    descriptor: PacketDescriptor
+
+
+@dataclass(frozen=True)
+class SourceMemoryRequest:
+    cycle: int
+    endpoint: int
+    packet_index: int
+    address: int
+    fragment: int
+
+
+@dataclass(frozen=True)
+class SourceMemoryResponse:
+    cycle: int
+    endpoint: int
+    packet_index: int
+    fragment: int
+    address: int
+
+
+@dataclass(frozen=True)
+class DestinationMemoryWrite:
+    cycle: int
+    endpoint: int
+    packet_index: int
+    address: int
+    fragment: int
+    data: int
+
+
+@dataclass(frozen=True)
+class CompletionEvent:
+    cycle: int
+    endpoint: int
+    packet_index: int
+    source: int
+    vc: int
+    tag: int
+
+
+@dataclass(frozen=True)
+class CompletionHandshake:
+    cycle: int
+    endpoint: int
+    packet_index: int
+    source: int
+    vc: int
+    tag: int
+
+
+@dataclass(frozen=True)
+class PacketDelivery:
+    cycle: int
+    packet_index: int
+    flit: ModelFlit
+
+
+@dataclass(frozen=True)
+class PacketMeshResult:
+    """Observable result of a paired endpoint/mesh simulation."""
+
+    cycles: int
+    descriptors: tuple[PacketDescriptor, ...]
+    rx_descriptor_handshakes: tuple[DescriptorHandshake, ...]
+    tx_descriptor_handshakes: tuple[DescriptorHandshake, ...]
+    source_memory_requests: tuple[SourceMemoryRequest, ...]
+    source_memory_responses: tuple[SourceMemoryResponse, ...]
+    destination_memory_writes: tuple[DestinationMemoryWrite, ...]
+    completions: tuple[CompletionEvent, ...]
+    completion_handshakes: tuple[CompletionHandshake, ...]
+    deliveries: tuple[PacketDelivery, ...]
+    link_transfers: tuple[MeshLinkTransfer, ...]
+    router_summaries: tuple[RouterSimulationResult, ...]
+    protocol_errors: tuple[int, ...]
+    max_rx_context_occupancy: int = 0
+    mesh_traces: tuple[MeshCycleTrace, ...] = ()
+
+    @property
+    def delivered_flits(self) -> tuple[PacketDelivery, ...]:
+        return self.deliveries
+
+    @property
+    def rx_context_peak(self) -> int:
+        return self.max_rx_context_occupancy
+
+
+@dataclass
+class _TxRead:
+    due_cycle: int
+    packet_index: int
+    descriptor: PacketDescriptor
+    fragment: int
+    address: int
+
+
+@dataclass
+class _RxContext:
+    packet_index: int
+    descriptor: PacketDescriptor
+    expected_fragment: int = 0
+
+
+@dataclass
+class _EndpointState:
+    endpoint: int
+    tx_fifo_depth: int = TX_DESC_DEPTH
+    tx_outstanding_limit: int = TX_OUTSTANDING
+    rx_context_limit: int = RX_CONTEXTS
+    tx_fifo: deque[tuple[int, PacketDescriptor]] = field(default_factory=deque)
+    tx_active: tuple[int, PacketDescriptor] | None = None
+    tx_issue_fragment: int = 0
+    tx_reads: deque[_TxRead] = field(default_factory=deque)
+    tx_output: _TxRead | None = None
+    rx_contexts: dict[tuple[int, int, int], _RxContext] = field(default_factory=dict)
+    completion: tuple[int, CompletionEvent] | None = None
+    protocol_error: bool = False
+
+    def tx_pop_ready(self) -> bool:
+        return self.tx_active is None and bool(self.tx_fifo)
+
+    def tx_desc_ready(self) -> bool:
+        return len(self.tx_fifo) < self.tx_fifo_depth or self.tx_pop_ready()
+
+    def rx_desc_ready(self, descriptor: PacketDescriptor) -> bool:
+        return (
+            len(self.rx_contexts) < self.rx_context_limit
+            and descriptor.key not in self.rx_contexts
+        )
+
+    def source_request_ready(self, ready: bool) -> bool:
+        return (
+            ready
+            and self.tx_active is not None
+            and len(self.tx_reads) < self.tx_outstanding_limit
+        )
+
+    def source_response_ready(self, tx_flit_fire: bool) -> bool:
+        return bool(self.tx_reads) and (self.tx_output is None or tx_flit_fire)
+
+    def rx_ready_for_flit(
+        self,
+        flit: ModelFlit | None,
+        *,
+        destination_sram_ready: bool,
+        completion_ready: bool,
+    ) -> bool:
+        if flit is None:
+            return True
+        context = self.rx_contexts.get((flit.source, flit.vc, flit.tag))
+        valid = (
+            flit.destination == self.endpoint
+            and context is not None
+            and flit.fragment == context.expected_fragment
+            and flit.last == (flit.fragment + 1 == context.descriptor.flit_count)
+        )
+        if not valid:
+            # The RTL consumes malformed/misrouted input and raises its sticky
+            # error; it does not hold the mesh output for an SRAM write.
+            return True
+        return destination_sram_ready and (
+            not flit.last or self.completion is None or completion_ready
+        )
+
+    def accept_rx_descriptor(self, packet_index: int, descriptor: PacketDescriptor) -> None:
+        if not self.rx_desc_ready(descriptor):
+            raise RuntimeError("RX descriptor accepted without a free context")
+        self.rx_contexts[descriptor.key] = _RxContext(packet_index, descriptor)
+
+    def accept_rx_flit(
+        self,
+        cycle: int,
+        flit: ModelFlit,
+        *,
+        destination_sram_ready: bool,
+        completion_ready: bool,
+    ) -> tuple[DestinationMemoryWrite | None, CompletionEvent | None, bool]:
+        context = self.rx_contexts.get((flit.source, flit.vc, flit.tag))
+        valid = (
+            flit.destination == self.endpoint
+            and context is not None
+            and flit.fragment == context.expected_fragment
+            and flit.last == (flit.fragment + 1 == context.descriptor.flit_count)
+        )
+        if not valid:
+            self.protocol_error = True
+            return None, None, True
+        if not destination_sram_ready:
+            raise RuntimeError("mesh delivered a flit while destination SRAM was not ready")
+        if flit.last and self.completion is not None and not completion_ready:
+            raise RuntimeError("mesh delivered a final flit while completion was blocked")
+
+        if self.completion is not None and completion_ready:
+            self.completion = None
+        address = context.descriptor.rx_base_addr + flit.fragment * FLIT_BYTES
+        write = DestinationMemoryWrite(
+            cycle=cycle,
+            endpoint=self.endpoint,
+            packet_index=context.packet_index,
+            address=address,
+            fragment=flit.fragment,
+            data=flit.data,
+        )
+        completion: CompletionEvent | None = None
+        if flit.last:
+            completion = CompletionEvent(
+                cycle=cycle,
+                endpoint=self.endpoint,
+                packet_index=context.packet_index,
+                source=flit.source,
+                vc=flit.vc,
+                tag=flit.tag,
+            )
+            del self.rx_contexts[flit.source, flit.vc, flit.tag]
+            self.completion = (context.packet_index, completion)
+        else:
+            context.expected_fragment += 1
+        return write, completion, True
+
+    def apply_cycle(
+        self,
+        *,
+        packet_index: int | None,
+        tx_descriptor: PacketDescriptor | None,
+        tx_pop: bool,
+        tx_request: SourceMemoryRequest | None,
+        response: SourceMemoryResponse | None,
+        tx_flit_fire: bool,
+        cycle: int,
+    ) -> None:
+        if tx_pop:
+            if self.tx_active is not None or not self.tx_fifo:
+                raise RuntimeError("invalid TX descriptor pop")
+            self.tx_active = self.tx_fifo.popleft()
+            self.tx_issue_fragment = 0
+        if tx_descriptor is not None:
+            if packet_index is None:
+                raise RuntimeError("TX descriptor lacks packet index")
+            if not self.tx_desc_ready():
+                raise RuntimeError("TX descriptor accepted without FIFO space")
+            self.tx_fifo.append((packet_index, tx_descriptor))
+
+        if tx_flit_fire:
+            if self.tx_output is None:
+                raise RuntimeError("TX flit handshake without a valid output")
+            self.tx_output = None
+        if response is not None:
+            if not self.tx_reads:
+                raise RuntimeError("source response without an outstanding read")
+            read = self.tx_reads.popleft()
+            if read.packet_index != response.packet_index or read.fragment != response.fragment:
+                raise RuntimeError("source response lost in-order metadata")
+            self.tx_output = read
+
+        if tx_request is not None:
+            if self.tx_active is None:
+                raise RuntimeError("source request without an active descriptor")
+            descriptor = self.tx_active[1]
+            self.tx_reads.append(
+                _TxRead(
+                    due_cycle=cycle + 1,
+                    packet_index=self.tx_active[0],
+                    descriptor=descriptor,
+                    fragment=tx_request.fragment,
+                    address=tx_request.address,
+                )
+            )
+            if tx_request.fragment + 1 == descriptor.flit_count:
+                self.tx_active = None
+                self.tx_issue_fragment = 0
+            else:
+                self.tx_issue_fragment += 1
+
+
+ReadySchedule = (
+    Sequence[Sequence[bool]]
+    | Mapping[int, Sequence[bool]]
+    | Callable[[int, int], bool]
+    | None
+)
+
+
+def _ready(schedule: ReadySchedule, cycle: int, endpoint: int) -> bool:
+    if schedule is None:
+        return True
+    if callable(schedule):
+        return bool(schedule(cycle, endpoint))
+    if isinstance(schedule, Mapping):
+        row = schedule.get(cycle)
+        return True if row is None else bool(row[endpoint])
+    if cycle >= len(schedule):
+        return True
+    row = schedule[cycle]
+    if len(row) != ENDPOINTS:
+        raise ValueError("ready schedule rows must contain 16 endpoint values")
+    return bool(row[endpoint])
+
+
+def _flit_for_read(read: _TxRead) -> ModelFlit:
+    descriptor = read.descriptor
+    return ModelFlit(
+        source=descriptor.source,
+        destination=descriptor.destination,
+        tag=descriptor.tag,
+        fragment=read.fragment,
+        last=read.fragment + 1 == descriptor.flit_count,
+        vc=descriptor.vc,
+        data=(descriptor.data_seed << 16) | (read.fragment & 0xFF),
+        label=descriptor.packet_id,
+    )
+
+
+def _ordered_indices(descriptors: Sequence[PacketDescriptor]) -> tuple[int, ...]:
+    return tuple(sorted(range(len(descriptors)), key=lambda i: (descriptors[i].release_cycle, descriptors[i].schedule_order, i)))
+
+
+def simulate_packet_mesh(
+    descriptors: Iterable[PacketDescriptor],
+    *,
+    destination_sram_ready_schedule: ReadySchedule = None,
+    source_sram_request_ready_schedule: ReadySchedule = None,
+    completion_ready_schedule: ReadySchedule = None,
+    max_cycles: int = 1_000_000,
+    record_mesh_trace: bool = False,
+) -> PacketMeshResult:
+    """Simulate paired descriptors and the existing registered-credit mesh.
+
+    RX descriptors are scheduled one per destination endpoint per cycle.  A
+    TX descriptor is eligible only in a cycle strictly after its RX handshake,
+    and is scheduled one per source endpoint per cycle.  Ready schedules are
+    indexed as ``[cycle][endpoint]``; a callable may be used for large replay
+    workloads without materializing a matrix.
+    """
+
+    packet_list = tuple(descriptors)
+    if not packet_list:
+        return PacketMeshResult(
+            cycles=0,
+            descriptors=(),
+            rx_descriptor_handshakes=(),
+            tx_descriptor_handshakes=(),
+            source_memory_requests=(),
+            source_memory_responses=(),
+            destination_memory_writes=(),
+            completions=(),
+            completion_handshakes=(),
+            deliveries=(),
+            link_transfers=(),
+            router_summaries=(),
+            protocol_errors=(),
+        )
+
+    states = [_EndpointState(endpoint) for endpoint in range(ENDPOINTS)]
+    routers = [
+        _RouterState(
+            x_coord=coordinates(endpoint)[0],
+            y_coord=coordinates(endpoint)[1],
+            fifo_depth=4,
+            vc_count=VIRTUAL_CHANNELS,
+        )
+        for endpoint in range(ENDPOINTS)
+    ]
+    rx_done: list[int | None] = [None] * len(packet_list)
+    tx_done: list[int | None] = [None] * len(packet_list)
+    ordered_indices = _ordered_indices(packet_list)
+    rx_queues = [deque() for _ in range(ENDPOINTS)]
+    tx_queues = [deque() for _ in range(ENDPOINTS)]
+    for index in ordered_indices:
+        descriptor = packet_list[index]
+        rx_queues[descriptor.destination].append(index)
+        tx_queues[descriptor.source].append(index)
+    rx_done_count = 0
+    tx_done_count = 0
+    rx_handshakes: list[DescriptorHandshake] = []
+    tx_handshakes: list[DescriptorHandshake] = []
+    source_requests: list[SourceMemoryRequest] = []
+    source_responses: list[SourceMemoryResponse] = []
+    destination_writes: list[DestinationMemoryWrite] = []
+    completions: list[CompletionEvent] = []
+    completion_handshakes: list[CompletionHandshake] = []
+    deliveries: list[PacketDelivery] = []
+    link_transfers: list[MeshLinkTransfer] = []
+    mesh_traces: list[MeshCycleTrace] = []
+    router_traces: list[list] = [[] for _ in range(ENDPOINTS)]
+    router_forwarded: list[list[tuple[int, ModelFlit]]] = [[] for _ in range(ENDPOINTS)]
+    max_rx_context_occupancy = 0
+
+    for cycle in range(max_cycles):
+        # Descriptor scheduling is intentionally separate from data movement.
+        # An RX handshake at this edge cannot make a same-edge TX release
+        # legal, matching the RTL's registered descriptor state.
+        rx_push: dict[int, int] = {}
+        for endpoint, queue in enumerate(rx_queues):
+            if not queue:
+                continue
+            index = queue[0]
+            descriptor = packet_list[index]
+            if (
+                descriptor.release_cycle <= cycle
+                and states[endpoint].rx_desc_ready(descriptor)
+            ):
+                rx_push[endpoint] = index
+
+        tx_push: dict[int, int] = {}
+        for endpoint, queue in enumerate(tx_queues):
+            if not queue or not states[endpoint].tx_desc_ready():
+                continue
+            index = queue[0]
+            descriptor = packet_list[index]
+            if (
+                rx_done[index] is not None
+                and rx_done[index] < cycle
+                and descriptor.release_cycle <= cycle
+            ):
+                tx_push[endpoint] = index
+
+        tx_pop = [state.tx_pop_ready() for state in states]
+        tx_requests_by_endpoint: list[SourceMemoryRequest | None] = [None] * ENDPOINTS
+        for endpoint, state in enumerate(states):
+            if not state.source_request_ready(
+                _ready(source_sram_request_ready_schedule, cycle, endpoint)
+            ):
+                continue
+            assert state.tx_active is not None
+            packet_index, descriptor = state.tx_active
+            fragment = state.tx_issue_fragment
+            tx_requests_by_endpoint[endpoint] = SourceMemoryRequest(
+                cycle=cycle,
+                endpoint=endpoint,
+                packet_index=packet_index,
+                address=descriptor.tx_base_addr + fragment * FLIT_BYTES,
+                fragment=fragment,
+            )
+
+        # The endpoint output register and router state are sampled before the
+        # edge.  This is the same registered-credit sequencing as the mesh
+        # model: local injection is accepted into a router FIFO, while a held
+        # local output can be delivered on this edge.
+        router_inputs: list[list[RouterCycleInput]] = []
+        for endpoint, state in enumerate(states):
+            inputs = [RouterCycleInput(False, None) for _ in range(5)]
+            if state.tx_output is not None:
+                inputs[PORT_LOCAL] = RouterCycleInput(True, _flit_for_read(state.tx_output))
+            for port in (PORT_NORTH, PORT_SOUTH, PORT_EAST, PORT_WEST):
+                neighbor = _neighbor(endpoint, port)
+                if neighbor is None:
+                    continue
+                upstream, upstream_port = neighbor
+                held = routers[upstream].out_holding[upstream_port]
+                if held is not None:
+                    inputs[port] = RouterCycleInput(True, held)
+            router_inputs.append(inputs)
+
+        endpoint_out_ready: list[bool] = []
+        for endpoint, state in enumerate(states):
+            held = routers[endpoint].out_holding[PORT_LOCAL]
+            endpoint_out_ready.append(
+                state.rx_ready_for_flit(
+                    held,
+                    destination_sram_ready=_ready(destination_sram_ready_schedule, cycle, endpoint),
+                    completion_ready=_ready(completion_ready_schedule, cycle, endpoint),
+                )
+            )
+
+        out_ready = [[False] * 5 for _ in range(ENDPOINTS)]
+        for endpoint in range(ENDPOINTS):
+            out_ready[endpoint][PORT_LOCAL] = endpoint_out_ready[endpoint]
+        credit_plans = [
+            routers[endpoint].compute_plan(router_inputs[endpoint], [False] * 5)
+            for endpoint in range(ENDPOINTS)
+        ]
+        for endpoint in range(ENDPOINTS):
+            for port in (PORT_NORTH, PORT_SOUTH, PORT_EAST, PORT_WEST):
+                neighbor = _neighbor(endpoint, port)
+                if neighbor is None:
+                    out_ready[endpoint][port] = True
+                else:
+                    downstream, downstream_port = neighbor
+                    out_ready[endpoint][port] = credit_plans[downstream].ready[downstream_port]
+        plans = [
+            routers[endpoint].compute_plan(router_inputs[endpoint], out_ready[endpoint])
+            for endpoint in range(ENDPOINTS)
+        ]
+
+        cycle_router_traces = []
+        cycle_deliveries: list[MeshDelivery] = []
+        cycle_links: list[MeshLinkTransfer] = []
+        tx_flit_fires = [False] * ENDPOINTS
+        rx_flit_events: list[tuple[int, ModelFlit] | None] = [None] * ENDPOINTS
+        for endpoint in range(ENDPOINTS):
+            trace = routers[endpoint].apply_plan(
+                cycle, router_inputs[endpoint], out_ready[endpoint], plans[endpoint]
+            )
+            cycle_router_traces.append(trace)
+            if record_mesh_trace:
+                router_traces[endpoint].append(trace)
+                router_forwarded[endpoint].extend(trace.forwarded)
+            if router_inputs[endpoint][PORT_LOCAL].valid and trace.ready[PORT_LOCAL]:
+                tx_flit_fires[endpoint] = True
+            for port, flit in trace.forwarded:
+                if port == PORT_LOCAL:
+                    delivery = MeshDelivery(cycle=cycle, endpoint=endpoint, flit=flit)
+                    cycle_deliveries.append(delivery)
+                    rx_flit_events[endpoint] = (endpoint, flit)
+                else:
+                    neighbor = _neighbor(endpoint, port)
+                    if neighbor is None:
+                        continue
+                    destination_node, destination_port = neighbor
+                    cycle_links.append(
+                        MeshLinkTransfer(
+                            cycle=cycle,
+                            source_node=endpoint,
+                            source_port=port,
+                            destination_node=destination_node,
+                            destination_port=destination_port,
+                            flit=flit,
+                        )
+                    )
+
+        # A response due this cycle can replace an output flit that was
+        # accepted on this same edge, exactly as tx_mem_rsp_ready permits.
+        response_by_endpoint: list[SourceMemoryResponse | None] = [None] * ENDPOINTS
+        for endpoint, state in enumerate(states):
+            if state.tx_reads and state.tx_reads[0].due_cycle <= cycle:
+                if state.source_response_ready(tx_flit_fires[endpoint]):
+                    read = state.tx_reads[0]
+                    response_by_endpoint[endpoint] = SourceMemoryResponse(
+                        cycle=cycle,
+                        endpoint=endpoint,
+                        packet_index=read.packet_index,
+                        fragment=read.fragment,
+                        address=read.address,
+                    )
+
+        for endpoint, state in enumerate(states):
+            packet_index = tx_push.get(endpoint)
+            descriptor = packet_list[packet_index] if packet_index is not None else None
+            request = tx_requests_by_endpoint[endpoint]
+            response = response_by_endpoint[endpoint]
+            if request is not None:
+                source_requests.append(request)
+            if response is not None:
+                source_responses.append(response)
+            state.apply_cycle(
+                packet_index=packet_index,
+                tx_descriptor=descriptor,
+                tx_pop=tx_pop[endpoint],
+                tx_request=request,
+                response=response,
+                tx_flit_fire=tx_flit_fires[endpoint],
+                cycle=cycle,
+            )
+            if endpoint in rx_push:
+                index = rx_push[endpoint]
+                if not rx_queues[endpoint] or rx_queues[endpoint][0] != index:
+                    raise RuntimeError("RX scheduler queue lost packet order")
+                rx_queues[endpoint].popleft()
+                state.accept_rx_descriptor(index, packet_list[index])
+                rx_done[index] = cycle
+                rx_done_count += 1
+                rx_handshakes.append(
+                    DescriptorHandshake(cycle, endpoint, "rx", index, packet_list[index])
+                )
+            if endpoint in tx_push:
+                index = tx_push[endpoint]
+                if not tx_queues[endpoint] or tx_queues[endpoint][0] != index:
+                    raise RuntimeError("TX scheduler queue lost packet order")
+                tx_queues[endpoint].popleft()
+                tx_done[index] = cycle
+                tx_done_count += 1
+                tx_handshakes.append(
+                    DescriptorHandshake(cycle, endpoint, "tx", index, packet_list[index])
+                )
+            if state.completion is not None and _ready(completion_ready_schedule, cycle, endpoint):
+                packet_index_completion, completion = state.completion
+                completion_handshakes.append(
+                    CompletionHandshake(
+                        cycle=cycle,
+                        endpoint=endpoint,
+                        packet_index=packet_index_completion,
+                        source=completion.source,
+                        vc=completion.vc,
+                        tag=completion.tag,
+                    )
+                )
+                # The RTL clears the held completion at this edge.  A new
+                # final RX flit in the same edge may install the next event.
+                state.completion = None
+
+        for endpoint, event in enumerate(rx_flit_events):
+            if event is None:
+                continue
+            _, flit = event
+            context = states[endpoint].rx_contexts.get((flit.source, flit.vc, flit.tag))
+            if context is None:
+                packet_index = _packet_index_for_flit(flit, packet_list)
+            else:
+                packet_index = context.packet_index
+            delivery = PacketDelivery(cycle, packet_index, flit)
+            deliveries.append(delivery)
+            write, completion, _ = states[endpoint].accept_rx_flit(
+                cycle,
+                flit,
+                destination_sram_ready=_ready(destination_sram_ready_schedule, cycle, endpoint),
+                completion_ready=_ready(completion_ready_schedule, cycle, endpoint),
+            )
+            if write is not None:
+                destination_writes.append(write)
+            if completion is not None:
+                completions.append(completion)
+
+        # Completion is intentionally generated by accept_rx_flit after the
+        # final write, matching the RTL's registered completion output.
+        link_transfers.extend(cycle_links)
+        if record_mesh_trace:
+            mesh_traces.append(
+                MeshCycleTrace(
+                    cycle=cycle,
+                    router_traces=tuple(cycle_router_traces),
+                    injected=tuple(
+                        (endpoint, router_inputs[endpoint][PORT_LOCAL].flit)
+                        for endpoint in range(ENDPOINTS)
+                        if tx_flit_fires[endpoint] and router_inputs[endpoint][PORT_LOCAL].flit is not None
+                    ),
+                    deliveries=tuple(cycle_deliveries),
+                    link_transfers=tuple(cycle_links),
+                    endpoint_in_ready=tuple(trace.ready[PORT_LOCAL] for trace in cycle_router_traces),
+                    endpoint_out_ready=tuple(endpoint_out_ready),
+                    endpoint_input_stall=tuple(
+                        1 if states[endpoint].tx_output is not None and not tx_flit_fires[endpoint] else 0
+                        for endpoint in range(ENDPOINTS)
+                    ),
+                )
+            )
+        max_rx_context_occupancy = max(
+            max_rx_context_occupancy,
+            max(len(state.rx_contexts) for state in states),
+        )
+
+        complete = (
+            rx_done_count == len(packet_list)
+            and tx_done_count == len(packet_list)
+            and all(
+                state.tx_active is None
+                and not state.tx_fifo
+                and not state.tx_reads
+                and state.tx_output is None
+                and not state.rx_contexts
+                and state.completion is None
+                for state in states
+            )
+            and all(router.idle() for router in routers)
+        )
+        if complete:
+            return PacketMeshResult(
+                cycles=cycle + 1,
+                descriptors=packet_list,
+                rx_descriptor_handshakes=tuple(rx_handshakes),
+                tx_descriptor_handshakes=tuple(tx_handshakes),
+                source_memory_requests=tuple(source_requests),
+                source_memory_responses=tuple(source_responses),
+                destination_memory_writes=tuple(destination_writes),
+                completions=tuple(completions),
+                completion_handshakes=tuple(completion_handshakes),
+                deliveries=tuple(deliveries),
+                link_transfers=tuple(link_transfers),
+                router_summaries=tuple(
+                    state.snapshot(router_traces[endpoint], router_forwarded[endpoint])
+                    for endpoint, state in enumerate(routers)
+                ),
+                protocol_errors=tuple(
+                    endpoint for endpoint, state in enumerate(states) if state.protocol_error
+                ),
+                max_rx_context_occupancy=max_rx_context_occupancy,
+                mesh_traces=tuple(mesh_traces),
+            )
+
+    raise RuntimeError(
+        f"packet mesh did not drain within max_cycles={max_cycles}; "
+        f"rx={sum(item is not None for item in rx_done)}/{len(packet_list)} "
+        f"tx={sum(item is not None for item in tx_done)}/{len(packet_list)}"
+    )
+
+
+def _packet_index_for_flit(flit: ModelFlit, descriptors: Sequence[PacketDescriptor]) -> int:
+    matches = [
+        index
+        for index, descriptor in enumerate(descriptors)
+        if descriptor.source == flit.source
+        and descriptor.destination == flit.destination
+        and descriptor.vc == flit.vc
+        and descriptor.tag == flit.tag
+    ]
+    if not matches:
+        raise RuntimeError("delivered flit does not match any packet descriptor")
+    # Concrete tags are the wire identity.  Duplicate live keys are rejected
+    # at RX descriptor installation, so the first match is unambiguous while a
+    # packet is in flight.
+    return matches[0]
+
+
+simulate_noc_sram_packet_mesh = simulate_packet_mesh

--- a/tests/noc_sram_packet_mesh4x4_workload_tb.sv
+++ b/tests/noc_sram_packet_mesh4x4_workload_tb.sv
@@ -15,6 +15,7 @@ module noc_sram_packet_mesh4x4_workload_tb;
   integer packet_count = 0;
   integer expected_flits = 0;
   integer timeout_cycles = 2000000;
+  integer plusarg_status;
   integer drain_cycle = 0;
   integer submitted_packets = 0;
   integer completed_packets = 0;
@@ -415,7 +416,7 @@ module noc_sram_packet_mesh4x4_workload_tb;
       $fatal(1, "PACKET_COUNT must be in [1, %0d]", MAX_PACKETS);
     if (!$value$plusargs("EXPECTED_FLITS=%d", expected_flits) || expected_flits <= 0)
       $fatal(1, "EXPECTED_FLITS must be positive");
-    void'($value$plusargs("TIMEOUT_CYCLES=%d", timeout_cycles));
+    plusarg_status = $value$plusargs("TIMEOUT_CYCLES=%d", timeout_cycles);
     if (!$value$plusargs("DESC_MEM=%s", descriptor_mem) ||
         !$value$plusargs("SRC_ORDER_MEM=%s", source_order_mem) ||
         !$value$plusargs("DST_ORDER_MEM=%s", destination_order_mem) ||

--- a/tests/noc_sram_packet_mesh4x4_workload_tb.sv
+++ b/tests/noc_sram_packet_mesh4x4_workload_tb.sv
@@ -1,0 +1,438 @@
+`timescale 1ns/1ps
+
+// Runtime-loaded workload replay for the exact endpoint plus 4x4 mesh RTL.
+// Descriptor word layout: release[31:0], source[35:32], destination[39:36],
+// VC[41:40], tag[49:42], flit_count[53:50]. Packet ID is the array index.
+module noc_sram_packet_mesh4x4_workload_tb;
+  localparam integer DATA_W = 256;
+  localparam integer ADDR_W = 24;
+  localparam integer MAX_PACKETS = 12000;
+  localparam integer RX_CONTEXTS = 8;
+
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  integer cycle = 0;
+  integer packet_count = 0;
+  integer expected_flits = 0;
+  integer timeout_cycles = 2000000;
+  integer drain_cycle = 0;
+  integer submitted_packets = 0;
+  integer completed_packets = 0;
+  integer accepted_writes = 0;
+  integer comb_endpoint_i;
+  integer comb_context_i;
+  integer seq_endpoint_i;
+  integer seq_context_i;
+  integer packet_i;
+  integer queue_i;
+  integer selected_packet;
+  integer selected_index;
+  integer free_context;
+  integer duplicate_context;
+  integer comb_selected_packet;
+  integer comb_selected_index;
+  integer comb_free_context;
+  integer comb_duplicate_context;
+  integer write_fragment;
+  integer tx_fire_count;
+  integer completion_fire_count;
+  integer write_fire_count;
+  integer completion_packet [0:15];
+  reg [15:0] completion_shadow_valid = 0;
+
+  reg [95:0] descriptors [0:MAX_PACKETS-1];
+  reg [15:0] source_order [0:MAX_PACKETS-1];
+  reg [15:0] destination_order [0:MAX_PACKETS-1];
+  reg [31:0] source_queue_meta [0:15];
+  reg [31:0] destination_queue_meta [0:15];
+  integer source_position [0:15];
+  integer destination_position [0:15];
+  reg [MAX_PACKETS-1:0] rx_installed = 0;
+  reg [MAX_PACKETS-1:0] tx_submitted = 0;
+  reg [MAX_PACKETS-1:0] packet_completed = 0;
+  reg [127:0] live_context_valid = 0;
+  integer live_context_packet [0:127];
+
+  reg [15:0] tx_desc_valid = 0;
+  wire [15:0] tx_desc_ready;
+  reg [63:0] tx_desc_destination = 0;
+  reg [31:0] tx_desc_vc = 0;
+  reg [127:0] tx_desc_tag = 0;
+  reg [16*ADDR_W-1:0] tx_desc_base_addr = 0;
+  reg [63:0] tx_desc_flit_count = 0;
+  wire [15:0] tx_mem_req_valid;
+  wire [15:0] tx_mem_req_ready;
+  wire [16*ADDR_W-1:0] tx_mem_req_addr;
+  reg [15:0] tx_mem_rsp_valid = 0;
+  wire [15:0] tx_mem_rsp_ready;
+  reg [16*DATA_W-1:0] tx_mem_rsp_data = 0;
+  reg [ADDR_W-1:0] pending_read_addr [0:16*8-1];
+  integer pending_read_rd [0:15];
+  integer pending_read_wr [0:15];
+  integer pending_read_count [0:15];
+
+  reg [15:0] rx_desc_valid = 0;
+  wire [15:0] rx_desc_ready;
+  reg [63:0] rx_desc_source = 0;
+  reg [31:0] rx_desc_vc = 0;
+  reg [127:0] rx_desc_tag = 0;
+  reg [16*ADDR_W-1:0] rx_desc_base_addr = 0;
+  reg [63:0] rx_desc_flit_count = 0;
+  wire [15:0] rx_mem_write_valid;
+  reg [15:0] rx_mem_write_ready = 16'hffff;
+  wire [16*ADDR_W-1:0] rx_mem_write_addr;
+  wire [16*DATA_W-1:0] rx_mem_write_data;
+  wire [15:0] rx_completion_valid;
+  reg [15:0] rx_completion_ready = 16'hffff;
+  wire [63:0] rx_completion_source;
+  wire [31:0] rx_completion_vc;
+  wire [127:0] rx_completion_tag;
+  wire [15:0] endpoint_protocol_error;
+
+  wire [16*32-1:0] router_accepted_flit_count;
+  wire [16*32-1:0] router_forwarded_flit_count;
+  wire [16*32-1:0] router_input_stall_cycles;
+  wire [16*32-1:0] router_output_stall_cycles;
+  wire [16*32-1:0] router_contention_cycles;
+  wire [16*32-1:0] router_current_input_occupancy;
+  wire [16*32-1:0] router_max_input_occupancy;
+  wire [16*5*32-1:0] router_route_flit_count;
+
+  string descriptor_mem;
+  string source_order_mem;
+  string destination_order_mem;
+  string source_meta_mem;
+  string destination_meta_mem;
+
+  function [DATA_W-1:0] memory_data;
+    input [3:0] source;
+    input [ADDR_W-1:0] address;
+    reg [15:0] packet_id;
+    reg [2:0] fragment;
+    begin
+      packet_id = address[23:8];
+      fragment = address[7:5];
+      memory_data = {DATA_W{1'b0}};
+      memory_data[3:0] = source;
+      memory_data[19:4] = packet_id;
+      memory_data[22:20] = fragment;
+      memory_data[54:23] = 32'h5a17c0de;
+    end
+  endfunction
+
+  noc_sram_packet_mesh4x4 #(
+    .ADDR_W(ADDR_W),
+    .RX_CONTEXTS(RX_CONTEXTS)
+  ) dut (
+    .clk(clk), .rst_n(rst_n),
+    .tx_desc_valid(tx_desc_valid), .tx_desc_ready(tx_desc_ready),
+    .tx_desc_destination(tx_desc_destination), .tx_desc_vc(tx_desc_vc),
+    .tx_desc_tag(tx_desc_tag), .tx_desc_base_addr(tx_desc_base_addr),
+    .tx_desc_flit_count(tx_desc_flit_count),
+    .tx_mem_req_valid(tx_mem_req_valid), .tx_mem_req_ready(tx_mem_req_ready),
+    .tx_mem_req_addr(tx_mem_req_addr), .tx_mem_rsp_valid(tx_mem_rsp_valid),
+    .tx_mem_rsp_ready(tx_mem_rsp_ready), .tx_mem_rsp_data(tx_mem_rsp_data),
+    .rx_desc_valid(rx_desc_valid), .rx_desc_ready(rx_desc_ready),
+    .rx_desc_source(rx_desc_source), .rx_desc_vc(rx_desc_vc),
+    .rx_desc_tag(rx_desc_tag), .rx_desc_base_addr(rx_desc_base_addr),
+    .rx_desc_flit_count(rx_desc_flit_count),
+    .rx_mem_write_valid(rx_mem_write_valid),
+    .rx_mem_write_ready(rx_mem_write_ready),
+    .rx_mem_write_addr(rx_mem_write_addr),
+    .rx_mem_write_data(rx_mem_write_data),
+    .rx_completion_valid(rx_completion_valid),
+    .rx_completion_ready(rx_completion_ready),
+    .rx_completion_source(rx_completion_source),
+    .rx_completion_vc(rx_completion_vc),
+    .rx_completion_tag(rx_completion_tag),
+    .endpoint_protocol_error(endpoint_protocol_error),
+    .router_accepted_flit_count(router_accepted_flit_count),
+    .router_forwarded_flit_count(router_forwarded_flit_count),
+    .router_input_stall_cycles(router_input_stall_cycles),
+    .router_output_stall_cycles(router_output_stall_cycles),
+    .router_contention_cycles(router_contention_cycles),
+    .router_current_input_occupancy(router_current_input_occupancy),
+    .router_max_input_occupancy(router_max_input_occupancy),
+    .router_route_flit_count(router_route_flit_count)
+  );
+
+  always #1 clk = ~clk;
+
+  genvar ready_g;
+  generate
+    for (ready_g = 0; ready_g < 16; ready_g = ready_g + 1) begin : g_sram_ready
+      assign tx_mem_req_ready[ready_g] = pending_read_count[ready_g] < 8;
+    end
+  endgenerate
+
+  // Select at most one released descriptor per source and destination. The
+  // receive side must handshake first; the transmit side observes that state
+  // no earlier than the following cycle.
+  always @(*) begin
+    tx_desc_valid = 0;
+    tx_desc_destination = 0;
+    tx_desc_vc = 0;
+    tx_desc_tag = 0;
+    tx_desc_base_addr = 0;
+    tx_desc_flit_count = 0;
+    rx_desc_valid = 0;
+    rx_desc_source = 0;
+    rx_desc_vc = 0;
+    rx_desc_tag = 0;
+    rx_desc_base_addr = 0;
+    rx_desc_flit_count = 0;
+
+    for (comb_endpoint_i = 0; comb_endpoint_i < 16; comb_endpoint_i = comb_endpoint_i + 1) begin
+      if (rst_n &&
+          destination_position[comb_endpoint_i] < destination_queue_meta[comb_endpoint_i][31:16]) begin
+        comb_selected_index = destination_queue_meta[comb_endpoint_i][15:0] +
+          destination_position[comb_endpoint_i];
+        comb_selected_packet = destination_order[comb_selected_index];
+        comb_free_context = 0;
+        comb_duplicate_context = 0;
+        for (comb_context_i = 0; comb_context_i < RX_CONTEXTS;
+             comb_context_i = comb_context_i + 1) begin
+          if (!live_context_valid[comb_endpoint_i*RX_CONTEXTS + comb_context_i])
+            comb_free_context = 1;
+          else if (descriptors[live_context_packet[comb_endpoint_i*RX_CONTEXTS + comb_context_i]][35:32] ==
+                   descriptors[comb_selected_packet][35:32] &&
+                   descriptors[live_context_packet[comb_endpoint_i*RX_CONTEXTS + comb_context_i]][41:40] ==
+                   descriptors[comb_selected_packet][41:40] &&
+                   descriptors[live_context_packet[comb_endpoint_i*RX_CONTEXTS + comb_context_i]][49:42] ==
+                   descriptors[comb_selected_packet][49:42])
+            comb_duplicate_context = 1;
+        end
+        if (descriptors[comb_selected_packet][31:0] <= cycle &&
+            comb_free_context && !comb_duplicate_context) begin
+          rx_desc_valid[comb_endpoint_i] = 1'b1;
+          rx_desc_source[(comb_endpoint_i*4) +: 4] = descriptors[comb_selected_packet][35:32];
+          rx_desc_vc[(comb_endpoint_i*2) +: 2] = descriptors[comb_selected_packet][41:40];
+          rx_desc_tag[(comb_endpoint_i*8) +: 8] = descriptors[comb_selected_packet][49:42];
+          rx_desc_base_addr[(comb_endpoint_i*ADDR_W) +: ADDR_W] = comb_selected_packet << 8;
+          rx_desc_flit_count[(comb_endpoint_i*4) +: 4] = descriptors[comb_selected_packet][53:50];
+        end
+      end
+
+      if (rst_n && source_position[comb_endpoint_i] < source_queue_meta[comb_endpoint_i][31:16]) begin
+        comb_selected_index = source_queue_meta[comb_endpoint_i][15:0] +
+          source_position[comb_endpoint_i];
+        comb_selected_packet = source_order[comb_selected_index];
+        if (descriptors[comb_selected_packet][31:0] <= cycle &&
+            rx_installed[comb_selected_packet]) begin
+          tx_desc_valid[comb_endpoint_i] = 1'b1;
+          tx_desc_destination[(comb_endpoint_i*4) +: 4] = descriptors[comb_selected_packet][39:36];
+          tx_desc_vc[(comb_endpoint_i*2) +: 2] = descriptors[comb_selected_packet][41:40];
+          tx_desc_tag[(comb_endpoint_i*8) +: 8] = descriptors[comb_selected_packet][49:42];
+          tx_desc_base_addr[(comb_endpoint_i*ADDR_W) +: ADDR_W] = comb_selected_packet << 8;
+          tx_desc_flit_count[(comb_endpoint_i*4) +: 4] = descriptors[comb_selected_packet][53:50];
+        end
+      end
+    end
+  end
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      cycle <= 0;
+      tx_mem_rsp_valid <= 0;
+      tx_mem_rsp_data <= 0;
+      submitted_packets <= 0;
+      completed_packets <= 0;
+      accepted_writes <= 0;
+      rx_installed <= 0;
+      tx_submitted <= 0;
+      packet_completed <= 0;
+      live_context_valid <= 0;
+      completion_shadow_valid <= 0;
+      for (seq_endpoint_i = 0; seq_endpoint_i < 16; seq_endpoint_i = seq_endpoint_i + 1) begin
+        source_position[seq_endpoint_i] <= 0;
+        destination_position[seq_endpoint_i] <= 0;
+        completion_packet[seq_endpoint_i] <= 0;
+        pending_read_rd[seq_endpoint_i] <= 0;
+        pending_read_wr[seq_endpoint_i] <= 0;
+        pending_read_count[seq_endpoint_i] <= 0;
+      end
+    end else begin
+      cycle <= cycle + 1;
+      tx_fire_count = 0;
+      completion_fire_count = 0;
+      write_fire_count = 0;
+
+      for (seq_endpoint_i = 0; seq_endpoint_i < 16; seq_endpoint_i = seq_endpoint_i + 1) begin
+        if (!tx_mem_rsp_valid[seq_endpoint_i] || tx_mem_rsp_ready[seq_endpoint_i]) begin
+          if (pending_read_count[seq_endpoint_i] > 0) begin
+            tx_mem_rsp_valid[seq_endpoint_i] <= 1'b1;
+            tx_mem_rsp_data[(seq_endpoint_i*DATA_W) +: DATA_W] <= memory_data(
+              seq_endpoint_i[3:0],
+              pending_read_addr[seq_endpoint_i*8 + pending_read_rd[seq_endpoint_i]]);
+            pending_read_rd[seq_endpoint_i] <= (pending_read_rd[seq_endpoint_i] + 1) % 8;
+            if (tx_mem_req_valid[seq_endpoint_i] && tx_mem_req_ready[seq_endpoint_i]) begin
+              pending_read_addr[seq_endpoint_i*8 + pending_read_wr[seq_endpoint_i]] <=
+                tx_mem_req_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W];
+              pending_read_wr[seq_endpoint_i] <= (pending_read_wr[seq_endpoint_i] + 1) % 8;
+            end else begin
+              pending_read_count[seq_endpoint_i] <= pending_read_count[seq_endpoint_i] - 1;
+            end
+          end else if (tx_mem_req_valid[seq_endpoint_i] && tx_mem_req_ready[seq_endpoint_i]) begin
+            // Empty-queue bypass: a request accepted at this edge becomes the
+            // response consumed at the following edge.
+            tx_mem_rsp_valid[seq_endpoint_i] <= 1'b1;
+            tx_mem_rsp_data[(seq_endpoint_i*DATA_W) +: DATA_W] <= memory_data(
+              seq_endpoint_i[3:0], tx_mem_req_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W]);
+          end else begin
+            tx_mem_rsp_valid[seq_endpoint_i] <= 1'b0;
+          end
+        end else if (tx_mem_req_valid[seq_endpoint_i] && tx_mem_req_ready[seq_endpoint_i]) begin
+          pending_read_addr[seq_endpoint_i*8 + pending_read_wr[seq_endpoint_i]] <=
+            tx_mem_req_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W];
+          pending_read_wr[seq_endpoint_i] <= (pending_read_wr[seq_endpoint_i] + 1) % 8;
+          pending_read_count[seq_endpoint_i] <= pending_read_count[seq_endpoint_i] + 1;
+        end
+
+        if (rx_desc_valid[seq_endpoint_i] && rx_desc_ready[seq_endpoint_i]) begin
+          selected_index = destination_queue_meta[seq_endpoint_i][15:0] +
+            destination_position[seq_endpoint_i];
+          selected_packet = destination_order[selected_index];
+          rx_installed[selected_packet] <= 1'b1;
+          destination_position[seq_endpoint_i] <= destination_position[seq_endpoint_i] + 1;
+          free_context = -1;
+          for (seq_context_i = 0; seq_context_i < RX_CONTEXTS;
+               seq_context_i = seq_context_i + 1)
+            if (!live_context_valid[seq_endpoint_i*RX_CONTEXTS + seq_context_i] && free_context < 0)
+              free_context = seq_context_i;
+          if (free_context < 0)
+            $fatal(1, "testbench lost RX context accounting at endpoint %0d", seq_endpoint_i);
+          live_context_valid[seq_endpoint_i*RX_CONTEXTS + free_context] <= 1'b1;
+          live_context_packet[seq_endpoint_i*RX_CONTEXTS + free_context] <= selected_packet;
+        end
+
+        if (tx_desc_valid[seq_endpoint_i] && tx_desc_ready[seq_endpoint_i]) begin
+          selected_index = source_queue_meta[seq_endpoint_i][15:0] + source_position[seq_endpoint_i];
+          selected_packet = source_order[selected_index];
+          if (!rx_installed[selected_packet])
+            $fatal(1, "TX descriptor accepted before RX descriptor for packet %0d", selected_packet);
+          tx_submitted[selected_packet] <= 1'b1;
+          source_position[seq_endpoint_i] <= source_position[seq_endpoint_i] + 1;
+          tx_fire_count = tx_fire_count + 1;
+        end
+
+        if (rx_completion_valid[seq_endpoint_i] && rx_completion_ready[seq_endpoint_i]) begin
+          selected_packet = completion_packet[seq_endpoint_i];
+          if (!completion_shadow_valid[seq_endpoint_i])
+            $fatal(1, "unexpected completion at endpoint %0d", seq_endpoint_i);
+          if (rx_completion_source[(seq_endpoint_i*4) +: 4] !== descriptors[selected_packet][35:32] ||
+              rx_completion_vc[(seq_endpoint_i*2) +: 2] !== descriptors[selected_packet][41:40] ||
+              rx_completion_tag[(seq_endpoint_i*8) +: 8] !== descriptors[selected_packet][49:42])
+            $fatal(1, "completion metadata mismatch for packet %0d", selected_packet);
+          if (packet_completed[selected_packet])
+            $fatal(1, "duplicate completion for packet %0d", selected_packet);
+          packet_completed[selected_packet] <= 1'b1;
+          completion_fire_count = completion_fire_count + 1;
+          completion_shadow_valid[seq_endpoint_i] <= 1'b0;
+        end
+
+        if (rx_mem_write_valid[seq_endpoint_i] && rx_mem_write_ready[seq_endpoint_i]) begin
+          selected_packet = rx_mem_write_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W] >> 8;
+          write_fragment =
+            (rx_mem_write_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W] >> 5) & 7;
+          if (selected_packet < 0 || selected_packet >= packet_count)
+            $fatal(1, "destination write names invalid packet %0d", selected_packet);
+          if (descriptors[selected_packet][39:36] != seq_endpoint_i[3:0])
+            $fatal(1, "packet %0d written at wrong endpoint %0d", selected_packet, seq_endpoint_i);
+          if (rx_mem_write_data[(seq_endpoint_i*DATA_W) +: DATA_W] !== memory_data(
+                descriptors[selected_packet][35:32],
+                (selected_packet << 8) |
+                  ((rx_mem_write_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W] & 24'h0000ff))))
+            $fatal(1, "packet %0d destination data mismatch", selected_packet);
+          write_fire_count = write_fire_count + 1;
+
+          if (write_fragment + 1 == descriptors[selected_packet][53:50]) begin
+            free_context = -1;
+            for (seq_context_i = 0; seq_context_i < RX_CONTEXTS;
+                 seq_context_i = seq_context_i + 1)
+              if (live_context_valid[seq_endpoint_i*RX_CONTEXTS + seq_context_i] &&
+                  live_context_packet[seq_endpoint_i*RX_CONTEXTS + seq_context_i] == selected_packet)
+                free_context = seq_context_i;
+            if (free_context < 0)
+              $fatal(1, "completed packet %0d has no live context", selected_packet);
+            live_context_valid[seq_endpoint_i*RX_CONTEXTS + free_context] <= 1'b0;
+            completion_packet[seq_endpoint_i] <= selected_packet;
+            completion_shadow_valid[seq_endpoint_i] <= 1'b1;
+          end
+        end
+      end
+
+      submitted_packets <= submitted_packets + tx_fire_count;
+      completed_packets <= completed_packets + completion_fire_count;
+      accepted_writes <= accepted_writes + write_fire_count;
+
+      if (endpoint_protocol_error != 0)
+        $fatal(1, "endpoint protocol error: %h", endpoint_protocol_error);
+      if (cycle > 0 && (cycle % 100000) == 0)
+        $display("PROGRESS workload cycle=%0d submitted=%0d completed=%0d writes=%0d",
+          cycle, submitted_packets, completed_packets, accepted_writes);
+      if (cycle >= timeout_cycles)
+        $fatal(1, "workload timeout cycle=%0d submitted=%0d completed=%0d", cycle,
+          submitted_packets, completed_packets);
+    end
+  end
+
+  task finish_and_check;
+    integer aggregate_contention;
+    integer aggregate_input_stalls;
+    integer aggregate_max_occupancy;
+    begin
+      aggregate_contention = 0;
+      aggregate_input_stalls = 0;
+      aggregate_max_occupancy = 0;
+      for (queue_i = 0; queue_i < 16; queue_i = queue_i + 1) begin
+        aggregate_contention = aggregate_contention +
+          router_contention_cycles[(queue_i*32) +: 32];
+        aggregate_input_stalls = aggregate_input_stalls +
+          router_input_stall_cycles[(queue_i*32) +: 32];
+        if (router_max_input_occupancy[(queue_i*32) +: 32] > aggregate_max_occupancy)
+          aggregate_max_occupancy = router_max_input_occupancy[(queue_i*32) +: 32];
+      end
+      if (submitted_packets != packet_count || completed_packets != packet_count)
+        $fatal(1, "packet count mismatch expected=%0d submitted=%0d completed=%0d",
+          packet_count, submitted_packets, completed_packets);
+      if (accepted_writes != expected_flits)
+        $fatal(1, "flit count mismatch expected=%0d writes=%0d",
+          expected_flits, accepted_writes);
+      for (packet_i = 0; packet_i < packet_count; packet_i = packet_i + 1)
+        if (!rx_installed[packet_i] || !tx_submitted[packet_i] || !packet_completed[packet_i])
+          $fatal(1, "packet %0d did not traverse the complete endpoint path", packet_i);
+      $display(
+        "PASS workload packets=%0d flits=%0d cycles=%0d contention=%0d input_stalls=%0d max_occupancy=%0d",
+        packet_count, accepted_writes, drain_cycle, aggregate_contention,
+        aggregate_input_stalls, aggregate_max_occupancy);
+      $finish;
+    end
+  endtask
+
+  initial begin
+    if (!$value$plusargs("PACKET_COUNT=%d", packet_count) || packet_count <= 0 ||
+        packet_count > MAX_PACKETS)
+      $fatal(1, "PACKET_COUNT must be in [1, %0d]", MAX_PACKETS);
+    if (!$value$plusargs("EXPECTED_FLITS=%d", expected_flits) || expected_flits <= 0)
+      $fatal(1, "EXPECTED_FLITS must be positive");
+    void'($value$plusargs("TIMEOUT_CYCLES=%d", timeout_cycles));
+    if (!$value$plusargs("DESC_MEM=%s", descriptor_mem) ||
+        !$value$plusargs("SRC_ORDER_MEM=%s", source_order_mem) ||
+        !$value$plusargs("DST_ORDER_MEM=%s", destination_order_mem) ||
+        !$value$plusargs("SRC_META_MEM=%s", source_meta_mem) ||
+        !$value$plusargs("DST_META_MEM=%s", destination_meta_mem))
+      $fatal(1, "all workload memory paths are required");
+    $readmemh(descriptor_mem, descriptors, 0, packet_count - 1);
+    $readmemh(source_order_mem, source_order, 0, packet_count - 1);
+    $readmemh(destination_order_mem, destination_order, 0, packet_count - 1);
+    $readmemh(source_meta_mem, source_queue_meta);
+    $readmemh(destination_meta_mem, destination_queue_meta);
+
+    repeat (3) @(negedge clk);
+    rst_n = 1'b1;
+    while (completed_packets < packet_count) @(negedge clk);
+    drain_cycle = cycle;
+    repeat (3) @(negedge clk);
+    finish_and_check();
+  end
+endmodule

--- a/tests/test_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py
+++ b/tests/test_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from npu.eval.verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl import (
+    WorkloadPacket,
+    run_performance_replay,
+    run_rtl_replay,
+    write_workload_memories,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _packets() -> list[WorkloadPacket]:
+    return [
+        WorkloadPacket(
+            packet_id=0,
+            schedule_order=0,
+            release_cycle=4,
+            source=0,
+            destination=15,
+            vc=1,
+            tag=255,
+            flit_count=8,
+            label="packet0",
+        ),
+        WorkloadPacket(
+            packet_id=1,
+            schedule_order=1,
+            release_cycle=4,
+            source=3,
+            destination=12,
+            vc=2,
+            tag=0,
+            flit_count=3,
+            label="packet1",
+        ),
+    ]
+
+
+def _contention_packets() -> list[WorkloadPacket]:
+    return [
+        WorkloadPacket(
+            packet_id=source,
+            schedule_order=source,
+            release_cycle=4,
+            source=source,
+            destination=15,
+            vc=source % 4,
+            tag=source,
+            flit_count=8,
+            label=f"packet{source}",
+        )
+        for source in range(8)
+    ]
+
+
+def test_workload_memories_encode_endpoint_queues_and_concrete_tags(
+    tmp_path: Path,
+) -> None:
+    paths = write_workload_memories(_packets(), tmp_path)
+
+    descriptor_words = [int(line, 16) for line in paths.descriptors.read_text().splitlines()]
+    assert [(word >> 42) & 0xFF for word in descriptor_words] == [255, 0]
+    assert [(word >> 50) & 0xF for word in descriptor_words] == [8, 3]
+
+    source_meta = [int(line, 16) for line in paths.source_meta.read_text().splitlines()]
+    destination_meta = [
+        int(line, 16) for line in paths.destination_meta.read_text().splitlines()
+    ]
+    assert source_meta[0] >> 16 == 1
+    assert source_meta[3] >> 16 == 1
+    assert destination_meta[12] >> 16 == 1
+    assert destination_meta[15] >> 16 == 1
+
+
+@pytest.mark.skipif(
+    not (shutil.which("iverilog") or Path("/oss-cad-suite/bin/iverilog").exists())
+    or not (shutil.which("vvp") or Path("/oss-cad-suite/bin/vvp").exists()),
+    reason="iverilog/vvp unavailable",
+)
+def test_composed_rtl_replays_paired_descriptors_and_all_flits(tmp_path: Path) -> None:
+    packets = _contention_packets()
+    performance = run_performance_replay(packets, max_cycles=10000)
+    result = run_rtl_replay(
+        repo_root=REPO_ROOT,
+        packets=packets,
+        work_dir=tmp_path,
+        timeout_cycles=10000,
+        wall_timeout_seconds=60,
+    )
+
+    assert result["counters"]["packets"] == 8
+    assert result["counters"]["flits"] == 64
+    assert result["counters"]["contention"] > 0
+    assert result["counters"]["input_stalls"] > 0
+    assert result["counters"] == {
+        key: performance[key]
+        for key in ("packets", "flits", "cycles", "contention", "input_stalls", "max_occupancy")
+    }
+    assert "PASS workload" in result["simulation_stdout"]

--- a/tests/test_llm_decoder_attention_score32_noc_phase2_schedule.py
+++ b/tests/test_llm_decoder_attention_score32_noc_phase2_schedule.py
@@ -80,12 +80,14 @@ def test_score32_noc_phase2_default_report_covers_full_declared_workload() -> No
 
 
 def test_score32_noc_phase2_explicit_wave_limit_is_bounded() -> None:
-    report = build_report(_args(wave_limit=1))
+    packet_specs = []
+    report = build_report(_args(wave_limit=1), packet_spec_output=packet_specs)
 
     assert report["source_contract"]["coverage"] == "bounded"
     assert report["source_contract"]["simulated_wave_count"] == 1
     assert report["traffic_quantities"]["simulated_tiles"] == report["source_contract"]["active_clusters"]
     assert report["schedule_parameters"]["requested_wave_limit"] == 1
+    assert len(packet_specs) == report["simulation"]["scheduled_packet_count"]
 
 
 def test_score32_noc_phase2_converts_absolute_release_times_between_clock_domains() -> None:

--- a/tests/test_noc_sram_packet_mesh_perf.py
+++ b/tests/test_noc_sram_packet_mesh_perf.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.sim.perf.noc_sram_packet_mesh import (  # noqa: E402
+    PacketDescriptor,
+    simulate_packet_mesh,
+)
+
+
+def test_rx_handshakes_before_tx_release() -> None:
+    result = simulate_packet_mesh(
+        [
+            PacketDescriptor(
+                source=0,
+                destination=15,
+                vc=1,
+                tag=0x41,
+                flit_count=2,
+                packet_id="ordered",
+            )
+        ]
+    )
+
+    rx = result.rx_descriptor_handshakes[0]
+    tx = result.tx_descriptor_handshakes[0]
+    assert rx.direction == "rx"
+    assert tx.direction == "tx"
+    assert rx.endpoint == 15
+    assert tx.endpoint == 0
+    assert tx.cycle > rx.cycle
+    assert not result.protocol_errors
+    assert result.mesh_traces == ()
+    assert all(router.traces == () for router in result.router_summaries)
+
+
+def test_eight_rx_contexts_throttle_a_ninth_packet() -> None:
+    descriptors = [
+        PacketDescriptor(
+            source=index,
+            destination=15,
+            vc=index % 4,
+            tag=index,
+            flit_count=1,
+            packet_id=f"packet-{index}",
+        )
+        for index in range(9)
+    ]
+    result = simulate_packet_mesh(descriptors)
+
+    rx_by_packet = {event.packet_index: event.cycle for event in result.rx_descriptor_handshakes}
+    completion_by_packet = {event.packet_index: event.cycle for event in result.completions}
+    assert len(rx_by_packet) == 9
+    assert max(rx_by_packet[index] for index in range(8)) < rx_by_packet[8]
+    assert rx_by_packet[8] > min(completion_by_packet[index] for index in range(8))
+    assert result.max_rx_context_occupancy <= 8
+    assert not result.protocol_errors
+
+
+def test_concrete_tags_are_preserved_across_wrap() -> None:
+    descriptors = [
+        PacketDescriptor(
+            source=0,
+            destination=15,
+            vc=0,
+            tag=tag,
+            flit_count=1,
+            schedule_order=index,
+            packet_id=f"tag-{tag:02x}",
+        )
+        for index, tag in enumerate((0xFE, 0xFF, 0x00, 0x01))
+    ]
+    result = simulate_packet_mesh(descriptors)
+
+    observed = [delivery.flit.tag for delivery in result.deliveries]
+    assert observed == [0xFE, 0xFF, 0x00, 0x01]
+    assert [event.descriptor.tag for event in result.tx_descriptor_handshakes] == observed
+    assert not result.protocol_errors
+
+
+def test_two_packet_composed_case_matches_endpoint_metadata() -> None:
+    result = simulate_packet_mesh(
+        [
+            PacketDescriptor(
+                source=0,
+                destination=15,
+                vc=1,
+                tag=0x08,
+                flit_count=8,
+                tx_base_addr=0x0100,
+                rx_base_addr=0x1800,
+                data_seed=0,
+                packet_id="source0-to-destination15",
+            ),
+            PacketDescriptor(
+                source=3,
+                destination=12,
+                vc=2,
+                tag=0x32,
+                flit_count=3,
+                tx_base_addr=0x0300,
+                rx_base_addr=0x1200,
+                data_seed=3,
+                packet_id="source3-to-destination12",
+            ),
+        ],
+        destination_sram_ready_schedule=lambda cycle, endpoint: not (
+            (endpoint == 15 and cycle % 5 == 2)
+            or (endpoint == 12 and cycle % 7 == 3)
+        ),
+    )
+
+    assert len(result.source_memory_requests) == 11
+    assert len(result.source_memory_responses) == 11
+    assert len(result.destination_memory_writes) == 11
+    assert len(result.completions) == 2
+    assert not result.protocol_errors
+
+    by_packet = {}
+    for delivery in result.deliveries:
+        by_packet.setdefault(delivery.packet_index, []).append(delivery.flit)
+    assert [flit.fragment for flit in by_packet[0]] == list(range(8))
+    assert [flit.fragment for flit in by_packet[1]] == list(range(3))
+    assert all(flit.tag == 0x08 for flit in by_packet[0])
+    assert all(flit.tag == 0x32 for flit in by_packet[1])
+    assert [write.address for write in result.destination_memory_writes if write.packet_index == 0] == [
+        0x1800 + 32 * fragment for fragment in range(8)
+    ]
+    assert [write.address for write in result.destination_memory_writes if write.packet_index == 1] == [
+        0x1200 + 32 * fragment for fragment in range(3)
+    ]


### PR DESCRIPTION
## Summary

- add a finite descriptor/SRAM/receive-context performance model around the registered-credit 4x4 mesh
- add a compact runtime workload driver for all sixteen endpoint and router RTL instances
- require exact performance/RTL agreement for packet, flit, cycle, contention, stall, and occupancy counters
- add a bounded remote L2 evidence job and result-consumer contract
- run the focused equivalence tests in GitHub golden CI

## Abstraction removed

The prior Phase-2 result injected flits from logical zero-copy release queues. This change installs each RX context before releasing TX, models four TX descriptors, eight outstanding SRAM reads, eight RX contexts, one-cycle source SRAM responses, direct destination writes, and completion retirement. SRAM bitcells, synthesized scheduler PPA, workload activity power, and HBM/DRAM remain explicit.

## Validation

- focused model/RTL/schedule gate: 11 passed
- high-contention eight-source RTL gate: exact 8 packets, 64 flits, 85 cycles, 169 contention cycles, 43 input stalls, occupancy 30
- bounded Llama7B wave: exact 1,583 packets, 12,604 flits, 61,414 cycles; endpoint cadence adds 199 cycles; 71 MB peak RSS
- L2 result consumer: 132 passed
- focused L2 task generator: passed
- `python scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`

## Remote gate

After merge, generate and dispatch `l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_llama7b_v1`. The command is evidence-only, exclusive, limited to 6 GB and one hour, and streams sparse progress records.