### PR TITLE
Scope portable task limits to the launched process tree

### DIFF
--- a/control_plane/control_plane/tests/test_run_bounded_command.py
+++ b/control_plane/control_plane/tests/test_run_bounded_command.py
@@ -136,7 +136,6 @@ def test_apply_fallback_limits_sets_rlimits_and_affinity() -> None:
     assert selected == (2, 4, 6)
     assert rlimit_calls == [
         (module.resource.RLIMIT_AS, (8 * 1024**3, 8 * 1024**3)),
-        (module.resource.RLIMIT_NPROC, (512, 512)),
     ]
     assert affinity_calls == [(0, (2, 4, 6))]
 
@@ -259,6 +258,40 @@ def test_run_portable_fallback_normalizes_signal_exit() -> None:
     )
 
     assert result == 137
+
+
+def test_run_portable_fallback_enforces_tasks_max_on_child_tree(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_launcher_module()
+    grandchild_pid_path = tmp_path / "tasks-max-grandchild.pid"
+    spec = module.LimitSpec(
+        memory_high=None,
+        memory_max=None,
+        cpu_quota=None,
+        tasks_max=1,
+        runtime_max_sec=10,
+    )
+    child_code = (
+        "import subprocess, sys, time\n"
+        "subprocess.Popen([sys.executable, '-c', "
+        "\"import os, pathlib, sys, time; pathlib.Path(sys.argv[1]).write_text(str(os.getpid())); time.sleep(60)\", "
+        "sys.argv[1]])\n"
+        "time.sleep(60)\n"
+    )
+
+    result = module._run_portable_fallback(
+        spec,
+        [sys.executable, "-c", child_code, str(grandchild_pid_path)],
+        term_grace_sec=0.2,
+    )
+
+    captured = capsys.readouterr()
+    assert result == module.TASKS_MAX_EXIT_CODE
+    assert '"event": "run_bounded_command_tasks_max_exceeded"' in captured.err
+    grandchild_pid = _read_pid(grandchild_pid_path)
+    _assert_process_gone(grandchild_pid)
 
 
 def test_run_portable_fallback_times_out_and_kills_process_group(tmp_path: Path) -> None:

--- a/control_plane/scripts/run_bounded_command.py
+++ b/control_plane/scripts/run_bounded_command.py
@@ -20,6 +20,7 @@ import time
 from typing import Any, Sequence
 
 TIMEOUT_EXIT_CODE = 124
+TASKS_MAX_EXIT_CODE = 125
 _SYSTEMD_CHECK_TIMEOUT_SEC = 5.0
 _TERM_GRACE_SEC = 5.0
 _POLL_INTERVAL_SEC = 0.05
@@ -249,8 +250,6 @@ def _apply_fallback_limits(
     if spec.memory_max is not None:
         memory_limit = _parse_size(spec.memory_max)
         setrlimit(resource.RLIMIT_AS, (memory_limit, memory_limit))
-    if spec.tasks_max is not None:
-        setrlimit(resource.RLIMIT_NPROC, (spec.tasks_max, spec.tasks_max))
     if sched_setaffinity is not None and selected_cpus:
         sched_setaffinity(0, selected_cpus)
     return selected_cpus
@@ -278,7 +277,7 @@ def _portable_backend_diagnostic(
             "memory_high": "advisory_unavailable",
             "memory_max": "rlimit_as" if spec.memory_max is not None else None,
             "cpu_quota": "sched_affinity_ceiling" if spec.cpu_quota is not None else None,
-            "tasks_max": "rlimit_nproc" if spec.tasks_max is not None else None,
+            "tasks_max": "process_tree_task_monitor" if spec.tasks_max is not None else None,
             "runtime_max_sec": "process_group_timeout" if spec.runtime_max_sec is not None else None,
         },
         "allowed_cpus": list(sorted(int(cpu) for cpu in allowed_cpus)),
@@ -384,6 +383,16 @@ def _collect_descendant_processes(owner_pid: int) -> dict[int, _ProcInfo]:
     return descendants
 
 
+def _count_descendant_tasks(owner_pid: int) -> int:
+    task_count = 0
+    for proc in _collect_descendant_processes(owner_pid).values():
+        try:
+            task_count += sum(1 for entry in Path(f"/proc/{proc.pid}/task").iterdir() if entry.name.isdigit())
+        except (FileNotFoundError, OSError):
+            continue
+    return task_count
+
+
 def _reap_descendant_processes(owner_pid: int, *, excluded_pid: int) -> None:
     for proc in _collect_descendant_processes(owner_pid).values():
         if proc.pid == excluded_pid:
@@ -471,6 +480,21 @@ def _run_portable_fallback(
                 _terminate_process_tree(process, term_grace_sec=term_grace_sec)
                 process.wait()
                 return 128 + signal_state.requested_signal
+            if spec.tasks_max is not None:
+                observed_tasks = _count_descendant_tasks(os.getpid())
+                if observed_tasks > spec.tasks_max:
+                    _emit_diagnostic(
+                        {
+                            "event": "run_bounded_command_tasks_max_exceeded",
+                            "backend": "portable_fallback",
+                            "tasks_max": spec.tasks_max,
+                            "observed_tasks": observed_tasks,
+                            "term_grace_sec": term_grace_sec,
+                        }
+                    )
+                    _terminate_process_tree(process, term_grace_sec=term_grace_sec)
+                    process.wait()
+                    return TASKS_MAX_EXIT_CODE
             if spec.runtime_max_sec is not None and time.monotonic() - started >= spec.runtime_max_sec:
                 _emit_diagnostic(
                     {

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/README.md
@@ -12,10 +12,12 @@ NoC behavior, or full-array physical feasibility.
 Dispatch uses `control_plane/scripts/run_bounded_command.py`. When the evaluator
 has a usable user `systemd` manager the launcher applies the existing cgroup
 limits through `systemd-run --user --scope`; when the evaluator is inside a
-container without a user bus it falls back to process-group timeout, `RLIMIT_AS`
-/ `RLIMIT_NPROC`, and a CPU-affinity ceiling derived from the current allowed
-CPUs and the requested quota rounded to whole CPUs. In both modes, timeout,
-OOM, or other resource termination remains inconclusive.
+container without a user bus it falls back to process-group timeout,
+`RLIMIT_AS`, descendant-tree task monitoring, and a CPU-affinity ceiling
+derived from the current allowed CPUs and the requested quota rounded to whole
+CPUs. The fallback does not use per-UID `RLIMIT_NPROC`, because remapped users
+also own unrelated editor and daemon processes. In both modes, timeout, OOM,
+or other resource termination remains inconclusive.
 
 The remote job requests `--sim-backend fine_compositional_icarus`. The probe
 first runs the existing strict generated-top regeneration, wiring, ordering,

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/evaluation_gate.md
@@ -18,11 +18,13 @@
 If a usable user `systemd` manager exists, the launcher applies the contract
 with `systemd-run --user --scope`. In evaluator containers without a user bus,
 the launcher falls back to process-group timeout, `RLIMIT_AS` for
-`MemoryMax=8G`, `RLIMIT_NPROC` for `TasksMax=512`, and a CPU-affinity ceiling
-derived from the current allowed CPUs and the requested quota rounded to whole
-CPUs (`CPUQuota=300%` becomes at most three allowed CPUs). `MemoryHigh=6G` is
-advisory and reported as unavailable in fallback mode rather than claimed as
-exact cgroup enforcement.
+`MemoryMax=8G`, descendant-tree task monitoring for `TasksMax=512`, and a
+CPU-affinity ceiling derived from the current allowed CPUs and the requested
+quota rounded to whole CPUs (`CPUQuota=300%` becomes at most three allowed
+CPUs). The fallback must not use `RLIMIT_NPROC`: that limit is scoped to every
+process sharing the remapped UID, not to this job. `MemoryHigh=6G` is advisory
+and reported as unavailable in fallback mode rather than claimed as exact
+cgroup enforcement.
 
 The probe backend should be `python3 npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py --sim-backend fine_compositional_icarus --compile-timeout-sec 1200 --timeout-sec 900`.
 It must pass the strict generated-top guard, serially replay the exact

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/evaluation_gate.md
@@ -18,11 +18,12 @@
 If a usable user `systemd` manager exists, the launcher applies the contract
 with `systemd-run --user --scope`. In evaluator containers without a user bus,
 the launcher falls back to process-group timeout, `RLIMIT_AS` for
-`MemoryMax=8G`, `RLIMIT_NPROC` for `TasksMax=512`, and a CPU-affinity ceiling
-derived from the current allowed CPUs and the requested quota rounded to whole
-CPUs (`CPUQuota=300%` becomes at most three allowed CPUs). `MemoryHigh=6G`
-stays advisory in fallback mode and is reported that way instead of claimed as
-exact cgroup enforcement.
+`MemoryMax=8G`, descendant-tree task monitoring for `TasksMax=512`, and a
+CPU-affinity ceiling derived from the current allowed CPUs and the requested
+quota rounded to whole CPUs (`CPUQuota=300%` becomes at most three allowed
+CPUs). The fallback must not use `RLIMIT_NPROC`, which includes unrelated
+processes sharing the remapped UID. `MemoryHigh=6G` stays advisory in fallback
+mode and is reported that way instead of claimed as exact cgroup enforcement.
 
 The probe backend should be `python3 npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py --sim-backend fine_compositional_icarus --compile-timeout-sec 1200 --timeout-sec 3600`.
 It must pass the strict generated-top guard, serially replay the exact


### PR DESCRIPTION
## Summary
- stop using per-UID `RLIMIT_NPROC` for portable `TasksMax`
- count threads only in the launched descendant tree and terminate it on overflow
- document the corrected fallback semantics in affected equivalence gates

## Root cause
Remote endpoint-equivalence run `...869fc3a63de3b549` failed before launching Icarus with `BlockingIOError: [Errno 11] Resource temporarily unavailable`. UID remapping means editor and daemon processes share UID 1000, so absolute `RLIMIT_NPROC=128` constrained unrelated processes rather than this job.

## Verification
- `python -m pytest -q control_plane/control_plane/tests/test_run_bounded_command.py` (`11 passed`)
- `python -m py_compile control_plane/scripts/run_bounded_command.py`
- `git diff --check`

The failed evidence remains preserved in issue #1669. After merge, regenerate the endpoint-equivalence item from the merge SHA and run it remotely.