### PR TITLE
Add finite-endpoint composed score32 recost

### DIFF
--- a/.github/workflows/npu-eval-tests.yml
+++ b/.github/workflows/npu-eval-tests.yml
@@ -34,9 +34,11 @@ jobs:
       - name: Install eval-tool test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pyyaml
+          python -m pip install pytest pyyaml
 
       - name: Run eval-tool regression tests
         run: |
           python tests/test_eval_campaign_tools.py
           python tests/test_run_campaign_mapper_notes.py
+          python -m pytest -q \
+            npu/eval/tests/test_recost_llm_decoder_attention_score32_noc_phase2_finite_endpoint_composed.py

--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -599,6 +599,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_score32_noc_phase2_endpoint_rtl_equivalence_report",
     ),
     (
+        "attention_score32_noc_phase2_finite_endpoint_composed_recost_out",
+        "attention_score32_noc_phase2_finite_endpoint_composed_recost_report",
+    ),
+    (
         "attention_score32_folded_global_exact_reduction_recost_out",
         "attention_score32_folded_global_exact_reduction_recost_report",
     ),
@@ -823,6 +827,11 @@ def _decoder_quality_brief(evidence_payload: dict[str, Any]) -> dict[str, Any]:
         "closure_flags",
         "closure_diagnosis",
         "clock_contract",
+        "logical_schedule",
+        "finite_endpoint_schedule",
+        "throughput",
+        "physical_recost",
+        "precision_contract",
         "schedule",
         "physical_accounting",
         "boundary_evidence",
@@ -1050,6 +1059,35 @@ def _decoder_recommendation_override(
 
 def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, Any]) -> tuple[str, str]:
     model = str(evidence_payload.get("model", "")).strip()
+    if (
+        model == "llama7b_proxy"
+        and str(evidence_payload.get("profile", "")).strip()
+        == "decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost"
+    ):
+        outcome = str(
+            evidence_payload.get("decision")
+            or "score32_noc_phase2_finite_endpoint_composed_recost_recorded"
+        )
+        clock = dict(evidence_payload.get("clock_contract") or {})
+        finite = dict(evidence_payload.get("finite_endpoint_schedule") or {})
+        throughput = dict(evidence_payload.get("throughput") or {})
+        physical = dict(evidence_payload.get("physical_recost") or {})
+        precision = dict(evidence_payload.get("precision_contract") or {})
+        parts = [
+            f"Decoder score32 finite-endpoint composed recost recorded from {evidence_ref}: decision={outcome}",
+        ]
+        for section, keys in (
+            (clock, ("effective_noc_clock_ns",)),
+            (finite, ("cycles", "drain_time_ns", "cadence_delta_cycles_vs_logical")),
+            (throughput, ("bottleneck", "token_throughput_per_s", "throughput_ratio_vs_source")),
+            (physical, ("total_embodied_area_um2", "area_fit", "recost_logic_vectorless_energy_per_token_mj")),
+            (precision, ("precision_profile", "semantic_profile")),
+        ):
+            for key in keys:
+                if key in section:
+                    parts.append(f"{key}={section.get(key)}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
     if (
         model == "llama7b_proxy"
         and str(evidence_payload.get("profile", "")).strip()

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5652,6 +5652,119 @@ def _decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_evidence(
     }
 
 
+def _decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_evidence(
+    *,
+    item_id: str,
+    depends_on_item_ids: list[str] | None,
+    proposal_id: str | None,
+    proposal_path: str | None,
+) -> dict[str, Any]:
+    expected_item_id = (
+        "l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1"
+    )
+    expected_proposal_id = (
+        "prop_l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_v1"
+    )
+    expected_dependencies = [
+        "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1",
+        "l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_llama7b_v1",
+        "l1_noc_sram_packet_mesh4x4_composed_ppa_v1",
+    ]
+    if item_id != expected_item_id:
+        raise Layer2TaskGenerationError("finite-endpoint composed recost only permits the exact item")
+    if str(proposal_id or "").strip() != expected_proposal_id:
+        raise Layer2TaskGenerationError("finite-endpoint composed recost proposal_id mismatch")
+    if str(proposal_path or "").strip() != f"docs/proposals/{expected_proposal_id}/proposal.json":
+        raise Layer2TaskGenerationError("finite-endpoint composed recost proposal_path mismatch")
+    if list(depends_on_item_ids or []) != expected_dependencies:
+        raise Layer2TaskGenerationError(
+            "finite-endpoint composed recost requires the exact schedule, equivalence, and PPA dependencies"
+        )
+
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    source = (
+        f"{base}/decoder_attention_score32_exact_reduction_recost__"
+        "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1.json"
+    )
+    measured_costs = (
+        "runs/campaigns/npu/l1_measured_costs/"
+        "llama7b_attention_local_costs_all_measured_endpoint_v1.json"
+    )
+    schedule = (
+        f"{base}/decoder_attention_score32_noc_phase2_schedule__"
+        "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1.json"
+    )
+    equivalence = (
+        f"{base}/decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence__"
+        "l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_llama7b_v1.json"
+    )
+    composed = (
+        "control_plane/shadow_exports/l1_promotions/"
+        "l1_noc_sram_packet_mesh4x4_composed_ppa_v1.json"
+    )
+    out = f"{base}/decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost__{item_id}.json"
+    report = f"{base}/decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost__{item_id}.md"
+    command = _bounded_launcher_command(
+        memory_high="4G",
+        memory_max="6G",
+        cpu_quota="200%",
+        tasks_max=128,
+        runtime_max_sec=900,
+        child_command=[
+            "python3",
+            "npu/eval/recost_llm_decoder_attention_score32_noc_phase2_finite_endpoint_composed.py",
+            "--repo-root",
+            ".",
+            "--source-json",
+            source,
+            "--measured-l1-costs",
+            measured_costs,
+            "--baseline-schedule-json",
+            schedule,
+            "--endpoint-equivalence-json",
+            equivalence,
+            "--composed-promotion-json",
+            composed,
+            "--out",
+            out,
+            "--report",
+            report,
+        ],
+    )
+    return {
+        "inputs": {
+            "attention_score32_noc_phase2_source_recost": source,
+            "attention_score32_noc_phase2_measured_l1_costs": measured_costs,
+            "attention_score32_noc_phase2_corrected_schedule": schedule,
+            "attention_score32_noc_phase2_endpoint_rtl_equivalence": equivalence,
+            "attention_score32_noc_phase2_composed_mesh_promotion": composed,
+            "attention_score32_noc_phase2_finite_endpoint_composed_recost_out": out,
+            "attention_score32_noc_phase2_finite_endpoint_composed_recost_report": report,
+        },
+        "commands": [{"name": "recost_attention_score32_finite_endpoint_composed", "run": command}],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+        "worker_resources": {
+            "exclusive_worker": True,
+            "memory_high": "4G",
+            "memory_max": "6G",
+            "cpu_quota": "200%",
+            "tasks_max": 128,
+            "outer_timeout_seconds": 900,
+            "stall_timeout_seconds": 480,
+        },
+        "acceptance": [
+            "Require exact workload-complete endpoint performance/RTL equivalence",
+            "Rerun the full finite-endpoint schedule at the conservative composed clock",
+            "Use max(compute layer time, finite endpoint drain time) for token throughput",
+            "Replace prior router, FIFO, and endpoint PPA with aggregate composed PPA",
+            "Inherit the exact arithmetic precision and quality contract unchanged",
+            "Keep scheduler PPA, SRAM macro physics and energy, activity power, and HBM/DRAM explicit",
+            "Write exactly one JSON and one Markdown report",
+        ],
+    }
+
+
 def _decoder_attention_kv_endpoint_full_onchip_service_schedule_evidence(
     *,
     item_id: str,
@@ -12530,6 +12643,7 @@ def _build_payload(
         "decoder_attention_score32_noc_phase2_measured_router_clock_reroute",
         "decoder_attention_score32_noc_phase2_composed_mesh_reroute",
         "decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence",
+        "decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost",
         "decoder_attention_kv_endpoint_full_onchip_service_schedule",
         "decoder_attention_kv_endpoint_ready_valid_service",
         "decoder_attention_kv_endpoint_router_sram_composition",
@@ -12780,6 +12894,13 @@ def _build_payload(
             )
         elif abstraction_layer_name == "decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence":
             decoder_evidence = _decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_evidence(
+                item_id=item_id,
+                depends_on_item_ids=depends_on_item_ids,
+                proposal_id=proposal_id,
+                proposal_path=proposal_path,
+            )
+        elif abstraction_layer_name == "decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost":
+            decoder_evidence = _decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_evidence(
                 item_id=item_id,
                 depends_on_item_ids=depends_on_item_ids,
                 proposal_id=proposal_id,

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -229,6 +229,65 @@ def test_decoder_evidence_paths_recognizes_score32_noc_composed_mesh_reroute(tmp
     }
 
 
+def test_decoder_evidence_paths_recognizes_finite_endpoint_composed_recost(tmp_path: Path) -> None:
+    evidence_rel = "runs/datasets/demo/score32_finite_endpoint_composed_recost.json"
+    report_rel = "runs/datasets/demo/score32_finite_endpoint_composed_recost.md"
+    _write(tmp_path / evidence_rel, "{}\n")
+    _write(tmp_path / report_rel, "# Finite endpoint composed recost\n")
+    work_item = SimpleNamespace(
+        input_manifest={
+            "decoder_contract": {
+                "attention_score32_noc_phase2_finite_endpoint_composed_recost_out": evidence_rel,
+                "attention_score32_noc_phase2_finite_endpoint_composed_recost_report": report_rel,
+            }
+        }
+    )
+
+    evidence_ref, source_refs = _decoder_evidence_paths(repo_root=tmp_path, work_item=work_item)
+
+    assert evidence_ref == evidence_rel
+    assert source_refs == {
+        "decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_out": evidence_rel,
+        "decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_report": report_rel,
+    }
+
+
+def test_decoder_evidence_summary_recognizes_finite_endpoint_composed_recost() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/score32_finite_endpoint_composed_recost.json",
+        evidence_payload={
+            "model": "llama7b_proxy",
+            "profile": "decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost",
+            "decision": "score32_noc_phase2_finite_endpoint_composed_recost_recorded",
+            "clock_contract": {"effective_noc_clock_ns": 1.0},
+            "finite_endpoint_schedule": {
+                "cycles": 400000,
+                "drain_time_ns": 400000.0,
+                "cadence_delta_cycles_vs_logical": 3000,
+            },
+            "throughput": {
+                "bottleneck": "compute",
+                "token_throughput_per_s": 74.0,
+                "throughput_ratio_vs_source": 0.998,
+            },
+            "physical_recost": {
+                "total_embodied_area_um2": 700000000.0,
+                "area_fit": True,
+                "recost_logic_vectorless_energy_per_token_mj": 320.0,
+            },
+            "precision_contract": {
+                "precision_profile": "q8_k8_v8_a32_s32_w16_exp_lut_div_b20_int8_compute",
+                "semantic_profile": "score32_exp_lut_div",
+            },
+        },
+    )
+
+    assert outcome == "score32_noc_phase2_finite_endpoint_composed_recost_recorded"
+    assert "cycles=400000" in summary
+    assert "area_fit=True" in summary
+    assert "precision_profile=q8_k8_v8_a32_s32_w16_exp_lut_div_b20_int8_compute" in summary
+
+
 def test_decoder_evidence_summary_recognizes_score32_noc_phase2_schedule() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/score32_noc_phase2_schedule.json",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -14872,6 +14872,65 @@ def test_generate_l2_campaign_task_adds_score32_endpoint_rtl_equivalence() -> No
             )
 
 
+def test_generate_l2_campaign_task_adds_finite_endpoint_composed_recost() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        dependencies = [
+            "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1",
+            "l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_llama7b_v1",
+            "l1_noc_sram_packet_mesh4x4_composed_ppa_v1",
+        ]
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                _make_l2_request(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=(
+                        "l2_decoder_attention_score32_noc_phase2_"
+                        "finite_endpoint_composed_recost_llama7b_v1"
+                    ),
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id=(
+                        "prop_l2_decoder_attention_score32_noc_phase2_"
+                        "finite_endpoint_composed_recost_v1"
+                    ),
+                    proposal_path=(
+                        "docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_"
+                        "finite_endpoint_composed_recost_v1/proposal.json"
+                    ),
+                    abstraction_layer=(
+                        "decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    depends_on_item_ids=dependencies,
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            run = work_item.command_manifest[0]["run"]
+            assert work_item.state == WorkItemState.BLOCKED
+            assert "recost_llm_decoder_attention_score32_noc_phase2_finite_endpoint_composed.py" in run
+            assert "--endpoint-equivalence-json" in run
+            assert "--composed-promotion-json" in run
+            assert "--runtime-max-sec 900" in run
+            assert work_item.input_manifest["worker_resources"]["stall_timeout_seconds"] == 480
+            assert work_item.expected_outputs[0].endswith(
+                "decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost__"
+                "l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1.json"
+            )
+
+
 def test_score32_noc_closure_rejects_inexact_dependencies() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_v1/README.md
@@ -1,0 +1,9 @@
+# Finite-Endpoint Composed Recost
+
+This proposal joins the corrected complete Phase 2 schedule, finite endpoint
+performance/RTL equivalence, and aggregate endpoint/mesh PPA. It produces the
+first score32 frontier point whose NoC timing includes endpoint cadence and
+whose area and vectorless power replace the earlier primitive estimates.
+
+The result remains a partial energy closure. SRAM access energy, workload
+activity, HBM/DRAM, and synthesized workload-scheduler PPA stay explicit.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_v1/design_brief.md
@@ -1,0 +1,11 @@
+# Design Brief
+
+The recost validates endpoint equivalence against the canonical schedule,
+selects `max(source NoC clock, composed critical path)`, and replays every
+packet through the finite endpoint performance model. The merged equivalence
+artifact establishes that this model matches RTL cycle and router counters.
+
+The physical accounting subtracts the prior per-cluster router, FIFO, and
+endpoint estimates from the source logic totals before adding the aggregate
+composed footprint and vectorless power. SRAM area remains included, while its
+dynamic access energy is excluded until workload-to-macro port activity exists.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_v1",
+  "source_commit": "TBD",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Recost the corrected score32 frontier with finite endpoint cadence and aggregate composed endpoint/mesh PPA.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost",
+      "comparison_role": "closure_detail",
+      "status": "pending_after_dependencies_merge",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1",
+        "l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_llama7b_v1",
+        "l1_noc_sram_packet_mesh4x4_composed_ppa_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost__l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost__l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1.md"
+      ],
+      "acceptance_notes": "Require exact endpoint performance/RTL counters and complete delivery. Rerun at the conservative composed clock, use the slower of compute and finite NoC drain for token latency, replace rather than add prior primitive NoC PPA, and preserve precision evidence unchanged."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_v1/proposal.json
@@ -1,0 +1,43 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_v1",
+  "created_utc": "2026-08-16T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Close finite endpoint timing and composed NoC PPA in the score32 frontier",
+  "hypothesis": "Binding workload-complete endpoint RTL equivalence and aggregate endpoint/mesh PPA into the corrected score32 schedule yields a defensible Llama7B throughput, area, vectorless logic energy, and precision point without double-counting primitive NoC costs.",
+  "direct_comparison": {
+    "primary_question": "Does the current score32 Llama7B point remain feasible and compute-bound after finite endpoint cadence and aggregate placed NoC costs replace their abstract counterparts?",
+    "include": [
+      "corrected workload-complete Phase 2 schedule",
+      "finite endpoint performance/RTL equivalence",
+      "sixteen-endpoint and sixteen-router aggregate PPA",
+      "fresh finite-endpoint replay at the conservative composed clock",
+      "inherited exact arithmetic precision and quality contract"
+    ],
+    "exclude": [
+      "synthesized workload command scheduler PPA",
+      "SRAM macro placement, port timing, and dynamic access energy",
+      "workload-derived switching activity",
+      "HBM/DRAM controller implementation and off-chip energy"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1",
+        "l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_llama7b_v1",
+        "l1_noc_sram_packet_mesh4x4_composed_ppa_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_schedule__l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence__l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_llama7b_v1.json",
+    "control_plane/shadow_exports/l1_promotions/l1_noc_sram_packet_mesh4x4_composed_ppa_v1.json"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_v1/quality_gate.md
@@ -1,0 +1,9 @@
+# Quality Gate
+
+- Consume only the exact three merged dependencies named by the proposal.
+- Require complete finite-endpoint RTL/performance counter equivalence.
+- Rerun release conversion, mesh routing, and finite endpoint service at the conservative composed clock.
+- Derive token latency from the slower of compute-layer time and finite NoC drain time.
+- Replace prior router, FIFO, and endpoint PPA; do not add aggregate PPA on top.
+- Inherit the arithmetic precision and quality evidence without claiming a new quality run.
+- Keep scheduler PPA, SRAM physical/energy closure, activity power, and HBM/DRAM explicit.

--- a/npu/eval/recost_llm_decoder_attention_score32_noc_phase2_finite_endpoint_composed.py
+++ b/npu/eval/recost_llm_decoder_attention_score32_noc_phase2_finite_endpoint_composed.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Recost the Llama7B score32 point with finite endpoints and composed NoC PPA."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from npu.eval import measure_llm_decoder_attention_score32_noc_phase2_schedule as phase2_schedule  # noqa: E402
+from npu.eval.audit_llm_decoder_attention_score32_noc_phase2_measured_router_closure import (  # noqa: E402
+    _load_json,
+    _validate_phase2_schedule,
+)
+from npu.eval.reroute_llm_decoder_attention_score32_noc_phase2_composed_mesh import (  # noqa: E402
+    _validate_composed_promotion,
+)
+from npu.eval.reroute_llm_decoder_attention_score32_noc_phase2_measured_router_clock import (  # noqa: E402
+    _compact_schedule,
+    _schedule_args,
+)
+from npu.eval.verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl import (  # noqa: E402
+    descriptors_from_packet_specs,
+    run_performance_replay,
+)
+from npu.eval.measure_llm_decoder_attention_score32_noc_phase2_schedule import (  # noqa: E402
+    PacketSpec,
+)
+
+JsonDict = dict[str, Any]
+
+_BASE = Path("runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1")
+DEFAULT_BASELINE_SCHEDULE = _BASE / (
+    "decoder_attention_score32_noc_phase2_schedule__"
+    "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1.json"
+)
+DEFAULT_ENDPOINT_EQUIVALENCE = _BASE / (
+    "decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence__"
+    "l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_llama7b_v1.json"
+)
+DEFAULT_COMPOSED_PROMOTION = Path(
+    "control_plane/shadow_exports/l1_promotions/"
+    "l1_noc_sram_packet_mesh4x4_composed_ppa_v1.json"
+)
+
+_EXPECTED_ENDPOINT_PROFILE = "decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence"
+_COUNTER_FIELDS = ("packets", "flits", "cycles", "contention", "input_stalls", "max_occupancy")
+
+
+def _positive_number(value: Any, label: str) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be numeric") from exc
+    if not math.isfinite(number) or number <= 0:
+        raise ValueError(f"{label} must be positive")
+    return number
+
+
+def _validate_endpoint_equivalence(payload: JsonDict, *, baseline: JsonDict) -> JsonDict:
+    if payload.get("version") != 1 or payload.get("profile") != _EXPECTED_ENDPOINT_PROFILE:
+        raise ValueError("endpoint equivalence profile/version mismatch")
+    if payload.get("coverage") != "workload_complete":
+        raise ValueError("endpoint equivalence must be workload_complete")
+    source = payload.get("source_schedule")
+    rtl = payload.get("rtl_replay")
+    performance = payload.get("endpoint_aware_performance_replay")
+    equivalence = payload.get("equivalence")
+    if not all(isinstance(section, dict) for section in (source, rtl, performance, equivalence)):
+        raise ValueError("endpoint equivalence is missing required sections")
+    required_flags = (
+        "all_packets_completed",
+        "all_flits_written",
+        "rx_descriptor_precedes_tx_enforced",
+        "cycle_and_router_counter_match",
+    )
+    if not all(equivalence.get(flag) is True for flag in required_flags):
+        raise ValueError("endpoint equivalence does not pass every required flag")
+    if equivalence.get("wire_tag_width_bits") != 8:
+        raise ValueError("endpoint equivalence must use concrete 8-bit tags")
+    mismatches = {
+        field: {"rtl": rtl.get(field), "performance": performance.get(field)}
+        for field in _COUNTER_FIELDS
+        if rtl.get(field) != performance.get(field)
+    }
+    if mismatches:
+        raise ValueError(f"endpoint RTL/performance counters differ: {mismatches}")
+    baseline_simulation = dict(baseline.get("simulation") or {})
+    expected_source = {
+        "packet_count": baseline_simulation.get("scheduled_packet_count"),
+        "flit_count": baseline_simulation.get("scheduled_flit_count"),
+        "logical_release_queue_cycles_to_drain": baseline_simulation.get("cycles_to_drain"),
+    }
+    source_mismatches = {
+        key: {"expected": expected, "observed": source.get(key)}
+        for key, expected in expected_source.items()
+        if source.get(key) != expected
+    }
+    if source_mismatches:
+        raise ValueError(f"endpoint equivalence source schedule mismatch: {source_mismatches}")
+    return {field: int(rtl[field]) for field in _COUNTER_FIELDS}
+
+
+def _prior_component_totals(best: JsonDict) -> JsonDict:
+    area_um2 = 0.0
+    power_mw = 0.0
+    details: list[JsonDict] = []
+    for name in ("noc_router", "noc_fifo", "onchip_endpoint"):
+        count = _positive_number(best.get(f"{name}_per_cluster"), f"{name}_per_cluster") * _positive_number(
+            best.get("cluster_count"), "cluster_count"
+        )
+        area_each = _positive_number(best.get(f"{name}_area_um2"), f"{name}_area_um2")
+        power_each = _positive_number(best.get(f"{name}_power_mw"), f"{name}_power_mw")
+        area_um2 += count * area_each
+        power_mw += count * power_each
+        details.append(
+            {
+                "component": name,
+                "count": int(count),
+                "area_um2_each": area_each,
+                "power_mw_each": power_each,
+            }
+        )
+    return {"area_um2": area_um2, "power_mw": power_mw, "components": details}
+
+
+def _build_physical_recost(*, source_recost: JsonDict, composed: JsonDict, token_time_ns: float) -> JsonDict:
+    best = dict(source_recost.get("best_requested") or {})
+    if not best:
+        raise ValueError("source recost is missing best_requested")
+    prior = _prior_component_totals(best)
+    source_logic_area_um2 = _positive_number(best.get("logic_area_used_um2"), "logic_area_used_um2")
+    source_logic_power_mw = _positive_number(
+        best.get("replica_recost_compute_power_mw", best.get("logic_power_mw")),
+        "source logic power",
+    ) + _positive_number(best.get("measured_l1_overhead_power_mw"), "measured_l1_overhead_power_mw")
+    composed_area_um2 = _positive_number(composed.get("footprint_um2"), "composed footprint")
+    composed_power_mw = _positive_number(composed.get("vectorless_power_mw"), "composed power")
+    recost_logic_area_um2 = source_logic_area_um2 - prior["area_um2"] + composed_area_um2
+    recost_logic_power_mw = source_logic_power_mw - prior["power_mw"] + composed_power_mw
+    die_area_um2 = _positive_number(best.get("die_area_mm2"), "die_area_mm2") * 1.0e6
+    shared_sram_area_um2 = _positive_number(
+        best.get("measured_shared_sram_used_area_um2"), "measured_shared_sram_used_area_um2"
+    )
+    tile_local_sram_area_um2 = _positive_number(
+        best.get("measured_tile_local_sram_area_um2"), "measured_tile_local_sram_area_um2"
+    )
+    reserved_area_um2 = _positive_number(best.get("reserved_area_fraction"), "reserved_area_fraction") * die_area_um2
+    total_embodied_area_um2 = (
+        recost_logic_area_um2 + shared_sram_area_um2 + tile_local_sram_area_um2 + reserved_area_um2
+    )
+    return {
+        "source_replaced_components": prior,
+        "composed_endpoint_mesh": composed,
+        "source_logic_area_um2": source_logic_area_um2,
+        "recost_logic_area_um2": recost_logic_area_um2,
+        "shared_sram_area_um2": shared_sram_area_um2,
+        "tile_local_sram_area_um2": tile_local_sram_area_um2,
+        "reserved_area_um2": reserved_area_um2,
+        "total_embodied_area_um2": total_embodied_area_um2,
+        "die_area_um2": die_area_um2,
+        "area_fit": total_embodied_area_um2 <= die_area_um2,
+        "source_logic_power_mw": source_logic_power_mw,
+        "recost_logic_vectorless_power_mw": recost_logic_power_mw,
+        "recost_logic_vectorless_energy_per_token_mj": recost_logic_power_mw * token_time_ns / 1.0e9,
+        "power_status": "vectorless_logic_only",
+        "energy_exclusions": [
+            "SRAM dynamic access energy requires workload-to-macro port mapping.",
+            "HBM/DRAM and controller energy remain outside the on-chip recost.",
+        ],
+    }
+
+
+def build_report(args: argparse.Namespace) -> JsonDict:
+    repo_root = args.repo_root.resolve()
+    baseline_path = repo_root / args.baseline_schedule_json
+    baseline = _validate_phase2_schedule(_load_json(baseline_path), source_path=baseline_path)
+    endpoint_reference = _validate_endpoint_equivalence(
+        _load_json(repo_root / args.endpoint_equivalence_json), baseline=baseline
+    )
+    composed = _validate_composed_promotion(_load_json(repo_root / args.composed_promotion_json))
+    source_recost = _load_json(repo_root / args.source_json)
+
+    source_clock_ns = _positive_number(baseline["source_contract"]["noc_clock_ns"], "source NoC clock")
+    measured_clock_ns = _positive_number(composed["critical_path_ns"], "composed critical path")
+    effective_clock_ns = max(source_clock_ns, measured_clock_ns)
+    packet_specs: list[PacketSpec] = []
+    logical_payload = phase2_schedule.build_report(
+        _schedule_args(args, noc_clock_ns=effective_clock_ns), packet_spec_output=packet_specs
+    )
+    logical_schedule = _compact_schedule(logical_payload)
+    finite = run_performance_replay(
+        descriptors_from_packet_specs(packet_specs), max_cycles=args.max_cycles
+    )
+    if finite["packets"] != logical_schedule["scheduled_packet_count"]:
+        raise ValueError("finite endpoint replay packet count differs from rerouted schedule")
+    if finite["flits"] != logical_schedule["scheduled_flit_count"]:
+        raise ValueError("finite endpoint replay flit count differs from rerouted schedule")
+    if effective_clock_ns == source_clock_ns:
+        mismatch = {
+            field: {"merged_equivalence": endpoint_reference[field], "recost": finite[field]}
+            for field in _COUNTER_FIELDS
+            if endpoint_reference[field] != finite[field]
+        }
+        if mismatch:
+            raise ValueError(f"finite endpoint recost drifted from merged equivalence: {mismatch}")
+
+    compute_layer_time_ns = _positive_number(
+        logical_schedule["compute_layer_time_ns"], "compute layer time"
+    )
+    finite_drain_time_ns = finite["cycles"] * effective_clock_ns
+    critical_layer_time_ns = max(compute_layer_time_ns, finite_drain_time_ns)
+    source_contract = dict(source_recost.get("corrected_contract") or {})
+    layers = int(_positive_number(source_contract.get("layers"), "layers"))
+    token_time_ns = critical_layer_time_ns * layers
+    token_throughput_per_s = 1.0e9 / token_time_ns
+    source_throughput = _positive_number(
+        source_contract.get("token_throughput_per_s"), "source token throughput"
+    )
+    physical = _build_physical_recost(
+        source_recost=source_recost,
+        composed=composed,
+        token_time_ns=token_time_ns,
+    )
+    best = dict(source_recost.get("best_requested") or {})
+    return {
+        "version": 1,
+        "model": "llama7b_proxy",
+        "profile": "decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost",
+        "decision": "score32_noc_phase2_finite_endpoint_composed_recost_recorded",
+        "source_items": {
+            "baseline_schedule": "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1",
+            "endpoint_equivalence": (
+                "l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_llama7b_v1"
+            ),
+            "composed_endpoint_mesh": "l1_noc_sram_packet_mesh4x4_composed_ppa_v1",
+        },
+        "clock_contract": {
+            "source_schedule_noc_clock_ns": source_clock_ns,
+            "measured_composed_logic_critical_path_ns": measured_clock_ns,
+            "effective_noc_clock_ns": effective_clock_ns,
+            "source_clock_floor_preserved": measured_clock_ns < source_clock_ns,
+            "release_conversion_rerun": True,
+            "finite_endpoint_replay_rerun": True,
+        },
+        "logical_schedule": logical_schedule,
+        "finite_endpoint_schedule": {
+            **finite,
+            "drain_time_ns": finite_drain_time_ns,
+            "cadence_delta_cycles_vs_logical": finite["cycles"] - logical_schedule["cycles_to_drain"],
+            "cadence_delta_ns_vs_logical": finite_drain_time_ns - logical_schedule["drain_time_ns"],
+        },
+        "throughput": {
+            "layers": layers,
+            "compute_layer_time_ns": compute_layer_time_ns,
+            "finite_endpoint_drain_time_ns": finite_drain_time_ns,
+            "critical_layer_time_ns": critical_layer_time_ns,
+            "bottleneck": "finite_endpoint_noc" if finite_drain_time_ns > compute_layer_time_ns else "compute",
+            "token_latency_us": token_time_ns / 1000.0,
+            "token_throughput_per_s": token_throughput_per_s,
+            "source_token_throughput_per_s": source_throughput,
+            "throughput_ratio_vs_source": token_throughput_per_s / source_throughput,
+        },
+        "physical_recost": physical,
+        "precision_contract": {
+            "precision_profile": best.get("precision_profile"),
+            "semantic_profile": best.get("measured_dual_stream_composed_semantic_profile"),
+            "arithmetic_changed_by_this_recost": False,
+            "quality_evidence_inherited": True,
+        },
+        "closure_flags": {
+            "finite_endpoint_and_mesh_cycle_equivalence_consumed": True,
+            "aggregate_endpoint_mesh_ppa_consumed": True,
+            "prior_primitive_area_power_replaced_not_added": True,
+            "sram_bitcells_physically_composed": False,
+            "command_scheduler_ppa_measured": False,
+            "workload_matched_power": False,
+            "hbm_dram_controller_included": False,
+        },
+        "remaining_abstractions": [
+            "The deterministic workload command scheduler is functional testbench logic, not synthesized PPA.",
+            "SRAM arrays use transaction-accurate ports; macro placement, port timing, and access energy are not composed.",
+            "The composed OpenROAD power is vectorless rather than workload-activity driven.",
+            "HBM/DRAM controller implementation and off-chip energy remain outside the design boundary.",
+        ],
+    }
+
+
+def write_report(payload: JsonDict, path: Path) -> None:
+    finite = payload["finite_endpoint_schedule"]
+    throughput = payload["throughput"]
+    physical = payload["physical_recost"]
+    precision = payload["precision_contract"]
+    lines = [
+        "# Llama7B Finite-Endpoint Composed NoC Recost",
+        "",
+        f"- effective NoC clock ns: `{payload['clock_contract']['effective_noc_clock_ns']}`",
+        f"- finite drain cycles/time ns: `{finite['cycles']}` / `{finite['drain_time_ns']}`",
+        f"- endpoint cadence delta cycles: `{finite['cadence_delta_cycles_vs_logical']}`",
+        f"- bottleneck: `{throughput['bottleneck']}`",
+        f"- token throughput/s: `{throughput['token_throughput_per_s']}`",
+        f"- total embodied area um2: `{physical['total_embodied_area_um2']}`",
+        f"- area fit: `{str(physical['area_fit']).lower()}`",
+        f"- recost logic vectorless energy/token mJ: `{physical['recost_logic_vectorless_energy_per_token_mj']}`",
+        f"- precision profile: `{precision['precision_profile']}`",
+        "",
+        "## Remaining Abstractions",
+        "",
+        *(f"- {item}" for item in payload["remaining_abstractions"]),
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--source-json", type=Path, default=phase2_schedule.DEFAULT_SOURCE_JSON)
+    parser.add_argument("--measured-l1-costs", type=Path, default=phase2_schedule.DEFAULT_MEASURED_L1_COSTS)
+    parser.add_argument("--baseline-schedule-json", type=Path, default=DEFAULT_BASELINE_SCHEDULE)
+    parser.add_argument("--endpoint-equivalence-json", type=Path, default=DEFAULT_ENDPOINT_EQUIVALENCE)
+    parser.add_argument("--composed-promotion-json", type=Path, default=DEFAULT_COMPOSED_PROMOTION)
+    parser.add_argument("--max-cycles", type=int, default=2000000)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--report", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_report(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_report(payload, args.report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/tests/test_recost_llm_decoder_attention_score32_noc_phase2_finite_endpoint_composed.py
+++ b/npu/eval/tests/test_recost_llm_decoder_attention_score32_noc_phase2_finite_endpoint_composed.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import argparse
+import copy
+from pathlib import Path
+
+import pytest
+
+from npu.eval import recost_llm_decoder_attention_score32_noc_phase2_finite_endpoint_composed as recost
+from npu.eval.recost_llm_decoder_attention_score32_noc_phase2_finite_endpoint_composed import (
+    _build_physical_recost,
+    _validate_endpoint_equivalence,
+)
+
+
+def _baseline() -> dict:
+    return {
+        "simulation": {
+            "scheduled_packet_count": 10,
+            "scheduled_flit_count": 80,
+            "cycles_to_drain": 123,
+        }
+    }
+
+
+def _endpoint() -> dict:
+    counters = {
+        "packets": 10,
+        "flits": 80,
+        "cycles": 140,
+        "contention": 7,
+        "input_stalls": 9,
+        "max_occupancy": 4,
+    }
+    return {
+        "version": 1,
+        "profile": "decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence",
+        "coverage": "workload_complete",
+        "source_schedule": {
+            "packet_count": 10,
+            "flit_count": 80,
+            "logical_release_queue_cycles_to_drain": 123,
+        },
+        "rtl_replay": counters,
+        "endpoint_aware_performance_replay": dict(counters),
+        "equivalence": {
+            "all_packets_completed": True,
+            "all_flits_written": True,
+            "rx_descriptor_precedes_tx_enforced": True,
+            "cycle_and_router_counter_match": True,
+            "wire_tag_width_bits": 8,
+        },
+    }
+
+
+def test_validate_endpoint_equivalence_rejects_counter_mismatch() -> None:
+    payload = _endpoint()
+    payload["rtl_replay"]["cycles"] += 1
+
+    with pytest.raises(ValueError, match="counters differ"):
+        _validate_endpoint_equivalence(payload, baseline=_baseline())
+
+
+def test_validate_endpoint_equivalence_rejects_source_schedule_mismatch() -> None:
+    payload = _endpoint()
+    payload["source_schedule"]["flit_count"] += 1
+
+    with pytest.raises(ValueError, match="source schedule mismatch"):
+        _validate_endpoint_equivalence(payload, baseline=_baseline())
+
+
+def test_physical_recost_replaces_prior_primitives_without_double_counting() -> None:
+    source = {
+        "best_requested": {
+            "cluster_count": 2,
+            "noc_router_per_cluster": 1,
+            "noc_router_area_um2": 10,
+            "noc_router_power_mw": 1,
+            "noc_fifo_per_cluster": 1,
+            "noc_fifo_area_um2": 20,
+            "noc_fifo_power_mw": 2,
+            "onchip_endpoint_per_cluster": 1,
+            "onchip_endpoint_area_um2": 30,
+            "onchip_endpoint_power_mw": 3,
+            "logic_area_used_um2": 1000,
+            "replica_recost_compute_power_mw": 100,
+            "measured_l1_overhead_power_mw": 20,
+            "die_area_mm2": 0.002,
+            "measured_shared_sram_used_area_um2": 100,
+            "measured_tile_local_sram_area_um2": 200,
+            "reserved_area_fraction": 0.1,
+        }
+    }
+    composed = {"footprint_um2": 150, "vectorless_power_mw": 15}
+
+    result = _build_physical_recost(
+        source_recost=copy.deepcopy(source), composed=composed, token_time_ns=1_000_000
+    )
+
+    assert result["source_replaced_components"]["area_um2"] == 120
+    assert result["source_replaced_components"]["power_mw"] == 12
+    assert result["recost_logic_area_um2"] == 1030
+    assert result["recost_logic_vectorless_power_mw"] == 123
+    assert result["total_embodied_area_um2"] == 1530
+    assert result["recost_logic_vectorless_energy_per_token_mj"] == pytest.approx(0.123)
+    assert result["area_fit"] is True
+
+
+def test_build_report_joins_finite_timing_physical_and_precision_contracts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    baseline = {
+        "source_contract": {"noc_clock_ns": 1.0},
+        "simulation": {
+            "scheduled_packet_count": 10,
+            "scheduled_flit_count": 80,
+            "cycles_to_drain": 123,
+        },
+    }
+    source = {
+        "corrected_contract": {"layers": 32, "token_throughput_per_s": 100.0},
+        "best_requested": {
+            "cluster_count": 2,
+            "noc_router_per_cluster": 1,
+            "noc_router_area_um2": 10,
+            "noc_router_power_mw": 1,
+            "noc_fifo_per_cluster": 1,
+            "noc_fifo_area_um2": 20,
+            "noc_fifo_power_mw": 2,
+            "onchip_endpoint_per_cluster": 1,
+            "onchip_endpoint_area_um2": 30,
+            "onchip_endpoint_power_mw": 3,
+            "logic_area_used_um2": 1000,
+            "replica_recost_compute_power_mw": 100,
+            "measured_l1_overhead_power_mw": 20,
+            "die_area_mm2": 0.002,
+            "measured_shared_sram_used_area_um2": 100,
+            "measured_tile_local_sram_area_um2": 200,
+            "reserved_area_fraction": 0.1,
+            "precision_profile": "exact-profile",
+            "measured_dual_stream_composed_semantic_profile": "exact-semantics",
+        },
+    }
+    endpoint = _endpoint()
+    composed = {"critical_path_ns": 2.0, "footprint_um2": 150, "vectorless_power_mw": 15}
+
+    def fake_load(path: Path) -> dict:
+        name = path.name
+        if "endpoint" in name:
+            return endpoint
+        if "promotion" in name:
+            return composed
+        if "source" in name:
+            return source
+        return baseline
+
+    monkeypatch.setattr(recost, "_load_json", fake_load)
+    monkeypatch.setattr(recost, "_validate_phase2_schedule", lambda payload, source_path: payload)
+    monkeypatch.setattr(recost, "_validate_composed_promotion", lambda payload: payload)
+    monkeypatch.setattr(
+        recost.phase2_schedule,
+        "build_report",
+        lambda args, packet_spec_output: {
+            "version": 2,
+            "profile": "decoder_attention_score32_noc_phase2_schedule",
+            "source_contract": {
+                "coverage": "workload_complete",
+                "declared_tile_waves": 8,
+                "simulated_wave_count": 8,
+                "noc_clock_ns": 2.0,
+                "compute_clock_ns": 1.0,
+                "compute_layer_time_ns": 500.0,
+            },
+            "traffic_quantities": {"tile_count": 128, "simulated_tiles": 128},
+            "simulation": {
+                "cycles_to_drain": 200,
+                "drain_time_ns": 400.0,
+                "drain_within_source_compute_layer_envelope": True,
+                "drain_minus_compute_layer_time_ns": -100.0,
+                "scheduled_packet_count": 10,
+                "scheduled_flit_count": 80,
+                "delivered_flit_count": 80,
+                "router_contention_cycles": 7,
+                "endpoint_input_stall_cycles_total": 9,
+            },
+            "schedule_parameters": {
+                "wave_start_noc_cycles": [0],
+                "reduction_release_noc_cycles": [1],
+                "release_conversion": "ceil(compute_cycles * compute_clock_ns / noc_clock_ns)",
+            },
+        },
+    )
+    monkeypatch.setattr(recost, "descriptors_from_packet_specs", lambda specs: [])
+    monkeypatch.setattr(
+        recost,
+        "run_performance_replay",
+        lambda packets, max_cycles: {
+            "packets": 10,
+            "flits": 80,
+            "cycles": 300,
+            "contention": 8,
+            "input_stalls": 11,
+            "max_occupancy": 5,
+        },
+    )
+    args = argparse.Namespace(
+        repo_root=tmp_path,
+        source_json=Path("source.json"),
+        measured_l1_costs=Path("costs.json"),
+        baseline_schedule_json=Path("baseline.json"),
+        endpoint_equivalence_json=Path("endpoint.json"),
+        composed_promotion_json=Path("promotion.json"),
+        max_cycles=1000,
+        out=tmp_path / "out.json",
+        report=tmp_path / "out.md",
+    )
+
+    result = recost.build_report(args)
+
+    assert result["clock_contract"]["effective_noc_clock_ns"] == 2.0
+    assert result["finite_endpoint_schedule"]["drain_time_ns"] == 600.0
+    assert result["throughput"]["bottleneck"] == "finite_endpoint_noc"
+    assert result["throughput"]["token_throughput_per_s"] == pytest.approx(52083.333333333336)
+    assert result["physical_recost"]["recost_logic_area_um2"] == 1030
+    assert result["precision_contract"]["precision_profile"] == "exact-profile"
+    assert result["precision_contract"]["arithmetic_changed_by_this_recost"] is False


### PR DESCRIPTION
## Summary

- add a dependency-gated Llama7B score32 recost that consumes the corrected schedule, workload-complete endpoint RTL equivalence, and aggregate endpoint/mesh PPA
- rerun finite endpoint service at the conservative composed clock and derive token throughput from the slower of compute and finite NoC drain
- replace prior router/FIFO/endpoint area and vectorless power instead of double-counting aggregate PPA
- preserve precision/quality provenance and expose remaining scheduler, SRAM, activity-power, and HBM/DRAM abstractions
- add control-plane generator/result-consumer contracts and focused regression coverage

## Validation

- `26 passed` across the new recost tests and related Phase-2 schedule, endpoint RTL, reroute, and closure tests
- `6 passed` for focused generator/result-consumer integration tests
- `python scripts/validate_runs.py`
- `git diff --check`

## Dependency behavior

The generated item requires the exact three merged dependencies and materialized refs, so it remains `BLOCKED` until endpoint equivalence and composed PPA succeed. No PPA retry should be dispatched before the evaluator image is rebuilt from `faa06cc9` or a descendant and ORFS ownership is verified.
