### PR TITLE
Add finite-endpoint final Llama7B frontier audit

### DIFF
--- a/.github/workflows/npu-eval-tests.yml
+++ b/.github/workflows/npu-eval-tests.yml
@@ -41,4 +41,5 @@ jobs:
           python tests/test_eval_campaign_tools.py
           python tests/test_run_campaign_mapper_notes.py
           python -m pytest -q \
-            npu/eval/tests/test_recost_llm_decoder_attention_score32_noc_phase2_finite_endpoint_composed.py
+            npu/eval/tests/test_recost_llm_decoder_attention_score32_noc_phase2_finite_endpoint_composed.py \
+            npu/eval/tests/test_audit_llm_decoder_attention_score32_finite_endpoint_final_frontier.py

--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -603,6 +603,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_score32_noc_phase2_finite_endpoint_composed_recost_report",
     ),
     (
+        "attention_score32_finite_endpoint_final_frontier_out",
+        "attention_score32_finite_endpoint_final_frontier_report",
+    ),
+    (
         "attention_score32_folded_global_exact_reduction_recost_out",
         "attention_score32_folded_global_exact_reduction_recost_report",
     ),
@@ -832,6 +836,12 @@ def _decoder_quality_brief(evidence_payload: dict[str, Any]) -> dict[str, Any]:
         "throughput",
         "physical_recost",
         "precision_contract",
+        "dimension_winners",
+        "conditional_recommendation",
+        "pareto_frontier",
+        "excluded_nonpromotable_history",
+        "comparison_limits",
+        "next_measurements",
         "schedule",
         "physical_accounting",
         "boundary_evidence",
@@ -1059,6 +1069,24 @@ def _decoder_recommendation_override(
 
 def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, Any]) -> tuple[str, str]:
     model = str(evidence_payload.get("model", "")).strip()
+    if model == "llama7b_score32_finite_endpoint_final_frontier_v1":
+        outcome = str(
+            evidence_payload.get("decision")
+            or "two_nondominated_precision_safe_points_no_universal_scalar_winner"
+        )
+        winners = dict(evidence_payload.get("dimension_winners") or {})
+        recommendation = dict(evidence_payload.get("conditional_recommendation") or {})
+        pareto = evidence_payload.get("pareto_frontier")
+        parts = [
+            f"Llama7B finite-endpoint final frontier recorded from {evidence_ref}: decision={outcome}",
+            f"pareto_count={len(pareto) if isinstance(pareto, list) else 0}",
+        ]
+        for key in ("token_throughput", "die_envelope_area", "energy_per_token", "arithmetic_precision"):
+            if key in winners:
+                parts.append(f"{key}_winner={winners.get(key)}")
+        parts.append(f"unconditional_best={recommendation.get('unconditional_best')}")
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
     if (
         model == "llama7b_proxy"
         and str(evidence_payload.get("profile", "")).strip()

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5765,6 +5765,97 @@ def _decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_eviden
     }
 
 
+def _decoder_attention_score32_finite_endpoint_final_frontier_evidence(
+    *,
+    item_id: str,
+    depends_on_item_ids: list[str] | None,
+    proposal_id: str | None,
+    proposal_path: str | None,
+) -> dict[str, Any]:
+    expected_item_id = (
+        "l2_decoder_attention_score32_finite_endpoint_final_frontier_llama7b_v1"
+    )
+    expected_proposal_id = (
+        "prop_l2_decoder_attention_score32_finite_endpoint_final_frontier_v1"
+    )
+    expected_dependencies = [
+        "l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1"
+    ]
+    if item_id != expected_item_id:
+        raise Layer2TaskGenerationError("finite-endpoint final frontier only permits the exact item")
+    if str(proposal_id or "").strip() != expected_proposal_id:
+        raise Layer2TaskGenerationError("finite-endpoint final frontier proposal_id mismatch")
+    if str(proposal_path or "").strip() != f"docs/proposals/{expected_proposal_id}/proposal.json":
+        raise Layer2TaskGenerationError("finite-endpoint final frontier proposal_path mismatch")
+    if list(depends_on_item_ids or []) != expected_dependencies:
+        raise Layer2TaskGenerationError(
+            "finite-endpoint final frontier requires the exact finite recost dependency"
+        )
+
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    finite_recost = (
+        f"{base}/decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost__"
+        "l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1.json"
+    )
+    quality_frontier = (
+        f"{base}/decoder_attention_score32_integrated_frontier_ranking__"
+        "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_"
+        "rtl_ppa_recost_frontier_llama7b_v1.json"
+    )
+    out = f"{base}/decoder_attention_score32_finite_endpoint_final_frontier__{item_id}.json"
+    report = f"{base}/decoder_attention_score32_finite_endpoint_final_frontier__{item_id}.md"
+    command = _bounded_launcher_command(
+        memory_high="1G",
+        memory_max="2G",
+        cpu_quota="100%",
+        tasks_max=32,
+        runtime_max_sec=300,
+        child_command=[
+            "python3",
+            "npu/eval/audit_llm_decoder_attention_score32_finite_endpoint_final_frontier.py",
+            "--repo-root",
+            ".",
+            "--finite-recost-json",
+            finite_recost,
+            "--quality-frontier-json",
+            quality_frontier,
+            "--out",
+            out,
+            "--report",
+            report,
+        ],
+    )
+    return {
+        "inputs": {
+            "attention_score32_finite_endpoint_composed_recost": finite_recost,
+            "attention_score32_quality_aware_frontier": quality_frontier,
+            "attention_score32_finite_endpoint_final_frontier_out": out,
+            "attention_score32_finite_endpoint_final_frontier_report": report,
+        },
+        "commands": [{"name": "audit_score32_finite_endpoint_final_frontier", "run": command}],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+        "worker_resources": {
+            "exclusive_worker": False,
+            "memory_high": "1G",
+            "memory_max": "2G",
+            "cpu_quota": "100%",
+            "tasks_max": 32,
+            "outer_timeout_seconds": 300,
+            "stall_timeout_seconds": 180,
+        },
+        "acceptance": [
+            "Consume the exact merged finite-endpoint composed recost",
+            "Require passing score32 and exact-FP16 quality-backed rows",
+            "Exclude planning-only and quality-invalid rows from promotion",
+            "Report throughput, die envelope, embodied area status, energy status, and precision separately",
+            "Return a Pareto frontier and per-dimension winners without a scalar universal winner",
+            "Keep workload activity, SRAM macro energy, vendor HBM signoff, and comparison-boundary gaps explicit",
+            "Write exactly one JSON and one Markdown report",
+        ],
+    }
+
+
 def _decoder_attention_kv_endpoint_full_onchip_service_schedule_evidence(
     *,
     item_id: str,
@@ -12644,6 +12735,7 @@ def _build_payload(
         "decoder_attention_score32_noc_phase2_composed_mesh_reroute",
         "decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence",
         "decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost",
+        "decoder_attention_score32_finite_endpoint_final_frontier",
         "decoder_attention_kv_endpoint_full_onchip_service_schedule",
         "decoder_attention_kv_endpoint_ready_valid_service",
         "decoder_attention_kv_endpoint_router_sram_composition",
@@ -12901,6 +12993,13 @@ def _build_payload(
             )
         elif abstraction_layer_name == "decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost":
             decoder_evidence = _decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_evidence(
+                item_id=item_id,
+                depends_on_item_ids=depends_on_item_ids,
+                proposal_id=proposal_id,
+                proposal_path=proposal_path,
+            )
+        elif abstraction_layer_name == "decoder_attention_score32_finite_endpoint_final_frontier":
+            decoder_evidence = _decoder_attention_score32_finite_endpoint_final_frontier_evidence(
                 item_id=item_id,
                 depends_on_item_ids=depends_on_item_ids,
                 proposal_id=proposal_id,

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -288,6 +288,53 @@ def test_decoder_evidence_summary_recognizes_finite_endpoint_composed_recost() -
     assert "precision_profile=q8_k8_v8_a32_s32_w16_exp_lut_div_b20_int8_compute" in summary
 
 
+def test_decoder_evidence_paths_recognizes_finite_endpoint_final_frontier(tmp_path: Path) -> None:
+    evidence_rel = "runs/datasets/demo/score32_finite_endpoint_final_frontier.json"
+    report_rel = "runs/datasets/demo/score32_finite_endpoint_final_frontier.md"
+    _write(tmp_path / evidence_rel, "{}\n")
+    _write(tmp_path / report_rel, "# Finite endpoint final frontier\n")
+    work_item = SimpleNamespace(
+        input_manifest={
+            "decoder_contract": {
+                "attention_score32_finite_endpoint_final_frontier_out": evidence_rel,
+                "attention_score32_finite_endpoint_final_frontier_report": report_rel,
+            }
+        }
+    )
+
+    evidence_ref, source_refs = _decoder_evidence_paths(repo_root=tmp_path, work_item=work_item)
+
+    assert evidence_ref == evidence_rel
+    assert source_refs == {
+        "decoder_attention_score32_finite_endpoint_final_frontier_out": evidence_rel,
+        "decoder_attention_score32_finite_endpoint_final_frontier_report": report_rel,
+    }
+
+
+def test_decoder_evidence_summary_recognizes_finite_endpoint_final_frontier() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/score32_finite_endpoint_final_frontier.json",
+        evidence_payload={
+            "model": "llama7b_score32_finite_endpoint_final_frontier_v1",
+            "decision": "two_nondominated_precision_safe_points_no_universal_scalar_winner",
+            "dimension_winners": {
+                "token_throughput": "score32",
+                "die_envelope_area": "score32",
+                "energy_per_token": "fp16",
+                "arithmetic_precision": "fp16",
+            },
+            "conditional_recommendation": {"unconditional_best": None},
+            "pareto_frontier": [{"candidate_id": "score32"}, {"candidate_id": "fp16"}],
+        },
+    )
+
+    assert outcome == "two_nondominated_precision_safe_points_no_universal_scalar_winner"
+    assert "pareto_count=2" in summary
+    assert "token_throughput_winner=score32" in summary
+    assert "energy_per_token_winner=fp16" in summary
+    assert "unconditional_best=None" in summary
+
+
 def test_decoder_evidence_summary_recognizes_score32_noc_phase2_schedule() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/score32_noc_phase2_schedule.json",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -14931,6 +14931,55 @@ def test_generate_l2_campaign_task_adds_finite_endpoint_composed_recost() -> Non
             )
 
 
+def test_generate_l2_campaign_task_adds_finite_endpoint_final_frontier() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        dependencies = [
+            "l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1"
+        ]
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                _make_l2_request(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_score32_finite_endpoint_final_frontier_llama7b_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_score32_finite_endpoint_final_frontier_v1",
+                    proposal_path=(
+                        "docs/proposals/prop_l2_decoder_attention_score32_"
+                        "finite_endpoint_final_frontier_v1/proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_score32_finite_endpoint_final_frontier",
+                    evaluation_mode="frontier_detail",
+                    depends_on_item_ids=dependencies,
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            run = work_item.command_manifest[0]["run"]
+            assert work_item.state == WorkItemState.BLOCKED
+            assert "audit_llm_decoder_attention_score32_finite_endpoint_final_frontier.py" in run
+            assert "--finite-recost-json" in run
+            assert "--quality-frontier-json" in run
+            assert "--runtime-max-sec 300" in run
+            assert work_item.input_manifest["worker_resources"]["exclusive_worker"] is False
+            assert work_item.expected_outputs[0].endswith(
+                "decoder_attention_score32_finite_endpoint_final_frontier__"
+                "l2_decoder_attention_score32_finite_endpoint_final_frontier_llama7b_v1.json"
+            )
+
+
 def test_score32_noc_closure_rejects_inexact_dependencies() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_score32_finite_endpoint_final_frontier_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_finite_endpoint_final_frontier_v1/README.md
@@ -1,0 +1,9 @@
+# Finite-Endpoint Final Frontier
+
+This proposal replaces the score32 entry in the quality-aware Llama7B
+frontier with finite endpoint timing and aggregate composed NoC accounting.
+It compares that point with measured exact FP16 without mixing invalid or
+planning-only candidates into the promotable ranks.
+
+The report keeps throughput, area, energy, and precision as separate
+dimensions and identifies Pareto and conditional winners.

--- a/docs/proposals/prop_l2_decoder_attention_score32_finite_endpoint_final_frontier_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_finite_endpoint_final_frontier_v1/design_brief.md
@@ -1,0 +1,10 @@
+# Design Brief
+
+The audit substitutes finite score32 throughput, aggregate embodied area, and
+recomputed vectorless logic-plus-HBM energy into the existing quality-aware
+frontier. The exact-FP16 row remains the measured energy and precision
+reference. Invalid mixed-int8 and abstract planning rows remain visible only
+as excluded history.
+
+No scalar weighting is imposed. Score32 and FP16 are both retained when each
+wins at least one strict design objective and neither dominates the other.

--- a/docs/proposals/prop_l2_decoder_attention_score32_finite_endpoint_final_frontier_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_finite_endpoint_final_frontier_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_finite_endpoint_final_frontier_v1",
+  "source_commit": "TBD",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_finite_endpoint_final_frontier_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Produce the quality-backed multidimensional Llama7B frontier after finite endpoint and composed NoC recost.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_finite_endpoint_final_frontier",
+      "comparison_role": "frontier_decision",
+      "status": "pending_after_dependency_merge",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_finite_endpoint_final_frontier__l2_decoder_attention_score32_finite_endpoint_final_frontier_llama7b_v1.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_finite_endpoint_final_frontier__l2_decoder_attention_score32_finite_endpoint_final_frontier_llama7b_v1.md"
+      ],
+      "acceptance_notes": "Require both promoted rows to be quality-backed. Exclude invalid and planning-only rows, report comparable metrics with their evidence status, and return Pareto and per-dimension winners without inventing a scalar utility function."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_finite_endpoint_final_frontier_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_finite_endpoint_final_frontier_v1/proposal.json
@@ -1,0 +1,38 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_finite_endpoint_final_frontier_v1",
+  "created_utc": "2026-08-16T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Rerank the Llama7B frontier after finite endpoint and composed NoC closure",
+  "hypothesis": "Replacing the score32 row with finite endpoint timing and aggregate physical accounting will expose a multidimensional Pareto frontier rather than a defensible single scalar winner.",
+  "direct_comparison": {
+    "primary_question": "Which quality-backed Llama7B architecture is best in throughput, area envelope, energy, and arithmetic precision after the score32 communication recost?",
+    "include": [
+      "finite endpoint and aggregate endpoint/mesh score32 recost",
+      "bounded generation-quality evidence",
+      "measured exact-FP16 energy reference",
+      "separate per-dimension winners and Pareto dominance"
+    ],
+    "exclude": [
+      "quality-invalid mixed-int8 rows from promotion",
+      "planning-only abstract throughput rows from promotion",
+      "scalar weighting across throughput, energy, area, and precision",
+      "claims of workload-complete NoC/SRAM energy"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_finite_endpoint_final_frontier_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_finite_endpoint_final_frontier_v1/quality_gate.md
@@ -1,0 +1,8 @@
+# Quality Gate
+
+- Require the exact merged finite-endpoint composed recost.
+- Require passing quality evidence for score32 and the exact-FP16 reference.
+- Exclude quality-invalid and planning-only rows from the promoted frontier.
+- Preserve evidence-status labels for area and energy boundaries.
+- Report Pareto and per-dimension winners without an arbitrary scalar score.
+- Keep workload activity, SRAM energy, vendor HBM signoff, and native-quality breadth explicit.

--- a/npu/eval/audit_llm_decoder_attention_score32_finite_endpoint_final_frontier.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_finite_endpoint_final_frontier.py
@@ -168,12 +168,40 @@ def _fp16_row(source: JsonDict) -> JsonDict:
     }
 
 
-def _pareto_rows(score32: JsonDict, fp16: JsonDict) -> list[JsonDict]:
-    # Each candidate wins at least one strict dimension, so neither dominates the other.
-    return [
-        {**score32, "pareto_reason": "higher throughput and smaller die envelope"},
-        {**fp16, "pareto_reason": "lower energy and higher arithmetic precision"},
-    ]
+def _precision_level(row: JsonDict) -> int:
+    return 2 if row.get("family") == _FP16_FAMILY else 1
+
+
+def _winner(rows: list[JsonDict], key: str, *, maximize: bool) -> str | list[str]:
+    values = [float(row[key]) for row in rows]
+    target = max(values) if maximize else min(values)
+    winners = [str(row["candidate_id"]) for row, value in zip(rows, values) if value == target]
+    return winners[0] if len(winners) == 1 else winners
+
+
+def _dominates(left: JsonDict, right: JsonDict) -> bool:
+    comparisons = (
+        float(left["token_throughput_per_s"]) >= float(right["token_throughput_per_s"]),
+        float(left["die_envelope_mm2"]) <= float(right["die_envelope_mm2"]),
+        float(left["energy_mj_per_token"]) <= float(right["energy_mj_per_token"]),
+        _precision_level(left) >= _precision_level(right),
+    )
+    strict = (
+        float(left["token_throughput_per_s"]) > float(right["token_throughput_per_s"]),
+        float(left["die_envelope_mm2"]) < float(right["die_envelope_mm2"]),
+        float(left["energy_mj_per_token"]) < float(right["energy_mj_per_token"]),
+        _precision_level(left) > _precision_level(right),
+    )
+    return all(comparisons) and any(strict)
+
+
+def _pareto_rows(rows: list[JsonDict]) -> list[JsonDict]:
+    result: list[JsonDict] = []
+    for row in rows:
+        dominators = [other["candidate_id"] for other in rows if other is not row and _dominates(other, row)]
+        if not dominators:
+            result.append({**row, "pareto_reason": "not dominated across all four objectives"})
+    return result
 
 
 def build_report(*, finite_recost: JsonDict, quality_frontier: JsonDict) -> JsonDict:
@@ -181,6 +209,14 @@ def build_report(*, finite_recost: JsonDict, quality_frontier: JsonDict) -> Json
     prior_score32, prior_fp16, all_prior_rows = _frontier_rows(quality_frontier)
     score32 = _score32_row(recost, prior_score32)
     fp16 = _fp16_row(prior_fp16)
+    candidates = [score32, fp16]
+    pareto = _pareto_rows(candidates)
+    dimension_winners = {
+        "token_throughput": _winner(candidates, "token_throughput_per_s", maximize=True),
+        "die_envelope_area": _winner(candidates, "die_envelope_mm2", maximize=False),
+        "energy_per_token": _winner(candidates, "energy_mj_per_token", maximize=False),
+        "arithmetic_precision": fp16["candidate_id"],
+    }
     excluded = [
         {
             "candidate_id": row.get("candidate_id"),
@@ -193,7 +229,11 @@ def build_report(*, finite_recost: JsonDict, quality_frontier: JsonDict) -> Json
     return {
         "version": 1,
         "model": "llama7b_score32_finite_endpoint_final_frontier_v1",
-        "decision": "two_nondominated_precision_safe_points_no_universal_scalar_winner",
+        "decision": (
+            "two_nondominated_precision_safe_points_no_universal_scalar_winner"
+            if len(pareto) == 2
+            else "single_dominant_precision_safe_point"
+        ),
         "source_items": {
             "finite_endpoint_composed_recost": (
                 "l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1"
@@ -203,19 +243,19 @@ def build_report(*, finite_recost: JsonDict, quality_frontier: JsonDict) -> Json
                 "rtl_ppa_recost_frontier_llama7b_v1"
             ),
         },
-        "dimension_winners": {
-            "token_throughput": score32["candidate_id"],
-            "die_envelope_area": score32["candidate_id"],
-            "energy_per_token": fp16["candidate_id"],
-            "arithmetic_precision": fp16["candidate_id"],
-        },
+        "dimension_winners": dimension_winners,
         "conditional_recommendation": {
             "throughput_under_800mm2_with_bounded_generation_quality": score32["candidate_id"],
-            "energy_and_precision_first": fp16["candidate_id"],
-            "unconditional_best": None,
-            "reason": "The two quality-backed points trade throughput and die envelope against energy and precision.",
+            "energy_first": dimension_winners["energy_per_token"],
+            "precision_first": dimension_winners["arithmetic_precision"],
+            "unconditional_best": pareto[0]["candidate_id"] if len(pareto) == 1 else None,
+            "reason": (
+                "One point dominates every measured objective."
+                if len(pareto) == 1
+                else "The two quality-backed points trade measured objectives."
+            ),
         },
-        "pareto_frontier": _pareto_rows(score32, fp16),
+        "pareto_frontier": pareto,
         "excluded_nonpromotable_history": excluded,
         "comparison_limits": [
             "Score32 has total embodied area; the FP16 reference currently exposes only its die envelope and compute area.",

--- a/npu/eval/audit_llm_decoder_attention_score32_finite_endpoint_final_frontier.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_finite_endpoint_final_frontier.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Build the final multidimensional Llama7B frontier after finite-endpoint recost."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+_BASE = Path("runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1")
+DEFAULT_FINITE_RECOST = _BASE / (
+    "decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost__"
+    "l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1.json"
+)
+DEFAULT_QUALITY_FRONTIER = _BASE / (
+    "decoder_attention_score32_integrated_frontier_ranking__"
+    "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_"
+    "llama7b_v1.json"
+)
+
+_RECOST_PROFILE = "decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost"
+_FRONTIER_MODEL = "llm_decoder_attention_score32_integrated_frontier_ranking_v1"
+_SCORE32_FAMILY = "score32_exp_lut_div"
+_FP16_FAMILY = "measured_exact_fp16_gqa8_kv8"
+
+
+def _load_json(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _positive(value: Any, label: str) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be numeric") from exc
+    if not math.isfinite(number) or number <= 0.0:
+        raise ValueError(f"{label} must be positive")
+    return number
+
+
+def _validate_finite_recost(payload: JsonDict) -> JsonDict:
+    if payload.get("version") != 1 or payload.get("model") != "llama7b_proxy":
+        raise ValueError("finite recost model/version mismatch")
+    if payload.get("profile") != _RECOST_PROFILE:
+        raise ValueError("finite recost profile mismatch")
+    if payload.get("decision") != "score32_noc_phase2_finite_endpoint_composed_recost_recorded":
+        raise ValueError("finite recost decision mismatch")
+    closure = payload.get("closure_flags")
+    throughput = payload.get("throughput")
+    physical = payload.get("physical_recost")
+    precision = payload.get("precision_contract")
+    if not all(isinstance(section, dict) for section in (closure, throughput, physical, precision)):
+        raise ValueError("finite recost is missing required sections")
+    required_flags = (
+        "finite_endpoint_and_mesh_cycle_equivalence_consumed",
+        "aggregate_endpoint_mesh_ppa_consumed",
+        "prior_primitive_area_power_replaced_not_added",
+    )
+    if not all(closure.get(flag) is True for flag in required_flags):
+        raise ValueError("finite recost does not close every required communication flag")
+    if physical.get("area_fit") is not True:
+        raise ValueError("finite recost does not fit its die envelope")
+    if precision.get("arithmetic_changed_by_this_recost") is not False:
+        raise ValueError("finite recost must preserve arithmetic semantics")
+    return payload
+
+
+def _frontier_rows(payload: JsonDict) -> tuple[JsonDict, JsonDict, list[JsonDict]]:
+    if payload.get("version") != 1 or payload.get("model") != _FRONTIER_MODEL:
+        raise ValueError("quality frontier model/version mismatch")
+    rows = payload.get("rows")
+    if not isinstance(rows, list):
+        raise ValueError("quality frontier rows are missing")
+    valid_rows = [dict(row) for row in rows if isinstance(row, dict)]
+
+    def unique_family(family: str) -> JsonDict:
+        matches = [row for row in valid_rows if row.get("family") == family]
+        if len(matches) != 1:
+            raise ValueError(f"quality frontier must contain exactly one {family} row")
+        row = matches[0]
+        if row.get("promotable") is not True or row.get("quality_backed") is not True:
+            raise ValueError(f"{family} row must be promotable and quality-backed")
+        return row
+
+    return unique_family(_SCORE32_FAMILY), unique_family(_FP16_FAMILY), valid_rows
+
+
+def _score32_row(recost: JsonDict, source: JsonDict) -> JsonDict:
+    throughput = dict(recost["throughput"])
+    physical = dict(recost["physical_recost"])
+    precision = dict(recost["precision_contract"])
+    controller = dict(source.get("score32_hbm_controller_replay_ppa") or {})
+    token_latency_us = _positive(throughput.get("token_latency_us"), "score32 token latency")
+    logic_energy_mj = _positive(
+        physical.get("recost_logic_vectorless_energy_per_token_mj"),
+        "score32 recost logic energy",
+    )
+    hbm_energy_mj = _positive(source.get("hbm_energy_mj_per_token"), "score32 HBM energy")
+    controller_power_mw = _positive(controller.get("controller_power_mw"), "controller power")
+    controller_area_mm2 = _positive(controller.get("controller_area_mm2"), "controller area")
+    controller_energy_mj = controller_power_mw * token_latency_us * 1.0e-6
+    total_energy_mj = logic_energy_mj + hbm_energy_mj + controller_energy_mj
+    recost_embodied_area_mm2 = _positive(
+        physical.get("total_embodied_area_um2"), "score32 embodied area"
+    ) / 1.0e6
+    total_embodied_area_mm2 = recost_embodied_area_mm2 + controller_area_mm2
+    die_area_mm2 = _positive(physical.get("die_area_um2"), "score32 die area") / 1.0e6
+    if total_embodied_area_mm2 > die_area_mm2:
+        raise ValueError("score32 recost plus HBM replay controller exceeds the die envelope")
+    quality = dict(source.get("quality") or {})
+    if quality.get("quality_backed") is not True or not str(quality.get("status", "")).endswith("_pass"):
+        raise ValueError("score32 quality evidence is not passing")
+    return {
+        "candidate_id": "score32_finite_endpoint_composed_quality_backed",
+        "family": _SCORE32_FAMILY,
+        "promotable": True,
+        "quality_backed": True,
+        "precision_class": "approximate_q8_k8_v8_score32_weight16_exp_lut_div",
+        "precision_profile": precision.get("precision_profile"),
+        "semantic_profile": precision.get("semantic_profile"),
+        "quality": quality,
+        "token_throughput_per_s": _positive(
+            throughput.get("token_throughput_per_s"), "score32 throughput"
+        ),
+        "token_latency_us": token_latency_us,
+        "bottleneck": throughput.get("bottleneck"),
+        "die_envelope_mm2": die_area_mm2,
+        "finite_recost_embodied_area_mm2": recost_embodied_area_mm2,
+        "hbm_controller_area_mm2": controller_area_mm2,
+        "total_embodied_area_mm2": total_embodied_area_mm2,
+        "area_status": "placed_logic_plus_measured_sram_area_plus_reserved_die_fraction",
+        "logic_vectorless_energy_mj_per_token": logic_energy_mj,
+        "hbm_source_backed_energy_mj_per_token": hbm_energy_mj,
+        "hbm_controller_vectorless_energy_mj_per_token": controller_energy_mj,
+        "energy_mj_per_token": total_energy_mj,
+        "energy_status": "vectorless_onchip_logic_plus_source_backed_hbm_and_measured_controller",
+        "source_candidate_id": source.get("candidate_id"),
+        "remaining_abstractions": sorted(
+            {
+                *[str(item) for item in recost.get("remaining_abstractions", [])],
+                *[str(item) for item in source.get("remaining_abstractions", [])],
+                "The combined score32 energy is not workload-toggle-complete for the composed NoC and SRAM macros.",
+            }
+        ),
+    }
+
+
+def _fp16_row(source: JsonDict) -> JsonDict:
+    return {
+        "candidate_id": source.get("candidate_id"),
+        "family": _FP16_FAMILY,
+        "promotable": True,
+        "quality_backed": True,
+        "precision_class": "measured_exact_fp16_with_native_gqa8_kv8",
+        "precision_profile": source.get("precision_status"),
+        "token_throughput_per_s": _positive(source.get("token_throughput_per_s"), "FP16 throughput"),
+        "token_latency_us": _positive(source.get("latency_us"), "FP16 latency"),
+        "die_envelope_mm2": _positive(source.get("die_area_mm2"), "FP16 die area"),
+        "total_embodied_area_mm2": None,
+        "area_status": "die_envelope_only_total_embodied_area_not_materialized",
+        "energy_mj_per_token": _positive(source.get("energy_mj_per_token"), "FP16 energy"),
+        "energy_status": source.get("abstraction_status"),
+        "remaining_abstractions": list(source.get("remaining_abstractions") or []),
+    }
+
+
+def _pareto_rows(score32: JsonDict, fp16: JsonDict) -> list[JsonDict]:
+    # Each candidate wins at least one strict dimension, so neither dominates the other.
+    return [
+        {**score32, "pareto_reason": "higher throughput and smaller die envelope"},
+        {**fp16, "pareto_reason": "lower energy and higher arithmetic precision"},
+    ]
+
+
+def build_report(*, finite_recost: JsonDict, quality_frontier: JsonDict) -> JsonDict:
+    recost = _validate_finite_recost(finite_recost)
+    prior_score32, prior_fp16, all_prior_rows = _frontier_rows(quality_frontier)
+    score32 = _score32_row(recost, prior_score32)
+    fp16 = _fp16_row(prior_fp16)
+    excluded = [
+        {
+            "candidate_id": row.get("candidate_id"),
+            "family": row.get("family"),
+            "reason": row.get("precision_status") or row.get("abstraction_status"),
+        }
+        for row in all_prior_rows
+        if row.get("promotable") is not True or row.get("quality_backed") is not True
+    ]
+    return {
+        "version": 1,
+        "model": "llama7b_score32_finite_endpoint_final_frontier_v1",
+        "decision": "two_nondominated_precision_safe_points_no_universal_scalar_winner",
+        "source_items": {
+            "finite_endpoint_composed_recost": (
+                "l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1"
+            ),
+            "quality_aware_frontier": (
+                "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_"
+                "rtl_ppa_recost_frontier_llama7b_v1"
+            ),
+        },
+        "dimension_winners": {
+            "token_throughput": score32["candidate_id"],
+            "die_envelope_area": score32["candidate_id"],
+            "energy_per_token": fp16["candidate_id"],
+            "arithmetic_precision": fp16["candidate_id"],
+        },
+        "conditional_recommendation": {
+            "throughput_under_800mm2_with_bounded_generation_quality": score32["candidate_id"],
+            "energy_and_precision_first": fp16["candidate_id"],
+            "unconditional_best": None,
+            "reason": "The two quality-backed points trade throughput and die envelope against energy and precision.",
+        },
+        "pareto_frontier": _pareto_rows(score32, fp16),
+        "excluded_nonpromotable_history": excluded,
+        "comparison_limits": [
+            "Score32 has total embodied area; the FP16 reference currently exposes only its die envelope and compute area.",
+            "Score32 energy uses vectorless composed-logic power plus source-backed HBM energy, not workload-complete NoC/SRAM activity.",
+            "The bounded Mistral-7B quality gate is evidence for the Llama7B-class arithmetic profile, not a full Llama-2-7B benchmark suite.",
+        ],
+        "remaining_abstractions": sorted(
+            {
+                *score32["remaining_abstractions"],
+                *[str(item) for item in fp16["remaining_abstractions"]],
+                "FP16 total embodied SRAM/NoC area is not materialized on the same accounting boundary.",
+            }
+        ),
+        "next_measurements": [
+            "Capture workload activity for the composed score32 endpoint/mesh and SRAM macro ports.",
+            "Materialize FP16 total embodied area on the same die/SRAM/NoC accounting boundary.",
+            "Expand native 7B generation quality beyond the bounded eight-prompt gate.",
+        ],
+    }
+
+
+def write_report(payload: JsonDict, path: Path) -> None:
+    rows = payload["pareto_frontier"]
+    lines = [
+        "# Llama7B Finite-Endpoint Final Frontier",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- unconditional best: `{payload['conditional_recommendation']['unconditional_best']}`",
+        "",
+        "| Candidate | Throughput token/s | Die envelope mm2 | Embodied area mm2 | Energy mJ/token | Precision |",
+        "|---|---:|---:|---:|---:|---|",
+    ]
+    for row in rows:
+        lines.append(
+            "| {candidate_id} | {token_throughput_per_s} | {die_envelope_mm2} | {area} | "
+            "{energy_mj_per_token} | {precision_class} |".format(
+                **row,
+                area=row.get("total_embodied_area_mm2"),
+            )
+        )
+    lines.extend(["", "## Dimension Winners", ""])
+    lines.extend(f"- {key}: `{value}`" for key, value in payload["dimension_winners"].items())
+    lines.extend(["", "## Remaining Abstractions", ""])
+    lines.extend(f"- {item}" for item in payload["remaining_abstractions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--finite-recost-json", type=Path, default=DEFAULT_FINITE_RECOST)
+    parser.add_argument("--quality-frontier-json", type=Path, default=DEFAULT_QUALITY_FRONTIER)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--report", type=Path, required=True)
+    args = parser.parse_args()
+    root = args.repo_root.resolve()
+    payload = build_report(
+        finite_recost=_load_json(root / args.finite_recost_json),
+        quality_frontier=_load_json(root / args.quality_frontier_json),
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_report(payload, args.report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/tests/test_audit_llm_decoder_attention_score32_finite_endpoint_final_frontier.py
+++ b/npu/eval/tests/test_audit_llm_decoder_attention_score32_finite_endpoint_final_frontier.py
@@ -118,3 +118,13 @@ def test_final_frontier_rejects_quality_regression() -> None:
 
     with pytest.raises(ValueError, match="quality evidence is not passing"):
         build_report(finite_recost=copy.deepcopy(_recost()), quality_frontier=frontier)
+
+
+def test_dimension_winner_uses_measured_throughput_not_candidate_identity() -> None:
+    recost = _recost()
+    recost["throughput"]["token_throughput_per_s"] = 10.0
+    recost["throughput"]["token_latency_us"] = 100000.0
+
+    result = build_report(finite_recost=recost, quality_frontier=_frontier())
+
+    assert result["dimension_winners"]["token_throughput"] == "fp16-reference"

--- a/npu/eval/tests/test_audit_llm_decoder_attention_score32_finite_endpoint_final_frontier.py
+++ b/npu/eval/tests/test_audit_llm_decoder_attention_score32_finite_endpoint_final_frontier.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from npu.eval.audit_llm_decoder_attention_score32_finite_endpoint_final_frontier import (
+    _validate_finite_recost,
+    build_report,
+)
+
+
+def _recost() -> dict:
+    return {
+        "version": 1,
+        "model": "llama7b_proxy",
+        "profile": "decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost",
+        "decision": "score32_noc_phase2_finite_endpoint_composed_recost_recorded",
+        "throughput": {
+            "token_throughput_per_s": 74.0,
+            "token_latency_us": 13513.5135135,
+            "bottleneck": "compute",
+        },
+        "physical_recost": {
+            "area_fit": True,
+            "die_area_um2": 800_000_000,
+            "total_embodied_area_um2": 760_000_000,
+            "recost_logic_vectorless_energy_per_token_mj": 350.0,
+        },
+        "precision_contract": {
+            "precision_profile": "q8_k8_v8_a32_s32_w16_exp_lut_div_b20_int8_compute",
+            "semantic_profile": "score32_exp_lut_div",
+            "arithmetic_changed_by_this_recost": False,
+        },
+        "closure_flags": {
+            "finite_endpoint_and_mesh_cycle_equivalence_consumed": True,
+            "aggregate_endpoint_mesh_ppa_consumed": True,
+            "prior_primitive_area_power_replaced_not_added": True,
+        },
+        "remaining_abstractions": ["SRAM activity energy"],
+    }
+
+
+def _frontier() -> dict:
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_score32_integrated_frontier_ranking_v1",
+        "rows": [
+            {
+                "candidate_id": "old-score32",
+                "family": "score32_exp_lut_div",
+                "promotable": True,
+                "quality_backed": True,
+                "quality": {
+                    "quality_backed": True,
+                    "status": "mixed_int8_generation_quality_pass",
+                },
+                "hbm_energy_mj_per_token": 134.0,
+                "score32_hbm_controller_replay_ppa": {
+                    "controller_power_mw": 0.1,
+                    "controller_area_mm2": 0.03,
+                },
+                "remaining_abstractions": ["vendor HBM signoff"],
+            },
+            {
+                "candidate_id": "fp16-reference",
+                "family": "measured_exact_fp16_gqa8_kv8",
+                "promotable": True,
+                "quality_backed": True,
+                "precision_status": "conservative_native_gqa8_kv8",
+                "token_throughput_per_s": 14.0,
+                "latency_us": 71428.5714,
+                "die_area_mm2": 1200.0,
+                "energy_mj_per_token": 82.0,
+                "abstraction_status": "measured_compute_with_source_backed_hbm_energy",
+                "remaining_abstractions": ["profile-scaled SRAM energy"],
+            },
+            {
+                "candidate_id": "invalid-fast",
+                "family": "abstract",
+                "promotable": False,
+                "quality_backed": False,
+                "precision_status": "planning_only",
+            },
+        ],
+    }
+
+
+def test_recost_validation_rejects_primitive_double_counting_flag() -> None:
+    payload = _recost()
+    payload["closure_flags"]["prior_primitive_area_power_replaced_not_added"] = False
+
+    with pytest.raises(ValueError, match="communication flag"):
+        _validate_finite_recost(payload)
+
+
+def test_final_frontier_has_two_nondominated_quality_backed_points() -> None:
+    result = build_report(finite_recost=_recost(), quality_frontier=_frontier())
+
+    assert result["decision"] == "two_nondominated_precision_safe_points_no_universal_scalar_winner"
+    assert result["conditional_recommendation"]["unconditional_best"] is None
+    assert len(result["pareto_frontier"]) == 2
+    score32, fp16 = result["pareto_frontier"]
+    assert score32["token_throughput_per_s"] == 74.0
+    assert score32["total_embodied_area_mm2"] == 760.03
+    assert score32["energy_mj_per_token"] == pytest.approx(484.00135135135134)
+    assert fp16["energy_mj_per_token"] == 82.0
+    assert result["dimension_winners"]["token_throughput"] == score32["candidate_id"]
+    assert result["dimension_winners"]["energy_per_token"] == fp16["candidate_id"]
+    assert result["excluded_nonpromotable_history"] == [
+        {"candidate_id": "invalid-fast", "family": "abstract", "reason": "planning_only"}
+    ]
+
+
+def test_final_frontier_rejects_quality_regression() -> None:
+    frontier = _frontier()
+    frontier["rows"][0]["quality"]["status"] = "mixed_int8_generation_quality_fail"
+
+    with pytest.raises(ValueError, match="quality evidence is not passing"):
+        build_report(finite_recost=copy.deepcopy(_recost()), quality_frontier=frontier)


### PR DESCRIPTION
## Summary

- add a dependency-gated final frontier audit that replaces the score32 row only after finite endpoint timing and aggregate composed NoC recost merge
- compare score32 with the measured exact-FP16/GQA8 reference across throughput, die envelope, embodied-area status, energy status, and precision
- exclude quality-invalid and planning-only candidates from promotion
- report Pareto and per-dimension winners without inventing a scalar utility score
- add generator, result-consumer, proposal, and CI coverage

## Accounting

- score32 embodied area includes the finite recost plus measured HBM replay-controller area and rechecks the 800 mm2 fit
- score32 energy combines recost vectorless on-chip logic, source-backed HBM energy, and measured controller power at the recost token latency
- remaining workload activity, SRAM macro energy, vendor HBM signoff, FP16 embodied-area parity, and quality breadth remain explicit

## Validation

- `13 passed` across the recost/frontier and control-plane focused tests
- actual merged quality-frontier schema exercised with a finite-recost fixture
- `python scripts/validate_runs.py`
- JSON parse validation and `git diff --check`

The generated item has one exact merged dependency, `l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1`, so it remains blocked until the physical chain completes.
