### PR TITLE
Recost exact Llama-2-7B MHA through global HBM

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -607,6 +607,10 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_score32_finite_endpoint_final_frontier_report",
     ),
     (
+        "attention_score32_global_hbm_exact_mha_recost_out",
+        "attention_score32_global_hbm_exact_mha_recost_report",
+    ),
+    (
         "attention_score32_folded_global_exact_reduction_recost_out",
         "attention_score32_folded_global_exact_reduction_recost_report",
     ),
@@ -841,6 +845,10 @@ def _decoder_quality_brief(evidence_payload: dict[str, Any]) -> dict[str, Any]:
         "conditional_recommendation",
         "pareto_frontier",
         "engineering_pareto_frontier",
+        "global_controller_correction",
+        "exact_mha_delta_vs_corrected_gqa8",
+        "invariants",
+        "rows",
         "excluded_nonpromotable_history",
         "comparison_limits",
         "next_measurements",
@@ -1071,6 +1079,30 @@ def _decoder_recommendation_override(
 
 def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, Any]) -> tuple[str, str]:
     model = str(evidence_payload.get("model", "")).strip()
+    if model == "llm_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1":
+        outcome = str(
+            evidence_payload.get("decision")
+            or "exact_llama2_mha_recost_recorded_native_quality_required"
+        )
+        correction = dict(evidence_payload.get("global_controller_correction") or {})
+        rows = list(evidence_payload.get("rows") or [])
+        by_id = {
+            str(row.get("candidate_id")): row
+            for row in rows
+            if isinstance(row, dict) and row.get("candidate_id")
+        }
+        gqa8 = dict(by_id.get("score32_gqa8_global_hbm_finite_endpoint") or {})
+        mha = dict(by_id.get("score32_exact_llama2_7b_mha_global_hbm_finite_endpoint") or {})
+        parts = [
+            f"Global-HBM exact Llama-2-7B MHA recost recorded from {evidence_ref}: decision={outcome}",
+            f"source_finite_token_s={correction.get('source_finite_token_throughput_per_s')}",
+            f"corrected_gqa8_token_s={dict(gqa8.get('throughput') or {}).get('token_throughput_per_s')}",
+            f"exact_mha_token_s={dict(mha.get('throughput') or {}).get('token_throughput_per_s')}",
+            f"exact_mha_hbm_mj_per_token={dict(mha.get('energy') or {}).get('hbm_energy_mj_per_token')}",
+            f"exact_mha_promotable={dict(mha.get('quality_contract') or {}).get('promotable')}",
+        ]
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
     if model == "llama7b_score32_finite_endpoint_final_frontier_v1":
         outcome = str(
             evidence_payload.get("decision")

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5864,6 +5864,114 @@ def _decoder_attention_score32_finite_endpoint_final_frontier_evidence(
     }
 
 
+def _decoder_attention_score32_global_hbm_exact_llama2_mha_recost_evidence(
+    *,
+    item_id: str,
+    depends_on_item_ids: list[str] | None,
+    proposal_id: str | None,
+    proposal_path: str | None,
+) -> dict[str, Any]:
+    expected_item_id = "l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1"
+    expected_proposal_id = "prop_l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1"
+    expected_dependencies = [
+        "l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1"
+    ]
+    if item_id != expected_item_id:
+        raise Layer2TaskGenerationError("global-HBM exact-MHA recost only permits the exact item")
+    if str(proposal_id or "").strip() != expected_proposal_id:
+        raise Layer2TaskGenerationError("global-HBM exact-MHA recost proposal_id mismatch")
+    if str(proposal_path or "").strip() != f"docs/proposals/{expected_proposal_id}/proposal.json":
+        raise Layer2TaskGenerationError("global-HBM exact-MHA recost proposal_path mismatch")
+    if list(depends_on_item_ids or []) != expected_dependencies:
+        raise Layer2TaskGenerationError(
+            "global-HBM exact-MHA recost requires the exact finite recost dependency"
+        )
+
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    finite = (
+        f"{base}/decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost__"
+        "l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1.json"
+    )
+    source = (
+        f"{base}/decoder_attention_score32_exact_reduction_recost__"
+        "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1.json"
+    )
+    hbm_replay = (
+        f"{base}/decoder_attention_score32_hbm_controller_replay__"
+        "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1.json"
+    )
+    hbm_energy = (
+        f"{base}/decoder_attention_score32_exp_lut_hbm_dram_service_closure__"
+        "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1.json"
+    )
+    measured_costs = (
+        "runs/campaigns/npu/l1_measured_costs/"
+        "llama7b_attention_local_costs_all_measured_endpoint_v1.json"
+    )
+    out = f"{base}/decoder_attention_score32_global_hbm_exact_llama2_mha_recost__{item_id}.json"
+    report = f"{base}/decoder_attention_score32_global_hbm_exact_llama2_mha_recost__{item_id}.md"
+    command = _bounded_launcher_command(
+        memory_high="4G",
+        memory_max="6G",
+        cpu_quota="100%",
+        tasks_max=64,
+        runtime_max_sec=3600,
+        child_command=[
+            "python3",
+            "npu/eval/recost_llm_decoder_attention_score32_global_hbm_exact_llama2_mha.py",
+            "--repo-root",
+            ".",
+            "--finite-recost-json",
+            finite,
+            "--source-recost-json",
+            source,
+            "--hbm-replay-json",
+            hbm_replay,
+            "--hbm-energy-json",
+            hbm_energy,
+            "--measured-l1-costs",
+            measured_costs,
+            "--out",
+            out,
+            "--report",
+            report,
+        ],
+    )
+    return {
+        "inputs": {
+            "attention_score32_finite_endpoint_composed_recost": finite,
+            "attention_score32_exact_reduction_recost": source,
+            "attention_score32_hbm_controller_replay": hbm_replay,
+            "attention_score32_hbm_energy_closure": hbm_energy,
+            "attention_score32_measured_l1_costs": measured_costs,
+            "attention_score32_global_hbm_exact_mha_recost_out": out,
+            "attention_score32_global_hbm_exact_mha_recost_report": report,
+        },
+        "commands": [{"name": "recost_score32_global_hbm_exact_llama2_mha", "run": command}],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+        "worker_resources": {
+            "exclusive_worker": True,
+            "memory_high": "4G",
+            "memory_max": "6G",
+            "cpu_quota": "100%",
+            "tasks_max": 64,
+            "outer_timeout_seconds": 3600,
+            "stall_timeout_seconds": 900,
+        },
+        "acceptance": [
+            "Replay aggregate bytes from every active cluster through one global HBM controller",
+            "Report the corrected GQA8 baseline before comparing exact Llama-2-7B MHA",
+            "Recompute MHA QKV projection cycles, KV writes, KV cache, tile bytes, and HBM energy",
+            "Keep shared-SRAM bytes and reduction payload fixed while recomputing residency fractions",
+            "Rerun finite endpoint scheduling with HBM-delayed wave releases",
+            "Keep compute/area sharing and every remaining energy and HBM abstraction explicit",
+            "Do not promote score32 without native Llama-2-7B generation-quality evidence",
+            "Write exactly one JSON and one Markdown report",
+        ],
+    }
+
+
 def _decoder_attention_kv_endpoint_full_onchip_service_schedule_evidence(
     *,
     item_id: str,
@@ -12744,6 +12852,7 @@ def _build_payload(
         "decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence",
         "decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost",
         "decoder_attention_score32_finite_endpoint_final_frontier",
+        "decoder_attention_score32_global_hbm_exact_llama2_mha_recost",
         "decoder_attention_kv_endpoint_full_onchip_service_schedule",
         "decoder_attention_kv_endpoint_ready_valid_service",
         "decoder_attention_kv_endpoint_router_sram_composition",
@@ -13008,6 +13117,13 @@ def _build_payload(
             )
         elif abstraction_layer_name == "decoder_attention_score32_finite_endpoint_final_frontier":
             decoder_evidence = _decoder_attention_score32_finite_endpoint_final_frontier_evidence(
+                item_id=item_id,
+                depends_on_item_ids=depends_on_item_ids,
+                proposal_id=proposal_id,
+                proposal_path=proposal_path,
+            )
+        elif abstraction_layer_name == "decoder_attention_score32_global_hbm_exact_llama2_mha_recost":
+            decoder_evidence = _decoder_attention_score32_global_hbm_exact_llama2_mha_recost_evidence(
                 item_id=item_id,
                 depends_on_item_ids=depends_on_item_ids,
                 proposal_id=proposal_id,

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -339,6 +339,58 @@ def test_decoder_evidence_summary_recognizes_finite_endpoint_final_frontier() ->
     assert "unconditional_best=None" in summary
 
 
+def test_decoder_evidence_paths_recognizes_global_hbm_exact_mha_recost(tmp_path: Path) -> None:
+    evidence_rel = "runs/datasets/demo/score32_global_hbm_exact_mha.json"
+    report_rel = "runs/datasets/demo/score32_global_hbm_exact_mha.md"
+    _write(tmp_path / evidence_rel, "{}\n")
+    _write(tmp_path / report_rel, "# Global HBM exact MHA\n")
+    work_item = SimpleNamespace(
+        input_manifest={
+            "decoder_contract": {
+                "attention_score32_global_hbm_exact_mha_recost_out": evidence_rel,
+                "attention_score32_global_hbm_exact_mha_recost_report": report_rel,
+            }
+        }
+    )
+
+    evidence_ref, source_refs = _decoder_evidence_paths(repo_root=tmp_path, work_item=work_item)
+
+    assert evidence_ref == evidence_rel
+    assert source_refs == {
+        "decoder_attention_score32_global_hbm_exact_mha_recost_out": evidence_rel,
+        "decoder_attention_score32_global_hbm_exact_mha_recost_report": report_rel,
+    }
+
+
+def test_decoder_evidence_summary_recognizes_global_hbm_exact_mha_recost() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/score32_global_hbm_exact_mha.json",
+        evidence_payload={
+            "model": "llm_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1",
+            "decision": "exact_llama2_mha_recost_recorded_native_quality_required",
+            "global_controller_correction": {"source_finite_token_throughput_per_s": 74.0},
+            "rows": [
+                {
+                    "candidate_id": "score32_gqa8_global_hbm_finite_endpoint",
+                    "throughput": {"token_throughput_per_s": 30.0},
+                },
+                {
+                    "candidate_id": "score32_exact_llama2_7b_mha_global_hbm_finite_endpoint",
+                    "throughput": {"token_throughput_per_s": 4.5},
+                    "energy": {"hbm_energy_mj_per_token": 1080.0},
+                    "quality_contract": {"promotable": False},
+                },
+            ],
+        },
+    )
+
+    assert outcome == "exact_llama2_mha_recost_recorded_native_quality_required"
+    assert "source_finite_token_s=74.0" in summary
+    assert "corrected_gqa8_token_s=30.0" in summary
+    assert "exact_mha_token_s=4.5" in summary
+    assert "exact_mha_promotable=False" in summary
+
+
 def test_decoder_evidence_summary_recognizes_score32_noc_phase2_schedule() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/score32_noc_phase2_schedule.json",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -14981,6 +14981,61 @@ def test_generate_l2_campaign_task_adds_finite_endpoint_final_frontier() -> None
             )
 
 
+def test_generate_l2_campaign_task_adds_global_hbm_exact_llama2_mha_recost() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        dependencies = [
+            "l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1"
+        ]
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                _make_l2_request(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id=(
+                        "prop_l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1"
+                    ),
+                    proposal_path=(
+                        "docs/proposals/prop_l2_decoder_attention_score32_"
+                        "global_hbm_exact_llama2_mha_recost_v1/proposal.json"
+                    ),
+                    abstraction_layer=(
+                        "decoder_attention_score32_global_hbm_exact_llama2_mha_recost"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    depends_on_item_ids=dependencies,
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            run = work_item.command_manifest[0]["run"]
+            assert work_item.state == WorkItemState.BLOCKED
+            assert "recost_llm_decoder_attention_score32_global_hbm_exact_llama2_mha.py" in run
+            assert "--finite-recost-json" in run
+            assert "--hbm-replay-json" in run
+            assert "--hbm-energy-json" in run
+            assert "--runtime-max-sec 3600" in run
+            assert work_item.input_manifest["worker_resources"]["exclusive_worker"] is True
+            assert work_item.input_manifest["worker_resources"]["stall_timeout_seconds"] == 900
+            assert work_item.expected_outputs[0].endswith(
+                "decoder_attention_score32_global_hbm_exact_llama2_mha_recost__"
+                "l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1.json"
+            )
+
+
 def test_score32_noc_closure_rejects_inexact_dependencies() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1/README.md
@@ -1,0 +1,11 @@
+# Global-HBM Exact Llama-2-7B MHA Recost
+
+This proposal corrects two model-identity errors before the score32 point can
+re-enter the Llama-2-7B frontier. The HBM controller is global, so each wave
+must replay the aggregate bytes from all 16 active clusters rather than one
+tile. Exact Llama-2-7B also uses 32 KV heads (MHA), not the current four-head
+GQA8 proxy.
+
+The evaluator reports a corrected GQA8 baseline and an exact-MHA structural
+recost. Neither row is promotable until native Llama-2-7B score32 generation
+quality is measured.

--- a/docs/proposals/prop_l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1/design_brief.md
@@ -1,0 +1,16 @@
+# Design Brief
+
+The recost retains the measured compute array, finite endpoint, composed mesh,
+fixed on-chip SRAM capacity, and calibrated HBM-controller parameters. It then
+rebuilds each candidate's upstream schedule row.
+
+For each wave, one global controller serves `active_clusters * tile_hbm_bytes`.
+The controller and compute clocks remain separate and are compared in time,
+not by comparing raw cycle counts from different domains. Wave release cadence
+is the slower of attention arithmetic and aggregate HBM service, after which
+the complete finite-endpoint NoC schedule is replayed.
+
+MHA changes QKV projection work from `H^2 + 2H(H/8)` to `3H^2`, expands the KV
+cache and KV writes by eight, and recomputes HBM command energy. Attention QK
+and value MACs, reduction payload, compute-array area, and fixed shared-SRAM
+bytes do not scale with KV-head count.

--- a/docs/proposals/prop_l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1/evaluation_requests.json
@@ -1,0 +1,25 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1",
+  "source_commit": "TBD",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1",
+      "task_type": "l2_campaign",
+      "objective": "Correct global HBM bandwidth sharing and recost the exact 32-KV-head Llama-2-7B MHA structure.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_global_hbm_exact_llama2_mha_recost",
+      "comparison_role": "structural_frontier_correction",
+      "status": "pending_after_dependency_merge",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_global_hbm_exact_llama2_mha_recost__l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_global_hbm_exact_llama2_mha_recost__l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1.md"
+      ],
+      "acceptance_notes": "Replay aggregate active-cluster HBM bytes, rebuild exact-MHA compute and memory quantities, rerun finite endpoint scheduling, and refuse promotion without native Llama-2-7B score32 quality evidence."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1/proposal.json
@@ -1,0 +1,41 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1",
+  "created_utc": "2026-08-16T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Correct global HBM service and recost exact Llama-2-7B MHA",
+  "hypothesis": "The prior score32 frontier overstates throughput because it replays one tile against a global HBM controller, and its GQA8 shape is not exact Llama-2-7B; aggregate-wave replay plus a 32-KV-head MHA recost will establish the structurally valid performance and energy bounds.",
+  "direct_comparison": {
+    "primary_question": "How do corrected GQA8 and exact Llama-2-7B MHA compare in token throughput, energy, area, and structural/precision evidence under one global HBM controller?",
+    "include": [
+      "aggregate 16-cluster HBM wave service",
+      "separate HBM and compute clock domains",
+      "exact MHA QKV projection and KV traffic",
+      "finite endpoint NoC replay with delayed releases",
+      "calibrated HBM command energy",
+      "explicit structural and native-quality promotion gates"
+    ],
+    "exclude": [
+      "per-tile ownership of global HBM bandwidth",
+      "blind eight-times scaling of QKV compute or reduction traffic",
+      "vendor HBM timing/current signoff claims",
+      "promotion from Mistral GQA4 arithmetic evidence"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exact_reduction_recost__l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_hbm_controller_replay__l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1.json"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1/quality_gate.md
@@ -1,0 +1,11 @@
+# Quality Gate
+
+- Require the merged finite-endpoint composed recost and its explicit GQA8 contract.
+- Require the exact-reduction source, deterministic HBM replay, and calibrated HBM energy inputs.
+- Replay all active-cluster bytes through one global HBM controller per wave.
+- Recompute QKV projection, KV writes/cache, residency fraction, HBM latency, and HBM energy for 32-head MHA.
+- Keep reduction payload and fixed shared-SRAM bytes invariant across GQA8 and MHA.
+- Rerun workload-complete finite endpoint scheduling after HBM changes wave cadence.
+- Record exact structural identity separately from arithmetic quality.
+- Do not promote either score32 row without native Llama-2-7B generation-quality evidence.
+- Keep HBM RTL/vendor signoff and workload clock-gating power explicit.

--- a/npu/eval/measure_llm_decoder_attention_score32_noc_phase2_schedule.py
+++ b/npu/eval/measure_llm_decoder_attention_score32_noc_phase2_schedule.py
@@ -385,14 +385,21 @@ def build_report(
     args: argparse.Namespace,
     *,
     packet_spec_output: list[PacketSpec] | None = None,
+    source_row_override: JsonDict | None = None,
+    source_artifact_override: str | Path | None = None,
 ) -> JsonDict:
     repo_root = args.repo_root.resolve()
     source_json = repo_root / args.source_json
     costs_json = repo_root / args.measured_l1_costs
-    source_payload = _load_json(source_json)
-    source_row = source_payload.get("best_requested")
-    if not isinstance(source_row, dict):
-        raise ValueError("source recost payload is missing best_requested")
+    if source_row_override is None:
+        source_payload = _load_json(source_json)
+        source_row = source_payload.get("best_requested")
+        if not isinstance(source_row, dict):
+            raise ValueError("source recost payload is missing best_requested")
+    else:
+        if not isinstance(source_row_override, dict):
+            raise ValueError("source_row_override must be a dict")
+        source_row = source_row_override
     _require_fields(
         source_row,
         [
@@ -611,7 +618,9 @@ def build_report(
         "model": "llama7b_proxy",
         "profile": "decoder_attention_score32_noc_phase2_schedule",
         "source_artifacts": {
-            "score32_recost_json": str(args.source_json),
+            "score32_recost_json": str(
+                source_artifact_override if source_artifact_override is not None else args.source_json
+            ),
             "measured_l1_costs_json": str(args.measured_l1_costs),
             "measured_l1_profile": measured_profile["name"],
         },

--- a/npu/eval/recost_llm_decoder_attention_score32_global_hbm_exact_llama2_mha.py
+++ b/npu/eval/recost_llm_decoder_attention_score32_global_hbm_exact_llama2_mha.py
@@ -1,0 +1,584 @@
+#!/usr/bin/env python3
+"""Recost finite score32 attention with global HBM service and exact Llama-2-7B MHA."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from npu.eval import measure_llm_decoder_attention_score32_noc_phase2_schedule as phase2_schedule  # noqa: E402
+from npu.eval.audit_llm_decoder_attention_score32_exp_lut_hbm_dram_service_closure import (  # noqa: E402
+    _hbm_energy,
+)
+from npu.eval.audit_llm_decoder_attention_score32_hbm_controller_replay import (  # noqa: E402
+    _build_burst_stream,
+    _simulate_replay_cycles,
+)
+from npu.eval.reroute_llm_decoder_attention_score32_noc_phase2_measured_router_clock import (  # noqa: E402
+    _compact_schedule,
+)
+from npu.eval.verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl import (  # noqa: E402
+    descriptors_from_packet_specs,
+    run_performance_replay,
+)
+from npu.eval.measure_llm_decoder_attention_score32_noc_phase2_schedule import (  # noqa: E402
+    PacketSpec,
+)
+
+JsonDict = dict[str, Any]
+
+_BASE = Path("runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1")
+DEFAULT_FINITE_RECOST = _BASE / (
+    "decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost__"
+    "l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1.json"
+)
+DEFAULT_SOURCE_RECOST = _BASE / (
+    "decoder_attention_score32_exact_reduction_recost__"
+    "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1.json"
+)
+DEFAULT_HBM_REPLAY = _BASE / (
+    "decoder_attention_score32_hbm_controller_replay__"
+    "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1.json"
+)
+DEFAULT_HBM_ENERGY = _BASE / (
+    "decoder_attention_score32_exp_lut_hbm_dram_service_closure__"
+    "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1.json"
+)
+
+_FINITE_PROFILE = "decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost"
+_SOURCE_MODEL = "llm_decoder_attention_score32_exact_reduction_recost_v1"
+_HBM_REPLAY_MODEL = "llm_decoder_attention_score32_hbm_controller_replay_v1"
+_HBM_ENERGY_MODEL = "llm_decoder_attention_score32_exp_lut_hbm_dram_service_closure_v1"
+
+
+def _load_json(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _positive(value: Any, label: str) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be numeric") from exc
+    if not math.isfinite(number) or number <= 0.0:
+        raise ValueError(f"{label} must be positive")
+    return number
+
+
+def _positive_int(value: Any, label: str) -> int:
+    number = _positive(value, label)
+    integer = int(number)
+    if float(integer) != number:
+        raise ValueError(f"{label} must be an integer")
+    return integer
+
+
+def _ceil_div(numerator: int, denominator: int) -> int:
+    if denominator <= 0:
+        raise ValueError("division denominator must be positive")
+    return (numerator + denominator - 1) // denominator
+
+
+def _validate_inputs(
+    *, finite: JsonDict, source: JsonDict, hbm_replay: JsonDict, hbm_energy: JsonDict
+) -> tuple[JsonDict, JsonDict, JsonDict, JsonDict]:
+    if finite.get("version") != 1 or finite.get("profile") != _FINITE_PROFILE:
+        raise ValueError("finite endpoint composed recost profile/version mismatch")
+    model = finite.get("model_contract")
+    throughput = finite.get("throughput")
+    physical = finite.get("physical_recost")
+    clock = finite.get("clock_contract")
+    logical = finite.get("logical_schedule")
+    if not all(isinstance(section, dict) for section in (model, throughput, physical, clock, logical)):
+        raise ValueError("finite recost is missing required sections")
+    if model.get("attention_heads") != 32 or model.get("kv_heads") != 4:
+        raise ValueError("finite source must be the 32-head/4-KV-head GQA8 point")
+    if model.get("gqa_group_size") != 8 or model.get("kv_sharing") != "gqa8":
+        raise ValueError("finite source must expose GQA8")
+    if physical.get("area_fit") is not True:
+        raise ValueError("finite source must fit its die envelope")
+
+    if source.get("version") != 1 or source.get("model") != _SOURCE_MODEL:
+        raise ValueError("exact-reduction source model/version mismatch")
+    best = source.get("best_requested")
+    if not isinstance(best, dict):
+        raise ValueError("exact-reduction source is missing best_requested")
+    source_contract = {
+        "hidden_size": _positive_int(best.get("hidden_size"), "hidden_size"),
+        "layers": _positive_int(best.get("layers"), "layers"),
+        "attention_heads": _positive_int(best.get("attention_heads"), "attention_heads"),
+        "kv_heads": _positive_int(best.get("kv_heads"), "kv_heads"),
+        "sequence_length": _positive_int(best.get("sequence_length"), "sequence_length"),
+    }
+    for key, value in source_contract.items():
+        if model.get(key) != value:
+            raise ValueError(f"finite/source model mismatch for {key}")
+    if best.get("kv_sharing") != "gqa8":
+        raise ValueError("exact-reduction source must be GQA8")
+
+    if hbm_replay.get("version") != 1 or hbm_replay.get("model") != _HBM_REPLAY_MODEL:
+        raise ValueError("HBM replay model/version mismatch")
+    controller = hbm_replay.get("best_latency")
+    if not isinstance(controller, dict):
+        raise ValueError("HBM replay is missing best_latency")
+
+    if hbm_energy.get("version") != 1 or hbm_energy.get("model") != _HBM_ENERGY_MODEL:
+        raise ValueError("HBM energy model/version mismatch")
+    energy_params = hbm_energy.get("energy_params")
+    if not isinstance(energy_params, dict):
+        raise ValueError("HBM energy source is missing calibrated parameters")
+    for key in (
+        "read_hit_pj_per_byte",
+        "read_miss_pj_per_byte",
+        "write_pj_per_byte",
+        "activate_precharge_pj_per_row",
+        "command_pj_per_burst",
+    ):
+        _positive(energy_params.get(key), f"HBM energy parameter {key}")
+    return model, best, controller, energy_params
+
+
+def _projection_cycles(*, row: JsonDict, kv_heads: int) -> JsonDict:
+    hidden_size = _positive_int(row.get("hidden_size"), "hidden_size")
+    attention_heads = _positive_int(row.get("attention_heads"), "attention_heads")
+    head_dim = hidden_size // attention_heads
+    macs_per_cycle = _positive_int(
+        row.get("replica_recost_macs_per_cycle", row.get("macs_per_cycle")), "macs_per_cycle"
+    )
+    source_kv_heads = _positive_int(row.get("kv_heads"), "source kv_heads")
+    source_macs = hidden_size * hidden_size + 2 * hidden_size * source_kv_heads * head_dim
+    source_cycles = _positive_int(row.get("qkv_cycles"), "source qkv_cycles")
+    if _ceil_div(source_macs, macs_per_cycle) != source_cycles:
+        raise ValueError("source qkv_cycles does not match the declared MAC throughput")
+    target_macs = hidden_size * hidden_size + 2 * hidden_size * kv_heads * head_dim
+    return {
+        "source_macs": source_macs,
+        "source_cycles": source_cycles,
+        "target_macs": target_macs,
+        "target_cycles": _ceil_div(target_macs, macs_per_cycle),
+        "macs_per_cycle": macs_per_cycle,
+    }
+
+
+def _global_hbm_service(
+    *, tile_hbm_bytes: int, active_clusters: int, controller: JsonDict, hbm_clock_ns: float
+) -> JsonDict:
+    aggregate_wave_bytes = tile_hbm_bytes * active_clusters
+    channel_count = _positive_int(controller.get("channel_count"), "HBM channel_count")
+    burst_bytes = _positive_int(controller.get("burst_bytes"), "HBM burst_bytes")
+    row_span = _positive_int(controller.get("row_span_bursts"), "HBM row_span_bursts")
+    row_hit_rate = _positive(controller.get("row_hit_rate"), "HBM row_hit_rate")
+    channels, misses, burst_count, miss_count = _build_burst_stream(
+        tile_hbm_bytes=aggregate_wave_bytes,
+        burst_bytes=burst_bytes,
+        channel_count=channel_count,
+        row_span_bursts=row_span,
+        row_hit_rate=row_hit_rate,
+    )
+    service_cycles = _simulate_replay_cycles(
+        channel_count=channel_count,
+        channel_bandwidth_bytes_per_cycle=_positive(
+            controller.get("channel_bandwidth_bytes_per_cycle"), "HBM channel bandwidth"
+        ),
+        burst_bytes=burst_bytes,
+        channels=channels,
+        miss_flags=misses,
+        request_overhead_cycles=int(controller.get("request_overhead_cycles", 0)),
+        row_miss_penalty_cycles=int(controller.get("row_miss_penalty_cycles", 0)),
+        scheduler_gap_cycles=int(controller.get("scheduler_gap_cycles", 0)),
+        outstanding=_positive_int(controller.get("hbm_outstanding"), "HBM outstanding"),
+        scheduler_efficiency=_positive(controller.get("scheduler_efficiency"), "HBM scheduler efficiency"),
+    )
+    return {
+        "scope": "one_global_controller_shared_by_all_active_clusters",
+        "active_clusters": active_clusters,
+        "tile_hbm_bytes": tile_hbm_bytes,
+        "aggregate_wave_hbm_bytes": aggregate_wave_bytes,
+        "burst_count": burst_count,
+        "deterministic_row_miss_count": miss_count,
+        "service_cycles": service_cycles,
+        "hbm_controller_clock_ns": hbm_clock_ns,
+        "service_time_ns": service_cycles * hbm_clock_ns,
+        "effective_global_bytes_per_second": (
+            aggregate_wave_bytes / (service_cycles * hbm_clock_ns * 1.0e-9)
+        ),
+        "controller_parameters": {
+            key: controller.get(key)
+            for key in (
+                "channel_count",
+                "channel_bandwidth_bytes_per_cycle",
+                "burst_bytes",
+                "row_span_bursts",
+                "row_hit_rate",
+                "request_overhead_cycles",
+                "row_miss_penalty_cycles",
+                "hbm_outstanding",
+                "scheduler_gap_cycles",
+                "scheduler_efficiency",
+            )
+        },
+    }
+
+
+def _phase2_args(args: argparse.Namespace, *, noc_clock_ns: float) -> argparse.Namespace:
+    return argparse.Namespace(
+        repo_root=args.repo_root,
+        source_json=args.source_recost_json,
+        measured_l1_costs=args.measured_l1_costs,
+        out=args.out,
+        report=args.report,
+        wave_limit=None,
+        packet_payload_bytes=256,
+        cluster_endpoints=None,
+        root_endpoint=15,
+        shared_vc=0,
+        reduction_vc=1,
+        compute_clock_ns=None,
+        noc_clock_ns=noc_clock_ns,
+        max_cycles=args.max_cycles,
+    )
+
+
+def _candidate(
+    *,
+    args: argparse.Namespace,
+    candidate_id: str,
+    kv_heads: int,
+    exact_llama2_structure: bool,
+    finite: JsonDict,
+    source_row: JsonDict,
+    controller: JsonDict,
+    energy_params: JsonDict,
+    fixed_shared_tile_bytes: int,
+) -> JsonDict:
+    hidden_size = _positive_int(source_row.get("hidden_size"), "hidden_size")
+    attention_heads = _positive_int(source_row.get("attention_heads"), "attention_heads")
+    head_dim = hidden_size // attention_heads
+    kv_bits = _positive_int(source_row.get("kv_bits"), "kv_bits")
+    tile_tokens = _positive_int(source_row.get("tile_tokens"), "tile_tokens")
+    tile_count = _positive_int(source_row.get("tile_count"), "tile_count")
+    waves = _positive_int(source_row.get("tile_waves"), "tile_waves")
+    active_clusters = _positive_int(source_row.get("active_clusters"), "active_clusters")
+    layers = _positive_int(source_row.get("layers"), "layers")
+    compute_clock_ns = _positive(
+        source_row.get("measured_dual_stream_composed_clock_ns"), "compute clock"
+    )
+    hbm_clock_ns = _positive(source_row.get("clock_ns"), "HBM controller clock")
+    full_tile_bytes = int(2 * tile_tokens * kv_heads * head_dim * kv_bits / 8)
+    if fixed_shared_tile_bytes >= full_tile_bytes:
+        raise ValueError("fixed shared payload must be smaller than the full KV tile")
+    tile_hbm_bytes = full_tile_bytes - fixed_shared_tile_bytes
+    projection = _projection_cycles(row=source_row, kv_heads=kv_heads)
+    source_kv_heads = _positive_int(source_row.get("kv_heads"), "source kv_heads")
+    source_kv_write_cycles = _positive_int(source_row.get("kv_write_cycles"), "kv_write_cycles")
+    kv_write_cycles = _ceil_div(source_kv_write_cycles * kv_heads, source_kv_heads)
+    hbm = _global_hbm_service(
+        tile_hbm_bytes=tile_hbm_bytes,
+        active_clusters=active_clusters,
+        controller=controller,
+        hbm_clock_ns=hbm_clock_ns,
+    )
+    arithmetic_tile_cycles = _positive_int(source_row.get("tile_attention_cycles"), "tile attention cycles")
+    arithmetic_tile_time_ns = arithmetic_tile_cycles * compute_clock_ns
+    wave_time_ns = max(arithmetic_tile_time_ns, float(hbm["service_time_ns"]))
+    wave_compute_cycles = int(math.ceil(wave_time_ns / compute_clock_ns))
+    reduction_cycles = _positive_int(source_row.get("cross_tile_reduction_cycles"), "reduction cycles")
+    layer_cycles = (
+        int(projection["target_cycles"])
+        + waves * wave_compute_cycles
+        + reduction_cycles
+        + kv_write_cycles
+    )
+
+    schedule_row = dict(source_row)
+    schedule_row.update(
+        {
+            "label": "llama2_7b_exact_mha" if exact_llama2_structure else "llama7b_gqa8_proxy",
+            "kv_heads": kv_heads,
+            "kv_sharing": "mha" if kv_heads == attention_heads else f"gqa{attention_heads // kv_heads}",
+            "shared_byte_share": fixed_shared_tile_bytes / full_tile_bytes,
+            "qkv_cycles": int(projection["target_cycles"]),
+            "tile_attention_cycles": wave_compute_cycles,
+            "layer_cycles": layer_cycles,
+            "kv_write_cycles": kv_write_cycles,
+            "kv_cache_mib": (
+                2
+                * _positive_int(source_row.get("sequence_length"), "sequence length")
+                * kv_heads
+                * head_dim
+                * kv_bits
+                / 8
+                * layers
+                / (1024 * 1024)
+            ),
+            "onchip_full_tile_bytes": full_tile_bytes,
+            "tile_hbm_bytes": tile_hbm_bytes,
+        }
+    )
+    packet_specs: list[PacketSpec] = []
+    logical_payload = phase2_schedule.build_report(
+        _phase2_args(args, noc_clock_ns=_positive(finite["clock_contract"]["effective_noc_clock_ns"], "NoC clock")),
+        packet_spec_output=packet_specs,
+        source_row_override=schedule_row,
+        source_artifact_override=candidate_id,
+    )
+    logical = _compact_schedule(logical_payload)
+    endpoint = run_performance_replay(
+        descriptors_from_packet_specs(packet_specs), max_cycles=args.max_cycles
+    )
+    if endpoint["packets"] != logical["scheduled_packet_count"]:
+        raise ValueError("finite endpoint replay packet count mismatch")
+    if endpoint["flits"] != logical["scheduled_flit_count"]:
+        raise ValueError("finite endpoint replay flit count mismatch")
+    noc_clock_ns = _positive(finite["clock_contract"]["effective_noc_clock_ns"], "NoC clock")
+    endpoint_time_ns = endpoint["cycles"] * noc_clock_ns
+    compute_layer_time_ns = layer_cycles * compute_clock_ns
+    critical_layer_time_ns = max(compute_layer_time_ns, endpoint_time_ns)
+    token_time_ns = critical_layer_time_ns * layers
+
+    service_for_energy = {
+        "row_hit_rate": controller["row_hit_rate"],
+        "burst_bytes": controller["burst_bytes"],
+    }
+    energy_row = dict(schedule_row)
+    energy_row["tile_count"] = tile_count
+    hbm_energy = _hbm_energy(
+        tile_hbm_bytes=tile_hbm_bytes,
+        service=service_for_energy,
+        params=energy_params,
+        source_row=energy_row,
+    )
+    logic_power_mw = _positive(
+        finite["physical_recost"]["recost_logic_vectorless_power_mw"], "logic vectorless power"
+    )
+    logic_energy_mj = logic_power_mw * token_time_ns / 1.0e9
+    return {
+        "candidate_id": candidate_id,
+        "model_contract": {
+            "contract_scope": (
+                "exact_llama2_7b_mha_structure"
+                if exact_llama2_structure
+                else "llama7b_shaped_gqa8_proxy_not_exact_llama2_7b"
+            ),
+            "hidden_size": hidden_size,
+            "layers": layers,
+            "attention_heads": attention_heads,
+            "kv_heads": kv_heads,
+            "gqa_group_size": attention_heads // kv_heads,
+            "kv_sharing": schedule_row["kv_sharing"],
+            "sequence_length": schedule_row["sequence_length"],
+            "kv_bits": kv_bits,
+        },
+        "projection": projection,
+        "memory": {
+            "full_tile_bytes": full_tile_bytes,
+            "fixed_shared_tile_bytes": fixed_shared_tile_bytes,
+            "tile_hbm_bytes": tile_hbm_bytes,
+            "kv_cache_mib": schedule_row["kv_cache_mib"],
+            "kv_write_cycles_per_layer": kv_write_cycles,
+            "read_bytes_per_token": hbm_energy["read_bytes_per_token"],
+            "write_bytes_per_token": hbm_energy["write_bytes_per_token"],
+        },
+        "global_hbm_service": hbm,
+        "schedule": {
+            "arithmetic_tile_cycles": arithmetic_tile_cycles,
+            "arithmetic_tile_time_ns": arithmetic_tile_time_ns,
+            "global_hbm_wave_time_ns": hbm["service_time_ns"],
+            "wave_compute_cycles": wave_compute_cycles,
+            "tile_waves": waves,
+            "layer_cycles": layer_cycles,
+            "compute_layer_time_ns": compute_layer_time_ns,
+            "finite_endpoint_drain_cycles": endpoint["cycles"],
+            "finite_endpoint_drain_time_ns": endpoint_time_ns,
+            "critical_layer_time_ns": critical_layer_time_ns,
+            "bottleneck": "finite_endpoint_noc" if endpoint_time_ns > compute_layer_time_ns else "compute_hbm",
+            "scheduled_packets": endpoint["packets"],
+            "scheduled_flits": endpoint["flits"],
+            "router_contention_cycles": endpoint["contention"],
+        },
+        "throughput": {
+            "token_latency_us": token_time_ns / 1000.0,
+            "token_throughput_per_s": 1.0e9 / token_time_ns,
+        },
+        "physical": {
+            "die_area_um2": finite["physical_recost"]["die_area_um2"],
+            "total_embodied_area_um2": finite["physical_recost"]["total_embodied_area_um2"],
+            "area_fit": finite["physical_recost"]["area_fit"],
+            "area_change_for_mha": "none_shared_compute_and_fixed_onchip_buffers",
+        },
+        "energy": {
+            "hbm_command_calibrated_energy": hbm_energy,
+            "hbm_energy_mj_per_token": hbm_energy["energy_mj"],
+            "logic_vectorless_energy_mj_per_token": logic_energy_mj,
+            "total_proxy_energy_mj_per_token": logic_energy_mj + float(hbm_energy["energy_mj"]),
+            "logic_energy_status": "always_on_vectorless_upper_proxy_without_clock_gating",
+            "hbm_energy_status": "command_calibrated_not_vendor_signoff",
+        },
+        "quality_contract": {
+            "arithmetic_profile": finite["precision_contract"]["precision_profile"],
+            "structural_model_match": exact_llama2_structure,
+            "native_llama2_generation_quality_measured": False,
+            "promotable": False,
+            "reason": (
+                "Exact MHA structure is recosted, but native Llama-2-7B score32 generation quality is not measured."
+                if exact_llama2_structure
+                else "GQA8 is not the exact Llama-2-7B MHA structure."
+            ),
+        },
+    }
+
+
+def build_report(args: argparse.Namespace) -> JsonDict:
+    root = args.repo_root.resolve()
+    finite = _load_json(root / args.finite_recost_json)
+    source = _load_json(root / args.source_recost_json)
+    hbm_replay = _load_json(root / args.hbm_replay_json)
+    hbm_energy = _load_json(root / args.hbm_energy_json)
+    _model, source_row, controller, energy_params = _validate_inputs(
+        finite=finite, source=source, hbm_replay=hbm_replay, hbm_energy=hbm_energy
+    )
+    fixed_shared_tile_bytes = _positive_int(
+        source_row.get("onchip_shared_bytes_per_cluster"), "fixed shared tile bytes"
+    )
+    gqa8 = _candidate(
+        args=args,
+        candidate_id="score32_gqa8_global_hbm_finite_endpoint",
+        kv_heads=4,
+        exact_llama2_structure=False,
+        finite=finite,
+        source_row=source_row,
+        controller=controller,
+        energy_params=energy_params,
+        fixed_shared_tile_bytes=fixed_shared_tile_bytes,
+    )
+    mha = _candidate(
+        args=args,
+        candidate_id="score32_exact_llama2_7b_mha_global_hbm_finite_endpoint",
+        kv_heads=32,
+        exact_llama2_structure=True,
+        finite=finite,
+        source_row=source_row,
+        controller=controller,
+        energy_params=energy_params,
+        fixed_shared_tile_bytes=fixed_shared_tile_bytes,
+    )
+    source_throughput = _positive(finite["throughput"]["token_throughput_per_s"], "finite throughput")
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1",
+        "decision": "exact_llama2_mha_recost_recorded_native_quality_required",
+        "source_items": {
+            "finite_endpoint_composed_recost": (
+                "l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1"
+            ),
+            "exact_reduction_recost": "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+            "hbm_controller_replay": "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1",
+            "hbm_energy_closure": "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1",
+        },
+        "global_controller_correction": {
+            "legacy_scope": "one_tile_replayed_as_if_it_owned_the_global_controller",
+            "corrected_scope": "all_active_cluster_tiles_in_one_wave_share_one_global_controller",
+            "active_cluster_multiplier": source_row["active_clusters"],
+            "source_finite_token_throughput_per_s": source_throughput,
+            "corrected_gqa8_token_throughput_per_s": gqa8["throughput"]["token_throughput_per_s"],
+            "throughput_ratio_corrected_vs_source": (
+                gqa8["throughput"]["token_throughput_per_s"] / source_throughput
+            ),
+        },
+        "rows": [gqa8, mha],
+        "exact_mha_delta_vs_corrected_gqa8": {
+            "qkv_projection_macs_ratio": mha["projection"]["target_macs"] / gqa8["projection"]["target_macs"],
+            "kv_cache_ratio": mha["memory"]["kv_cache_mib"] / gqa8["memory"]["kv_cache_mib"],
+            "read_bytes_ratio": mha["memory"]["read_bytes_per_token"] / gqa8["memory"]["read_bytes_per_token"],
+            "token_latency_ratio": mha["throughput"]["token_latency_us"] / gqa8["throughput"]["token_latency_us"],
+            "token_throughput_ratio": mha["throughput"]["token_throughput_per_s"] / gqa8["throughput"]["token_throughput_per_s"],
+            "hbm_energy_ratio": mha["energy"]["hbm_energy_mj_per_token"] / gqa8["energy"]["hbm_energy_mj_per_token"],
+        },
+        "invariants": {
+            "attention_qk_value_macs_unchanged": True,
+            "partial_reduction_payload_unchanged": True,
+            "fixed_shared_sram_bytes_unchanged": True,
+            "finite_endpoint_packet_volume_unchanged": (
+                gqa8["schedule"]["scheduled_packets"] == mha["schedule"]["scheduled_packets"]
+                and gqa8["schedule"]["scheduled_flits"] == mha["schedule"]["scheduled_flits"]
+            ),
+            "compute_array_and_onchip_area_unchanged": True,
+        },
+        "remaining_abstractions": [
+            "HBM controller service is deterministic burst replay, not controller RTL or vendor timing signoff.",
+            "HBM energy is command calibrated rather than vendor current signoff.",
+            "Logic energy is an always-on vectorless upper proxy; workload clock-gating activity is not measured.",
+            "Native Llama-2-7B score32 generation quality has not been measured.",
+            "The fixed shared-SRAM residency policy is recosted but not reoptimized for MHA.",
+        ],
+        "next_step": {
+            "required_quality_job": "native_llama2_7b_score32_generation_quality",
+            "required_architecture_job": "exact_mha_shared_sram_hbm_residency_sweep",
+            "frontier_promotion_allowed": False,
+        },
+    }
+
+
+def write_report(payload: JsonDict, path: Path) -> None:
+    gqa8, mha = payload["rows"]
+    lines = [
+        "# Global-HBM Exact Llama-2-7B MHA Recost",
+        "",
+        f"- decision: `{payload['decision']}`",
+        f"- corrected GQA8 throughput token/s: `{gqa8['throughput']['token_throughput_per_s']}`",
+        f"- exact MHA throughput token/s: `{mha['throughput']['token_throughput_per_s']}`",
+        f"- exact MHA KV cache MiB: `{mha['memory']['kv_cache_mib']}`",
+        f"- exact MHA HBM energy mJ/token: `{mha['energy']['hbm_energy_mj_per_token']}`",
+        "",
+        "| Candidate | KV heads | QKV cycles | Wave HBM bytes | Layer cycles | Token/s | HBM mJ/token | Structural match | Promotable |",
+        "|---|---:|---:|---:|---:|---:|---:|---|---|",
+    ]
+    for row in payload["rows"]:
+        lines.append(
+            "| {candidate_id} | {kv_heads} | {qkv} | {wave_bytes} | {layer_cycles} | {throughput} | {energy} | {structural} | {promotable} |".format(
+                candidate_id=row["candidate_id"],
+                kv_heads=row["model_contract"]["kv_heads"],
+                qkv=row["projection"]["target_cycles"],
+                wave_bytes=row["global_hbm_service"]["aggregate_wave_hbm_bytes"],
+                layer_cycles=row["schedule"]["layer_cycles"],
+                throughput=row["throughput"]["token_throughput_per_s"],
+                energy=row["energy"]["hbm_energy_mj_per_token"],
+                structural=row["quality_contract"]["structural_model_match"],
+                promotable=row["quality_contract"]["promotable"],
+            )
+        )
+    lines.extend(["", "## Remaining Abstractions", ""])
+    lines.extend(f"- {item}" for item in payload["remaining_abstractions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--finite-recost-json", type=Path, default=DEFAULT_FINITE_RECOST)
+    parser.add_argument("--source-recost-json", type=Path, default=DEFAULT_SOURCE_RECOST)
+    parser.add_argument("--hbm-replay-json", type=Path, default=DEFAULT_HBM_REPLAY)
+    parser.add_argument("--hbm-energy-json", type=Path, default=DEFAULT_HBM_ENERGY)
+    parser.add_argument("--measured-l1-costs", type=Path, default=phase2_schedule.DEFAULT_MEASURED_L1_COSTS)
+    parser.add_argument("--max-cycles", type=int, default=20_000_000)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--report", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_report(args)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_report(payload, args.report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/tests/test_measure_llm_decoder_attention_score32_noc_phase2_schedule_override.py
+++ b/npu/eval/tests/test_measure_llm_decoder_attention_score32_noc_phase2_schedule_override.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from npu.eval import measure_llm_decoder_attention_score32_noc_phase2_schedule as schedule
+
+
+def _args(tmp_path: Path, **overrides: object) -> argparse.Namespace:
+    values: dict[str, object] = {
+        "repo_root": tmp_path,
+        "source_json": Path("missing_source.json"),
+        "measured_l1_costs": Path("measured_costs.json"),
+        "wave_limit": None,
+        "packet_payload_bytes": 256,
+        "cluster_endpoints": [0, 1],
+        "root_endpoint": 1,
+        "shared_vc": 0,
+        "reduction_vc": 1,
+        "compute_clock_ns": None,
+        "noc_clock_ns": 1.25,
+        "max_cycles": 1000,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _source_row(**overrides: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "active_clusters": 2,
+        "cluster_count": 2,
+        "sequence_length": 10,
+        "tile_tokens": 5,
+        "tile_waves": 1,
+        "hidden_size": 16,
+        "attention_heads": 4,
+        "kv_heads": 3,
+        "kv_bits": 8,
+        "shared_byte_share": 0.25,
+        "partial_reduction_payload_bytes": 7,
+        "cross_tile_reduction_payload_bytes": 14,
+        "tile_attention_cycles": 13,
+        "qkv_cycles": 11,
+        "layer_cycles": 29,
+        "measured_dual_stream_composed_clock_ns": 2.5,
+        "noc_hops": 1,
+        "measured_l1_profile": "override-profile",
+        "cross_tile_reduction_cycles": 4,
+        "topology": "mesh4x4",
+        "scheduler_policy": "phase2-static",
+        "reduction_strategy": "root",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_build_report_source_row_override_skips_source_json_and_controls_quantities(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    costs_path = tmp_path / "measured_costs.json"
+    args = _args(tmp_path)
+    load_calls: list[Path] = []
+
+    def fake_load(path: Path) -> dict[str, object]:
+        load_calls.append(path)
+        if path == costs_path:
+            return {
+                "profiles": [
+                    {
+                        "name": "override-profile",
+                        "latency_cycles": 99,
+                        "area_um2": 123.0,
+                    }
+                ]
+            }
+        raise AssertionError(f"unexpected JSON load: {path}")
+
+    monkeypatch.setattr(schedule, "_load_json", fake_load)
+
+    report = schedule.build_report(
+        args,
+        source_row_override=_source_row(),
+        source_artifact_override="inline://score32-override",
+    )
+
+    assert load_calls == [costs_path]
+    assert report["source_artifacts"]["score32_recost_json"] == "inline://score32-override"
+    assert report["source_artifacts"]["measured_l1_profile"] == "override-profile"
+    assert report["source_contract"]["kv_heads"] == 3
+    assert report["traffic_quantities"]["full_tile_bytes"] == 120
+    assert report["traffic_quantities"]["shared_tile_payload_bytes"] == 30
+    assert report["traffic_quantities"]["local_tile_payload_bytes"] == 90
+    assert report["flow_summary"]["remote_shared_bytes"] == 60
+    assert report["flow_summary"]["local_only_shared_bytes"] == 0
+    assert report["flow_summary"]["remote_reduction_bytes"] == 7
+    assert report["flow_summary"]["local_only_reduction_bytes"] == 7
+    assert report["schedule_parameters"]["compute_qkv_cycles_before_wave0"] == 11
+    assert report["schedule_parameters"]["compute_tile_attention_cycles_per_wave"] == 13
+    assert report["schedule_parameters"]["wave_start_compute_cycles"] == [11]
+    assert report["schedule_parameters"]["wave_start_noc_cycles"] == [22]
+    assert report["schedule_parameters"]["reduction_release_compute_cycles"] == [24]
+    assert report["schedule_parameters"]["reduction_release_noc_cycles"] == [48]
+    assert report["source_contract"]["compute_layer_cycles"] == 29
+    assert report["source_contract"]["compute_clock_ns"] == pytest.approx(2.5)
+    assert report["source_contract"]["compute_layer_time_ns"] == pytest.approx(72.5)
+
+
+def test_build_report_source_row_override_can_fall_back_to_args_source_provenance(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    costs_path = tmp_path / "measured_costs.json"
+    args = _args(tmp_path, source_json=Path("kept_source_provenance.json"))
+
+    def fake_load(path: Path) -> dict[str, object]:
+        if path == costs_path:
+            return {"profiles": [{"name": "override-profile"}]}
+        raise AssertionError(f"unexpected JSON load: {path}")
+
+    monkeypatch.setattr(schedule, "_load_json", fake_load)
+
+    report = schedule.build_report(args, source_row_override=_source_row(kv_heads=1, shared_byte_share=0.5))
+
+    assert report["source_artifacts"]["score32_recost_json"] == "kept_source_provenance.json"
+    assert report["source_contract"]["kv_heads"] == 1
+    assert report["traffic_quantities"]["shared_tile_payload_bytes"] == 20
+    assert report["flow_summary"]["remote_shared_bytes"] == 40

--- a/npu/eval/tests/test_recost_llm_decoder_attention_score32_global_hbm_exact_llama2_mha.py
+++ b/npu/eval/tests/test_recost_llm_decoder_attention_score32_global_hbm_exact_llama2_mha.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from npu.eval import recost_llm_decoder_attention_score32_global_hbm_exact_llama2_mha as recost
+
+
+def _source_row() -> dict:
+    return {
+        "active_clusters": 16,
+        "cluster_count": 16,
+        "sequence_length": 131072,
+        "tile_tokens": 1024,
+        "tile_count": 128,
+        "tile_waves": 8,
+        "hidden_size": 4096,
+        "attention_heads": 32,
+        "kv_heads": 4,
+        "kv_bits": 8,
+        "kv_sharing": "gqa8",
+        "shared_byte_share": 17408 / 1048576,
+        "partial_reduction_payload_bytes": 8320,
+        "cross_tile_reduction_payload_bytes": 133120,
+        "cross_tile_reduction_cycles": 574,
+        "tile_attention_cycles": 986,
+        "qkv_cycles": 192,
+        "kv_write_cycles": 10,
+        "layer_cycles": 8664,
+        "layers": 32,
+        "measured_dual_stream_composed_clock_ns": 48.6509,
+        "clock_ns": 5.9811,
+        "replica_recost_macs_per_cycle": 109568,
+        "measured_l1_profile": "test-profile",
+        "noc_hops": 6,
+        "topology": "mesh2d",
+        "scheduler_policy": "locality_aware",
+        "reduction_strategy": "cluster_tree",
+        "onchip_shared_bytes_per_cluster": 17408,
+    }
+
+
+def _finite() -> dict:
+    return {
+        "version": 1,
+        "profile": "decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost",
+        "model_contract": {
+            "hidden_size": 4096,
+            "layers": 32,
+            "attention_heads": 32,
+            "kv_heads": 4,
+            "gqa_group_size": 8,
+            "kv_sharing": "gqa8",
+            "sequence_length": 131072,
+        },
+        "throughput": {"token_throughput_per_s": 74.0},
+        "physical_recost": {
+            "area_fit": True,
+            "die_area_um2": 800_000_000.0,
+            "total_embodied_area_um2": 760_000_000.0,
+            "recost_logic_vectorless_power_mw": 26000.0,
+        },
+        "clock_contract": {"effective_noc_clock_ns": 1.0},
+        "logical_schedule": {},
+        "precision_contract": {"precision_profile": "score32-exp-lut"},
+    }
+
+
+def _controller() -> dict:
+    return {
+        "channel_count": 4,
+        "channel_bandwidth_bytes_per_cycle": 1024.0,
+        "burst_bytes": 1024,
+        "row_span_bursts": 16,
+        "row_hit_rate": 0.95,
+        "request_overhead_cycles": 2,
+        "row_miss_penalty_cycles": 8,
+        "hbm_outstanding": 4,
+        "scheduler_gap_cycles": 0,
+        "scheduler_efficiency": 0.75,
+    }
+
+
+def _energy_params() -> dict:
+    return {
+        "read_hit_pj_per_byte": 2.0,
+        "read_miss_pj_per_byte": 4.0,
+        "write_pj_per_byte": 3.0,
+        "activate_precharge_pj_per_row": 5.0,
+        "command_pj_per_burst": 1.0,
+        "source": "test",
+    }
+
+
+def _args(tmp_path: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        repo_root=tmp_path,
+        source_recost_json=Path("source.json"),
+        measured_l1_costs=Path("costs.json"),
+        out=tmp_path / "out.json",
+        report=tmp_path / "out.md",
+        max_cycles=20_000_000,
+    )
+
+
+def test_projection_recomputes_mha_instead_of_scaling_qkv_by_eight() -> None:
+    gqa8 = recost._projection_cycles(row=_source_row(), kv_heads=4)
+    mha = recost._projection_cycles(row=_source_row(), kv_heads=32)
+
+    assert gqa8["source_macs"] == 20_971_520
+    assert gqa8["target_cycles"] == 192
+    assert mha["target_macs"] == 50_331_648
+    assert mha["target_cycles"] == 460
+    assert mha["target_macs"] / gqa8["target_macs"] == 2.4
+
+
+def test_global_hbm_service_replays_all_cluster_tiles_in_each_wave() -> None:
+    service = recost._global_hbm_service(
+        tile_hbm_bytes=1_000_000,
+        active_clusters=16,
+        controller=_controller(),
+        hbm_clock_ns=5.0,
+    )
+
+    assert service["scope"] == "one_global_controller_shared_by_all_active_clusters"
+    assert service["aggregate_wave_hbm_bytes"] == 16_000_000
+    assert service["burst_count"] == 15625
+    assert service["service_cycles"] > 1000
+    assert service["service_time_ns"] == service["service_cycles"] * 5.0
+
+
+def test_exact_mha_candidate_rebuilds_memory_compute_and_finite_release_schedule(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    seen_rows: list[dict] = []
+
+    def fake_phase2(_args, *, packet_spec_output, source_row_override, source_artifact_override):
+        seen_rows.append(dict(source_row_override))
+        packet_spec_output.extend([object(), object()])
+        return {"source_artifact_override": source_artifact_override}
+
+    monkeypatch.setattr(recost.phase2_schedule, "build_report", fake_phase2)
+    monkeypatch.setattr(
+        recost,
+        "_compact_schedule",
+        lambda _payload: {
+            "scheduled_packet_count": 2,
+            "scheduled_flit_count": 16,
+        },
+    )
+    monkeypatch.setattr(recost, "descriptors_from_packet_specs", lambda _specs: [])
+    monkeypatch.setattr(
+        recost,
+        "run_performance_replay",
+        lambda _descriptors, max_cycles: {
+            "packets": 2,
+            "flits": 16,
+            "cycles": 1000,
+            "contention": 7,
+        },
+    )
+
+    result = recost._candidate(
+        args=_args(tmp_path),
+        candidate_id="exact-mha",
+        kv_heads=32,
+        exact_llama2_structure=True,
+        finite=_finite(),
+        source_row=_source_row(),
+        controller=_controller(),
+        energy_params=_energy_params(),
+        fixed_shared_tile_bytes=17408,
+    )
+
+    schedule_row = seen_rows[0]
+    assert schedule_row["kv_heads"] == 32
+    assert schedule_row["kv_sharing"] == "mha"
+    assert schedule_row["qkv_cycles"] == 460
+    assert schedule_row["kv_write_cycles"] == 80
+    assert schedule_row["kv_cache_mib"] == 32768.0
+    assert result["memory"]["full_tile_bytes"] == 8_388_608
+    assert result["memory"]["fixed_shared_tile_bytes"] == 17_408
+    assert result["memory"]["tile_hbm_bytes"] == 8_371_200
+    assert result["memory"]["read_bytes_per_token"] == 34_288_435_200
+    assert result["memory"]["write_bytes_per_token"] == 262_144
+    assert result["global_hbm_service"]["aggregate_wave_hbm_bytes"] == 133_939_200
+    assert result["schedule"]["scheduled_packets"] == 2
+    assert result["schedule"]["scheduled_flits"] == 16
+    assert result["quality_contract"]["structural_model_match"] is True
+    assert result["quality_contract"]["promotable"] is False
+
+
+def test_validation_rejects_structurally_mismatched_finite_source() -> None:
+    finite = _finite()
+    finite["model_contract"]["kv_heads"] = 8
+
+    with pytest.raises(ValueError, match="32-head/4-KV-head"):
+        recost._validate_inputs(
+            finite=finite,
+            source={"version": 1, "model": recost._SOURCE_MODEL, "best_requested": _source_row()},
+            hbm_replay={"version": 1, "model": recost._HBM_REPLAY_MODEL, "best_latency": _controller()},
+            hbm_energy={"version": 1, "model": recost._HBM_ENERGY_MODEL, "energy_params": _energy_params()},
+        )

--- a/npu/eval/verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py
+++ b/npu/eval/verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py
@@ -325,6 +325,7 @@ def run_performance_replay(
             for packet in packets
         ],
         max_cycles=max_cycles,
+        fast_forward_idle=True,
     )
     counters = {
         "packets": len(result.completions),

--- a/npu/sim/perf/noc_sram_packet_mesh.py
+++ b/npu/sim/perf/noc_sram_packet_mesh.py
@@ -412,6 +412,7 @@ def simulate_packet_mesh(
     completion_ready_schedule: ReadySchedule = None,
     max_cycles: int = 1_000_000,
     record_mesh_trace: bool = False,
+    fast_forward_idle: bool = False,
 ) -> PacketMeshResult:
     """Simulate paired descriptors and the existing registered-credit mesh.
 
@@ -475,7 +476,28 @@ def simulate_packet_mesh(
     router_forwarded: list[list[tuple[int, ModelFlit]]] = [[] for _ in range(ENDPOINTS)]
     max_rx_context_occupancy = 0
 
-    for cycle in range(max_cycles):
+    cycle = 0
+    while cycle < max_cycles:
+        if fast_forward_idle:
+            endpoints_idle = all(
+                state.tx_active is None
+                and not state.tx_fifo
+                and not state.tx_reads
+                and state.tx_output is None
+                and not state.rx_contexts
+                and state.completion is None
+                for state in states
+            )
+            if endpoints_idle and all(router.idle() for router in routers):
+                pending_releases = [
+                    packet_list[queue[0]].release_cycle for queue in rx_queues if queue
+                ]
+                if pending_releases:
+                    next_release = min(pending_releases)
+                    if next_release >= max_cycles:
+                        break
+                    cycle = max(cycle, next_release)
+
         # Descriptor scheduling is intentionally separate from data movement.
         # An RX handshake at this edge cannot make a same-edge TX release
         # legal, matching the RTL's registered descriptor state.
@@ -765,6 +787,7 @@ def simulate_packet_mesh(
                 max_rx_context_occupancy=max_rx_context_occupancy,
                 mesh_traces=tuple(mesh_traces),
             )
+        cycle += 1
 
     raise RuntimeError(
         f"packet mesh did not drain within max_cycles={max_cycles}; "

--- a/tests/test_noc_sram_packet_mesh_perf.py
+++ b/tests/test_noc_sram_packet_mesh_perf.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
@@ -134,3 +136,46 @@ def test_two_packet_composed_case_matches_endpoint_metadata() -> None:
     assert [write.address for write in result.destination_memory_writes if write.packet_index == 1] == [
         0x1200 + 32 * fragment for fragment in range(3)
     ]
+
+
+def test_idle_fast_forward_preserves_cycle_accurate_observables() -> None:
+    descriptors = [
+        PacketDescriptor(
+            source=0,
+            destination=15,
+            vc=1,
+            tag=0x21,
+            flit_count=4,
+            release_cycle=1000,
+            packet_id="late-a",
+        ),
+        PacketDescriptor(
+            source=3,
+            destination=12,
+            vc=2,
+            tag=0x22,
+            flit_count=3,
+            release_cycle=2000,
+            packet_id="late-b",
+        ),
+    ]
+
+    reference = simulate_packet_mesh(descriptors, max_cycles=5000)
+    accelerated = simulate_packet_mesh(descriptors, max_cycles=5000, fast_forward_idle=True)
+
+    assert accelerated == reference
+
+
+def test_idle_fast_forward_respects_max_cycle_bound() -> None:
+    descriptor = PacketDescriptor(
+        source=0,
+        destination=15,
+        vc=1,
+        tag=0x23,
+        flit_count=1,
+        release_cycle=1000,
+        packet_id="after-timeout",
+    )
+
+    with pytest.raises(RuntimeError, match="max_cycles=999"):
+        simulate_packet_mesh([descriptor], max_cycles=999, fast_forward_idle=True)


### PR DESCRIPTION
## Summary
- add a backward-compatible in-memory schedule source override
- correct HBM replay from per-tile bandwidth ownership to one global controller serving all 16 active clusters
- rebuild exact Llama-2-7B MHA QKV, KV cache/write/read traffic, HBM latency/energy, and finite endpoint releases
- add quiescent-cycle fast-forward without changing active-cycle observables
- add the gated control-plane job, proposal, result summary, and focused tests

## Root causes
The prior score32 point replayed one tile against controller bandwidth even though 16 cluster tiles share the global controller. It also used four KV heads (GQA8), while exact Llama-2-7B uses 32 KV heads (MHA). MHA requires 2.4x QKV projection MACs, 8x KV capacity/writes, and recomputed residency/service; reduction traffic does not scale with KV heads.

## Provisional integration result
Using the checked-in source/controller/energy artifacts and a finite-recost-shaped local fixture:
- corrected GQA8: 34.52 token/s, down from the 74 token/s source assumption
- exact MHA: 4.40 token/s, 32 GiB KV cache, 989.7 mJ/token calibrated HBM energy
- packet volume remains 11,576 packets / 92,128 flits

The evaluator job must reproduce these with the merged finite artifact. Neither row is promotable until native Llama-2-7B score32 generation quality is measured.

## Validation
- 16 relevant schedule/endpoint/simulator/generator tests passed
- 6 recost/override formula tests passed
- 2 result-consumer tests passed
- full integration replay completed locally after idle fast-forward
- Python compilation, `scripts/validate_runs.py`, and `git diff --check` passed