### PR TITLE
Add exact Llama-2 MHA native-quality frontier

### DIFF
--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -1100,12 +1100,19 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             if isinstance(row, dict) and row.get("candidate_id")
         }
         gqa8 = dict(by_id.get("score32_gqa8_global_hbm_finite_endpoint") or {})
+        long_mha = dict(
+            by_id.get(
+                "score32_llama2_7b_mha_131k_extrapolation_global_hbm_finite_endpoint"
+            )
+            or {}
+        )
         mha = dict(by_id.get("score32_exact_llama2_7b_mha_global_hbm_finite_endpoint") or {})
         parts = [
             f"Global-HBM exact Llama-2-7B MHA recost recorded from {evidence_ref}: decision={outcome}",
             f"source_finite_token_s={correction.get('source_finite_token_throughput_per_s')}",
             f"corrected_gqa8_token_s={dict(gqa8.get('throughput') or {}).get('token_throughput_per_s')}",
-            f"exact_mha_token_s={dict(mha.get('throughput') or {}).get('token_throughput_per_s')}",
+            f"long_context_mha_token_s={dict(long_mha.get('throughput') or {}).get('token_throughput_per_s')}",
+            f"native_context_exact_mha_token_s={dict(mha.get('throughput') or {}).get('token_throughput_per_s')}",
             f"exact_mha_hbm_mj_per_token={dict(mha.get('energy') or {}).get('hbm_energy_mj_per_token')}",
             f"exact_mha_promotable={dict(mha.get('quality_contract') or {}).get('promotable')}",
         ]
@@ -1116,18 +1123,27 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             evidence_payload.get("decision")
             or "exact_llama2_mha_score32_quality_hold"
         )
-        winners = dict(evidence_payload.get("dimension_winners") or {})
-        engineering = evidence_payload.get("engineering_pareto_frontier")
+        winners_by_workload = dict(evidence_payload.get("dimension_winners_by_workload") or {})
+        engineering_by_workload = dict(
+            evidence_payload.get("engineering_pareto_frontiers_by_workload") or {}
+        )
+        native_winners = dict(
+            winners_by_workload.get("official_llama2_7b_native_context_4096") or {}
+        )
         promotable = evidence_payload.get("promotable_pareto_frontier")
         references = evidence_payload.get("noncomparable_reference_rows")
         parts = [
             f"Exact Llama-2-7B MHA frontier recorded from {evidence_ref}: decision={outcome}",
-            f"engineering_pareto_count={len(engineering) if isinstance(engineering, list) else 0}",
+            f"engineering_workload_count={len(engineering_by_workload)}",
             f"promotable_pareto_count={len(promotable) if isinstance(promotable, list) else 0}",
             f"noncomparable_reference_count={len(references) if isinstance(references, list) else 0}",
-            f"throughput_winner={winners.get('throughput_comparable_boundary')}",
-            f"energy_winner={winners.get('energy_comparable_boundary')}",
-            f"higher_precision_reference={winners.get('higher_precision_noncomparable_reference')}",
+            f"native_context_throughput_winner={native_winners.get('throughput')}",
+            f"native_context_energy_winner={native_winners.get('energy')}",
+            "higher_precision_reference={}".format(
+                dict(evidence_payload.get("noncomparable_reference_winners") or {}).get(
+                    "higher_precision_noncomparable_reference"
+                )
+            ),
             f"scalar_universal_winner={evidence_payload.get('scalar_universal_winner')}",
         ]
         summary = "; ".join(parts)

--- a/control_plane/control_plane/services/l2_result_consumer.py
+++ b/control_plane/control_plane/services/l2_result_consumer.py
@@ -611,6 +611,14 @@ _DECODER_EVIDENCE_OUTPUT_KEYS: tuple[tuple[str, str], ...] = (
         "attention_score32_global_hbm_exact_mha_recost_report",
     ),
     (
+        "attention_score32_exact_llama2_mha_generation_quality_out",
+        "attention_score32_exact_llama2_mha_generation_quality_report",
+    ),
+    (
+        "attention_score32_exact_llama2_mha_final_frontier_out",
+        "attention_score32_exact_llama2_mha_final_frontier_report",
+    ),
+    (
         "attention_score32_folded_global_exact_reduction_recost_out",
         "attention_score32_folded_global_exact_reduction_recost_report",
     ),
@@ -1100,6 +1108,27 @@ def _decoder_evidence_summary(*, evidence_ref: str, evidence_payload: dict[str, 
             f"exact_mha_token_s={dict(mha.get('throughput') or {}).get('token_throughput_per_s')}",
             f"exact_mha_hbm_mj_per_token={dict(mha.get('energy') or {}).get('hbm_energy_mj_per_token')}",
             f"exact_mha_promotable={dict(mha.get('quality_contract') or {}).get('promotable')}",
+        ]
+        summary = "; ".join(parts)
+        return outcome, summary if summary.endswith(".") else summary + "."
+    if model == "llama2_7b_score32_exact_mha_final_frontier_v1":
+        outcome = str(
+            evidence_payload.get("decision")
+            or "exact_llama2_mha_score32_quality_hold"
+        )
+        winners = dict(evidence_payload.get("dimension_winners") or {})
+        engineering = evidence_payload.get("engineering_pareto_frontier")
+        promotable = evidence_payload.get("promotable_pareto_frontier")
+        references = evidence_payload.get("noncomparable_reference_rows")
+        parts = [
+            f"Exact Llama-2-7B MHA frontier recorded from {evidence_ref}: decision={outcome}",
+            f"engineering_pareto_count={len(engineering) if isinstance(engineering, list) else 0}",
+            f"promotable_pareto_count={len(promotable) if isinstance(promotable, list) else 0}",
+            f"noncomparable_reference_count={len(references) if isinstance(references, list) else 0}",
+            f"throughput_winner={winners.get('throughput_comparable_boundary')}",
+            f"energy_winner={winners.get('energy_comparable_boundary')}",
+            f"higher_precision_reference={winners.get('higher_precision_noncomparable_reference')}",
+            f"scalar_universal_winner={evidence_payload.get('scalar_universal_winner')}",
         ]
         summary = "; ".join(parts)
         return outcome, summary if summary.endswith(".") else summary + "."

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5970,6 +5970,7 @@ def _decoder_attention_score32_global_hbm_exact_llama2_mha_recost_evidence(
         "acceptance": [
             "Replay aggregate bytes from every active cluster through one global HBM controller",
             "Report the corrected GQA8 baseline before comparing exact Llama-2-7B MHA",
+            "Separate the 131072-token extrapolation from the official 4096-token native context",
             "Recompute MHA QKV projection cycles, KV writes, KV cache, tile bytes, and HBM energy",
             "Include measured HBM replay-controller area and latency-scaled vectorless energy",
             "Keep shared-SRAM bytes and reduction payload fixed while recomputing residency fractions",
@@ -6068,6 +6069,7 @@ def _decoder_attention_score32_exact_llama2_mha_final_frontier_evidence(
             "Require exact-MHA global-HBM recost and exact official-checkpoint quality evidence",
             "Promote score32 only when native exact-model generation quality passes",
             "Keep GQA8 score32 and GQA8 FP16 visible but structurally nonpromotable",
+            "Partition winners and Pareto sets by sequence-length workload identity",
             "Report throughput, embodied area, energy, and precision independently",
             "Return engineering and promotable Pareto sets without a scalar universal winner",
             "Carry every remaining HBM, activity, SRAM-policy, bounded-quality, and FP16-MHA gap",

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5908,6 +5908,11 @@ def _decoder_attention_score32_global_hbm_exact_llama2_mha_recost_evidence(
         "runs/campaigns/npu/l1_measured_costs/"
         "llama7b_attention_local_costs_all_measured_endpoint_v1.json"
     )
+    quality_frontier = (
+        f"{base}/decoder_attention_score32_integrated_frontier_ranking__"
+        "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_"
+        "rtl_ppa_recost_frontier_llama7b_v1.json"
+    )
     out = f"{base}/decoder_attention_score32_global_hbm_exact_llama2_mha_recost__{item_id}.json"
     report = f"{base}/decoder_attention_score32_global_hbm_exact_llama2_mha_recost__{item_id}.md"
     command = _bounded_launcher_command(
@@ -5929,6 +5934,8 @@ def _decoder_attention_score32_global_hbm_exact_llama2_mha_recost_evidence(
             hbm_replay,
             "--hbm-energy-json",
             hbm_energy,
+            "--quality-frontier-json",
+            quality_frontier,
             "--measured-l1-costs",
             measured_costs,
             "--out",
@@ -5943,6 +5950,7 @@ def _decoder_attention_score32_global_hbm_exact_llama2_mha_recost_evidence(
             "attention_score32_exact_reduction_recost": source,
             "attention_score32_hbm_controller_replay": hbm_replay,
             "attention_score32_hbm_energy_closure": hbm_energy,
+            "attention_score32_quality_aware_frontier": quality_frontier,
             "attention_score32_measured_l1_costs": measured_costs,
             "attention_score32_global_hbm_exact_mha_recost_out": out,
             "attention_score32_global_hbm_exact_mha_recost_report": report,
@@ -5963,10 +5971,106 @@ def _decoder_attention_score32_global_hbm_exact_llama2_mha_recost_evidence(
             "Replay aggregate bytes from every active cluster through one global HBM controller",
             "Report the corrected GQA8 baseline before comparing exact Llama-2-7B MHA",
             "Recompute MHA QKV projection cycles, KV writes, KV cache, tile bytes, and HBM energy",
+            "Include measured HBM replay-controller area and latency-scaled vectorless energy",
             "Keep shared-SRAM bytes and reduction payload fixed while recomputing residency fractions",
             "Rerun finite endpoint scheduling with HBM-delayed wave releases",
             "Keep compute/area sharing and every remaining energy and HBM abstraction explicit",
             "Do not promote score32 without native Llama-2-7B generation-quality evidence",
+            "Write exactly one JSON and one Markdown report",
+        ],
+    }
+
+
+def _decoder_attention_score32_exact_llama2_mha_final_frontier_evidence(
+    *,
+    item_id: str,
+    depends_on_item_ids: list[str] | None,
+    proposal_id: str | None,
+    proposal_path: str | None,
+) -> dict[str, Any]:
+    expected_item_id = "l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1"
+    expected_proposal_id = "prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1"
+    expected_dependencies = [
+        "l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1",
+        "l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1",
+    ]
+    if item_id != expected_item_id:
+        raise Layer2TaskGenerationError("exact Llama-2 MHA final frontier only permits the exact item")
+    if str(proposal_id or "").strip() != expected_proposal_id:
+        raise Layer2TaskGenerationError("exact Llama-2 MHA final frontier proposal_id mismatch")
+    if str(proposal_path or "").strip() != f"docs/proposals/{expected_proposal_id}/proposal.json":
+        raise Layer2TaskGenerationError("exact Llama-2 MHA final frontier proposal_path mismatch")
+    if list(depends_on_item_ids or []) != expected_dependencies:
+        raise Layer2TaskGenerationError(
+            "exact Llama-2 MHA final frontier requires exact recost and exact quality dependencies"
+        )
+
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    recost = (
+        f"{base}/decoder_attention_score32_global_hbm_exact_llama2_mha_recost__"
+        "l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1.json"
+    )
+    quality = (
+        f"{base}/decoder_attention_score32_exact_llama2_mha_generation_quality__"
+        "l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1.json"
+    )
+    prior_frontier = (
+        f"{base}/decoder_attention_score32_integrated_frontier_ranking__"
+        "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_"
+        "rtl_ppa_recost_frontier_llama7b_v1.json"
+    )
+    out = f"{base}/decoder_attention_score32_exact_llama2_mha_final_frontier__{item_id}.json"
+    report = f"{base}/decoder_attention_score32_exact_llama2_mha_final_frontier__{item_id}.md"
+    command = _bounded_launcher_command(
+        memory_high="1G",
+        memory_max="2G",
+        cpu_quota="100%",
+        tasks_max=32,
+        runtime_max_sec=300,
+        child_command=[
+            "python3",
+            "npu/eval/audit_llm_decoder_attention_score32_exact_llama2_mha_final_frontier.py",
+            "--repo-root",
+            ".",
+            "--exact-mha-recost-json",
+            recost,
+            "--exact-generation-quality-json",
+            quality,
+            "--prior-quality-frontier-json",
+            prior_frontier,
+            "--out",
+            out,
+            "--report",
+            report,
+        ],
+    )
+    return {
+        "inputs": {
+            "attention_score32_global_hbm_exact_mha_recost": recost,
+            "attention_score32_exact_llama2_mha_generation_quality": quality,
+            "attention_score32_prior_quality_aware_frontier": prior_frontier,
+            "attention_score32_exact_llama2_mha_final_frontier_out": out,
+            "attention_score32_exact_llama2_mha_final_frontier_report": report,
+        },
+        "commands": [{"name": "audit_score32_exact_llama2_mha_final_frontier", "run": command}],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+        "worker_resources": {
+            "exclusive_worker": False,
+            "memory_high": "1G",
+            "memory_max": "2G",
+            "cpu_quota": "100%",
+            "tasks_max": 32,
+            "outer_timeout_seconds": 300,
+            "stall_timeout_seconds": 180,
+        },
+        "acceptance": [
+            "Require exact-MHA global-HBM recost and exact official-checkpoint quality evidence",
+            "Promote score32 only when native exact-model generation quality passes",
+            "Keep GQA8 score32 and GQA8 FP16 visible but structurally nonpromotable",
+            "Report throughput, embodied area, energy, and precision independently",
+            "Return engineering and promotable Pareto sets without a scalar universal winner",
+            "Carry every remaining HBM, activity, SRAM-policy, bounded-quality, and FP16-MHA gap",
             "Write exactly one JSON and one Markdown report",
         ],
     }
@@ -10190,6 +10294,98 @@ def _decoder_attention_mixed_int8_generation_quality_evidence(*, item_id: str) -
     }
 
 
+def _decoder_attention_score32_exact_llama2_mha_generation_quality_evidence(
+    *,
+    item_id: str,
+    depends_on_item_ids: list[str] | None,
+    proposal_id: str | None,
+    proposal_path: str | None,
+) -> dict[str, Any]:
+    expected_item_id = "l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1"
+    expected_proposal_id = "prop_l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1"
+    if item_id != expected_item_id:
+        raise Layer2TaskGenerationError("exact Llama-2 MHA quality only permits the exact item")
+    if str(proposal_id or "").strip() != expected_proposal_id:
+        raise Layer2TaskGenerationError("exact Llama-2 MHA quality proposal_id mismatch")
+    if str(proposal_path or "").strip() != f"docs/proposals/{expected_proposal_id}/proposal.json":
+        raise Layer2TaskGenerationError("exact Llama-2 MHA quality proposal_path mismatch")
+    if list(depends_on_item_ids or []):
+        raise Layer2TaskGenerationError("exact Llama-2 MHA quality must not wait on hardware recost")
+
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    out = f"{base}/decoder_attention_score32_exact_llama2_mha_generation_quality__{item_id}.json"
+    report = f"{base}/decoder_attention_score32_exact_llama2_mha_generation_quality__{item_id}.md"
+    command = _bounded_launcher_command(
+        memory_high="48G",
+        memory_max="56G",
+        cpu_quota="800%",
+        tasks_max=256,
+        runtime_max_sec=21600,
+        child_command=[
+            "bash",
+            "npu/eval/run_hf_eval_python.sh",
+            "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py",
+            "--model-id",
+            "meta-llama/Llama-2-7b-hf",
+            "--expected-model-id",
+            "meta-llama/Llama-2-7b-hf",
+            "--expected-attention-head-count",
+            "32",
+            "--expected-kv-head-count",
+            "32",
+            "--expected-hidden-size",
+            "4096",
+            "--expected-gqa-group-size",
+            "1",
+            "--max-prompts",
+            "8",
+            "--generation-steps",
+            "8",
+            "--dtype",
+            "bfloat16",
+            "--candidate",
+            "score32_exp_lut_div:q8,k8,v8,s32,w16,exp_lut_div_bucket20",
+            "--primary-candidate-id",
+            "score32_exp_lut_div",
+            "--out",
+            out,
+            "--out-md",
+            report,
+        ],
+    )
+    return {
+        "inputs": {
+            "attention_score32_exact_llama2_mha_generation_quality_out": out,
+            "attention_score32_exact_llama2_mha_generation_quality_report": report,
+            "attention_score32_exact_llama2_mha_generation_quality_scope": (
+                "Measure score32 exp-LUT/div generation quality on the exact official "
+                "Llama-2-7B MHA checkpoint. Model identity and 32/32/4096 structure are "
+                "hard gates; no GQA proxy or environment-selected fallback is permitted."
+            ),
+        },
+        "commands": [{"name": "evaluate_score32_exact_llama2_mha_generation_quality", "run": command}],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+        "worker_resources": {
+            "exclusive_worker": True,
+            "memory_high": "48G",
+            "memory_max": "56G",
+            "cpu_quota": "800%",
+            "tasks_max": 256,
+            "outer_timeout_seconds": 21600,
+            "stall_timeout_seconds": 3600,
+        },
+        "acceptance": [
+            "Load only meta-llama/Llama-2-7b-hf; fail rather than substitute another checkpoint",
+            "Require hidden size 4096, 32 attention heads, 32 KV heads, and MHA group size 1",
+            "Evaluate the same score32 exp-LUT/div arithmetic profile used by the exact-MHA recost",
+            "Record teacher-forced NLL drift and bounded free-running greedy divergence",
+            "Require evaluator-local Hugging Face authorization for the gated official checkpoint",
+            "Write exactly one JSON and one Markdown report",
+        ],
+    }
+
+
 def _decoder_attention_mixed_int8_score32_w16_recip_lut_q16_generation_quality_evidence(
     *,
     item_id: str,
@@ -12853,6 +13049,8 @@ def _build_payload(
         "decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost",
         "decoder_attention_score32_finite_endpoint_final_frontier",
         "decoder_attention_score32_global_hbm_exact_llama2_mha_recost",
+        "decoder_attention_score32_exact_llama2_mha_generation_quality",
+        "decoder_attention_score32_exact_llama2_mha_final_frontier",
         "decoder_attention_kv_endpoint_full_onchip_service_schedule",
         "decoder_attention_kv_endpoint_ready_valid_service",
         "decoder_attention_kv_endpoint_router_sram_composition",
@@ -13124,6 +13322,20 @@ def _build_payload(
             )
         elif abstraction_layer_name == "decoder_attention_score32_global_hbm_exact_llama2_mha_recost":
             decoder_evidence = _decoder_attention_score32_global_hbm_exact_llama2_mha_recost_evidence(
+                item_id=item_id,
+                depends_on_item_ids=depends_on_item_ids,
+                proposal_id=proposal_id,
+                proposal_path=proposal_path,
+            )
+        elif abstraction_layer_name == "decoder_attention_score32_exact_llama2_mha_generation_quality":
+            decoder_evidence = _decoder_attention_score32_exact_llama2_mha_generation_quality_evidence(
+                item_id=item_id,
+                depends_on_item_ids=depends_on_item_ids,
+                proposal_id=proposal_id,
+                proposal_path=proposal_path,
+            )
+        elif abstraction_layer_name == "decoder_attention_score32_exact_llama2_mha_final_frontier":
+            decoder_evidence = _decoder_attention_score32_exact_llama2_mha_final_frontier_evidence(
                 item_id=item_id,
                 depends_on_item_ids=depends_on_item_ids,
                 proposal_id=proposal_id,

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -362,6 +362,52 @@ def test_decoder_evidence_paths_recognizes_global_hbm_exact_mha_recost(tmp_path:
     }
 
 
+def test_decoder_evidence_paths_recognizes_exact_llama2_mha_quality(tmp_path: Path) -> None:
+    evidence_rel = "runs/datasets/demo/exact_llama2_mha_quality.json"
+    report_rel = "runs/datasets/demo/exact_llama2_mha_quality.md"
+    _write(tmp_path / evidence_rel, "{}\n")
+    _write(tmp_path / report_rel, "# Exact Llama-2 quality\n")
+    work_item = SimpleNamespace(
+        input_manifest={
+            "decoder_contract": {
+                "attention_score32_exact_llama2_mha_generation_quality_out": evidence_rel,
+                "attention_score32_exact_llama2_mha_generation_quality_report": report_rel,
+            }
+        }
+    )
+
+    evidence_ref, source_refs = _decoder_evidence_paths(repo_root=tmp_path, work_item=work_item)
+
+    assert evidence_ref == evidence_rel
+    assert source_refs == {
+        "decoder_attention_score32_exact_llama2_mha_generation_quality_out": evidence_rel,
+        "decoder_attention_score32_exact_llama2_mha_generation_quality_report": report_rel,
+    }
+
+
+def test_decoder_evidence_paths_recognizes_exact_llama2_mha_final_frontier(tmp_path: Path) -> None:
+    evidence_rel = "runs/datasets/demo/exact_llama2_mha_final_frontier.json"
+    report_rel = "runs/datasets/demo/exact_llama2_mha_final_frontier.md"
+    _write(tmp_path / evidence_rel, "{}\n")
+    _write(tmp_path / report_rel, "# Exact Llama-2 frontier\n")
+    work_item = SimpleNamespace(
+        input_manifest={
+            "decoder_contract": {
+                "attention_score32_exact_llama2_mha_final_frontier_out": evidence_rel,
+                "attention_score32_exact_llama2_mha_final_frontier_report": report_rel,
+            }
+        }
+    )
+
+    evidence_ref, source_refs = _decoder_evidence_paths(repo_root=tmp_path, work_item=work_item)
+
+    assert evidence_ref == evidence_rel
+    assert source_refs == {
+        "decoder_attention_score32_exact_llama2_mha_final_frontier_out": evidence_rel,
+        "decoder_attention_score32_exact_llama2_mha_final_frontier_report": report_rel,
+    }
+
+
 def test_decoder_evidence_summary_recognizes_global_hbm_exact_mha_recost() -> None:
     outcome, summary = _decoder_evidence_summary(
         evidence_ref="runs/datasets/demo/score32_global_hbm_exact_mha.json",
@@ -389,6 +435,33 @@ def test_decoder_evidence_summary_recognizes_global_hbm_exact_mha_recost() -> No
     assert "corrected_gqa8_token_s=30.0" in summary
     assert "exact_mha_token_s=4.5" in summary
     assert "exact_mha_promotable=False" in summary
+
+
+def test_decoder_evidence_summary_recognizes_exact_llama2_mha_final_frontier() -> None:
+    outcome, summary = _decoder_evidence_summary(
+        evidence_ref="runs/datasets/demo/exact_llama2_mha_final_frontier.json",
+        evidence_payload={
+            "model": "llama2_7b_score32_exact_mha_final_frontier_v1",
+            "decision": "exact_llama2_mha_quality_backed_frontier_available",
+            "dimension_winners": {
+                "throughput_comparable_boundary": "gqa8",
+                "energy_comparable_boundary": "gqa8",
+                "higher_precision_noncomparable_reference": "fp16",
+            },
+            "engineering_pareto_frontier": [{"candidate_id": "gqa8"}],
+            "promotable_pareto_frontier": [{"candidate_id": "exact_mha"}],
+            "noncomparable_reference_rows": [{"candidate_id": "fp16"}],
+            "scalar_universal_winner": None,
+        },
+    )
+
+    assert outcome == "exact_llama2_mha_quality_backed_frontier_available"
+    assert "engineering_pareto_count=1" in summary
+    assert "promotable_pareto_count=1" in summary
+    assert "noncomparable_reference_count=1" in summary
+    assert "throughput_winner=gqa8" in summary
+    assert "higher_precision_reference=fp16" in summary
+    assert "scalar_universal_winner=None" in summary
 
 
 def test_decoder_evidence_summary_recognizes_score32_noc_phase2_schedule() -> None:

--- a/control_plane/control_plane/tests/test_l2_result_consumer.py
+++ b/control_plane/control_plane/tests/test_l2_result_consumer.py
@@ -421,8 +421,12 @@ def test_decoder_evidence_summary_recognizes_global_hbm_exact_mha_recost() -> No
                     "throughput": {"token_throughput_per_s": 30.0},
                 },
                 {
-                    "candidate_id": "score32_exact_llama2_7b_mha_global_hbm_finite_endpoint",
+                    "candidate_id": "score32_llama2_7b_mha_131k_extrapolation_global_hbm_finite_endpoint",
                     "throughput": {"token_throughput_per_s": 4.5},
+                },
+                {
+                    "candidate_id": "score32_exact_llama2_7b_mha_global_hbm_finite_endpoint",
+                    "throughput": {"token_throughput_per_s": 114.0},
                     "energy": {"hbm_energy_mj_per_token": 1080.0},
                     "quality_contract": {"promotable": False},
                 },
@@ -433,7 +437,8 @@ def test_decoder_evidence_summary_recognizes_global_hbm_exact_mha_recost() -> No
     assert outcome == "exact_llama2_mha_recost_recorded_native_quality_required"
     assert "source_finite_token_s=74.0" in summary
     assert "corrected_gqa8_token_s=30.0" in summary
-    assert "exact_mha_token_s=4.5" in summary
+    assert "long_context_mha_token_s=4.5" in summary
+    assert "native_context_exact_mha_token_s=114.0" in summary
     assert "exact_mha_promotable=False" in summary
 
 
@@ -443,12 +448,19 @@ def test_decoder_evidence_summary_recognizes_exact_llama2_mha_final_frontier() -
         evidence_payload={
             "model": "llama2_7b_score32_exact_mha_final_frontier_v1",
             "decision": "exact_llama2_mha_quality_backed_frontier_available",
-            "dimension_winners": {
-                "throughput_comparable_boundary": "gqa8",
-                "energy_comparable_boundary": "gqa8",
+            "dimension_winners_by_workload": {
+                "official_llama2_7b_native_context_4096": {
+                    "throughput": "exact_mha",
+                    "energy": "exact_mha",
+                },
+            },
+            "noncomparable_reference_winners": {
                 "higher_precision_noncomparable_reference": "fp16",
             },
-            "engineering_pareto_frontier": [{"candidate_id": "gqa8"}],
+            "engineering_pareto_frontiers_by_workload": {
+                "long_context_131072_extrapolation": [{"candidate_id": "gqa8"}],
+                "official_llama2_7b_native_context_4096": [{"candidate_id": "exact_mha"}],
+            },
             "promotable_pareto_frontier": [{"candidate_id": "exact_mha"}],
             "noncomparable_reference_rows": [{"candidate_id": "fp16"}],
             "scalar_universal_winner": None,
@@ -456,10 +468,10 @@ def test_decoder_evidence_summary_recognizes_exact_llama2_mha_final_frontier() -
     )
 
     assert outcome == "exact_llama2_mha_quality_backed_frontier_available"
-    assert "engineering_pareto_count=1" in summary
+    assert "engineering_workload_count=2" in summary
     assert "promotable_pareto_count=1" in summary
     assert "noncomparable_reference_count=1" in summary
-    assert "throughput_winner=gqa8" in summary
+    assert "native_context_throughput_winner=exact_mha" in summary
     assert "higher_precision_reference=fp16" in summary
     assert "scalar_universal_winner=None" in summary
 

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import re
 import subprocess
 import tempfile
 from unittest.mock import patch
@@ -9271,6 +9272,7 @@ def test_service_activity_power_request_manifests_remain_dependency_gated() -> N
         "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r2",
         "l2_decoder_attention_decode_score_multivalue_cluster_equivalence_llama7b_v1",
     }
+    base_item_id = "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1"
 
     for manifest_name, items_key in (
         ("proposal.json", "required_evaluations"),
@@ -9284,17 +9286,21 @@ def test_service_activity_power_request_manifests_remain_dependency_gated() -> N
             assert "does not claim that r2 has passed" in note
             assert "later retries resolve dynamically" in note
         item = manifest[items_key][0]
-        assert (
-            item["item_id"]
-            == "l2_decoder_attention_decode_score_multivalue_service_c1_activity_power_llama7b_v1"
-        )
+        if manifest_name == "proposal.json":
+            assert item["item_id"] == base_item_id
+            assert item["status"] == "pending_implementation_merge"
+        else:
+            assert re.fullmatch(rf"{re.escape(base_item_id)}(?:_r\d+)?", item["item_id"])
+            assert base_item_id in item.get("prior_item_ids", [])
+            assert item["status"] == "merged"
+            assert int(item["merged_pr_number"]) > 0
+            assert item["merge_commit"]
         assert set(item["depends_on_item_ids"]) == expected_depends
         assert item["paired_baseline_item_id"] == (
             "l1_decoder_attention_decode_score_multivalue_service_c1_p128_b4_q4_rl2_rr_pnr_v1_r2"
         )
         assert item["requires_merged_inputs"] is True
         assert item["requires_materialized_refs"] is True
-        assert item["status"] == "pending_implementation_merge"
         assert "dependency-gated" in item["notes"]
         assert "not ready for normal dispatch" in item["notes"]
         assert "August 5, 2026" in item["notes"]
@@ -15027,13 +15033,163 @@ def test_generate_l2_campaign_task_adds_global_hbm_exact_llama2_mha_recost() -> 
             assert "--finite-recost-json" in run
             assert "--hbm-replay-json" in run
             assert "--hbm-energy-json" in run
+            assert "--quality-frontier-json" in run
             assert "--runtime-max-sec 3600" in run
             assert work_item.input_manifest["worker_resources"]["exclusive_worker"] is True
             assert work_item.input_manifest["worker_resources"]["stall_timeout_seconds"] == 900
+            assert work_item.input_manifest["decoder_contract"][
+                "attention_score32_quality_aware_frontier"
+            ].endswith(
+                "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_"
+                "rtl_ppa_recost_frontier_llama7b_v1.json"
+            )
             assert work_item.expected_outputs[0].endswith(
                 "decoder_attention_score32_global_hbm_exact_llama2_mha_recost__"
                 "l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1.json"
             )
+
+
+def test_generate_l2_campaign_task_adds_exact_llama2_mha_generation_quality() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                _make_l2_request(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1",
+                    proposal_path=(
+                        "docs/proposals/prop_l2_decoder_attention_score32_"
+                        "exact_llama2_mha_generation_quality_v1/proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_score32_exact_llama2_mha_generation_quality",
+                    evaluation_mode="quality_gate",
+                    comparison_role="exact_model_precision_gate",
+                    depends_on_item_ids=[],
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=False,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            run = work_item.command_manifest[0]["run"]
+            decoder_inputs = work_item.input_manifest["decoder_contract"]
+            assert work_item.state == WorkItemState.DISPATCH_PENDING
+            assert "evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py" in run
+            assert "--model-id meta-llama/Llama-2-7b-hf" in run
+            assert "--expected-model-id meta-llama/Llama-2-7b-hf" in run
+            assert "--expected-attention-head-count 32" in run
+            assert "--expected-kv-head-count 32" in run
+            assert "--expected-hidden-size 4096" in run
+            assert "--expected-gqa-group-size 1" in run
+            assert "score32_exp_lut_div:q8,k8,v8,s32,w16,exp_lut_div_bucket20" in run
+            assert "RTLGEN_MODEL_NATIVE_7B_MODEL_ID" not in run
+            assert "--runtime-max-sec 21600" in run
+            assert work_item.input_manifest["worker_resources"]["exclusive_worker"] is True
+            assert work_item.input_manifest["worker_resources"]["memory_max"] == "56G"
+            assert decoder_inputs["attention_score32_exact_llama2_mha_generation_quality_out"] in (
+                work_item.expected_outputs
+            )
+
+
+def test_exact_llama2_mha_generation_quality_rejects_dependencies() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session, pytest.raises(
+            Layer2TaskGenerationError,
+            match="must not wait on hardware recost",
+        ):
+            generate_l2_campaign_task(
+                session,
+                _make_l2_request(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1",
+                    proposal_path=(
+                        "docs/proposals/prop_l2_decoder_attention_score32_"
+                        "exact_llama2_mha_generation_quality_v1/proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_score32_exact_llama2_mha_generation_quality",
+                    evaluation_mode="quality_gate",
+                    depends_on_item_ids=["l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1"],
+                    requires_merged_inputs=True,
+                    run_physical=False,
+                ),
+            )
+
+
+def test_generate_l2_campaign_task_adds_exact_llama2_mha_final_frontier() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+        dependencies = [
+            "l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1",
+            "l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1",
+        ]
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                _make_l2_request(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id="l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1",
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id="prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1",
+                    proposal_path=(
+                        "docs/proposals/prop_l2_decoder_attention_score32_"
+                        "exact_llama2_mha_final_frontier_v1/proposal.json"
+                    ),
+                    abstraction_layer="decoder_attention_score32_exact_llama2_mha_final_frontier",
+                    evaluation_mode="frontier_detail",
+                    comparison_role="exact_model_frontier_decision",
+                    depends_on_item_ids=dependencies,
+                    requires_merged_inputs=True,
+                    requires_materialized_refs=True,
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            run = work_item.command_manifest[0]["run"]
+            assert work_item.state == WorkItemState.BLOCKED
+            assert "audit_llm_decoder_attention_score32_exact_llama2_mha_final_frontier.py" in run
+            assert "--exact-mha-recost-json" in run
+            assert "--exact-generation-quality-json" in run
+            assert "--prior-quality-frontier-json" in run
+            assert "--runtime-max-sec 300" in run
+            assert work_item.input_manifest["worker_resources"]["exclusive_worker"] is False
+            assert work_item.expected_outputs[0].endswith(
+                "decoder_attention_score32_exact_llama2_mha_final_frontier__"
+                "l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1.json"
+            )
+            assert work_item.task_request.request_payload["developer_loop"]["dependencies"][
+                "item_ids"
+            ] == dependencies
 
 
 def test_score32_noc_closure_rejects_inexact_dependencies() -> None:

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1/README.md
@@ -1,0 +1,3 @@
+# Exact Llama-2-7B MHA Final Frontier
+
+This proposal joins the structurally exact score32 MHA hardware recost with native official-checkpoint generation quality. It reports throughput, embodied area, energy, and precision independently and retains structurally mismatched GQA points only as engineering references.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1/design_brief.md
@@ -2,4 +2,4 @@
 
 The audit consumes two new authoritative artifacts: the global-HBM exact-MHA recost and exact official-checkpoint generation quality. It also imports the previously measured FP16 GQA8 point for engineering context without treating it as structurally or physically comparable. That row has compute area rather than total embodied area, so it is excluded from cross-objective Pareto dominance and area winners.
 
-Dominance is evaluated over higher throughput, lower embodied area, lower energy per token, and higher arithmetic precision. No scalar weighting is introduced.
+Dominance is evaluated over higher throughput, lower embodied area, lower energy per token, and higher arithmetic precision only inside one workload identity. The 4096-token official native-context row and 131072-token long-context extrapolation have separate winner and Pareto sets. No scalar weighting is introduced.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1/design_brief.md
@@ -1,0 +1,5 @@
+# Design Brief
+
+The audit consumes two new authoritative artifacts: the global-HBM exact-MHA recost and exact official-checkpoint generation quality. It also imports the previously measured FP16 GQA8 point for engineering context without treating it as structurally or physically comparable. That row has compute area rather than total embodied area, so it is excluded from cross-objective Pareto dominance and area winners.
+
+Dominance is evaluated over higher throughput, lower embodied area, lower energy per token, and higher arithmetic precision. No scalar weighting is introduced.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1/evaluation_gate.md
@@ -1,0 +1,9 @@
+# Evaluation Gate
+
+- The exact hardware row declares hidden size 4096, 32 attention heads, 32 KV heads, and MHA.
+- The quality artifact declares the official Llama-2-7B checkpoint with the same dimensions.
+- The arithmetic profile is score32 q8/k8/v8, weight16, exp-LUT/div.
+- A quality hold leaves the exact row nonpromotable but does not erase its engineering measurements.
+- Area uses total embodied logic, memory, NoC/endpoint, and measured HBM-controller area.
+- Rows without the same total-embodied-area boundary are reported separately and cannot win the comparable Pareto ranking.
+- Energy status and remaining abstractions are reported alongside values.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1/evaluation_gate.md
@@ -6,4 +6,6 @@
 - A quality hold leaves the exact row nonpromotable but does not erase its engineering measurements.
 - Area uses total embodied logic, memory, NoC/endpoint, and measured HBM-controller area.
 - Rows without the same total-embodied-area boundary are reported separately and cannot win the comparable Pareto ranking.
+- Rows with different sequence lengths are placed in separate workload-specific winner and Pareto sets.
+- Native checkpoint quality can promote only the official 4096-context MHA row, never the 131k extrapolation.
 - Energy status and remaining abstractions are reported alongside values.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1",
+  "source_commit": "TBD",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1",
+      "task_type": "l2_campaign",
+      "objective": "Produce the structurally exact multidimensional Llama-2-7B frontier from exact-MHA hardware and native quality evidence.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_exact_llama2_mha_final_frontier",
+      "comparison_role": "exact_model_frontier_decision",
+      "status": "pending_after_dependencies_merge",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1",
+        "l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exact_llama2_mha_final_frontier__l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exact_llama2_mha_final_frontier__l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1.md"
+      ],
+      "acceptance_notes": "Require exact structural and native quality identity, report all four objectives separately, and retain GQA rows as nonpromotable references."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1/promotion_gate.md
@@ -1,0 +1,5 @@
+# Promotion Gate
+
+The exact score32 MHA row may enter the promotable Pareto set only after both dependencies merge and every structural and quality check passes.
+
+This audit is not the end of exploration. Its next frontier work must optimize exact-MHA SRAM residency and establish a structurally exact FP16 MHA comparison before claiming a final precision tradeoff.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1/proposal.json
@@ -8,7 +8,7 @@
   "abstraction_layer": "decoder_attention_score32_exact_llama2_mha_final_frontier",
   "hypothesis": "Joining the corrected global-HBM exact-MHA recost with exact-checkpoint score32 quality will establish the first structurally and arithmetically valid Llama-2-7B candidate, while exposing remaining energy, memory-policy, and FP16 comparison gaps.",
   "direct_comparison": {
-    "primary_question": "Which currently measured architecture is nondominated in token throughput, embodied area, energy, and precision after enforcing exact Llama-2-7B model identity?",
+    "primary_question": "Which currently measured architecture is nondominated within each identical workload/accounting boundary after enforcing exact Llama-2-7B model and context identity?",
     "include": [
       "exact 32-KV-head score32 MHA recost under one global HBM controller",
       "native meta-llama/Llama-2-7b-hf generation-quality evidence",
@@ -21,6 +21,7 @@
       "scalar weighting across objectives",
       "promotion of GQA8 rows as exact Llama-2-7B",
       "promotion after failed or missing exact-checkpoint quality",
+      "cross-ranking 4096-token native and 131072-token extrapolated workloads",
       "vendor HBM signoff claims",
       "claims that exact FP16 MHA has already been physically recosted"
     ],

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1/proposal.json
@@ -1,0 +1,64 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1",
+  "created_utc": "2026-08-17T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Join exact Llama-2-7B MHA hardware and precision evidence",
+  "abstraction_layer": "decoder_attention_score32_exact_llama2_mha_final_frontier",
+  "hypothesis": "Joining the corrected global-HBM exact-MHA recost with exact-checkpoint score32 quality will establish the first structurally and arithmetically valid Llama-2-7B candidate, while exposing remaining energy, memory-policy, and FP16 comparison gaps.",
+  "direct_comparison": {
+    "primary_question": "Which currently measured architecture is nondominated in token throughput, embodied area, energy, and precision after enforcing exact Llama-2-7B model identity?",
+    "include": [
+      "exact 32-KV-head score32 MHA recost under one global HBM controller",
+      "native meta-llama/Llama-2-7b-hf generation-quality evidence",
+      "corrected GQA8 score32 engineering reference",
+      "measured exact-FP16 GQA8 engineering reference",
+      "separate engineering and structurally promotable Pareto sets",
+      "explicit exclusion of incomplete-area references from cross-objective dominance"
+    ],
+    "exclude": [
+      "scalar weighting across objectives",
+      "promotion of GQA8 rows as exact Llama-2-7B",
+      "promotion after failed or missing exact-checkpoint quality",
+      "vendor HBM signoff claims",
+      "claims that exact FP16 MHA has already been physically recosted"
+    ],
+    "metrics": [
+      "token_throughput_per_s",
+      "token_latency_us",
+      "total_embodied_area_mm2",
+      "die_envelope_mm2",
+      "energy_mj_per_token",
+      "precision_class",
+      "promotable",
+      "pareto_membership"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1",
+      "task_type": "l2_campaign",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_exact_llama2_mha_final_frontier",
+      "comparison_role": "exact_model_frontier_decision",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1",
+        "l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json"
+  ],
+  "risks": [
+    "The exact score32 row still uses deterministic HBM replay and command-calibrated HBM energy.",
+    "Logic energy remains vectorless rather than workload-toggle-complete.",
+    "The shared-SRAM residency allocation is fixed rather than optimized for MHA.",
+    "No structurally exact FP16 MHA physical reference exists yet."
+  ],
+  "needs_mapper_change": false
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_final_frontier_v1/quality_gate.md
@@ -1,0 +1,3 @@
+# Quality Gate
+
+Only `mixed_int8_generation_quality_pass` from the hard-gated official Llama-2-7B MHA job qualifies score32 as precision-backed. Proxy-checkpoint evidence and structural ratio matches without exact dimensions are rejected.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1/README.md
@@ -1,5 +1,5 @@
 # Exact Llama-2-7B MHA Generation Quality
 
-This proposal closes the model-identity gap in the score32 attention frontier. It evaluates the score32 exp-LUT/div arithmetic on the official `meta-llama/Llama-2-7b-hf` checkpoint and refuses proxy checkpoints or non-MHA structures.
+This proposal closes the model-identity gap in the native-context score32 attention frontier. It evaluates the score32 exp-LUT/div arithmetic on the official `meta-llama/Llama-2-7b-hf` checkpoint and refuses proxy checkpoints or non-MHA structures. It does not validate the separate 131k-token extrapolation.
 
 The checkpoint is gated. The remote evaluator must already have Hugging Face authorization; authentication failure is a failed prerequisite, not quality evidence.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1/README.md
@@ -1,0 +1,5 @@
+# Exact Llama-2-7B MHA Generation Quality
+
+This proposal closes the model-identity gap in the score32 attention frontier. It evaluates the score32 exp-LUT/div arithmetic on the official `meta-llama/Llama-2-7b-hf` checkpoint and refuses proxy checkpoints or non-MHA structures.
+
+The checkpoint is gated. The remote evaluator must already have Hugging Face authorization; authentication failure is a failed prerequisite, not quality evidence.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1/design_brief.md
@@ -1,0 +1,5 @@
+# Design Brief
+
+The candidate is the existing score32 q8/k8/v8, weight16, exp-LUT/div attention arithmetic. Reference and candidate runs use the same official Llama-2-7B checkpoint, prompts, dtype, and greedy decode sequence.
+
+The evaluator validates both the requested model ID and loaded structural dimensions before collecting evidence. The job has no hardware dependency so model-quality execution can proceed in parallel with the physical recost chain.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1/evaluation_gate.md
@@ -1,0 +1,13 @@
+# Evaluation Gate
+
+- The requested model ID is exactly `meta-llama/Llama-2-7b-hf`.
+- Hidden size is 4096.
+- Attention-head count is 32.
+- KV-head count is 32.
+- GQA group size is 1 (MHA).
+- The primary candidate is `score32_exp_lut_div`.
+- Teacher-forced mean NLL delta is at most 0.4.
+- Candidate mean probability on the reference token is at least 0.1.
+- Free-running token match rate is at least 0.75.
+
+Missing checkpoint authorization fails the job prerequisite and must not be interpreted as a quality hold.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1/evaluation_requests.json
@@ -1,0 +1,24 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1",
+  "source_commit": "TBD",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1",
+      "task_type": "l2_campaign",
+      "objective": "Measure score32 exp-LUT/div generation quality on the exact official Llama-2-7B MHA checkpoint.",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_score32_exact_llama2_mha_generation_quality",
+      "comparison_role": "exact_model_precision_gate",
+      "status": "pending",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": false,
+      "run_physical": false,
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exact_llama2_mha_generation_quality__l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exact_llama2_mha_generation_quality__l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1.md"
+      ],
+      "acceptance_notes": "Fail instead of substituting another model; require exact model identity, hidden size 4096, 32 attention heads, 32 KV heads, and GQA group size 1."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1/promotion_gate.md
@@ -1,0 +1,5 @@
+# Promotion Gate
+
+Promotion requires both this native exact-checkpoint quality result and the exact-MHA global-HBM hardware recost. Neither artifact is sufficient alone.
+
+The final frontier must continue to expose throughput, area, energy, and precision separately; it must not collapse them into an unsupported scalar score.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1/proposal.json
@@ -1,0 +1,65 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1",
+  "created_utc": "2026-08-17T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "architecture",
+  "title": "Measure score32 generation quality on exact Llama-2-7B MHA",
+  "abstraction_layer": "decoder_attention_score32_exact_llama2_mha_generation_quality",
+  "hypothesis": "The score32 q8/k8/v8 exp-LUT/div arithmetic may preserve bounded generation quality on the exact Llama-2-7B MHA checkpoint, but Mistral GQA4 evidence cannot establish that claim.",
+  "direct_comparison": {
+    "primary_question": "Does the exact official Llama-2-7B MHA checkpoint preserve bounded greedy generation and reference-token likelihood with the score32 exp-LUT/div attention arithmetic?",
+    "baseline": "unmodified meta-llama/Llama-2-7b-hf",
+    "candidate": "score32_exp_lut_div:q8,k8,v8,s32,w16,exp_lut_div_bucket20",
+    "include": [
+      "hard model identity gate for meta-llama/Llama-2-7b-hf",
+      "hard structural gates for hidden size 4096, 32 attention heads, and 32 KV heads",
+      "teacher-forced reference-token NLL and top-1 agreement",
+      "bounded free-running greedy token agreement and first divergence"
+    ],
+    "exclude": [
+      "Mistral, TinyLlama, or environment-selected proxy substitution",
+      "QAT or fine-tuning recovery",
+      "full benchmark accuracy or perplexity claims",
+      "hardware PPA execution"
+    ],
+    "metrics": [
+      "teacher_forced_nll_delta_mean",
+      "teacher_forced_top1_match_rate",
+      "free_running_match_rate",
+      "free_running_first_divergence_step_mean",
+      "structural_contract_status"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1",
+      "task_type": "l2_campaign",
+      "evaluation_mode": "quality_gate",
+      "abstraction_layer": "decoder_attention_score32_exact_llama2_mha_generation_quality",
+      "comparison_role": "exact_model_precision_gate",
+      "cost_class": "high",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": false,
+      "run_physical": false,
+      "expected_result": {
+        "direction": "accept_or_hold_exact_mha_score32",
+        "reason": "Only a passing exact-checkpoint result may make the exact-MHA hardware row precision-backed."
+      }
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__l2_decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality_llama7b_v1.json"
+  ],
+  "knowledge_refs": [
+    "npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py",
+    "docs/proposals/prop_l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1/proposal.json"
+  ],
+  "risks": [
+    "The official checkpoint requires evaluator-local Hugging Face authorization.",
+    "Eight prompts and eight generated tokens are a bounded gate, not broad accuracy validation.",
+    "Two model instances require substantial evaluator memory."
+  ],
+  "needs_mapper_change": false
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1/quality_gate.md
@@ -1,0 +1,5 @@
+# Quality Gate
+
+A passing bounded result supplies native arithmetic-quality evidence only for the exact MHA model structure checked by the job. It does not establish full-task accuracy, long-context quality, or recovery after training.
+
+A threshold failure keeps the score32 exact-MHA row visible as engineering evidence but excludes it from the precision-backed promotion frontier.

--- a/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1/quality_gate.md
@@ -1,5 +1,5 @@
 # Quality Gate
 
-A passing bounded result supplies native arithmetic-quality evidence only for the exact MHA model structure checked by the job. It does not establish full-task accuracy, long-context quality, or recovery after training.
+A passing bounded result supplies native arithmetic-quality evidence only for the exact MHA model structure and official 4096-token context contract checked by the job. It does not establish full-task accuracy, 131k-context quality, or recovery after training.
 
 A threshold failure keeps the score32 exact-MHA row visible as engineering evidence but excludes it from the precision-backed promotion frontier.

--- a/docs/proposals/prop_l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1/evaluation_requests.json
@@ -19,7 +19,7 @@
         "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_global_hbm_exact_llama2_mha_recost__l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1.json",
         "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_global_hbm_exact_llama2_mha_recost__l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1.md"
       ],
-      "acceptance_notes": "Replay aggregate active-cluster HBM bytes, rebuild exact-MHA compute and memory quantities, rerun finite endpoint scheduling, and refuse promotion without native Llama-2-7B score32 quality evidence."
+      "acceptance_notes": "Replay aggregate active-cluster HBM bytes, rebuild exact-MHA compute and memory quantities, include measured replay-controller area and latency-scaled energy, rerun finite endpoint scheduling, and refuse promotion without native Llama-2-7B score32 quality evidence."
     }
   ]
 }

--- a/docs/proposals/prop_l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1/evaluation_requests.json
@@ -5,7 +5,7 @@
     {
       "item_id": "l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1",
       "task_type": "l2_campaign",
-      "objective": "Correct global HBM bandwidth sharing and recost the exact 32-KV-head Llama-2-7B MHA structure.",
+      "objective": "Correct global HBM sharing, retain the 131k MHA extrapolation, and recost exact 4096-context Llama-2-7B MHA separately.",
       "evaluation_mode": "frontier_detail",
       "abstraction_layer": "decoder_attention_score32_global_hbm_exact_llama2_mha_recost",
       "comparison_role": "structural_frontier_correction",
@@ -19,7 +19,7 @@
         "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_global_hbm_exact_llama2_mha_recost__l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1.json",
         "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_global_hbm_exact_llama2_mha_recost__l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1.md"
       ],
-      "acceptance_notes": "Replay aggregate active-cluster HBM bytes, rebuild exact-MHA compute and memory quantities, include measured replay-controller area and latency-scaled energy, rerun finite endpoint scheduling, and refuse promotion without native Llama-2-7B score32 quality evidence."
+      "acceptance_notes": "Replay aggregate active-cluster HBM bytes, rebuild MHA compute and memory quantities at both 131072 and native 4096 context, include measured replay-controller area and latency-scaled energy, never compare unlike contexts in one Pareto set, and refuse native promotion without native Llama-2-7B score32 quality evidence."
     }
   ]
 }

--- a/docs/proposals/prop_l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1/proposal.json
@@ -14,6 +14,7 @@
       "exact MHA QKV projection and KV traffic",
       "finite endpoint NoC replay with delayed releases",
       "calibrated HBM command energy",
+      "measured HBM replay-controller area and latency-scaled power",
       "explicit structural and native-quality promotion gates"
     ],
     "exclude": [
@@ -36,6 +37,7 @@
   ],
   "baseline_refs": [
     "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exact_reduction_recost__l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1.json",
-    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_hbm_controller_replay__l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1.json"
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_hbm_controller_replay__l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_integrated_frontier_ranking__l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1.json"
   ]
 }

--- a/docs/proposals/prop_l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1/proposal.json
@@ -7,11 +7,12 @@
   "title": "Correct global HBM service and recost exact Llama-2-7B MHA",
   "hypothesis": "The prior score32 frontier overstates throughput because it replays one tile against a global HBM controller, and its GQA8 shape is not exact Llama-2-7B; aggregate-wave replay plus a 32-KV-head MHA recost will establish the structurally valid performance and energy bounds.",
   "direct_comparison": {
-    "primary_question": "How do corrected GQA8 and exact Llama-2-7B MHA compare in token throughput, energy, area, and structural/precision evidence under one global HBM controller?",
+    "primary_question": "How do corrected GQA8 and MHA compare under the same 131k stress workload, and what is the exact native-context Llama-2-7B MHA result under one global HBM controller?",
     "include": [
       "aggregate 16-cluster HBM wave service",
       "separate HBM and compute clock domains",
       "exact MHA QKV projection and KV traffic",
+      "separate 131072-token extrapolation and official 4096-token native-context workloads",
       "finite endpoint NoC replay with delayed releases",
       "calibrated HBM command energy",
       "measured HBM replay-controller area and latency-scaled power",

--- a/npu/eval/README.md
+++ b/npu/eval/README.md
@@ -111,6 +111,29 @@ Treat a recovered non-tensor granularity as a hardware metadata/scale-cost
 question, not as QAT evidence. If no granularity recovers top-1/top-k ranking,
 the next quality path is true QAT/fine-tuning or the KV8 fallback.
 
+Gated checkpoints require evaluator-local authorization. Supply `HF_TOKEN` in
+the evaluator daemon environment or use an equivalent Hugging Face credential
+store mounted into the evaluator container; never place a token in a proposal,
+task command, artifact, log, or committed environment file. Jobs that claim an
+exact checkpoint must pass both `--model-id` and `--expected-model-id` plus the
+expected head/KV/hidden dimensions. An authorization or checkpoint-download
+failure is an execution-prerequisite failure and must not be consumed as a
+quality hold. For exact Llama-2-7B MHA, the required identity is:
+
+```sh
+bash npu/eval/run_hf_eval_python.sh \
+  npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py \
+  --model-id meta-llama/Llama-2-7b-hf \
+  --expected-model-id meta-llama/Llama-2-7b-hf \
+  --expected-attention-head-count 32 \
+  --expected-kv-head-count 32 \
+  --expected-hidden-size 4096 \
+  --expected-gqa-group-size 1 \
+  --candidate score32_exp_lut_div:q8,k8,v8,s32,w16,exp_lut_div_bucket20 \
+  --out /tmp/llama2_score32_quality.json \
+  --out-md /tmp/llama2_score32_quality.md
+```
+
 ## Validation
 Validate campaign manifest:
 ```sh

--- a/npu/eval/audit_llm_decoder_attention_score32_exact_llama2_mha_final_frontier.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_exact_llama2_mha_final_frontier.py
@@ -22,7 +22,7 @@ DEFAULT_RECOST = _BASE / (
     "l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1.json"
 )
 DEFAULT_GENERATION_QUALITY = _BASE / (
-    "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__"
+    "decoder_attention_score32_exact_llama2_mha_generation_quality__"
     "l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1.json"
 )
 DEFAULT_QUALITY_FRONTIER = _BASE / (
@@ -49,6 +49,8 @@ _SCORE32_PRECISION = {
     "weight_bits": 16,
     "softmax_mode": "exp_lut_div_bucket20",
 }
+_GQA8_CANDIDATE_ID = "score32_gqa8_global_hbm_finite_endpoint"
+_EXACT_MHA_CANDIDATE_ID = "score32_exact_llama2_7b_mha_global_hbm_finite_endpoint"
 
 
 def _load_json(path: Path) -> JsonDict:
@@ -103,9 +105,14 @@ def _validate_recost(payload: JsonDict) -> tuple[JsonDict, JsonDict]:
         hidden_size = int(_positive(contract.get("hidden_size"), "recost hidden_size"))
         if hidden_size != 4096 or attention_heads != 32:
             raise ValueError("exact MHA recost rows must remain on the 4096-wide 32-head model")
-        if kv_heads == 4 and gqa_group_size == 8:
+        candidate_id = row.get("candidate_id")
+        if kv_heads == 4 and gqa_group_size == 8 and candidate_id == _GQA8_CANDIDATE_ID:
+            if contract.get("kv_sharing") != "gqa8":
+                raise ValueError("corrected GQA8 row kv_sharing mismatch")
             gqa8_row = dict(row)
-        elif kv_heads == 32 and gqa_group_size == 1:
+        elif kv_heads == 32 and gqa_group_size == 1 and candidate_id == _EXACT_MHA_CANDIDATE_ID:
+            if contract.get("kv_sharing") != "mha" or contract.get("contract_scope") != "exact_llama2_7b_mha_structure":
+                raise ValueError("exact MHA row structural contract mismatch")
             mha_row = dict(row)
 
     if gqa8_row is None or mha_row is None:
@@ -145,6 +152,8 @@ def _validate_generation_quality(payload: JsonDict) -> JsonDict:
         raise ValueError(
             f"generation quality model_id mismatch: expected {_EXACT_MODEL_ID!r}, observed {observed_model_id!r}"
         )
+    if model.get("expected_model_id") != _EXACT_MODEL_ID:
+        raise ValueError("generation quality expected_model_id does not lock the official checkpoint")
 
     hidden_size = int(_exact_number(_quality_model_field(model, "hidden_size"), 4096, "quality hidden_size"))
     attention_heads = int(
@@ -302,7 +311,10 @@ def _fp16_row(source: JsonDict) -> JsonDict:
         "precision_dimension_rank": 2,
         "token_throughput_per_s": _positive(source.get("token_throughput_per_s"), "fp16 throughput"),
         "token_latency_us": _positive(source.get("latency_us"), "fp16 latency"),
-        "embodied_area_mm2": _embodied_area_mm2(source, source_label="fp16 reference"),
+        "embodied_area_mm2": None,
+        "compute_area_mm2": _positive(source.get("compute_area_mm2"), "fp16 compute area"),
+        "die_envelope_mm2": _positive(source.get("die_area_mm2"), "fp16 die envelope"),
+        "area_metric_status": "compute_only_not_total_embodied_noncomparable",
         "energy_mj_per_token": _positive(source.get("energy_mj_per_token"), "fp16 energy"),
         "remaining_abstractions": [
             *[str(item) for item in source.get("remaining_abstractions", [])],
@@ -403,21 +415,23 @@ def build_report(*, recost: JsonDict, generation_quality: JsonDict, quality_fron
     )
     fp16_row = _fp16_row(fp16_reference)
 
-    engineering_rows = [gqa8_row, exact_mha_row, fp16_row]
-    engineering_pareto = _pareto_rows(engineering_rows)
-    promotable_rows = [row for row in engineering_rows if row["promotable"] and row["quality_backed"]]
+    comparable_rows = [gqa8_row, exact_mha_row]
+    all_rows = [*comparable_rows, fp16_row]
+    engineering_pareto = _pareto_rows(comparable_rows)
+    promotable_rows = [row for row in comparable_rows if row["promotable"] and row["quality_backed"]]
     promotable_pareto = _pareto_rows(promotable_rows)
 
     dimension_winners = {
-        "throughput": _winner(engineering_rows, "token_throughput_per_s", maximize=True),
-        "embodied_area": _winner(engineering_rows, "embodied_area_mm2", maximize=False),
-        "energy": _winner(engineering_rows, "energy_mj_per_token", maximize=False),
-        "precision": _precision_winner(engineering_rows),
+        "throughput_comparable_boundary": _winner(comparable_rows, "token_throughput_per_s", maximize=True),
+        "embodied_area_comparable_boundary": _winner(comparable_rows, "embodied_area_mm2", maximize=False),
+        "energy_comparable_boundary": _winner(comparable_rows, "energy_mj_per_token", maximize=False),
+        "precision_comparable_boundary": _precision_winner(comparable_rows),
+        "higher_precision_noncomparable_reference": fp16_row["candidate_id"],
     }
 
     remaining_abstractions = sorted(
         {
-            *[item for row in engineering_rows for item in row["remaining_abstractions"]],
+            *[item for row in all_rows for item in row["remaining_abstractions"]],
             *[str(item) for item in recost.get("remaining_abstractions", [])],
             "HBM controller service remains deterministic global replay rather than controller RTL or vendor timing signoff.",
             "Logic energy remains a vectorless activity proxy rather than workload-toggle-complete power.",
@@ -440,7 +454,7 @@ def build_report(*, recost: JsonDict, generation_quality: JsonDict, quality_fron
             ),
         },
         "dimension_winners": dimension_winners,
-        "dimension_winner_scope": "engineering_metrics_across_exact_mha_gqa8_and_fp16_reference",
+        "dimension_winner_scope": "only rows with the same total-embodied-area accounting boundary",
         "scalar_universal_winner": None,
         "conditional_recommendation": {
             "universal_winner": None,
@@ -463,7 +477,8 @@ def build_report(*, recost: JsonDict, generation_quality: JsonDict, quality_fron
         "quality_contract": quality,
         "engineering_pareto_frontier": engineering_pareto,
         "promotable_pareto_frontier": promotable_pareto,
-        "all_rows": engineering_rows,
+        "noncomparable_reference_rows": [fp16_row],
+        "all_rows": all_rows,
         "excluded_nonpromotable_history": excluded_history,
         "remaining_abstractions": remaining_abstractions,
         "next_measurements": [
@@ -486,10 +501,11 @@ def write_report(payload: JsonDict, path: Path) -> None:
         "",
         "## Dimension Winners",
         "",
-        f"- throughput: `{payload['dimension_winners']['throughput']}`",
-        f"- embodied_area: `{payload['dimension_winners']['embodied_area']}`",
-        f"- energy: `{payload['dimension_winners']['energy']}`",
-        f"- precision: `{payload['dimension_winners']['precision']}`",
+        f"- throughput (comparable boundary): `{payload['dimension_winners']['throughput_comparable_boundary']}`",
+        f"- embodied_area (comparable boundary): `{payload['dimension_winners']['embodied_area_comparable_boundary']}`",
+        f"- energy (comparable boundary): `{payload['dimension_winners']['energy_comparable_boundary']}`",
+        f"- precision (comparable boundary): `{payload['dimension_winners']['precision_comparable_boundary']}`",
+        f"- higher-precision noncomparable reference: `{payload['dimension_winners']['higher_precision_noncomparable_reference']}`",
         "",
         "## Engineering Pareto",
         "",
@@ -518,6 +534,11 @@ def write_report(payload: JsonDict, path: Path) -> None:
             )
     else:
         lines.append("- No promotable frontier row is currently available.")
+    lines.extend(["", "## Noncomparable References", ""])
+    for row in payload["noncomparable_reference_rows"]:
+        lines.append(
+            f"- `{row['candidate_id']}`: {row['area_metric_status']}; excluded from cross-objective Pareto ranking."
+        )
     lines.extend(["", "## Remaining Abstractions", ""])
     lines.extend(f"- {item}" for item in payload["remaining_abstractions"])
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -527,18 +548,18 @@ def write_report(payload: JsonDict, path: Path) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo-root", type=Path, default=Path("."))
-    parser.add_argument("--recost-json", type=Path, default=DEFAULT_RECOST)
-    parser.add_argument("--generation-quality-json", type=Path, default=DEFAULT_GENERATION_QUALITY)
-    parser.add_argument("--quality-frontier-json", type=Path, default=DEFAULT_QUALITY_FRONTIER)
+    parser.add_argument("--exact-mha-recost-json", type=Path, default=DEFAULT_RECOST)
+    parser.add_argument("--exact-generation-quality-json", type=Path, default=DEFAULT_GENERATION_QUALITY)
+    parser.add_argument("--prior-quality-frontier-json", type=Path, default=DEFAULT_QUALITY_FRONTIER)
     parser.add_argument("--out", type=Path, required=True)
     parser.add_argument("--report", type=Path, required=True)
     args = parser.parse_args()
 
     root = args.repo_root.resolve()
     payload = build_report(
-        recost=_load_json(root / args.recost_json),
-        generation_quality=_load_json(root / args.generation_quality_json),
-        quality_frontier=_load_json(root / args.quality_frontier_json),
+        recost=_load_json(root / args.exact_mha_recost_json),
+        generation_quality=_load_json(root / args.exact_generation_quality_json),
+        quality_frontier=_load_json(root / args.prior_quality_frontier_json),
     )
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/npu/eval/audit_llm_decoder_attention_score32_exact_llama2_mha_final_frontier.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_exact_llama2_mha_final_frontier.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+"""Build the exact Llama-2-7B score32 final frontier without collapsing to one scalar winner."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+JsonDict = dict[str, Any]
+
+_BASE = Path("runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1")
+DEFAULT_RECOST = _BASE / (
+    "decoder_attention_score32_global_hbm_exact_llama2_mha_recost__"
+    "l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1.json"
+)
+DEFAULT_GENERATION_QUALITY = _BASE / (
+    "decoder_attention_mixed_int8_score32_exp_lut_div_generation_quality__"
+    "l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1.json"
+)
+DEFAULT_QUALITY_FRONTIER = _BASE / (
+    "decoder_attention_score32_integrated_frontier_ranking__"
+    "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_"
+    "llama7b_v1.json"
+)
+
+_MODEL_ID = "llama2_7b_score32_exact_mha_final_frontier_v1"
+_RECOST_MODEL = "llm_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1"
+_QUALITY_GATE = "mixed_int8_generation_quality"
+_QUALITY_PASS = "mixed_int8_generation_quality_pass"
+_QUALITY_HOLD = "mixed_int8_generation_quality_hold"
+_DECISION_PASS = "exact_llama2_mha_quality_backed_frontier_available"
+_DECISION_HOLD = "exact_llama2_mha_score32_quality_hold"
+_QUALITY_FRONTIER_MODEL = "llm_decoder_attention_score32_integrated_frontier_ranking_v1"
+_EXACT_MODEL_ID = "meta-llama/Llama-2-7b-hf"
+_SCORE32_PRECISION = {
+    "candidate_id": "score32_exp_lut_div",
+    "q_bits": 8,
+    "k_bits": 8,
+    "v_bits": 8,
+    "score_bits": 32,
+    "weight_bits": 16,
+    "softmax_mode": "exp_lut_div_bucket20",
+}
+
+
+def _load_json(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _positive(value: Any, label: str) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be numeric") from exc
+    if not math.isfinite(number) or number <= 0.0:
+        raise ValueError(f"{label} must be positive")
+    return number
+
+
+def _string(value: Any, label: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{label} must be non-empty")
+    return text
+
+
+def _exact_number(value: Any, expected: float, label: str) -> float:
+    observed = _positive(value, label)
+    if observed != expected:
+        raise ValueError(f"{label} mismatch: expected {expected}, observed {observed}")
+    return observed
+
+
+def _validate_recost(payload: JsonDict) -> tuple[JsonDict, JsonDict]:
+    if payload.get("version") != 1 or payload.get("model") != _RECOST_MODEL:
+        raise ValueError("exact MHA recost model/version mismatch")
+    rows = payload.get("rows")
+    if not isinstance(rows, list):
+        raise ValueError("exact MHA recost rows are missing")
+
+    gqa8_row: JsonDict | None = None
+    mha_row: JsonDict | None = None
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        contract = row.get("model_contract")
+        throughput = row.get("throughput")
+        physical = row.get("physical")
+        energy = row.get("energy")
+        if not all(isinstance(section, dict) for section in (contract, throughput, physical, energy)):
+            raise ValueError("exact MHA recost row is missing required sections")
+        kv_heads = int(_positive(contract.get("kv_heads"), "recost kv_heads"))
+        attention_heads = int(_positive(contract.get("attention_heads"), "recost attention_heads"))
+        gqa_group_size = _positive(contract.get("gqa_group_size"), "recost gqa_group_size")
+        hidden_size = int(_positive(contract.get("hidden_size"), "recost hidden_size"))
+        if hidden_size != 4096 or attention_heads != 32:
+            raise ValueError("exact MHA recost rows must remain on the 4096-wide 32-head model")
+        if kv_heads == 4 and gqa_group_size == 8:
+            gqa8_row = dict(row)
+        elif kv_heads == 32 and gqa_group_size == 1:
+            mha_row = dict(row)
+
+    if gqa8_row is None or mha_row is None:
+        raise ValueError("exact MHA recost must contain corrected GQA8 and exact MHA rows")
+    return gqa8_row, mha_row
+
+
+def _quality_model_field(model: JsonDict, field: str) -> Any:
+    if field in model:
+        return model.get(field)
+    contract = model.get("structural_contract")
+    if isinstance(contract, dict):
+        loaded = contract.get("loaded_model_structure")
+        if isinstance(loaded, dict):
+            actual = loaded.get("actual")
+            if isinstance(actual, dict) and field in actual:
+                return actual.get(field)
+    return None
+
+
+def _validate_generation_quality(payload: JsonDict) -> JsonDict:
+    if float(payload.get("version", 0.0)) != 1.0:
+        raise ValueError("generation quality version mismatch")
+    if payload.get("quality_gate") != _QUALITY_GATE:
+        raise ValueError("generation quality gate mismatch")
+    model = payload.get("model")
+    precision = payload.get("precision")
+    decision = payload.get("decision")
+    if not all(isinstance(section, dict) for section in (model, precision, decision)):
+        raise ValueError("generation quality payload is missing required sections")
+
+    observed_model_id = _string(
+        model.get("resolved_model_id") or model.get("model_id"),
+        "generation quality model_id",
+    )
+    if observed_model_id != _EXACT_MODEL_ID:
+        raise ValueError(
+            f"generation quality model_id mismatch: expected {_EXACT_MODEL_ID!r}, observed {observed_model_id!r}"
+        )
+
+    hidden_size = int(_exact_number(_quality_model_field(model, "hidden_size"), 4096, "quality hidden_size"))
+    attention_heads = int(
+        _exact_number(
+            _quality_model_field(model, "attention_head_count"),
+            32,
+            "quality attention_head_count",
+        )
+    )
+    kv_heads = int(
+        _exact_number(
+            _quality_model_field(model, "kv_head_count"),
+            32,
+            "quality kv_head_count",
+        )
+    )
+    gqa_group_size = _exact_number(_quality_model_field(model, "gqa_group_size"), 1, "quality gqa_group_size")
+    structural_status = _string(
+        model.get("structural_contract_status")
+        or model.get("structural_contract", {}).get("loaded_model_structure", {}).get("status"),
+        "generation quality structural_contract_status",
+    )
+    if structural_status != "pass":
+        raise ValueError("generation quality structural contract did not pass")
+
+    mismatches = {
+        key: {"expected": expected, "observed": precision.get(key)}
+        for key, expected in _SCORE32_PRECISION.items()
+        if precision.get(key) != expected
+    }
+    if mismatches:
+        raise ValueError(f"generation quality precision mismatch: {mismatches}")
+
+    decision_status = _string(decision.get("status"), "generation quality decision status")
+    if decision_status not in {_QUALITY_PASS, _QUALITY_HOLD}:
+        raise ValueError(f"generation quality decision status is unsupported: {decision_status}")
+
+    summary = payload.get("summary")
+    prompt_count = None
+    if isinstance(summary, dict) and summary.get("prompt_count") not in (None, ""):
+        prompt_count = int(_positive(summary.get("prompt_count"), "quality prompt_count"))
+
+    return {
+        "model_id": observed_model_id,
+        "hidden_size": hidden_size,
+        "attention_head_count": attention_heads,
+        "kv_head_count": kv_heads,
+        "gqa_group_size": gqa_group_size,
+        "structural_contract_status": structural_status,
+        "decision_status": decision_status,
+        "prompt_count": prompt_count,
+        "generation_steps": model.get("generation_steps"),
+        "precision": dict(precision),
+    }
+
+
+def _validate_quality_frontier(payload: JsonDict) -> tuple[JsonDict, list[JsonDict]]:
+    if payload.get("version") != 1 or payload.get("model") != _QUALITY_FRONTIER_MODEL:
+        raise ValueError("quality-aware frontier model/version mismatch")
+    rows = payload.get("rows")
+    if not isinstance(rows, list):
+        raise ValueError("quality-aware frontier rows are missing")
+
+    fp16_row: JsonDict | None = None
+    excluded: list[JsonDict] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        if row.get("family") == "measured_exact_fp16_gqa8_kv8":
+            if fp16_row is not None:
+                raise ValueError("quality-aware frontier must contain exactly one measured exact-FP16 GQA8 row")
+            fp16_row = dict(row)
+            continue
+        if row.get("promotable") is not True or row.get("quality_backed") is not True:
+            excluded.append(
+                {
+                    "candidate_id": row.get("candidate_id"),
+                    "family": row.get("family"),
+                    "reason": row.get("precision_status") or row.get("abstraction_status") or "nonpromotable_history",
+                }
+            )
+    if fp16_row is None:
+        raise ValueError("quality-aware frontier is missing the measured exact-FP16 GQA8 engineering reference")
+    return fp16_row, excluded
+
+
+def _embodied_area_mm2(row: JsonDict, *, source_label: str) -> float:
+    if "total_embodied_area_mm2" in row and row.get("total_embodied_area_mm2") not in (None, ""):
+        return _positive(row.get("total_embodied_area_mm2"), f"{source_label} total_embodied_area_mm2")
+    if "total_embodied_area_um2" in row and row.get("total_embodied_area_um2") not in (None, ""):
+        return _positive(row.get("total_embodied_area_um2"), f"{source_label} total_embodied_area_um2") / 1.0e6
+    if "die_area_mm2" in row and row.get("die_area_mm2") not in (None, ""):
+        return _positive(row.get("die_area_mm2"), f"{source_label} die_area_mm2")
+    raise ValueError(f"{source_label} is missing an embodied-area metric")
+
+
+def _recost_engineering_row(
+    row: JsonDict,
+    *,
+    promotable: bool,
+    quality_backed: bool,
+    structural_quality_backed: bool,
+    arithmetic_quality_backed: bool,
+    precision_level: int,
+    precision_dimension_label: str,
+    precision_dimension_rank: int,
+    promotion_blocker: str | None,
+    structural_mismatch: JsonDict | None,
+    quality_meta: JsonDict,
+) -> JsonDict:
+    contract = dict(row["model_contract"])
+    throughput = dict(row["throughput"])
+    physical = dict(row["physical"])
+    energy = dict(row["energy"])
+    return {
+        "candidate_id": row["candidate_id"],
+        "source_model_contract": contract,
+        "promotable": promotable,
+        "quality_backed": quality_backed,
+        "structural_quality_backed": structural_quality_backed,
+        "arithmetic_quality_backed": arithmetic_quality_backed,
+        "precision_level": precision_level,
+        "precision_dimension_label": precision_dimension_label,
+        "precision_dimension_rank": precision_dimension_rank,
+        "token_throughput_per_s": _positive(throughput.get("token_throughput_per_s"), "token throughput"),
+        "token_latency_us": _positive(throughput.get("token_latency_us"), "token latency"),
+        "embodied_area_mm2": _embodied_area_mm2(physical, source_label=str(row["candidate_id"])),
+        "energy_mj_per_token": _positive(
+            energy.get("total_proxy_energy_mj_per_token"),
+            f"{row['candidate_id']} total_proxy_energy_mj_per_token",
+        ),
+        "remaining_abstractions": [str(item) for item in row.get("remaining_abstractions", [])],
+        "promotion_blocker": promotion_blocker,
+        "structural_mismatch": structural_mismatch,
+        "quality_validation": quality_meta,
+    }
+
+
+def _fp16_row(source: JsonDict) -> JsonDict:
+    return {
+        "candidate_id": source["candidate_id"],
+        "source_model_contract": {
+            "contract_scope": "measured_exact_fp16_gqa8_engineering_reference",
+            "attention_heads": 32,
+            "kv_heads": 4,
+            "gqa_group_size": 8,
+            "kv_sharing": "gqa8",
+        },
+        "promotable": False,
+        "quality_backed": False,
+        "structural_quality_backed": False,
+        "arithmetic_quality_backed": True,
+        "precision_level": 2,
+        "precision_dimension_label": "exact_fp16_gqa8_reference",
+        "precision_dimension_rank": 2,
+        "token_throughput_per_s": _positive(source.get("token_throughput_per_s"), "fp16 throughput"),
+        "token_latency_us": _positive(source.get("latency_us"), "fp16 latency"),
+        "embodied_area_mm2": _embodied_area_mm2(source, source_label="fp16 reference"),
+        "energy_mj_per_token": _positive(source.get("energy_mj_per_token"), "fp16 energy"),
+        "remaining_abstractions": [
+            *[str(item) for item in source.get("remaining_abstractions", [])],
+            "Exact FP16 MHA has not been physically recosted on the same accounting boundary.",
+        ],
+        "promotion_blocker": "The measured exact-FP16 reference remains GQA8 rather than exact Llama-2-7B MHA.",
+        "structural_mismatch": {
+            "hardware_kv_sharing": "gqa8",
+            "exact_llama2_kv_sharing": "mha",
+            "reason": "The measured FP16 engineering reference is structurally mismatched to exact Llama-2-7B.",
+        },
+        "quality_validation": {
+            "decision_status": None,
+            "model_id": None,
+        },
+    }
+
+
+def _precision_rank(row: JsonDict) -> int:
+    return int(row["precision_dimension_rank"])
+
+
+def _dominates(left: JsonDict, right: JsonDict) -> bool:
+    comparisons = (
+        float(left["token_throughput_per_s"]) >= float(right["token_throughput_per_s"]),
+        float(left["embodied_area_mm2"]) <= float(right["embodied_area_mm2"]),
+        float(left["energy_mj_per_token"]) <= float(right["energy_mj_per_token"]),
+        _precision_rank(left) >= _precision_rank(right),
+    )
+    strict = (
+        float(left["token_throughput_per_s"]) > float(right["token_throughput_per_s"]),
+        float(left["embodied_area_mm2"]) < float(right["embodied_area_mm2"]),
+        float(left["energy_mj_per_token"]) < float(right["energy_mj_per_token"]),
+        _precision_rank(left) > _precision_rank(right),
+    )
+    return all(comparisons) and any(strict)
+
+
+def _pareto_rows(rows: list[JsonDict]) -> list[JsonDict]:
+    frontier: list[JsonDict] = []
+    for row in rows:
+        dominators = [other["candidate_id"] for other in rows if other is not row and _dominates(other, row)]
+        if not dominators:
+            frontier.append({**row, "pareto_reason": "not dominated across throughput, embodied area, energy, and precision"})
+    return frontier
+
+
+def _winner(rows: list[JsonDict], key: str, *, maximize: bool) -> str | list[str]:
+    values = [float(row[key]) for row in rows]
+    target = max(values) if maximize else min(values)
+    winners = [str(row["candidate_id"]) for row, value in zip(rows, values) if value == target]
+    return winners[0] if len(winners) == 1 else winners
+
+
+def _precision_winner(rows: list[JsonDict]) -> str | list[str]:
+    values = [_precision_rank(row) for row in rows]
+    target = max(values)
+    winners = [str(row["candidate_id"]) for row, value in zip(rows, values) if value == target]
+    return winners[0] if len(winners) == 1 else winners
+
+
+def build_report(*, recost: JsonDict, generation_quality: JsonDict, quality_frontier: JsonDict) -> JsonDict:
+    corrected_gqa8, exact_mha = _validate_recost(recost)
+    quality = _validate_generation_quality(generation_quality)
+    fp16_reference, excluded_history = _validate_quality_frontier(quality_frontier)
+
+    gqa8_row = _recost_engineering_row(
+        corrected_gqa8,
+        promotable=False,
+        quality_backed=False,
+        structural_quality_backed=False,
+        arithmetic_quality_backed=False,
+        precision_level=1,
+        precision_dimension_label="score32_exp_lut_div",
+        precision_dimension_rank=1,
+        promotion_blocker="Corrected GQA8 score32 remains structurally mismatched to exact Llama-2-7B MHA.",
+        structural_mismatch={
+            "hardware_kv_sharing": "gqa8",
+            "exact_llama2_kv_sharing": "mha",
+            "reason": "Corrected GQA8 score32 does not match the exact 32-KV-head Llama-2-7B structure.",
+        },
+        quality_meta=quality,
+    )
+
+    exact_quality_pass = quality["decision_status"] == _QUALITY_PASS
+    exact_mha_row = _recost_engineering_row(
+        exact_mha,
+        promotable=exact_quality_pass,
+        quality_backed=exact_quality_pass,
+        structural_quality_backed=True,
+        arithmetic_quality_backed=exact_quality_pass,
+        precision_level=1,
+        precision_dimension_label="score32_exp_lut_div",
+        precision_dimension_rank=1,
+        promotion_blocker=None if exact_quality_pass else "Exact score32 MHA lacks a passing native Llama-2-7B generation-quality gate.",
+        structural_mismatch=None,
+        quality_meta=quality,
+    )
+    fp16_row = _fp16_row(fp16_reference)
+
+    engineering_rows = [gqa8_row, exact_mha_row, fp16_row]
+    engineering_pareto = _pareto_rows(engineering_rows)
+    promotable_rows = [row for row in engineering_rows if row["promotable"] and row["quality_backed"]]
+    promotable_pareto = _pareto_rows(promotable_rows)
+
+    dimension_winners = {
+        "throughput": _winner(engineering_rows, "token_throughput_per_s", maximize=True),
+        "embodied_area": _winner(engineering_rows, "embodied_area_mm2", maximize=False),
+        "energy": _winner(engineering_rows, "energy_mj_per_token", maximize=False),
+        "precision": _precision_winner(engineering_rows),
+    }
+
+    remaining_abstractions = sorted(
+        {
+            *[item for row in engineering_rows for item in row["remaining_abstractions"]],
+            *[str(item) for item in recost.get("remaining_abstractions", [])],
+            "HBM controller service remains deterministic global replay rather than controller RTL or vendor timing signoff.",
+            "Logic energy remains a vectorless activity proxy rather than workload-toggle-complete power.",
+            "Fixed shared-SRAM residency is recosted but not reoptimized for exact MHA.",
+            "Native exact Llama-2-7B quality is bounded to a limited prompt sample rather than a full benchmark suite.",
+            "Exact FP16 MHA has not been physically recosted on the same accounting boundary.",
+        }
+    )
+
+    decision = _DECISION_PASS if exact_quality_pass else _DECISION_HOLD
+    return {
+        "version": 1,
+        "model": _MODEL_ID,
+        "decision": decision,
+        "source_items": {
+            "global_hbm_exact_mha_recost": "l2_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1",
+            "exact_native_generation_quality": "l2_decoder_attention_score32_exact_llama2_mha_generation_quality_v1",
+            "quality_aware_frontier_reference": (
+                "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1"
+            ),
+        },
+        "dimension_winners": dimension_winners,
+        "dimension_winner_scope": "engineering_metrics_across_exact_mha_gqa8_and_fp16_reference",
+        "scalar_universal_winner": None,
+        "conditional_recommendation": {
+            "universal_winner": None,
+            "promotable_frontier_available": bool(promotable_pareto),
+            "reason": (
+                "Exact score32 MHA has a passing native Llama-2-7B quality contract."
+                if exact_quality_pass
+                else "Exact score32 MHA is still held behind the native Llama-2-7B quality gate."
+            ),
+        },
+        "precision_contract": {
+            "candidate_id": _SCORE32_PRECISION["candidate_id"],
+            "q_bits": _SCORE32_PRECISION["q_bits"],
+            "k_bits": _SCORE32_PRECISION["k_bits"],
+            "v_bits": _SCORE32_PRECISION["v_bits"],
+            "score_bits": _SCORE32_PRECISION["score_bits"],
+            "weight_bits": _SCORE32_PRECISION["weight_bits"],
+            "softmax_mode": _SCORE32_PRECISION["softmax_mode"],
+        },
+        "quality_contract": quality,
+        "engineering_pareto_frontier": engineering_pareto,
+        "promotable_pareto_frontier": promotable_pareto,
+        "all_rows": engineering_rows,
+        "excluded_nonpromotable_history": excluded_history,
+        "remaining_abstractions": remaining_abstractions,
+        "next_measurements": [
+            "Recost exact FP16 MHA on the same embodied-area and energy accounting boundary.",
+            "Optimize fixed shared-SRAM residency for the exact MHA point rather than inheriting the GQA8 policy.",
+            "Expand native exact Llama-2-7B quality beyond the bounded prompt sample.",
+        ],
+    }
+
+
+def write_report(payload: JsonDict, path: Path) -> None:
+    engineering = payload["engineering_pareto_frontier"]
+    promotable = payload["promotable_pareto_frontier"]
+    lines = [
+        "# Exact Llama-2-7B Score32 Final Frontier",
+        "",
+        f"- model: `{payload['model']}`",
+        f"- decision: `{payload['decision']}`",
+        "- scalar universal winner: `None`",
+        "",
+        "## Dimension Winners",
+        "",
+        f"- throughput: `{payload['dimension_winners']['throughput']}`",
+        f"- embodied_area: `{payload['dimension_winners']['embodied_area']}`",
+        f"- energy: `{payload['dimension_winners']['energy']}`",
+        f"- precision: `{payload['dimension_winners']['precision']}`",
+        "",
+        "## Engineering Pareto",
+        "",
+        "| Candidate | Throughput token/s | Embodied area mm2 | Energy mJ/token | Precision | Promotable |",
+        "|---|---:|---:|---:|---|---|",
+    ]
+    for row in engineering:
+        lines.append(
+            "| {candidate_id} | {token_throughput_per_s} | {embodied_area_mm2} | {energy_mj_per_token} | {precision_dimension_label} | {promotable} |".format(
+                **row
+            )
+        )
+    lines.extend(["", "## Promotable Pareto", ""])
+    if promotable:
+        lines.extend(
+            [
+                "| Candidate | Throughput token/s | Embodied area mm2 | Energy mJ/token |",
+                "|---|---:|---:|---:|",
+            ]
+        )
+        for row in promotable:
+            lines.append(
+                "| {candidate_id} | {token_throughput_per_s} | {embodied_area_mm2} | {energy_mj_per_token} |".format(
+                    **row
+                )
+            )
+    else:
+        lines.append("- No promotable frontier row is currently available.")
+    lines.extend(["", "## Remaining Abstractions", ""])
+    lines.extend(f"- {item}" for item in payload["remaining_abstractions"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--recost-json", type=Path, default=DEFAULT_RECOST)
+    parser.add_argument("--generation-quality-json", type=Path, default=DEFAULT_GENERATION_QUALITY)
+    parser.add_argument("--quality-frontier-json", type=Path, default=DEFAULT_QUALITY_FRONTIER)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--report", type=Path, required=True)
+    args = parser.parse_args()
+
+    root = args.repo_root.resolve()
+    payload = build_report(
+        recost=_load_json(root / args.recost_json),
+        generation_quality=_load_json(root / args.generation_quality_json),
+        quality_frontier=_load_json(root / args.quality_frontier_json),
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_report(payload, args.report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/audit_llm_decoder_attention_score32_exact_llama2_mha_final_frontier.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_exact_llama2_mha_final_frontier.py
@@ -50,6 +50,7 @@ _SCORE32_PRECISION = {
     "softmax_mode": "exp_lut_div_bucket20",
 }
 _GQA8_CANDIDATE_ID = "score32_gqa8_global_hbm_finite_endpoint"
+_LONG_CONTEXT_MHA_CANDIDATE_ID = "score32_llama2_7b_mha_131k_extrapolation_global_hbm_finite_endpoint"
 _EXACT_MHA_CANDIDATE_ID = "score32_exact_llama2_7b_mha_global_hbm_finite_endpoint"
 
 
@@ -81,7 +82,7 @@ def _exact_number(value: Any, expected: float, label: str) -> float:
     return observed
 
 
-def _validate_recost(payload: JsonDict) -> tuple[JsonDict, JsonDict]:
+def _validate_recost(payload: JsonDict) -> tuple[JsonDict, JsonDict, JsonDict]:
     if payload.get("version") != 1 or payload.get("model") != _RECOST_MODEL:
         raise ValueError("exact MHA recost model/version mismatch")
     rows = payload.get("rows")
@@ -89,7 +90,8 @@ def _validate_recost(payload: JsonDict) -> tuple[JsonDict, JsonDict]:
         raise ValueError("exact MHA recost rows are missing")
 
     gqa8_row: JsonDict | None = None
-    mha_row: JsonDict | None = None
+    long_context_mha_row: JsonDict | None = None
+    native_mha_row: JsonDict | None = None
     for row in rows:
         if not isinstance(row, dict):
             continue
@@ -107,17 +109,26 @@ def _validate_recost(payload: JsonDict) -> tuple[JsonDict, JsonDict]:
             raise ValueError("exact MHA recost rows must remain on the 4096-wide 32-head model")
         candidate_id = row.get("candidate_id")
         if kv_heads == 4 and gqa_group_size == 8 and candidate_id == _GQA8_CANDIDATE_ID:
-            if contract.get("kv_sharing") != "gqa8":
+            if contract.get("kv_sharing") != "gqa8" or int(contract.get("sequence_length", 0)) != 131072:
                 raise ValueError("corrected GQA8 row kv_sharing mismatch")
             gqa8_row = dict(row)
+        elif kv_heads == 32 and gqa_group_size == 1 and candidate_id == _LONG_CONTEXT_MHA_CANDIDATE_ID:
+            if contract.get("kv_sharing") != "mha" or int(contract.get("sequence_length", 0)) != 131072:
+                raise ValueError("long-context MHA row contract mismatch")
+            long_context_mha_row = dict(row)
         elif kv_heads == 32 and gqa_group_size == 1 and candidate_id == _EXACT_MHA_CANDIDATE_ID:
-            if contract.get("kv_sharing") != "mha" or contract.get("contract_scope") != "exact_llama2_7b_mha_structure":
+            if (
+                contract.get("kv_sharing") != "mha"
+                or contract.get("contract_scope") != "exact_llama2_7b_mha_structure"
+                or int(contract.get("sequence_length", 0)) != 4096
+                or contract.get("native_context_match") is not True
+            ):
                 raise ValueError("exact MHA row structural contract mismatch")
-            mha_row = dict(row)
+            native_mha_row = dict(row)
 
-    if gqa8_row is None or mha_row is None:
-        raise ValueError("exact MHA recost must contain corrected GQA8 and exact MHA rows")
-    return gqa8_row, mha_row
+    if gqa8_row is None or long_context_mha_row is None or native_mha_row is None:
+        raise ValueError("exact MHA recost must contain corrected GQA8, 131k MHA, and native-context MHA rows")
+    return gqa8_row, long_context_mha_row, native_mha_row
 
 
 def _quality_model_field(model: JsonDict, field: str) -> Any:
@@ -263,6 +274,7 @@ def _recost_engineering_row(
     promotion_blocker: str | None,
     structural_mismatch: JsonDict | None,
     quality_meta: JsonDict,
+    workload_id: str,
 ) -> JsonDict:
     contract = dict(row["model_contract"])
     throughput = dict(row["throughput"])
@@ -270,6 +282,7 @@ def _recost_engineering_row(
     energy = dict(row["energy"])
     return {
         "candidate_id": row["candidate_id"],
+        "workload_id": workload_id,
         "source_model_contract": contract,
         "promotable": promotable,
         "quality_backed": quality_backed,
@@ -295,6 +308,7 @@ def _recost_engineering_row(
 def _fp16_row(source: JsonDict) -> JsonDict:
     return {
         "candidate_id": source["candidate_id"],
+        "workload_id": "legacy_llama7b_gqa8_131k_accounting",
         "source_model_contract": {
             "contract_scope": "measured_exact_fp16_gqa8_engineering_reference",
             "attention_heads": 32,
@@ -377,7 +391,7 @@ def _precision_winner(rows: list[JsonDict]) -> str | list[str]:
 
 
 def build_report(*, recost: JsonDict, generation_quality: JsonDict, quality_frontier: JsonDict) -> JsonDict:
-    corrected_gqa8, exact_mha = _validate_recost(recost)
+    corrected_gqa8, long_context_mha, exact_mha = _validate_recost(recost)
     quality = _validate_generation_quality(generation_quality)
     fp16_reference, excluded_history = _validate_quality_frontier(quality_frontier)
 
@@ -397,6 +411,29 @@ def build_report(*, recost: JsonDict, generation_quality: JsonDict, quality_fron
             "reason": "Corrected GQA8 score32 does not match the exact 32-KV-head Llama-2-7B structure.",
         },
         quality_meta=quality,
+        workload_id="long_context_131072_extrapolation",
+    )
+
+    long_context_mha_row = _recost_engineering_row(
+        long_context_mha,
+        promotable=False,
+        quality_backed=False,
+        structural_quality_backed=True,
+        arithmetic_quality_backed=False,
+        precision_level=1,
+        precision_dimension_label="score32_exp_lut_div",
+        precision_dimension_rank=1,
+        promotion_blocker=(
+            "The 131k MHA extrapolation exceeds the official checkpoint context and lacks matching long-context quality evidence."
+        ),
+        structural_mismatch={
+            "hardware_kv_sharing": "mha",
+            "sequence_length": 131072,
+            "official_native_context_length": 4096,
+            "reason": "MHA dimensions match, but the workload context does not match the official checkpoint contract.",
+        },
+        quality_meta=quality,
+        workload_id="long_context_131072_extrapolation",
     )
 
     exact_quality_pass = quality["decision_status"] == _QUALITY_PASS
@@ -412,20 +449,35 @@ def build_report(*, recost: JsonDict, generation_quality: JsonDict, quality_fron
         promotion_blocker=None if exact_quality_pass else "Exact score32 MHA lacks a passing native Llama-2-7B generation-quality gate.",
         structural_mismatch=None,
         quality_meta=quality,
+        workload_id="official_llama2_7b_native_context_4096",
     )
     fp16_row = _fp16_row(fp16_reference)
 
-    comparable_rows = [gqa8_row, exact_mha_row]
-    all_rows = [*comparable_rows, fp16_row]
-    engineering_pareto = _pareto_rows(comparable_rows)
-    promotable_rows = [row for row in comparable_rows if row["promotable"] and row["quality_backed"]]
+    long_context_rows = [gqa8_row, long_context_mha_row]
+    native_context_rows = [exact_mha_row]
+    all_rows = [*long_context_rows, *native_context_rows, fp16_row]
+    engineering_pareto_by_workload = {
+        "long_context_131072_extrapolation": _pareto_rows(long_context_rows),
+        "official_llama2_7b_native_context_4096": _pareto_rows(native_context_rows),
+    }
+    promotable_rows = [row for row in native_context_rows if row["promotable"] and row["quality_backed"]]
     promotable_pareto = _pareto_rows(promotable_rows)
 
-    dimension_winners = {
-        "throughput_comparable_boundary": _winner(comparable_rows, "token_throughput_per_s", maximize=True),
-        "embodied_area_comparable_boundary": _winner(comparable_rows, "embodied_area_mm2", maximize=False),
-        "energy_comparable_boundary": _winner(comparable_rows, "energy_mj_per_token", maximize=False),
-        "precision_comparable_boundary": _precision_winner(comparable_rows),
+    dimension_winners_by_workload = {
+        "long_context_131072_extrapolation": {
+            "throughput": _winner(long_context_rows, "token_throughput_per_s", maximize=True),
+            "embodied_area": _winner(long_context_rows, "embodied_area_mm2", maximize=False),
+            "energy": _winner(long_context_rows, "energy_mj_per_token", maximize=False),
+            "precision": _precision_winner(long_context_rows),
+        },
+        "official_llama2_7b_native_context_4096": {
+            "throughput": exact_mha_row["candidate_id"],
+            "embodied_area": exact_mha_row["candidate_id"],
+            "energy": exact_mha_row["candidate_id"],
+            "precision": exact_mha_row["candidate_id"],
+        },
+    }
+    noncomparable_reference_winners = {
         "higher_precision_noncomparable_reference": fp16_row["candidate_id"],
     }
 
@@ -437,6 +489,7 @@ def build_report(*, recost: JsonDict, generation_quality: JsonDict, quality_fron
             "Logic energy remains a vectorless activity proxy rather than workload-toggle-complete power.",
             "Fixed shared-SRAM residency is recosted but not reoptimized for exact MHA.",
             "Native exact Llama-2-7B quality is bounded to a limited prompt sample rather than a full benchmark suite.",
+            "The 131072-token stress workload is a long-context extrapolation beyond the official Llama-2-7B 4096-token context and is not quality-backed.",
             "Exact FP16 MHA has not been physically recosted on the same accounting boundary.",
         }
     )
@@ -453,8 +506,9 @@ def build_report(*, recost: JsonDict, generation_quality: JsonDict, quality_fron
                 "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1"
             ),
         },
-        "dimension_winners": dimension_winners,
-        "dimension_winner_scope": "only rows with the same total-embodied-area accounting boundary",
+        "dimension_winners_by_workload": dimension_winners_by_workload,
+        "dimension_winner_scope": "rows are compared only within identical sequence-length and total-embodied-area boundaries",
+        "noncomparable_reference_winners": noncomparable_reference_winners,
         "scalar_universal_winner": None,
         "conditional_recommendation": {
             "universal_winner": None,
@@ -475,7 +529,7 @@ def build_report(*, recost: JsonDict, generation_quality: JsonDict, quality_fron
             "softmax_mode": _SCORE32_PRECISION["softmax_mode"],
         },
         "quality_contract": quality,
-        "engineering_pareto_frontier": engineering_pareto,
+        "engineering_pareto_frontiers_by_workload": engineering_pareto_by_workload,
         "promotable_pareto_frontier": promotable_pareto,
         "noncomparable_reference_rows": [fp16_row],
         "all_rows": all_rows,
@@ -490,7 +544,7 @@ def build_report(*, recost: JsonDict, generation_quality: JsonDict, quality_fron
 
 
 def write_report(payload: JsonDict, path: Path) -> None:
-    engineering = payload["engineering_pareto_frontier"]
+    engineering_by_workload = payload["engineering_pareto_frontiers_by_workload"]
     promotable = payload["promotable_pareto_frontier"]
     lines = [
         "# Exact Llama-2-7B Score32 Final Frontier",
@@ -499,25 +553,30 @@ def write_report(payload: JsonDict, path: Path) -> None:
         f"- decision: `{payload['decision']}`",
         "- scalar universal winner: `None`",
         "",
-        "## Dimension Winners",
+        "## Dimension Winners By Workload",
         "",
-        f"- throughput (comparable boundary): `{payload['dimension_winners']['throughput_comparable_boundary']}`",
-        f"- embodied_area (comparable boundary): `{payload['dimension_winners']['embodied_area_comparable_boundary']}`",
-        f"- energy (comparable boundary): `{payload['dimension_winners']['energy_comparable_boundary']}`",
-        f"- precision (comparable boundary): `{payload['dimension_winners']['precision_comparable_boundary']}`",
-        f"- higher-precision noncomparable reference: `{payload['dimension_winners']['higher_precision_noncomparable_reference']}`",
-        "",
-        "## Engineering Pareto",
-        "",
-        "| Candidate | Throughput token/s | Embodied area mm2 | Energy mJ/token | Precision | Promotable |",
-        "|---|---:|---:|---:|---|---|",
     ]
-    for row in engineering:
-        lines.append(
-            "| {candidate_id} | {token_throughput_per_s} | {embodied_area_mm2} | {energy_mj_per_token} | {precision_dimension_label} | {promotable} |".format(
-                **row
-            )
+    for workload_id, winners in payload["dimension_winners_by_workload"].items():
+        lines.append(f"- `{workload_id}`: `{winners}`")
+    lines.append(
+        f"- higher-precision noncomparable reference: `{payload['noncomparable_reference_winners']['higher_precision_noncomparable_reference']}`"
+    )
+    for workload_id, engineering in engineering_by_workload.items():
+        lines.extend(
+            [
+                "",
+                f"## Engineering Pareto: {workload_id}",
+                "",
+                "| Candidate | Throughput token/s | Embodied area mm2 | Energy mJ/token | Precision | Promotable |",
+                "|---|---:|---:|---:|---|---|",
+            ]
         )
+        for row in engineering:
+            lines.append(
+                "| {candidate_id} | {token_throughput_per_s} | {embodied_area_mm2} | {energy_mj_per_token} | {precision_dimension_label} | {promotable} |".format(
+                    **row
+                )
+            )
     lines.extend(["", "## Promotable Pareto", ""])
     if promotable:
         lines.extend(

--- a/npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py
+++ b/npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py
@@ -162,6 +162,13 @@ def _build_structural_contract(args: argparse.Namespace, model: Any, *, resolved
     gqa_matches_expectation = True
     if expected_gqa_group_size > 0:
         gqa_matches_expectation = abs(actual["gqa_group_size"] - expected_gqa_group_size) <= DIVISIBILITY_EPSILON
+        if not gqa_matches_expectation:
+            blockers.append(
+                "GQA group size {} does not match expected {}".format(
+                    actual["gqa_group_size"],
+                    expected_gqa_group_size,
+                )
+            )
 
     status = "pass" if not blockers else "fail"
     return {

--- a/npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py
+++ b/npu/eval/evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py
@@ -62,6 +62,135 @@ def _resolve_model_id(args: argparse.Namespace) -> str:
     )
 
 
+def _normalize_optional_str(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _optional_positive_int(value: Any) -> int:
+    if value in (None, ""):
+        return 0
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("expected non-negative integer")
+    return parsed
+
+
+def _config_positive_int(config: Any, field_names: tuple[str, ...], label: str) -> int:
+    for field_name in field_names:
+        value = getattr(config, field_name, None)
+        if value is None:
+            continue
+        parsed = int(value)
+        if parsed <= 0:
+            raise SystemExit(f"model config exposes non-positive {label}: {field_name}={value!r}")
+        return parsed
+    raise SystemExit(f"model config does not expose {label}")
+
+
+def _resolve_model_structure(config: Any) -> JsonDict:
+    attention_heads = _config_positive_int(
+        config,
+        ("num_attention_heads", "n_head"),
+        "attention head count",
+    )
+    kv_heads_value = getattr(config, "num_key_value_heads", None)
+    kv_heads = attention_heads if kv_heads_value is None else int(kv_heads_value)
+    if kv_heads <= 0:
+        raise SystemExit(f"model config exposes non-positive KV head count: num_key_value_heads={kv_heads_value!r}")
+    hidden_size = _config_positive_int(
+        config,
+        ("hidden_size", "n_embd", "d_model"),
+        "hidden size",
+    )
+    if attention_heads % kv_heads != 0:
+        raise SystemExit("model uses non-integer GQA group size; expected divisible attention and KV heads")
+    return {
+        "attention_head_count": attention_heads,
+        "kv_head_count": kv_heads,
+        "hidden_size": hidden_size,
+        "gqa_group_size": attention_heads / kv_heads,
+        "loaded_model_id": _normalize_optional_str(getattr(config, "_name_or_path", "")),
+    }
+
+
+def _build_requested_model_contract(args: argparse.Namespace, resolved_model_id: str) -> JsonDict:
+    expected_model_id = _normalize_optional_str(getattr(args, "expected_model_id", ""))
+    blockers: list[str] = []
+    if expected_model_id and resolved_model_id != expected_model_id:
+        blockers.append(
+            f"resolved model_id {resolved_model_id!r} does not match expected {expected_model_id!r}"
+        )
+    status = "pass" if not blockers else "fail"
+    return {
+        "status": status,
+        "blockers": blockers,
+        "resolved_model_id": resolved_model_id,
+        "expected_model_id": expected_model_id,
+    }
+
+
+def _build_structural_contract(args: argparse.Namespace, model: Any, *, resolved_model_id: str) -> JsonDict:
+    actual = _resolve_model_structure(model.config)
+    expected_attention_heads = _optional_positive_int(getattr(args, "expected_attention_head_count", 0))
+    expected_kv_heads = _optional_positive_int(getattr(args, "expected_kv_head_count", 0))
+    expected_hidden_size = _optional_positive_int(getattr(args, "expected_hidden_size", 0))
+    expected_gqa_group_size = int(getattr(args, "expected_gqa_group_size", 0) or 0)
+
+    blockers: list[str] = []
+    if expected_attention_heads and actual["attention_head_count"] != expected_attention_heads:
+        blockers.append(
+            "attention head count {} does not match expected {}".format(
+                actual["attention_head_count"],
+                expected_attention_heads,
+            )
+        )
+    if expected_kv_heads and actual["kv_head_count"] != expected_kv_heads:
+        blockers.append(
+            "KV head count {} does not match expected {}".format(
+                actual["kv_head_count"],
+                expected_kv_heads,
+            )
+        )
+    if expected_hidden_size and actual["hidden_size"] != expected_hidden_size:
+        blockers.append(
+            "hidden size {} does not match expected {}".format(
+                actual["hidden_size"],
+                expected_hidden_size,
+            )
+        )
+
+    gqa_matches_expectation = True
+    if expected_gqa_group_size > 0:
+        gqa_matches_expectation = abs(actual["gqa_group_size"] - expected_gqa_group_size) <= DIVISIBILITY_EPSILON
+
+    status = "pass" if not blockers else "fail"
+    return {
+        "status": status,
+        "blockers": blockers,
+        "resolved_model_id": resolved_model_id,
+        "expected": {
+            "attention_head_count": expected_attention_heads,
+            "kv_head_count": expected_kv_heads,
+            "hidden_size": expected_hidden_size,
+            "gqa_group_size": expected_gqa_group_size,
+        },
+        "actual": {
+            "attention_head_count": actual["attention_head_count"],
+            "kv_head_count": actual["kv_head_count"],
+            "hidden_size": actual["hidden_size"],
+            "gqa_group_size": actual["gqa_group_size"],
+            "loaded_model_id": actual["loaded_model_id"] or resolved_model_id,
+        },
+        "gqa_group_size_matches_expectation": gqa_matches_expectation,
+    }
+
+
+def _enforce_contract(contract: JsonDict, *, label: str) -> None:
+    blockers = contract.get("blockers") or []
+    if blockers:
+        raise SystemExit(f"{label} failed: {'; '.join(str(blocker) for blocker in blockers)}")
+
+
 def _resolve_candidates(args: argparse.Namespace) -> list[attention_eval.CandidateConfig]:
     candidates: list[attention_eval.CandidateConfig] = []
     if args.candidate:
@@ -76,14 +205,7 @@ def _resolve_candidates(args: argparse.Namespace) -> list[attention_eval.Candida
 
 
 def _model_gqa_group_size(model: Any) -> float:
-    config = model.config
-    attention_heads = int(getattr(config, "num_attention_heads", 0) or getattr(config, "n_head", 0) or 0)
-    kv_heads = int(getattr(config, "num_key_value_heads", 0) or attention_heads)
-    if attention_heads <= 0 or kv_heads <= 0:
-        raise SystemExit("model config does not expose attention and KV head counts")
-    if attention_heads % kv_heads != 0:
-        raise SystemExit("model uses non-integer GQA group size; expected divisible attention and KV heads")
-    return attention_heads / kv_heads
+    return float(_resolve_model_structure(model.config)["gqa_group_size"])
 
 
 def _collect_teacher_forced_rows(
@@ -497,6 +619,8 @@ def _candidate_precision(candidate: attention_eval.CandidateConfig) -> JsonDict:
 def _run_model_eval(args: argparse.Namespace) -> JsonDict:
     torch_module, AutoModelForCausalLM, AutoTokenizer = attention_eval._load_runtime_modules()
     model_id = _resolve_model_id(args)
+    requested_model_contract = _build_requested_model_contract(args, model_id)
+    _enforce_contract(requested_model_contract, label="requested model identity contract")
     device = args.device
     if device == "auto":
         device = "cuda" if torch_module.cuda.is_available() else "cpu"
@@ -515,6 +639,8 @@ def _run_model_eval(args: argparse.Namespace) -> JsonDict:
     tokenizer = AutoTokenizer.from_pretrained(model_id)
     reference_model = load_model().to(device)
     candidate_model = load_model().to(device)
+    structural_contract = _build_structural_contract(args, reference_model, resolved_model_id=model_id)
+    _enforce_contract(structural_contract, label="model structural contract")
     reference_model.eval()
     candidate_model.eval()
 
@@ -631,12 +757,28 @@ def _run_model_eval(args: argparse.Namespace) -> JsonDict:
         "quality_gate": "mixed_int8_generation_quality",
         "model": {
             "model_id": model_id,
-            "gqa_group_size": actual_gqa_group_size,
+            "resolved_model_id": model_id,
+            "loaded_model_id": structural_contract["actual"]["loaded_model_id"],
+            "attention_head_count": structural_contract["actual"]["attention_head_count"],
+            "kv_head_count": structural_contract["actual"]["kv_head_count"],
+            "hidden_size": structural_contract["actual"]["hidden_size"],
+            "gqa_group_size": structural_contract["actual"]["gqa_group_size"],
             "device": device,
             "dtype": attention_eval._dtype_label(dtype),
             "requested_dtype": args.dtype,
             "generation_steps": args.generation_steps,
             "max_prompts": args.max_prompts,
+            "expected_model_id": requested_model_contract["expected_model_id"],
+            "expected_attention_head_count": structural_contract["expected"]["attention_head_count"],
+            "expected_kv_head_count": structural_contract["expected"]["kv_head_count"],
+            "expected_hidden_size": structural_contract["expected"]["hidden_size"],
+            "expected_gqa_group_size": structural_contract["expected"]["gqa_group_size"],
+            "structural_contract_status": structural_contract["status"],
+            "structural_contract_blockers": structural_contract["blockers"],
+            "structural_contract": {
+                "requested_model_identity": requested_model_contract,
+                "loaded_model_structure": structural_contract,
+            },
         },
         "inputs": {
             "score_margin_audit_json": str(args.score_margin_audit_json) if args.score_margin_audit_json else "",
@@ -721,10 +863,14 @@ def _write_report_md(payload: JsonDict) -> str:
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--model-id", default="")
+    ap.add_argument("--expected-model-id", default="")
     ap.add_argument("--prompt-file", default="")
     ap.add_argument("--max-prompts", type=_parse_positive_int, default=2)
     ap.add_argument("--generation-steps", type=_parse_positive_int, default=4)
     ap.add_argument("--expected-gqa-group-size", type=int, default=8)
+    ap.add_argument("--expected-attention-head-count", type=_optional_positive_int, default=0)
+    ap.add_argument("--expected-kv-head-count", type=_optional_positive_int, default=0)
+    ap.add_argument("--expected-hidden-size", type=_optional_positive_int, default=0)
     ap.add_argument("--candidate", action="append", type=attention_eval._parse_candidate_spec, default=[])
     ap.add_argument("--candidate-list", action="append", type=attention_eval._parse_candidate_list, default=[])
     ap.add_argument("--primary-candidate-id", default="")

--- a/npu/eval/recost_llm_decoder_attention_score32_global_hbm_exact_llama2_mha.py
+++ b/npu/eval/recost_llm_decoder_attention_score32_global_hbm_exact_llama2_mha.py
@@ -286,6 +286,8 @@ def _candidate(
     candidate_id: str,
     kv_heads: int,
     exact_llama2_structure: bool,
+    sequence_length: int,
+    native_context_match: bool,
     finite: JsonDict,
     source_row: JsonDict,
     controller: JsonDict,
@@ -298,15 +300,16 @@ def _candidate(
     head_dim = hidden_size // attention_heads
     kv_bits = _positive_int(source_row.get("kv_bits"), "kv_bits")
     tile_tokens = _positive_int(source_row.get("tile_tokens"), "tile_tokens")
-    tile_count = _positive_int(source_row.get("tile_count"), "tile_count")
-    waves = _positive_int(source_row.get("tile_waves"), "tile_waves")
-    active_clusters = _positive_int(source_row.get("active_clusters"), "active_clusters")
+    source_active_clusters = _positive_int(source_row.get("active_clusters"), "active_clusters")
     layers = _positive_int(source_row.get("layers"), "layers")
     compute_clock_ns = _positive(
         source_row.get("measured_dual_stream_composed_clock_ns"), "compute clock"
     )
     hbm_clock_ns = _positive(source_row.get("clock_ns"), "HBM controller clock")
     full_tile_bytes = int(2 * tile_tokens * kv_heads * head_dim * kv_bits / 8)
+    tile_count = _ceil_div(sequence_length, tile_tokens)
+    active_clusters = min(source_active_clusters, tile_count)
+    waves = _ceil_div(tile_count, active_clusters)
     if fixed_shared_tile_bytes >= full_tile_bytes:
         raise ValueError("fixed shared payload must be smaller than the full KV tile")
     tile_hbm_bytes = full_tile_bytes - fixed_shared_tile_bytes
@@ -336,6 +339,10 @@ def _candidate(
     schedule_row.update(
         {
             "label": "llama2_7b_exact_mha" if exact_llama2_structure else "llama7b_gqa8_proxy",
+            "sequence_length": sequence_length,
+            "tile_count": tile_count,
+            "active_clusters": active_clusters,
+            "tile_waves": waves,
             "kv_heads": kv_heads,
             "kv_sharing": "mha" if kv_heads == attention_heads else f"gqa{attention_heads // kv_heads}",
             "shared_byte_share": fixed_shared_tile_bytes / full_tile_bytes,
@@ -345,7 +352,7 @@ def _candidate(
             "kv_write_cycles": kv_write_cycles,
             "kv_cache_mib": (
                 2
-                * _positive_int(source_row.get("sequence_length"), "sequence length")
+                * sequence_length
                 * kv_heads
                 * head_dim
                 * kv_bits
@@ -364,7 +371,11 @@ def _candidate(
         source_row_override=schedule_row,
         source_artifact_override=candidate_id,
     )
-    logical = _compact_schedule(logical_payload)
+    logical = _compact_schedule(
+        logical_payload,
+        expected_wave_count=waves,
+        expected_tile_count=tile_count,
+    )
     endpoint = run_performance_replay(
         descriptors_from_packet_specs(packet_specs), max_cycles=args.max_cycles
     )
@@ -422,10 +433,13 @@ def _candidate(
             "gqa_group_size": attention_heads // kv_heads,
             "kv_sharing": schedule_row["kv_sharing"],
             "sequence_length": schedule_row["sequence_length"],
+            "native_context_length": 4096,
+            "native_context_match": native_context_match,
             "kv_bits": kv_bits,
         },
         "projection": projection,
         "memory": {
+            "tile_count": tile_count,
             "full_tile_bytes": full_tile_bytes,
             "fixed_shared_tile_bytes": fixed_shared_tile_bytes,
             "tile_hbm_bytes": tile_hbm_bytes,
@@ -479,9 +493,12 @@ def _candidate(
             "arithmetic_profile": finite["precision_contract"]["precision_profile"],
             "structural_model_match": exact_llama2_structure,
             "native_llama2_generation_quality_measured": False,
+            "native_context_match": native_context_match,
             "promotable": False,
             "reason": (
-                "Exact MHA structure is recosted, but native Llama-2-7B score32 generation quality is not measured."
+                "Exact native-context MHA structure is recosted, but native Llama-2-7B score32 generation quality is not measured."
+                if exact_llama2_structure and native_context_match
+                else "The 131k MHA row extrapolates beyond the official Llama-2-7B native context and lacks matching long-context quality evidence."
                 if exact_llama2_structure
                 else "GQA8 is not the exact Llama-2-7B MHA structure."
             ),
@@ -508,6 +525,8 @@ def build_report(args: argparse.Namespace) -> JsonDict:
         candidate_id="score32_gqa8_global_hbm_finite_endpoint",
         kv_heads=4,
         exact_llama2_structure=False,
+        sequence_length=_positive_int(source_row.get("sequence_length"), "source sequence length"),
+        native_context_match=False,
         finite=finite,
         source_row=source_row,
         controller=controller,
@@ -515,11 +534,27 @@ def build_report(args: argparse.Namespace) -> JsonDict:
         energy_params=energy_params,
         fixed_shared_tile_bytes=fixed_shared_tile_bytes,
     )
-    mha = _candidate(
+    long_context_mha = _candidate(
+        args=args,
+        candidate_id="score32_llama2_7b_mha_131k_extrapolation_global_hbm_finite_endpoint",
+        kv_heads=32,
+        exact_llama2_structure=True,
+        sequence_length=_positive_int(source_row.get("sequence_length"), "source sequence length"),
+        native_context_match=False,
+        finite=finite,
+        source_row=source_row,
+        controller=controller,
+        controller_ppa=controller_ppa,
+        energy_params=energy_params,
+        fixed_shared_tile_bytes=fixed_shared_tile_bytes,
+    )
+    native_mha = _candidate(
         args=args,
         candidate_id="score32_exact_llama2_7b_mha_global_hbm_finite_endpoint",
         kv_heads=32,
         exact_llama2_structure=True,
+        sequence_length=4096,
+        native_context_match=True,
         finite=finite,
         source_row=source_row,
         controller=controller,
@@ -554,22 +589,28 @@ def build_report(args: argparse.Namespace) -> JsonDict:
                 gqa8["throughput"]["token_throughput_per_s"] / source_throughput
             ),
         },
-        "rows": [gqa8, mha],
-        "exact_mha_delta_vs_corrected_gqa8": {
-            "qkv_projection_macs_ratio": mha["projection"]["target_macs"] / gqa8["projection"]["target_macs"],
-            "kv_cache_ratio": mha["memory"]["kv_cache_mib"] / gqa8["memory"]["kv_cache_mib"],
-            "read_bytes_ratio": mha["memory"]["read_bytes_per_token"] / gqa8["memory"]["read_bytes_per_token"],
-            "token_latency_ratio": mha["throughput"]["token_latency_us"] / gqa8["throughput"]["token_latency_us"],
-            "token_throughput_ratio": mha["throughput"]["token_throughput_per_s"] / gqa8["throughput"]["token_throughput_per_s"],
-            "hbm_energy_ratio": mha["energy"]["hbm_energy_mj_per_token"] / gqa8["energy"]["hbm_energy_mj_per_token"],
+        "rows": [gqa8, long_context_mha, native_mha],
+        "long_context_mha_delta_vs_corrected_gqa8": {
+            "qkv_projection_macs_ratio": long_context_mha["projection"]["target_macs"] / gqa8["projection"]["target_macs"],
+            "kv_cache_ratio": long_context_mha["memory"]["kv_cache_mib"] / gqa8["memory"]["kv_cache_mib"],
+            "read_bytes_ratio": long_context_mha["memory"]["read_bytes_per_token"] / gqa8["memory"]["read_bytes_per_token"],
+            "token_latency_ratio": long_context_mha["throughput"]["token_latency_us"] / gqa8["throughput"]["token_latency_us"],
+            "token_throughput_ratio": long_context_mha["throughput"]["token_throughput_per_s"] / gqa8["throughput"]["token_throughput_per_s"],
+            "hbm_energy_ratio": long_context_mha["energy"]["hbm_energy_mj_per_token"] / gqa8["energy"]["hbm_energy_mj_per_token"],
+        },
+        "native_context_exact_mha": {
+            "sequence_length": native_mha["model_contract"]["sequence_length"],
+            "token_throughput_per_s": native_mha["throughput"]["token_throughput_per_s"],
+            "energy_mj_per_token": native_mha["energy"]["total_proxy_energy_mj_per_token"],
+            "quality_required": True,
         },
         "invariants": {
             "attention_qk_value_macs_unchanged": True,
             "partial_reduction_payload_unchanged": True,
             "fixed_shared_sram_bytes_unchanged": True,
             "finite_endpoint_packet_volume_unchanged": (
-                gqa8["schedule"]["scheduled_packets"] == mha["schedule"]["scheduled_packets"]
-                and gqa8["schedule"]["scheduled_flits"] == mha["schedule"]["scheduled_flits"]
+                gqa8["schedule"]["scheduled_packets"] == long_context_mha["schedule"]["scheduled_packets"]
+                and gqa8["schedule"]["scheduled_flits"] == long_context_mha["schedule"]["scheduled_flits"]
             ),
             "compute_array_and_onchip_area_unchanged": True,
         },
@@ -578,6 +619,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "HBM energy is command calibrated rather than vendor current signoff.",
             "Logic energy is an always-on vectorless upper proxy; workload clock-gating activity is not measured.",
             "Native Llama-2-7B score32 generation quality has not been measured.",
+            "The 131k-token rows are long-context extrapolations beyond the official Llama-2-7B 4096-token context and have no matching trained-checkpoint quality evidence.",
             "The fixed shared-SRAM residency policy is recosted but not reoptimized for MHA.",
         ],
         "next_step": {
@@ -589,32 +631,36 @@ def build_report(args: argparse.Namespace) -> JsonDict:
 
 
 def write_report(payload: JsonDict, path: Path) -> None:
-    gqa8, mha = payload["rows"]
+    gqa8, long_context_mha, native_mha = payload["rows"]
     lines = [
         "# Global-HBM Exact Llama-2-7B MHA Recost",
         "",
         f"- decision: `{payload['decision']}`",
         f"- corrected GQA8 throughput token/s: `{gqa8['throughput']['token_throughput_per_s']}`",
-        f"- exact MHA throughput token/s: `{mha['throughput']['token_throughput_per_s']}`",
-        f"- exact MHA KV cache MiB: `{mha['memory']['kv_cache_mib']}`",
-        f"- exact MHA total proxy energy mJ/token: `{mha['energy']['total_proxy_energy_mj_per_token']}`",
-        f"- total embodied area mm2: `{mha['physical']['total_embodied_area_um2'] / 1.0e6}`",
+        f"- 131k MHA extrapolation throughput token/s: `{long_context_mha['throughput']['token_throughput_per_s']}`",
+        f"- native 4096-context exact MHA throughput token/s: `{native_mha['throughput']['token_throughput_per_s']}`",
+        f"- native exact MHA KV cache MiB: `{native_mha['memory']['kv_cache_mib']}`",
+        f"- native exact MHA total proxy energy mJ/token: `{native_mha['energy']['total_proxy_energy_mj_per_token']}`",
+        f"- total embodied area mm2: `{native_mha['physical']['total_embodied_area_um2'] / 1.0e6}`",
         "",
-        "| Candidate | KV heads | QKV cycles | Wave HBM bytes | Layer cycles | Token/s | Total mJ/token | Embodied mm2 | Structural match | Promotable |",
-        "|---|---:|---:|---:|---:|---:|---:|---:|---|---|",
+        "| Candidate | Sequence | KV heads | Tiles/waves | Wave HBM bytes | Layer cycles | Token/s | Total mJ/token | Embodied mm2 | Structural/context match | Promotable |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---|",
     ]
     for row in payload["rows"]:
         lines.append(
-            "| {candidate_id} | {kv_heads} | {qkv} | {wave_bytes} | {layer_cycles} | {throughput} | {energy} | {area} | {structural} | {promotable} |".format(
+            "| {candidate_id} | {sequence} | {kv_heads} | {tiles}/{waves} | {wave_bytes} | {layer_cycles} | {throughput} | {energy} | {area} | {structural}/{context} | {promotable} |".format(
                 candidate_id=row["candidate_id"],
+                sequence=row["model_contract"]["sequence_length"],
                 kv_heads=row["model_contract"]["kv_heads"],
-                qkv=row["projection"]["target_cycles"],
+                tiles=row["memory"]["tile_count"],
+                waves=row["schedule"]["tile_waves"],
                 wave_bytes=row["global_hbm_service"]["aggregate_wave_hbm_bytes"],
                 layer_cycles=row["schedule"]["layer_cycles"],
                 throughput=row["throughput"]["token_throughput_per_s"],
                 energy=row["energy"]["total_proxy_energy_mj_per_token"],
                 area=row["physical"]["total_embodied_area_um2"] / 1.0e6,
                 structural=row["quality_contract"]["structural_model_match"],
+                context=row["quality_contract"]["native_context_match"],
                 promotable=row["quality_contract"]["promotable"],
             )
         )

--- a/npu/eval/recost_llm_decoder_attention_score32_global_hbm_exact_llama2_mha.py
+++ b/npu/eval/recost_llm_decoder_attention_score32_global_hbm_exact_llama2_mha.py
@@ -52,11 +52,17 @@ DEFAULT_HBM_ENERGY = _BASE / (
     "decoder_attention_score32_exp_lut_hbm_dram_service_closure__"
     "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1.json"
 )
+DEFAULT_QUALITY_FRONTIER = _BASE / (
+    "decoder_attention_score32_integrated_frontier_ranking__"
+    "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_"
+    "rtl_ppa_recost_frontier_llama7b_v1.json"
+)
 
 _FINITE_PROFILE = "decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost"
 _SOURCE_MODEL = "llm_decoder_attention_score32_exact_reduction_recost_v1"
 _HBM_REPLAY_MODEL = "llm_decoder_attention_score32_hbm_controller_replay_v1"
 _HBM_ENERGY_MODEL = "llm_decoder_attention_score32_exp_lut_hbm_dram_service_closure_v1"
+_QUALITY_FRONTIER_MODEL = "llm_decoder_attention_score32_integrated_frontier_ranking_v1"
 
 
 def _load_json(path: Path) -> JsonDict:
@@ -144,6 +150,33 @@ def _validate_inputs(
     ):
         _positive(energy_params.get(key), f"HBM energy parameter {key}")
     return model, best, controller, energy_params
+
+
+def _controller_ppa(quality_frontier: JsonDict) -> JsonDict:
+    if quality_frontier.get("version") != 1 or quality_frontier.get("model") != _QUALITY_FRONTIER_MODEL:
+        raise ValueError("quality frontier model/version mismatch")
+    rows = quality_frontier.get("rows")
+    if not isinstance(rows, list):
+        raise ValueError("quality frontier rows are missing")
+    matches = [
+        row
+        for row in rows
+        if isinstance(row, dict) and row.get("family") == "score32_exp_lut_div"
+    ]
+    if len(matches) != 1:
+        raise ValueError("quality frontier must contain exactly one score32 row")
+    ppa = matches[0].get("score32_hbm_controller_replay_ppa")
+    if not isinstance(ppa, dict):
+        raise ValueError("score32 row is missing measured HBM controller PPA")
+    return {
+        "artifact_item_id": str(ppa.get("artifact_item_id") or ""),
+        "area_mm2": _positive(ppa.get("controller_area_mm2"), "HBM controller area"),
+        "power_mw": _positive(ppa.get("controller_power_mw"), "HBM controller power"),
+        "critical_path_ns": _positive(
+            ppa.get("critical_path_ns_best"), "HBM controller critical path"
+        ),
+        "metrics_csv": str(ppa.get("metrics_csv") or ""),
+    }
 
 
 def _projection_cycles(*, row: JsonDict, kv_heads: int) -> JsonDict:
@@ -256,6 +289,7 @@ def _candidate(
     finite: JsonDict,
     source_row: JsonDict,
     controller: JsonDict,
+    controller_ppa: JsonDict,
     energy_params: JsonDict,
     fixed_shared_tile_bytes: int,
 ) -> JsonDict:
@@ -360,6 +394,19 @@ def _candidate(
         finite["physical_recost"]["recost_logic_vectorless_power_mw"], "logic vectorless power"
     )
     logic_energy_mj = logic_power_mw * token_time_ns / 1.0e9
+    controller_energy_mj = (
+        _positive(controller_ppa.get("power_mw"), "HBM controller power")
+        * token_time_ns
+        / 1.0e9
+    )
+    logic_area_um2 = _positive(
+        finite["physical_recost"]["total_embodied_area_um2"], "logic embodied area"
+    )
+    controller_area_um2 = (
+        _positive(controller_ppa.get("area_mm2"), "HBM controller area") * 1.0e6
+    )
+    total_embodied_area_um2 = logic_area_um2 + controller_area_um2
+    die_area_um2 = _positive(finite["physical_recost"]["die_area_um2"], "die area")
     return {
         "candidate_id": candidate_id,
         "model_contract": {
@@ -409,16 +456,22 @@ def _candidate(
             "token_throughput_per_s": 1.0e9 / token_time_ns,
         },
         "physical": {
-            "die_area_um2": finite["physical_recost"]["die_area_um2"],
-            "total_embodied_area_um2": finite["physical_recost"]["total_embodied_area_um2"],
-            "area_fit": finite["physical_recost"]["area_fit"],
+            "die_area_um2": die_area_um2,
+            "logic_and_onchip_memory_embodied_area_um2": logic_area_um2,
+            "hbm_controller_area_um2": controller_area_um2,
+            "total_embodied_area_um2": total_embodied_area_um2,
+            "area_fit": total_embodied_area_um2 <= die_area_um2,
             "area_change_for_mha": "none_shared_compute_and_fixed_onchip_buffers",
+            "hbm_controller_ppa": controller_ppa,
         },
         "energy": {
             "hbm_command_calibrated_energy": hbm_energy,
             "hbm_energy_mj_per_token": hbm_energy["energy_mj"],
             "logic_vectorless_energy_mj_per_token": logic_energy_mj,
-            "total_proxy_energy_mj_per_token": logic_energy_mj + float(hbm_energy["energy_mj"]),
+            "hbm_controller_vectorless_energy_mj_per_token": controller_energy_mj,
+            "total_proxy_energy_mj_per_token": (
+                logic_energy_mj + controller_energy_mj + float(hbm_energy["energy_mj"])
+            ),
             "logic_energy_status": "always_on_vectorless_upper_proxy_without_clock_gating",
             "hbm_energy_status": "command_calibrated_not_vendor_signoff",
         },
@@ -442,9 +495,11 @@ def build_report(args: argparse.Namespace) -> JsonDict:
     source = _load_json(root / args.source_recost_json)
     hbm_replay = _load_json(root / args.hbm_replay_json)
     hbm_energy = _load_json(root / args.hbm_energy_json)
+    quality_frontier = _load_json(root / args.quality_frontier_json)
     _model, source_row, controller, energy_params = _validate_inputs(
         finite=finite, source=source, hbm_replay=hbm_replay, hbm_energy=hbm_energy
     )
+    controller_ppa = _controller_ppa(quality_frontier)
     fixed_shared_tile_bytes = _positive_int(
         source_row.get("onchip_shared_bytes_per_cluster"), "fixed shared tile bytes"
     )
@@ -456,6 +511,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
         finite=finite,
         source_row=source_row,
         controller=controller,
+        controller_ppa=controller_ppa,
         energy_params=energy_params,
         fixed_shared_tile_bytes=fixed_shared_tile_bytes,
     )
@@ -467,6 +523,7 @@ def build_report(args: argparse.Namespace) -> JsonDict:
         finite=finite,
         source_row=source_row,
         controller=controller,
+        controller_ppa=controller_ppa,
         energy_params=energy_params,
         fixed_shared_tile_bytes=fixed_shared_tile_bytes,
     )
@@ -482,6 +539,10 @@ def build_report(args: argparse.Namespace) -> JsonDict:
             "exact_reduction_recost": "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
             "hbm_controller_replay": "l2_decoder_attention_score32_hbm_controller_replay_llama7b_v1",
             "hbm_energy_closure": "l2_decoder_attention_score32_exp_lut_hbm_dram_service_closure_llama7b_v1",
+            "hbm_controller_ppa_frontier": (
+                "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_"
+                "rtl_ppa_recost_frontier_llama7b_v1"
+            ),
         },
         "global_controller_correction": {
             "legacy_scope": "one_tile_replayed_as_if_it_owned_the_global_controller",
@@ -536,21 +597,23 @@ def write_report(payload: JsonDict, path: Path) -> None:
         f"- corrected GQA8 throughput token/s: `{gqa8['throughput']['token_throughput_per_s']}`",
         f"- exact MHA throughput token/s: `{mha['throughput']['token_throughput_per_s']}`",
         f"- exact MHA KV cache MiB: `{mha['memory']['kv_cache_mib']}`",
-        f"- exact MHA HBM energy mJ/token: `{mha['energy']['hbm_energy_mj_per_token']}`",
+        f"- exact MHA total proxy energy mJ/token: `{mha['energy']['total_proxy_energy_mj_per_token']}`",
+        f"- total embodied area mm2: `{mha['physical']['total_embodied_area_um2'] / 1.0e6}`",
         "",
-        "| Candidate | KV heads | QKV cycles | Wave HBM bytes | Layer cycles | Token/s | HBM mJ/token | Structural match | Promotable |",
-        "|---|---:|---:|---:|---:|---:|---:|---|---|",
+        "| Candidate | KV heads | QKV cycles | Wave HBM bytes | Layer cycles | Token/s | Total mJ/token | Embodied mm2 | Structural match | Promotable |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---|---|",
     ]
     for row in payload["rows"]:
         lines.append(
-            "| {candidate_id} | {kv_heads} | {qkv} | {wave_bytes} | {layer_cycles} | {throughput} | {energy} | {structural} | {promotable} |".format(
+            "| {candidate_id} | {kv_heads} | {qkv} | {wave_bytes} | {layer_cycles} | {throughput} | {energy} | {area} | {structural} | {promotable} |".format(
                 candidate_id=row["candidate_id"],
                 kv_heads=row["model_contract"]["kv_heads"],
                 qkv=row["projection"]["target_cycles"],
                 wave_bytes=row["global_hbm_service"]["aggregate_wave_hbm_bytes"],
                 layer_cycles=row["schedule"]["layer_cycles"],
                 throughput=row["throughput"]["token_throughput_per_s"],
-                energy=row["energy"]["hbm_energy_mj_per_token"],
+                energy=row["energy"]["total_proxy_energy_mj_per_token"],
+                area=row["physical"]["total_embodied_area_um2"] / 1.0e6,
                 structural=row["quality_contract"]["structural_model_match"],
                 promotable=row["quality_contract"]["promotable"],
             )
@@ -568,6 +631,7 @@ def main() -> int:
     parser.add_argument("--source-recost-json", type=Path, default=DEFAULT_SOURCE_RECOST)
     parser.add_argument("--hbm-replay-json", type=Path, default=DEFAULT_HBM_REPLAY)
     parser.add_argument("--hbm-energy-json", type=Path, default=DEFAULT_HBM_ENERGY)
+    parser.add_argument("--quality-frontier-json", type=Path, default=DEFAULT_QUALITY_FRONTIER)
     parser.add_argument("--measured-l1-costs", type=Path, default=phase2_schedule.DEFAULT_MEASURED_L1_COSTS)
     parser.add_argument("--max-cycles", type=int, default=20_000_000)
     parser.add_argument("--out", type=Path, required=True)

--- a/npu/eval/reroute_llm_decoder_attention_score32_noc_phase2_measured_router_clock.py
+++ b/npu/eval/reroute_llm_decoder_attention_score32_noc_phase2_measured_router_clock.py
@@ -51,7 +51,12 @@ def _schedule_args(args: argparse.Namespace, *, noc_clock_ns: float) -> argparse
     )
 
 
-def _compact_schedule(payload: JsonDict) -> JsonDict:
+def _compact_schedule(
+    payload: JsonDict,
+    *,
+    expected_wave_count: int = 8,
+    expected_tile_count: int = 128,
+) -> JsonDict:
     if payload.get("version") != 2 or payload.get("profile") != "decoder_attention_score32_noc_phase2_schedule":
         raise ValueError("rerouted schedule must preserve the Phase 2 v2 profile")
     source = payload.get("source_contract")
@@ -62,10 +67,22 @@ def _compact_schedule(payload: JsonDict) -> JsonDict:
         raise ValueError("rerouted schedule is missing required sections")
     if source.get("coverage") != "workload_complete":
         raise ValueError("rerouted schedule must remain workload_complete")
-    if source.get("declared_tile_waves") != 8 or source.get("simulated_wave_count") != 8:
-        raise ValueError("rerouted schedule must cover exactly eight waves")
-    if traffic.get("tile_count") != 128 or traffic.get("simulated_tiles") != 128:
-        raise ValueError("rerouted schedule must cover exactly 128 tiles")
+    if expected_wave_count <= 0 or expected_tile_count <= 0:
+        raise ValueError("expected workload dimensions must be positive")
+    if (
+        source.get("declared_tile_waves") != expected_wave_count
+        or source.get("simulated_wave_count") != expected_wave_count
+    ):
+        raise ValueError(
+            f"rerouted schedule must cover exactly {expected_wave_count} waves"
+        )
+    if (
+        traffic.get("tile_count") != expected_tile_count
+        or traffic.get("simulated_tiles") != expected_tile_count
+    ):
+        raise ValueError(
+            f"rerouted schedule must cover exactly {expected_tile_count} tiles"
+        )
     if simulation.get("scheduled_flit_count") != simulation.get("delivered_flit_count"):
         raise ValueError("rerouted schedule must deliver every scheduled flit")
     return {

--- a/npu/eval/tests/test_audit_llm_decoder_attention_score32_exact_llama2_mha_final_frontier.py
+++ b/npu/eval/tests/test_audit_llm_decoder_attention_score32_exact_llama2_mha_final_frontier.py
@@ -31,6 +31,8 @@ def _recost() -> dict:
                     "kv_heads": 4,
                     "gqa_group_size": 8,
                     "kv_sharing": "gqa8",
+                    "sequence_length": 131072,
+                    "native_context_match": False,
                 },
                 "throughput": {
                     "token_throughput_per_s": 34.5,
@@ -48,7 +50,7 @@ def _recost() -> dict:
                 ],
             },
             {
-                "candidate_id": "score32_exact_llama2_7b_mha_global_hbm_finite_endpoint",
+                "candidate_id": "score32_llama2_7b_mha_131k_extrapolation_global_hbm_finite_endpoint",
                 "model_contract": {
                     "contract_scope": "exact_llama2_7b_mha_structure",
                     "hidden_size": 4096,
@@ -56,6 +58,8 @@ def _recost() -> dict:
                     "kv_heads": 32,
                     "gqa_group_size": 1,
                     "kv_sharing": "mha",
+                    "sequence_length": 131072,
+                    "native_context_match": False,
                 },
                 "throughput": {
                     "token_throughput_per_s": 4.4043,
@@ -66,6 +70,32 @@ def _recost() -> dict:
                 },
                 "energy": {
                     "total_proxy_energy_mj_per_token": 6893.038,
+                },
+                "remaining_abstractions": [
+                    "The fixed shared-SRAM residency policy is recosted but not reoptimized for MHA.",
+                ],
+            },
+            {
+                "candidate_id": "score32_exact_llama2_7b_mha_global_hbm_finite_endpoint",
+                "model_contract": {
+                    "contract_scope": "exact_llama2_7b_mha_structure",
+                    "hidden_size": 4096,
+                    "attention_heads": 32,
+                    "kv_heads": 32,
+                    "gqa_group_size": 1,
+                    "kv_sharing": "mha",
+                    "sequence_length": 4096,
+                    "native_context_match": True,
+                },
+                "throughput": {
+                    "token_throughput_per_s": 80.0,
+                    "token_latency_us": 12500.0,
+                },
+                "physical": {
+                    "total_embodied_area_um2": 790_000_000,
+                },
+                "energy": {
+                    "total_proxy_energy_mj_per_token": 250.0,
                 },
                 "remaining_abstractions": [
                     "The fixed shared-SRAM residency policy is recosted but not reoptimized for MHA.",
@@ -152,15 +182,25 @@ def test_exact_quality_pass_yields_promotable_frontier_with_unchanged_candidate_
     assert result["model"] == "llama2_7b_score32_exact_mha_final_frontier_v1"
     assert result["decision"] == _DECISION_PASS
     assert result["scalar_universal_winner"] is None
-    assert result["dimension_winners"] == {
-        "throughput_comparable_boundary": "score32_gqa8_global_hbm_finite_endpoint",
-        "embodied_area_comparable_boundary": "score32_gqa8_global_hbm_finite_endpoint",
-        "energy_comparable_boundary": "score32_gqa8_global_hbm_finite_endpoint",
-        "precision_comparable_boundary": [
-            "score32_gqa8_global_hbm_finite_endpoint",
-            "score32_exact_llama2_7b_mha_global_hbm_finite_endpoint",
-        ],
-        "higher_precision_noncomparable_reference": "measured_exact_fp16_gqa8_kv8_reference",
+    assert result["dimension_winners_by_workload"] == {
+        "long_context_131072_extrapolation": {
+            "throughput": "score32_gqa8_global_hbm_finite_endpoint",
+            "embodied_area": "score32_gqa8_global_hbm_finite_endpoint",
+            "energy": "score32_gqa8_global_hbm_finite_endpoint",
+            "precision": [
+                "score32_gqa8_global_hbm_finite_endpoint",
+                "score32_llama2_7b_mha_131k_extrapolation_global_hbm_finite_endpoint",
+            ],
+        },
+        "official_llama2_7b_native_context_4096": {
+            "throughput": "score32_exact_llama2_7b_mha_global_hbm_finite_endpoint",
+            "embodied_area": "score32_exact_llama2_7b_mha_global_hbm_finite_endpoint",
+            "energy": "score32_exact_llama2_7b_mha_global_hbm_finite_endpoint",
+            "precision": "score32_exact_llama2_7b_mha_global_hbm_finite_endpoint",
+        },
+    }
+    assert result["noncomparable_reference_winners"] == {
+        "higher_precision_noncomparable_reference": "measured_exact_fp16_gqa8_kv8_reference"
     }
 
     promotable = result["promotable_pareto_frontier"]
@@ -175,8 +215,13 @@ def test_exact_quality_pass_yields_promotable_frontier_with_unchanged_candidate_
     assert all_rows["score32_gqa8_global_hbm_finite_endpoint"]["structural_quality_backed"] is False
     assert all_rows["measured_exact_fp16_gqa8_kv8_reference"]["promotable"] is False
 
-    engineering = [row["candidate_id"] for row in result["engineering_pareto_frontier"]]
-    assert engineering == ["score32_gqa8_global_hbm_finite_endpoint"]
+    engineering = result["engineering_pareto_frontiers_by_workload"]
+    assert [row["candidate_id"] for row in engineering["long_context_131072_extrapolation"]] == [
+        "score32_gqa8_global_hbm_finite_endpoint"
+    ]
+    assert [row["candidate_id"] for row in engineering["official_llama2_7b_native_context_4096"]] == [
+        "score32_exact_llama2_7b_mha_global_hbm_finite_endpoint"
+    ]
     references = result["noncomparable_reference_rows"]
     assert [row["candidate_id"] for row in references] == [
         "measured_exact_fp16_gqa8_kv8_reference"
@@ -223,4 +268,5 @@ def test_remaining_abstractions_preserve_required_frontier_caveats() -> None:
     assert "Logic energy remains a vectorless activity proxy rather than workload-toggle-complete power." in abstractions
     assert "Fixed shared-SRAM residency is recosted but not reoptimized for exact MHA." in abstractions
     assert "Native exact Llama-2-7B quality is bounded to a limited prompt sample rather than a full benchmark suite." in abstractions
+    assert "The 131072-token stress workload is a long-context extrapolation beyond the official Llama-2-7B 4096-token context and is not quality-backed." in abstractions
     assert "Exact FP16 MHA has not been physically recosted on the same accounting boundary." in abstractions

--- a/npu/eval/tests/test_audit_llm_decoder_attention_score32_exact_llama2_mha_final_frontier.py
+++ b/npu/eval/tests/test_audit_llm_decoder_attention_score32_exact_llama2_mha_final_frontier.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval.audit_llm_decoder_attention_score32_exact_llama2_mha_final_frontier import (  # noqa: E402
+    _DECISION_HOLD,
+    _DECISION_PASS,
+    build_report,
+)
+
+
+def _recost() -> dict:
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_score32_global_hbm_exact_llama2_mha_recost_v1",
+        "decision": "exact_llama2_mha_recost_recorded_native_quality_required",
+        "rows": [
+            {
+                "candidate_id": "score32_gqa8_global_hbm_finite_endpoint",
+                "model_contract": {
+                    "hidden_size": 4096,
+                    "attention_heads": 32,
+                    "kv_heads": 4,
+                    "gqa_group_size": 8,
+                    "kv_sharing": "gqa8",
+                },
+                "throughput": {
+                    "token_throughput_per_s": 34.5,
+                    "token_latency_us": 28985.507246,
+                },
+                "physical": {
+                    "total_embodied_area_um2": 780_000_000,
+                },
+                "energy": {
+                    "total_proxy_energy_mj_per_token": 880.0,
+                },
+                "remaining_abstractions": [
+                    "HBM controller service is deterministic burst replay, not controller RTL or vendor timing signoff.",
+                    "Logic energy is an always-on vectorless upper proxy; workload clock-gating activity is not measured.",
+                ],
+            },
+            {
+                "candidate_id": "score32_exact_llama2_7b_mha_global_hbm_finite_endpoint",
+                "model_contract": {
+                    "hidden_size": 4096,
+                    "attention_heads": 32,
+                    "kv_heads": 32,
+                    "gqa_group_size": 1,
+                    "kv_sharing": "mha",
+                },
+                "throughput": {
+                    "token_throughput_per_s": 4.4043,
+                    "token_latency_us": 227050.832595,
+                },
+                "physical": {
+                    "total_embodied_area_um2": 790_000_000,
+                },
+                "energy": {
+                    "total_proxy_energy_mj_per_token": 6893.038,
+                },
+                "remaining_abstractions": [
+                    "The fixed shared-SRAM residency policy is recosted but not reoptimized for MHA.",
+                ],
+            },
+        ],
+        "remaining_abstractions": [
+            "HBM energy is command calibrated rather than vendor current signoff.",
+            "Native Llama-2-7B score32 generation quality has not been measured.",
+        ],
+    }
+
+
+def _quality(*, status: str = "mixed_int8_generation_quality_pass", model_id: str = "meta-llama/Llama-2-7b-hf") -> dict:
+    return {
+        "version": 1.0,
+        "quality_gate": "mixed_int8_generation_quality",
+        "model": {
+            "model_id": model_id,
+            "resolved_model_id": model_id,
+            "hidden_size": 4096,
+            "attention_head_count": 32,
+            "kv_head_count": 32,
+            "gqa_group_size": 1.0,
+            "structural_contract_status": "pass",
+            "generation_steps": 8,
+        },
+        "precision": {
+            "candidate_id": "score32_exp_lut_div",
+            "q_bits": 8,
+            "k_bits": 8,
+            "v_bits": 8,
+            "score_bits": 32,
+            "weight_bits": 16,
+            "softmax_mode": "exp_lut_div_bucket20",
+        },
+        "decision": {
+            "status": status,
+        },
+        "summary": {
+            "prompt_count": 8,
+        },
+    }
+
+
+def _quality_frontier() -> dict:
+    return {
+        "version": 1,
+        "model": "llm_decoder_attention_score32_integrated_frontier_ranking_v1",
+        "rows": [
+            {
+                "candidate_id": "measured_exact_fp16_gqa8_kv8_reference",
+                "family": "measured_exact_fp16_gqa8_kv8",
+                "promotable": False,
+                "quality_backed": False,
+                "token_throughput_per_s": 12.0,
+                "latency_us": 83333.333333,
+                "total_embodied_area_mm2": 920.0,
+                "energy_mj_per_token": 120.0,
+                "remaining_abstractions": [
+                    "Profile-scaled SRAM activity remains approximate.",
+                ],
+            },
+            {
+                "candidate_id": "planning_only_history",
+                "family": "abstract",
+                "promotable": False,
+                "quality_backed": False,
+                "precision_status": "planning_only",
+            },
+        ],
+    }
+
+
+def test_exact_quality_pass_yields_promotable_frontier_with_unchanged_candidate_ids() -> None:
+    result = build_report(
+        recost=_recost(),
+        generation_quality=_quality(),
+        quality_frontier=_quality_frontier(),
+    )
+
+    assert result["model"] == "llama2_7b_score32_exact_mha_final_frontier_v1"
+    assert result["decision"] == _DECISION_PASS
+    assert result["scalar_universal_winner"] is None
+    assert result["dimension_winners"] == {
+        "throughput": "score32_gqa8_global_hbm_finite_endpoint",
+        "embodied_area": "score32_gqa8_global_hbm_finite_endpoint",
+        "energy": "measured_exact_fp16_gqa8_kv8_reference",
+        "precision": "measured_exact_fp16_gqa8_kv8_reference",
+    }
+
+    promotable = result["promotable_pareto_frontier"]
+    assert [row["candidate_id"] for row in promotable] == [
+        "score32_exact_llama2_7b_mha_global_hbm_finite_endpoint"
+    ]
+    assert promotable[0]["promotable"] is True
+    assert promotable[0]["quality_backed"] is True
+
+    all_rows = {row["candidate_id"]: row for row in result["all_rows"]}
+    assert all_rows["score32_gqa8_global_hbm_finite_endpoint"]["promotable"] is False
+    assert all_rows["score32_gqa8_global_hbm_finite_endpoint"]["structural_quality_backed"] is False
+    assert all_rows["measured_exact_fp16_gqa8_kv8_reference"]["promotable"] is False
+
+    engineering = [row["candidate_id"] for row in result["engineering_pareto_frontier"]]
+    assert engineering == [
+        "score32_gqa8_global_hbm_finite_endpoint",
+        "measured_exact_fp16_gqa8_kv8_reference",
+    ]
+
+
+def test_quality_hold_keeps_exact_mha_nonpromotable_but_preserves_engineering_frontier() -> None:
+    result = build_report(
+        recost=_recost(),
+        generation_quality=_quality(status="mixed_int8_generation_quality_hold"),
+        quality_frontier=_quality_frontier(),
+    )
+
+    assert result["decision"] == _DECISION_HOLD
+    assert result["promotable_pareto_frontier"] == []
+    exact_row = next(
+        row for row in result["all_rows"] if row["candidate_id"] == "score32_exact_llama2_7b_mha_global_hbm_finite_endpoint"
+    )
+    assert exact_row["promotable"] is False
+    assert exact_row["quality_backed"] is False
+    assert "quality gate" in exact_row["promotion_blocker"]
+
+
+def test_exact_identity_rejection_requires_official_llama2_checkpoint() -> None:
+    with pytest.raises(ValueError, match="generation quality model_id mismatch"):
+        build_report(
+            recost=_recost(),
+            generation_quality=_quality(model_id="mistralai/Mistral-7B-v0.1"),
+            quality_frontier=_quality_frontier(),
+        )
+
+
+def test_remaining_abstractions_preserve_required_frontier_caveats() -> None:
+    result = build_report(
+        recost=_recost(),
+        generation_quality=_quality(),
+        quality_frontier=_quality_frontier(),
+    )
+
+    abstractions = result["remaining_abstractions"]
+    assert "HBM controller service remains deterministic global replay rather than controller RTL or vendor timing signoff." in abstractions
+    assert "Logic energy remains a vectorless activity proxy rather than workload-toggle-complete power." in abstractions
+    assert "Fixed shared-SRAM residency is recosted but not reoptimized for exact MHA." in abstractions
+    assert "Native exact Llama-2-7B quality is bounded to a limited prompt sample rather than a full benchmark suite." in abstractions
+    assert "Exact FP16 MHA has not been physically recosted on the same accounting boundary." in abstractions

--- a/npu/eval/tests/test_audit_llm_decoder_attention_score32_exact_llama2_mha_final_frontier.py
+++ b/npu/eval/tests/test_audit_llm_decoder_attention_score32_exact_llama2_mha_final_frontier.py
@@ -25,6 +25,7 @@ def _recost() -> dict:
             {
                 "candidate_id": "score32_gqa8_global_hbm_finite_endpoint",
                 "model_contract": {
+                    "contract_scope": "llama7b_shaped_gqa8_proxy_not_exact_llama2_7b",
                     "hidden_size": 4096,
                     "attention_heads": 32,
                     "kv_heads": 4,
@@ -49,6 +50,7 @@ def _recost() -> dict:
             {
                 "candidate_id": "score32_exact_llama2_7b_mha_global_hbm_finite_endpoint",
                 "model_contract": {
+                    "contract_scope": "exact_llama2_7b_mha_structure",
                     "hidden_size": 4096,
                     "attention_heads": 32,
                     "kv_heads": 32,
@@ -84,6 +86,7 @@ def _quality(*, status: str = "mixed_int8_generation_quality_pass", model_id: st
         "model": {
             "model_id": model_id,
             "resolved_model_id": model_id,
+            "expected_model_id": "meta-llama/Llama-2-7b-hf",
             "hidden_size": 4096,
             "attention_head_count": 32,
             "kv_head_count": 32,
@@ -121,7 +124,8 @@ def _quality_frontier() -> dict:
                 "quality_backed": False,
                 "token_throughput_per_s": 12.0,
                 "latency_us": 83333.333333,
-                "total_embodied_area_mm2": 920.0,
+                "compute_area_mm2": 479.6,
+                "die_area_mm2": 1200.0,
                 "energy_mj_per_token": 120.0,
                 "remaining_abstractions": [
                     "Profile-scaled SRAM activity remains approximate.",
@@ -149,10 +153,14 @@ def test_exact_quality_pass_yields_promotable_frontier_with_unchanged_candidate_
     assert result["decision"] == _DECISION_PASS
     assert result["scalar_universal_winner"] is None
     assert result["dimension_winners"] == {
-        "throughput": "score32_gqa8_global_hbm_finite_endpoint",
-        "embodied_area": "score32_gqa8_global_hbm_finite_endpoint",
-        "energy": "measured_exact_fp16_gqa8_kv8_reference",
-        "precision": "measured_exact_fp16_gqa8_kv8_reference",
+        "throughput_comparable_boundary": "score32_gqa8_global_hbm_finite_endpoint",
+        "embodied_area_comparable_boundary": "score32_gqa8_global_hbm_finite_endpoint",
+        "energy_comparable_boundary": "score32_gqa8_global_hbm_finite_endpoint",
+        "precision_comparable_boundary": [
+            "score32_gqa8_global_hbm_finite_endpoint",
+            "score32_exact_llama2_7b_mha_global_hbm_finite_endpoint",
+        ],
+        "higher_precision_noncomparable_reference": "measured_exact_fp16_gqa8_kv8_reference",
     }
 
     promotable = result["promotable_pareto_frontier"]
@@ -168,10 +176,13 @@ def test_exact_quality_pass_yields_promotable_frontier_with_unchanged_candidate_
     assert all_rows["measured_exact_fp16_gqa8_kv8_reference"]["promotable"] is False
 
     engineering = [row["candidate_id"] for row in result["engineering_pareto_frontier"]]
-    assert engineering == [
-        "score32_gqa8_global_hbm_finite_endpoint",
-        "measured_exact_fp16_gqa8_kv8_reference",
+    assert engineering == ["score32_gqa8_global_hbm_finite_endpoint"]
+    references = result["noncomparable_reference_rows"]
+    assert [row["candidate_id"] for row in references] == [
+        "measured_exact_fp16_gqa8_kv8_reference"
     ]
+    assert references[0]["embodied_area_mm2"] is None
+    assert references[0]["area_metric_status"] == "compute_only_not_total_embodied_noncomparable"
 
 
 def test_quality_hold_keeps_exact_mha_nonpromotable_but_preserves_engineering_frontier() -> None:

--- a/npu/eval/tests/test_recost_llm_decoder_attention_score32_global_hbm_exact_llama2_mha.py
+++ b/npu/eval/tests/test_recost_llm_decoder_attention_score32_global_hbm_exact_llama2_mha.py
@@ -156,7 +156,7 @@ def test_exact_mha_candidate_rebuilds_memory_compute_and_finite_release_schedule
     monkeypatch.setattr(
         recost,
         "_compact_schedule",
-        lambda _payload: {
+        lambda _payload, **_kwargs: {
             "scheduled_packet_count": 2,
             "scheduled_flit_count": 16,
         },
@@ -178,6 +178,8 @@ def test_exact_mha_candidate_rebuilds_memory_compute_and_finite_release_schedule
         candidate_id="exact-mha",
         kv_heads=32,
         exact_llama2_structure=True,
+        sequence_length=4096,
+        native_context_match=True,
         finite=_finite(),
         source_row=_source_row(),
         controller=_controller(),
@@ -191,16 +193,22 @@ def test_exact_mha_candidate_rebuilds_memory_compute_and_finite_release_schedule
     assert schedule_row["kv_sharing"] == "mha"
     assert schedule_row["qkv_cycles"] == 460
     assert schedule_row["kv_write_cycles"] == 80
-    assert schedule_row["kv_cache_mib"] == 32768.0
+    assert schedule_row["sequence_length"] == 4096
+    assert schedule_row["tile_count"] == 4
+    assert schedule_row["active_clusters"] == 4
+    assert schedule_row["tile_waves"] == 1
+    assert schedule_row["kv_cache_mib"] == 1024.0
     assert result["memory"]["full_tile_bytes"] == 8_388_608
     assert result["memory"]["fixed_shared_tile_bytes"] == 17_408
     assert result["memory"]["tile_hbm_bytes"] == 8_371_200
-    assert result["memory"]["read_bytes_per_token"] == 34_288_435_200
+    assert result["memory"]["tile_count"] == 4
+    assert result["memory"]["read_bytes_per_token"] == 1_071_513_600
     assert result["memory"]["write_bytes_per_token"] == 262_144
-    assert result["global_hbm_service"]["aggregate_wave_hbm_bytes"] == 133_939_200
+    assert result["global_hbm_service"]["aggregate_wave_hbm_bytes"] == 33_484_800
     assert result["schedule"]["scheduled_packets"] == 2
     assert result["schedule"]["scheduled_flits"] == 16
     assert result["quality_contract"]["structural_model_match"] is True
+    assert result["quality_contract"]["native_context_match"] is True
     assert result["quality_contract"]["promotable"] is False
     assert result["physical"]["hbm_controller_area_um2"] == 30_000.0
     assert result["physical"]["total_embodied_area_um2"] == 760_030_000.0

--- a/npu/eval/tests/test_recost_llm_decoder_attention_score32_global_hbm_exact_llama2_mha.py
+++ b/npu/eval/tests/test_recost_llm_decoder_attention_score32_global_hbm_exact_llama2_mha.py
@@ -94,10 +94,21 @@ def _energy_params() -> dict:
     }
 
 
+def _controller_ppa() -> dict:
+    return {
+        "artifact_item_id": "l1_hbm_controller",
+        "area_mm2": 0.03,
+        "power_mw": 0.1,
+        "critical_path_ns": 2.0,
+        "metrics_csv": "runs/designs/hbm/metrics.csv",
+    }
+
+
 def _args(tmp_path: Path) -> argparse.Namespace:
     return argparse.Namespace(
         repo_root=tmp_path,
         source_recost_json=Path("source.json"),
+        quality_frontier_json=Path("quality.json"),
         measured_l1_costs=Path("costs.json"),
         out=tmp_path / "out.json",
         report=tmp_path / "out.md",
@@ -170,6 +181,7 @@ def test_exact_mha_candidate_rebuilds_memory_compute_and_finite_release_schedule
         finite=_finite(),
         source_row=_source_row(),
         controller=_controller(),
+        controller_ppa=_controller_ppa(),
         energy_params=_energy_params(),
         fixed_shared_tile_bytes=17408,
     )
@@ -190,6 +202,31 @@ def test_exact_mha_candidate_rebuilds_memory_compute_and_finite_release_schedule
     assert result["schedule"]["scheduled_flits"] == 16
     assert result["quality_contract"]["structural_model_match"] is True
     assert result["quality_contract"]["promotable"] is False
+    assert result["physical"]["hbm_controller_area_um2"] == 30_000.0
+    assert result["physical"]["total_embodied_area_um2"] == 760_030_000.0
+    assert result["energy"]["hbm_controller_vectorless_energy_mj_per_token"] > 0.0
+    assert result["energy"]["total_proxy_energy_mj_per_token"] > result["energy"]["hbm_energy_mj_per_token"]
+
+
+def test_controller_ppa_requires_the_measured_score32_row() -> None:
+    payload = {
+        "version": 1,
+        "model": recost._QUALITY_FRONTIER_MODEL,
+        "rows": [
+            {
+                "family": "score32_exp_lut_div",
+                "score32_hbm_controller_replay_ppa": {
+                    "artifact_item_id": "l1_hbm_controller",
+                    "controller_area_mm2": 0.03,
+                    "controller_power_mw": 0.1,
+                    "critical_path_ns_best": 2.0,
+                    "metrics_csv": "runs/designs/hbm/metrics.csv",
+                },
+            }
+        ],
+    }
+
+    assert recost._controller_ppa(payload) == _controller_ppa()
 
 
 def test_validation_rejects_structurally_mismatched_finite_source() -> None:

--- a/tests/test_evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py
+++ b/tests/test_evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py
@@ -268,7 +268,10 @@ def test_structural_contract_rejects_dimension_mismatch_without_loading_models()
     contract = _build_structural_contract(args, model, resolved_model_id="other/model")
 
     assert contract["status"] == "fail"
-    assert contract["blockers"] == ["KV head count 8 does not match expected 32"]
+    assert contract["blockers"] == [
+        "KV head count 8 does not match expected 32",
+        "GQA group size 4.0 does not match expected 1",
+    ]
     assert contract["gqa_group_size_matches_expectation"] is False
     with pytest.raises(SystemExit, match="model structural contract failed"):
         _enforce_contract(contract, label="model structural contract")

--- a/tests/test_evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py
+++ b/tests/test_evaluate_llm_decoder_model_native_mixed_int8_generation_quality.py
@@ -13,13 +13,37 @@ if str(REPO_ROOT) not in sys.path:
 
 from npu.eval.evaluate_llm_decoder_model_native_mixed_int8_generation_quality import (
     DEFAULT_CANDIDATE_SPEC,
+    _build_requested_model_contract,
+    _build_structural_contract,
     _decision,
+    _enforce_contract,
     _resolve_candidates,
+    _resolve_model_structure,
     _summarize_free_running_rows,
     _summarize_teacher_forced_rows,
     _write_report_md,
 )
 from npu.eval import evaluate_llm_decoder_model_native_mixed_int8_attention as attention_eval
+
+
+class _FakeConfig:
+    def __init__(
+        self,
+        *,
+        attention_heads: int,
+        kv_heads: int,
+        hidden_size: int,
+        name_or_path: str = "",
+    ) -> None:
+        self.num_attention_heads = attention_heads
+        self.num_key_value_heads = kv_heads
+        self.hidden_size = hidden_size
+        self._name_or_path = name_or_path
+
+
+class _FakeModel:
+    def __init__(self, config: _FakeConfig) -> None:
+        self.config = config
 
 
 def test_summarize_teacher_and_free_running_rows_record_divergence_and_nll() -> None:
@@ -137,3 +161,114 @@ def test_report_and_hold_message_use_primary_candidate_label() -> None:
     assert "Hold this score24 w16 rtl exact mixed/int8 generation candidate" in decision["next_step"]
     assert "# Native-Checkpoint Mixed/Int8 Score24 W16 RTL Exact Generation Quality" in report
     assert "score32" not in report
+
+
+def test_requested_model_contract_accepts_exact_expected_identity() -> None:
+    args = argparse.Namespace(expected_model_id="meta-llama/Llama-2-7b-hf")
+
+    contract = _build_requested_model_contract(args, "meta-llama/Llama-2-7b-hf")
+
+    assert contract == {
+        "status": "pass",
+        "blockers": [],
+        "resolved_model_id": "meta-llama/Llama-2-7b-hf",
+        "expected_model_id": "meta-llama/Llama-2-7b-hf",
+    }
+
+
+def test_requested_model_contract_rejects_mismatched_identity() -> None:
+    args = argparse.Namespace(expected_model_id="meta-llama/Llama-2-7b-hf")
+    contract = _build_requested_model_contract(args, "mistralai/Mistral-7B-v0.1")
+
+    assert contract["status"] == "fail"
+    assert contract["blockers"] == [
+        "resolved model_id 'mistralai/Mistral-7B-v0.1' does not match expected 'meta-llama/Llama-2-7b-hf'"
+    ]
+    with pytest.raises(SystemExit, match="requested model identity contract failed"):
+        _enforce_contract(contract, label="requested model identity contract")
+
+
+def test_resolve_model_structure_reports_exact_llama2_dimensions() -> None:
+    model = _FakeModel(
+        _FakeConfig(
+            attention_heads=32,
+            kv_heads=32,
+            hidden_size=4096,
+            name_or_path="meta-llama/Llama-2-7b-hf",
+        )
+    )
+
+    structure = _resolve_model_structure(model.config)
+
+    assert structure == {
+        "attention_head_count": 32,
+        "kv_head_count": 32,
+        "hidden_size": 4096,
+        "gqa_group_size": 1.0,
+        "loaded_model_id": "meta-llama/Llama-2-7b-hf",
+    }
+
+
+def test_structural_contract_accepts_exact_llama2_requirements() -> None:
+    args = argparse.Namespace(
+        expected_attention_head_count=32,
+        expected_kv_head_count=32,
+        expected_hidden_size=4096,
+        expected_gqa_group_size=1,
+    )
+    model = _FakeModel(
+        _FakeConfig(
+            attention_heads=32,
+            kv_heads=32,
+            hidden_size=4096,
+            name_or_path="meta-llama/Llama-2-7b-hf",
+        )
+    )
+
+    contract = _build_structural_contract(
+        args,
+        model,
+        resolved_model_id="meta-llama/Llama-2-7b-hf",
+    )
+
+    assert contract["status"] == "pass"
+    assert contract["blockers"] == []
+    assert contract["expected"] == {
+        "attention_head_count": 32,
+        "kv_head_count": 32,
+        "hidden_size": 4096,
+        "gqa_group_size": 1,
+    }
+    assert contract["actual"] == {
+        "attention_head_count": 32,
+        "kv_head_count": 32,
+        "hidden_size": 4096,
+        "gqa_group_size": 1.0,
+        "loaded_model_id": "meta-llama/Llama-2-7b-hf",
+    }
+    assert contract["gqa_group_size_matches_expectation"] is True
+
+
+def test_structural_contract_rejects_dimension_mismatch_without_loading_models() -> None:
+    args = argparse.Namespace(
+        expected_attention_head_count=32,
+        expected_kv_head_count=32,
+        expected_hidden_size=4096,
+        expected_gqa_group_size=1,
+    )
+    model = _FakeModel(
+        _FakeConfig(
+            attention_heads=32,
+            kv_heads=8,
+            hidden_size=4096,
+            name_or_path="other/model",
+        )
+    )
+
+    contract = _build_structural_contract(args, model, resolved_model_id="other/model")
+
+    assert contract["status"] == "fail"
+    assert contract["blockers"] == ["KV head count 8 does not match expected 32"]
+    assert contract["gqa_group_size_matches_expectation"] is False
+    with pytest.raises(SystemExit, match="model structural contract failed"):
+        _enforce_contract(contract, label="model structural contract")

--- a/tests/test_reroute_llm_decoder_attention_score32_noc_phase2_measured_router_clock.py
+++ b/tests/test_reroute_llm_decoder_attention_score32_noc_phase2_measured_router_clock.py
@@ -166,3 +166,22 @@ def test_reroute_rejects_noncanonical_baseline_item(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="phase2 item_id"):
         reroute.build_report(args)
+
+
+def test_compact_schedule_accepts_an_explicit_workload_complete_shape() -> None:
+    payload = _rerouted(1.0)
+    payload["source_contract"]["declared_tile_waves"] = 1
+    payload["source_contract"]["simulated_wave_count"] = 1
+    payload["traffic_quantities"]["tile_count"] = 4
+    payload["traffic_quantities"]["simulated_tiles"] = 4
+    payload["schedule_parameters"]["wave_start_noc_cycles"] = [1]
+    payload["schedule_parameters"]["reduction_release_noc_cycles"] = [2]
+
+    compact = reroute._compact_schedule(
+        payload,
+        expected_wave_count=1,
+        expected_tile_count=4,
+    )
+
+    assert compact["scheduled_flit_count"] == compact["delivered_flit_count"]
+    assert compact["wave_start_noc_cycles"] == [1]


### PR DESCRIPTION
## Summary
- hard-gate native generation quality on the official `meta-llama/Llama-2-7b-hf` identity and exact 4096/32/32 MHA structure
- add independent exact-checkpoint score32 quality and dependency-joined exact-MHA frontier jobs
- include measured HBM replay-controller area and latency-scaled energy in the global-HBM recost
- keep incomplete-area FP16 evidence outside cross-objective Pareto ranking while retaining it as a precision/energy reference
- document evaluator-local gated-checkpoint authorization and fix retry-aware manifest regression coverage

## Validation
- `430 passed` across the exact frontier, recost, quality evaluator, L2 task generator, and result consumer suites
- `python scripts/validate_runs.py --skip_eval_queue`
- `git diff --check`
- local integration replay using the checked-in controller/energy/quality-frontier artifacts and the finite-endpoint fixture

## Execution contract
The exact quality job is independent of the physical chain and must run on the remote evaluator. It requires evaluator-local Hugging Face authorization for `meta-llama/Llama-2-7b-hf`; authorization/download failure is an execution prerequisite failure, not quality evidence.
