### PR TITLE
Fail fast on stale evaluator image bootstrap

### DIFF
--- a/.devcontainer/start_control_plane_services.sh
+++ b/.devcontainer/start_control_plane_services.sh
@@ -8,6 +8,42 @@ AUTOSTART_COMPLETIONS="${RTLCP_AUTOSTART_COMPLETIONS:-}"
 AUTOSTART_API="${RTLCP_AUTOSTART_API:-}"
 AUTOSTART_RESOLVER="${RTLCP_AUTOSTART_RESOLVER:-}"
 DEFAULT_DB_URL="postgresql+psycopg://rtlgen:rtlgen@localhost:5432/rtlgen_control_plane"
+IMAGE_INIT_HELPER="/usr/local/sbin/rtlgen-container-init"
+REPO_INIT_HELPER="/workspaces/RTLGen/.devcontainer/rtlgen-container-init"
+ORFS_RUNTIME_ROOTS=(
+  /orfs/flow/designs/src
+  /orfs/flow/designs/nangate45
+  /orfs/flow/logs
+  /orfs/flow/objects
+  /orfs/flow/reports
+  /orfs/flow/results
+)
+
+prepare_runtime_paths() {
+  local path
+
+  if [[ ! -x "${IMAGE_INIT_HELPER}" ]]; then
+    echo "Installed container initializer is missing: ${IMAGE_INIT_HELPER}" >&2
+    echo "Rebuild the devcontainer image from the current repository source." >&2
+    exit 1
+  fi
+  if [[ ! -f "${REPO_INIT_HELPER}" ]] || ! cmp -s "${IMAGE_INIT_HELPER}" "${REPO_INIT_HELPER}"; then
+    echo "Installed container initializer does not match ${REPO_INIT_HELPER}." >&2
+    echo "Rebuild the devcontainer image before starting control-plane services." >&2
+    exit 1
+  fi
+
+  sudo -n "${IMAGE_INIT_HELPER}" prepare
+  for path in "${ORFS_RUNTIME_ROOTS[@]}"; do
+    if [[ ! -d "${path}" || ! -w "${path}" ]]; then
+      echo "OpenROAD runtime path is not writable by uid=$(id -u): ${path}" >&2
+      echo "Rebuild the devcontainer image or repair its runtime-path initialization." >&2
+      exit 1
+    fi
+  done
+}
+
+prepare_runtime_paths
 
 case "${ROLE}" in
   server)

--- a/tests/test_devcontainer_user_contract.py
+++ b/tests/test_devcontainer_user_contract.py
@@ -125,6 +125,37 @@ def test_server_starts_api_before_resolver() -> None:
     assert server_case.index("start api") < server_case.index("start resolver")
 
 
+def test_service_bootstrap_rejects_stale_image_helper_before_starting_daemons() -> None:
+    startup = (DEVCONTAINER / "start_control_plane_services.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'IMAGE_INIT_HELPER="/usr/local/sbin/rtlgen-container-init"' in startup
+    assert 'REPO_INIT_HELPER="/workspaces/RTLGen/.devcontainer/rtlgen-container-init"' in startup
+    assert 'cmp -s "${IMAGE_INIT_HELPER}" "${REPO_INIT_HELPER}"' in startup
+    assert "Rebuild the devcontainer image before starting control-plane services." in startup
+    assert startup.index("prepare_runtime_paths") < startup.index('case "${ROLE}" in')
+
+
+def test_service_bootstrap_prepares_and_checks_orfs_runtime_roots() -> None:
+    startup = (DEVCONTAINER / "start_control_plane_services.sh").read_text(
+        encoding="utf-8"
+    )
+    expected_paths = (
+        "/orfs/flow/designs/src",
+        "/orfs/flow/designs/nangate45",
+        "/orfs/flow/logs",
+        "/orfs/flow/objects",
+        "/orfs/flow/reports",
+        "/orfs/flow/results",
+    )
+
+    assert 'sudo -n "${IMAGE_INIT_HELPER}" prepare' in startup
+    assert '[[ ! -d "${path}" || ! -w "${path}" ]]' in startup
+    for path in expected_paths:
+        assert path in startup
+
+
 def test_migration_scripts_honor_external_devcontainer_venv() -> None:
     scripts = REPO_ROOT / "control_plane" / "scripts"
 


### PR DESCRIPTION
## Summary
- compare the installed privileged container initializer with the checked-out source before starting control-plane services
- run idempotent runtime-path preparation from the canonical service bootstrap, including evaluator starts that bypass VS Code `postStartCommand`
- verify every OpenROAD output root is writable by the remapped runtime UID before workers can lease jobs

## Root cause
The evaluator repository had the non-root ownership fix from `51bb6740`, but its image-installed `/usr/local/sbin/rtlgen-container-init` predated that commit. Repository refresh alone therefore left `/orfs/flow/designs/src` root-owned. Router and endpoint L1 sweeps failed while generating collateral, before OpenROAD ran.

The new preflight makes image/repository skew an explicit rebuild error and prevents those infrastructure failures from being recorded as PPA outcomes.

## Validation
- `bash -n .devcontainer/start_control_plane_services.sh .devcontainer/post_start.sh .devcontainer/rtlgen-container-init`
- `python -m pytest -q tests/test_devcontainer_user_contract.py` (`13 passed`)
- broader worker/dispatcher/L1 suite: relevant service tests passed; five pre-existing proposal-state tests fail against already-merged evaluation-request metadata and are unrelated to this patch
- `git diff --check`
