### PR TITLE
Embody paired NoC descriptor scheduling

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5565,14 +5565,22 @@ def _decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_evidence(
     proposal_id: str | None,
     proposal_path: str | None,
 ) -> dict[str, Any]:
-    expected_item_id = (
-        "l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_llama7b_v1"
-    )
-    expected_proposal_id = (
-        "prop_l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_v1"
-    )
-    if item_id != expected_item_id:
-        raise Layer2TaskGenerationError("score32 endpoint/RTL equivalence only permits the exact item")
+    variants = {
+        "l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_llama7b_v1": (
+            "prop_l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_v1",
+            "endpoint_parallel",
+        ),
+        "l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_llama7b_v1": (
+            "prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1",
+            "serial_paired",
+        ),
+    }
+    variant = variants.get(item_id)
+    if variant is None:
+        raise Layer2TaskGenerationError(
+            "score32 endpoint/RTL equivalence only permits a registered exact item"
+        )
+    expected_proposal_id, descriptor_scheduler = variant
     if str(proposal_id or "").strip() != expected_proposal_id:
         raise Layer2TaskGenerationError("score32 endpoint/RTL equivalence proposal_id mismatch")
     if str(proposal_path or "").strip() != f"docs/proposals/{expected_proposal_id}/proposal.json":
@@ -5610,6 +5618,8 @@ def _decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_evidence(
             measured_costs,
             "--wall-timeout-seconds",
             "2400",
+            "--descriptor-scheduler",
+            descriptor_scheduler,
             "--out",
             out,
             "--report",
@@ -5646,7 +5656,12 @@ def _decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_evidence(
             "Use one-cycle in-order source SRAM responses, four-entry TX descriptor FIFOs, eight outstanding reads, and eight RX contexts",
             "Require exact performance/RTL agreement for packets, flits, drain cycles, contention, stalls, and occupancy",
             "Require zero endpoint protocol errors and concrete 8-bit wire tags",
-            "Keep SRAM bitcells, synthesized command scheduler, workload activity power, and HBM/DRAM explicit",
+            (
+                "Require the serial paired command scheduler RTL in the composed replay"
+                if descriptor_scheduler == "serial_paired"
+                else "Keep synthesized command scheduler PPA explicit"
+            ),
+            "Keep SRAM bitcells, workload activity power, and HBM/DRAM explicit",
             "Write exactly one JSON and one Markdown report",
         ],
     }

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -14824,7 +14824,26 @@ def test_generate_l2_campaign_task_adds_score32_noc_composed_mesh_reroute() -> N
             )
 
 
-def test_generate_l2_campaign_task_adds_score32_endpoint_rtl_equivalence() -> None:
+@pytest.mark.parametrize(
+    ("item_suffix", "proposal_suffix", "descriptor_scheduler"),
+    [
+        (
+            "endpoint_rtl_equivalence_llama7b_v1",
+            "endpoint_rtl_equivalence_v1",
+            "endpoint_parallel",
+        ),
+        (
+            "serial_scheduler_equivalence_llama7b_v1",
+            "serial_scheduler_equivalence_v1",
+            "serial_paired",
+        ),
+    ],
+)
+def test_generate_l2_campaign_task_adds_score32_endpoint_rtl_equivalence(
+    item_suffix: str,
+    proposal_suffix: str,
+    descriptor_scheduler: str,
+) -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"
         repo_root.mkdir()
@@ -14841,17 +14860,17 @@ def test_generate_l2_campaign_task_adds_score32_endpoint_rtl_equivalence() -> No
                     campaign_path=campaign_path,
                     item_id=(
                         "l2_decoder_attention_score32_noc_phase2_"
-                        "endpoint_rtl_equivalence_llama7b_v1"
+                        f"{item_suffix}"
                     ),
                     requested_by="@tester",
                     source_commit=source_commit,
                     proposal_id=(
                         "prop_l2_decoder_attention_score32_noc_phase2_"
-                        "endpoint_rtl_equivalence_v1"
+                        f"{proposal_suffix}"
                     ),
                     proposal_path=(
                         "docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_"
-                        "endpoint_rtl_equivalence_v1/proposal.json"
+                        f"{proposal_suffix}/proposal.json"
                     ),
                     abstraction_layer=(
                         "decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence"
@@ -14870,11 +14889,12 @@ def test_generate_l2_campaign_task_adds_score32_endpoint_rtl_equivalence() -> No
             assert "--memory-high 4G" in run
             assert "--memory-max 6G" in run
             assert "--wall-timeout-seconds 2400" in run
+            assert f"--descriptor-scheduler {descriptor_scheduler}" in run
             assert work_item.input_manifest["worker_resources"]["exclusive_worker"] is True
             assert work_item.input_manifest["worker_resources"]["stall_timeout_seconds"] == 1200
             assert work_item.expected_outputs[0].endswith(
                 "decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence__"
-                "l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_llama7b_v1.json"
+                f"l2_decoder_attention_score32_noc_phase2_{item_suffix}.json"
             )
 
 

--- a/docs/architecture/llama7b_attention_abstraction_closure_plan.md
+++ b/docs/architecture/llama7b_attention_abstraction_closure_plan.md
@@ -250,6 +250,20 @@ evidence gaps:
   composed test proves simultaneous multihop packets and exact data/address
   delivery. Endpoint receive logic now rejects a flit whose destination does
   not name the local endpoint.
+- Command scheduling: `noc_descriptor_pair_scheduler` now embodies the
+  previously testbench-only packet issuer as a one-active-command controller.
+  It gates on the concrete release cycle, holds RX and TX descriptors under
+  endpoint backpressure, enforces an RX handshake on an earlier edge than TX,
+  and accepts a replacement command when TX completes. The matching
+  `serial_paired` performance policy is exact against composed RTL on the
+  focused contention case and the complete 11,576-packet/92,128-flit replay.
+  Full drain is 397,227 cycles, only 24 cycles above the merged parallel-issuer
+  baseline, while contention/input stalls/peak occupancy fall from
+  30,285/46,504/11 to 8,736/11,816/7. The prepared L1 PPA item and remote L2
+  reproduction are required before removing scheduler cost and cadence from
+  the abstraction list. Its external command record is 102 bits; command SRAM
+  bitcells and prefetch service remain separate macro/interface evidence
+  rather than hidden flops.
 - Physical composition: the prepared
   `l1_noc_sram_packet_mesh4x4_composed_ppa_v1` item places the complete
   endpoint/mesh hierarchy at the same initial floorplan envelope as the

--- a/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/README.md
+++ b/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/README.md
@@ -1,0 +1,4 @@
+# NoC Descriptor Pair Scheduler
+
+This proposal replaces the testbench-only Phase-2 packet descriptor issuer
+with synthesizable RX-before-TX control and measures its Nangate45 PPA.

--- a/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/analysis_report.md
+++ b/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/analysis_report.md
@@ -1,0 +1,10 @@
+# Analysis Report
+
+Measured PPA is pending. Functional evidence establishes one RX and one TX
+handshake per valid command with a two-cycle minimum issue cadence.
+
+The complete local Llama7B replay drained 11,576 packets and 92,128 flits in
+397,227 cycles with exact RTL/performance agreement. This is 24 cycles slower
+than the merged endpoint-parallel issuer result, while router contention fell
+from 30,285 to 8,736 cycles, input stalls from 46,504 to 11,816 cycles, and
+peak router occupancy from 11 to 7.

--- a/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/design_brief.md
+++ b/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/design_brief.md
@@ -1,0 +1,11 @@
+# Design Brief
+
+The controller holds one command containing release cycle, source,
+destination, VC, tag, TX/RX base addresses, and flit count. After release it
+holds the destination RX descriptor until accepted, then holds the source TX
+descriptor until accepted. A completing TX may be replaced by the next command
+on the same edge. This gives a deterministic minimum cadence of two cycles per
+packet without allowing packet arrival to race RX context allocation.
+
+The command record is 102 bits (`32+4+4+2+8+24+24+4`). Its backing SRAM is not
+implemented as flops in this block; capacity is reported and costed separately.

--- a/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/evaluation_gate.md
@@ -1,0 +1,4 @@
+# Evaluation Gate
+
+Pending remote Nangate45 sweep after the evaluator image passes initializer
+and OpenROAD-directory ownership preflight.

--- a/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/evaluation_requests.json
@@ -1,0 +1,31 @@
+{
+  "proposal_id": "prop_l1_noc_descriptor_pair_scheduler_v1",
+  "source_commit": "TBD",
+  "requested_items": [
+    {
+      "item_id": "l1_noc_descriptor_pair_scheduler_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the synthesizable sixteen-endpoint paired descriptor scheduler.",
+      "evaluation_mode": "ppa",
+      "abstraction_layer": "architecture_block",
+      "config_paths": [
+        "runs/designs/noc/l1_noc_descriptor_pair_scheduler_n16_wrapper/config_l1_noc_descriptor_pair_scheduler_n16.json"
+      ],
+      "sweep_path": "runs/campaigns/noc/l1_descriptor_pair_scheduler/sweeps/nangate45_macro_frontier.json",
+      "expected_outputs": [
+        "runs/designs/noc/l1_noc_descriptor_pair_scheduler_n16_wrapper/metrics.csv"
+      ],
+      "status": "pending_after_proposal_merge",
+      "comparison_role": "phase2_descriptor_scheduler_physical_anchor",
+      "paired_baseline_item_id": "",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_phase2_descriptor_scheduler",
+        "reason": "Replace testbench-only command issue with concrete controller timing, area, and vectorless power."
+      },
+      "acceptance_notes": "Require RX-before-TX protocol simulation, exact generated hierarchy, all command fields retained, protocol_error=0, and timing/area/power rows for the requested sweep. Treat the result as scheduler-plus-harness evidence, not command-SRAM or workload-activity evidence."
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/implementation_summary.md
@@ -1,0 +1,8 @@
+# Implementation Summary
+
+- Added synthesizable paired descriptor scheduler RTL.
+- Added a PPA harness with varying commands, endpoint backpressure, counters,
+  and active-lane observation.
+- Added direct-generator support, an exact source manifest, config, and sweep.
+- Added protocol and generated-hierarchy tests.
+- Added a matching serial policy to the endpoint/mesh performance model.

--- a/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/promotion_decision.json
+++ b/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/promotion_decision.json
@@ -1,0 +1,9 @@
+{
+  "proposal_id": "prop_l1_noc_descriptor_pair_scheduler_v1",
+  "candidate_id": "",
+  "decision": "iterate",
+  "reason": "Functional implementation is complete; remote physical evidence is pending.",
+  "evidence_refs": [],
+  "next_action": "run l1_noc_descriptor_pair_scheduler_v1",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/promotion_gate.md
+++ b/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/promotion_gate.md
@@ -1,0 +1,4 @@
+# Promotion Gate
+
+Promote only after timing-feasible PPA is recorded and the full Llama7B serial
+scheduler RTL/performance replay matches exactly.

--- a/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/promotion_result.json
+++ b/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l1_noc_descriptor_pair_scheduler_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/proposal.json
+++ b/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/proposal.json
@@ -1,0 +1,61 @@
+{
+  "proposal_id": "prop_l1_noc_descriptor_pair_scheduler_v1",
+  "created_utc": "2026-08-18T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "abstraction_layer": "architecture_block",
+  "title": "Embody the Phase-2 paired descriptor scheduler",
+  "hypothesis": "A single-command RX-before-TX scheduler is small enough to be negligible beside the endpoint/mesh while sustaining the burst cadence of the complete Llama7B Phase-2 workload.",
+  "direct_comparison": {
+    "primary_question": "What PPA and issue cadence replace the unmeasured deterministic testbench descriptor scheduler?",
+    "include": [
+      "one active 102-bit packet command",
+      "release-cycle gating",
+      "receive descriptor installation before transmit submission",
+      "endpoint backpressure",
+      "same-edge command replacement after transmit acceptance",
+      "sixteen endpoint descriptor interfaces"
+    ],
+    "exclude": [
+      "external command SRAM bitcells",
+      "endpoint and router logic",
+      "HBM/DRAM",
+      "workload-matched switching power"
+    ]
+  },
+  "expected_benefit": [
+    "remove synthesized command-scheduler PPA from the Phase-2 abstraction list",
+    "establish a concrete one-command-per-two-cycle scheduling policy",
+    "bound command storage separately as a 102-bit external SRAM record"
+  ],
+  "risks": [
+    "global serialization may increase congestion or drain latency",
+    "the physical harness contributes disclosed source, backpressure, and observation logic",
+    "command SRAM capacity and macro energy remain separate physical evidence"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l1_noc_descriptor_pair_scheduler_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the synthesizable sixteen-endpoint paired descriptor scheduler.",
+      "evaluation_mode": "ppa",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "phase2_descriptor_scheduler_physical_anchor",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "config_paths": [
+        "runs/designs/noc/l1_noc_descriptor_pair_scheduler_n16_wrapper/config_l1_noc_descriptor_pair_scheduler_n16.json"
+      ],
+      "sweep_path": "runs/campaigns/noc/l1_descriptor_pair_scheduler/sweeps/nangate45_macro_frontier.json",
+      "expected_outputs": [
+        "runs/designs/noc/l1_noc_descriptor_pair_scheduler_n16_wrapper/metrics.csv"
+      ]
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_v1/proposal.json",
+    "npu/sim/rtl/noc_sram_packet_mesh4x4.sv"
+  ]
+}

--- a/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/quality_gate.md
@@ -1,0 +1,9 @@
+# Quality Gate
+
+- `pytest -q tests/test_noc_descriptor_pair_scheduler.py`
+- Require valid-command RX-before-TX ordering and held-valid backpressure.
+- Require invalid commands to set sticky `protocol_error` without submission.
+- Require all generated scheduler sources in OpenROAD `VERILOG_FILES`.
+- Require generated wrapper elaboration with Icarus Verilog.
+
+Status: passed locally; physical evaluation pending.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/README.md
@@ -1,0 +1,4 @@
+# Phase-2 Serial Scheduler Equivalence
+
+Replay every Llama7B Phase-2 packet through the synthesized paired scheduler,
+finite endpoints, and composed 4x4 mesh, with exact performance/RTL counters.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/analysis_report.md
@@ -1,0 +1,16 @@
+# Analysis Report
+
+The 8-packet contention case matches exactly at 88 cycles, 171 contention
+cycles, 53 input stalls, and peak router occupancy 29.
+
+The complete local Llama7B replay also matches exactly:
+
+- packets/flits: 11,576 / 92,128
+- serial scheduler drain: 397,227 cycles
+- merged endpoint-parallel baseline: 397,203 cycles
+- serialization cost: 24 cycles (0.006%)
+- contention: 8,736 versus 30,285 baseline
+- input stalls: 11,816 versus 46,504 baseline
+- peak occupancy: 7 versus 11 baseline
+
+Remote reproduction remains the promotion evidence.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/design_brief.md
@@ -1,0 +1,6 @@
+# Design Brief
+
+The replay streams globally ordered 102-bit command records from an external
+memory model into the concrete scheduler. The scheduler alone drives endpoint
+RX/TX descriptors. All packet payload, SRAM-port, endpoint, router, and
+completion behavior remains identical to the merged finite endpoint baseline.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/evaluation_gate.md
@@ -1,0 +1,4 @@
+# Evaluation Gate
+
+Focused and full-workload local equivalence pass. Full remote reproduction is
+pending proposal merge and evaluator source refresh.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/evaluation_requests.json
@@ -1,0 +1,23 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1",
+  "source_commit": "TBD",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Prove full-workload equivalence and measure cadence with the serial paired scheduler.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence",
+      "comparison_role": "scheduler_closure_detail",
+      "status": "pending_after_proposal_merge",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": false,
+      "requires_materialized_refs": false,
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence__l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_llama7b_v1.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence__l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_llama7b_v1.md"
+      ],
+      "acceptance_notes": "Require all 11,576 packets and 92,128 flits, scheduler RX-before-TX ordering, zero protocol errors, and exact performance/RTL agreement for drain cycles, contention, stalls, and occupancy. Compare directly with the merged endpoint-parallel issuer baseline."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/implementation_summary.md
@@ -1,0 +1,7 @@
+# Implementation Summary
+
+- Added `serial_paired` scheduling to the packet-mesh performance model.
+- Added global command-order memory generation.
+- Added selectable scheduler RTL composition to the full workload testbench.
+- Added remote task generation for a distinct serial-scheduler revision.
+- Preserved the historical endpoint-parallel replay as the default API mode.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/promotion_decision.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/promotion_decision.json
@@ -1,0 +1,9 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1",
+  "candidate_id": "",
+  "decision": "iterate",
+  "reason": "Focused equivalence passes; full workload evidence is pending.",
+  "evidence_refs": [],
+  "next_action": "run l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_llama7b_v1",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/promotion_gate.md
@@ -1,0 +1,5 @@
+# Promotion Gate
+
+Promote only if the full serial-scheduler RTL replay exactly matches the
+performance model and its token-cadence delta is incorporated into the final
+frontier recost.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/promotion_result.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/proposal.json
@@ -1,0 +1,56 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1",
+  "created_utc": "2026-08-18T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "equivalence",
+  "title": "Workload-complete synthesized descriptor scheduler equivalence",
+  "hypothesis": "The area-conservative serial paired scheduler fits between Llama7B release waves without materially reducing token throughput while exactly matching composed RTL behavior.",
+  "direct_comparison": {
+    "primary_question": "How do drain time and congestion move when the abstract endpoint-parallel issuer is replaced by the synthesizable serial paired scheduler?",
+    "include": [
+      "all eight waves and every canonical packet",
+      "synthesizable global paired scheduler",
+      "finite TX queues and RX contexts",
+      "one-cycle SRAM transaction ports",
+      "all sixteen endpoints and routers",
+      "exact cycle and router-counter comparison"
+    ],
+    "exclude": [
+      "command and packet SRAM bitcells",
+      "workload-derived switching power",
+      "HBM/DRAM controller implementation"
+    ]
+  },
+  "expected_benefit": [
+    "remove the logical command-issuer timing abstraction",
+    "quantify scheduler serialization at full Llama7B scale",
+    "provide exact cadence for final physical recost"
+  ],
+  "risks": [
+    "global serialization may expose head-of-line blocking",
+    "transaction-accurate SRAM ports still require macro composition",
+    "functional replay does not provide workload switching energy"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Prove full-workload equivalence and measure cadence with the serial paired scheduler.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence",
+      "comparison_role": "scheduler_closure_detail",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": false,
+      "requires_materialized_refs": false,
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence__l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_llama7b_v1.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence__l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_llama7b_v1.md"
+      ]
+    }
+  ],
+  "baseline_refs": [
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence__l2_decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_llama7b_v1.json",
+    "docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/proposal.json"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/quality_gate.md
@@ -1,0 +1,7 @@
+# Quality Gate
+
+- Focused composed stress case must match RTL and performance simulation on
+  packets, flits, cycles, contention, stalls, and occupancy.
+- Full replay must cover all eight waves, `11,576` packets, and `92,128` flits.
+- Every RX descriptor must precede its paired TX descriptor.
+- Endpoint and scheduler protocol-error vectors must remain zero.

--- a/examples/about_config.md
+++ b/examples/about_config.md
@@ -489,13 +489,19 @@ divisible by 16.
 `primitive: "endpoint"` emits a ready/valid on-chip service endpoint with
 finite endpoint buffering, finite per-bank queues, locality-first bank
 draining, and synthetic producer/consumer backpressure.
+`primitive: "sram_packet_endpoint"` emits the finite descriptor-driven packet
+endpoint. `primitive: "sram_packet_mesh4x4"` emits its full 16-endpoint,
+16-router composition. `primitive: "descriptor_pair_scheduler"` emits the
+synthesizable sixteen-endpoint command controller that waits for release,
+installs each RX descriptor, and only then submits its paired TX descriptor.
 
 Supported common options are `primitive`, `flit_bits`, `depth`, `ports`, and
 `counter_bits`. Segmented-router and segmented-mesh options are `vc_count`,
 `dest_bits`, `source_bits`, `tag_bits`, and `fragment_bits`; the single-router
 form also accepts `x_coord` and `y_coord`.
 Endpoint-specific options are `banks`, `endpoint_depth`, and
-`bank_queue_depth`.
+`bank_queue_depth`. Packet-endpoint options include `addr_bits`,
+`flit_count_bits`, `tx_desc_depth`, `tx_outstanding`, and `rx_contexts`.
 
 See `examples/config_l1_memory_noc_primitive.json` for a FIFO smoke
 configuration and `examples/config_l1_onchip_service_endpoint.json` for an

--- a/npu/eval/verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py
+++ b/npu/eval/verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py
@@ -40,6 +40,7 @@ RTL_SOURCES = (
     Path("npu/sim/rtl/noc_sram_packet_endpoint.sv"),
     Path("npu/sim/rtl/noc_sram_packet_mesh4x4.sv"),
 )
+SCHEDULER_RTL_SOURCE = Path("npu/sim/rtl/noc_descriptor_pair_scheduler.sv")
 RTL_TB = Path("tests/noc_sram_packet_mesh4x4_workload_tb.sv")
 PASS_RE = re.compile(
     r"PASS workload packets=(?P<packets>\d+) flits=(?P<flits>\d+) "
@@ -64,6 +65,7 @@ class WorkloadPacket:
 @dataclass(frozen=True)
 class WorkloadMemoryPaths:
     descriptors: Path
+    command_order: Path
     source_order: Path
     destination_order: Path
     source_meta: Path
@@ -153,6 +155,7 @@ def write_workload_memories(
         raise ValueError("RTL workload must contain at least one packet")
     output_dir.mkdir(parents=True, exist_ok=True)
     descriptors = output_dir / "descriptors.mem"
+    command_order_path = output_dir / "command_order.mem"
     source_order_path = output_dir / "source_order.mem"
     destination_order_path = output_dir / "destination_order.mem"
     source_meta_path = output_dir / "source_meta.mem"
@@ -177,6 +180,21 @@ def write_workload_memories(
         words.append(word)
     _write_hex_lines(descriptors, words, 24)
 
+    command_order = [
+        packet.packet_id
+        for packet in sorted(
+            packets,
+            key=lambda packet: (
+                packet.release_cycle,
+                packet.schedule_order,
+                packet.packet_id,
+            ),
+        )
+    ]
+    if sorted(command_order) != list(range(len(packets))):
+        raise ValueError("global command order is not a packet permutation")
+    _write_hex_lines(command_order_path, command_order, 4)
+
     source_order, source_meta = _queue_order_and_meta(packets, endpoint_field="source")
     destination_order, destination_meta = _queue_order_and_meta(
         packets, endpoint_field="destination"
@@ -187,6 +205,7 @@ def write_workload_memories(
     _write_hex_lines(destination_meta_path, destination_meta, 8)
     return WorkloadMemoryPaths(
         descriptors=descriptors,
+        command_order=command_order_path,
         source_order=source_order_path,
         destination_order=destination_order_path,
         source_meta=source_meta_path,
@@ -201,20 +220,30 @@ def run_rtl_replay(
     work_dir: Path,
     timeout_cycles: int,
     wall_timeout_seconds: int,
+    descriptor_scheduler: str = "endpoint_parallel",
 ) -> JsonDict:
+    if descriptor_scheduler not in ("endpoint_parallel", "serial_paired"):
+        raise ValueError(
+            "descriptor_scheduler must be endpoint_parallel or serial_paired"
+        )
     memories = write_workload_memories(packets, work_dir)
     simulator = work_dir / "phase2_endpoint_mesh.vvp"
+    compile_command = [
+        _tool("iverilog"),
+        "-g2012",
+        "-s",
+        "noc_sram_packet_mesh4x4_workload_tb",
+        "-o",
+        str(simulator),
+    ]
+    if descriptor_scheduler == "serial_paired":
+        compile_command.extend(
+            ["-DSERIAL_PAIRED_SCHEDULER", str(repo_root / SCHEDULER_RTL_SOURCE)]
+        )
+    compile_command.extend(str(repo_root / path) for path in RTL_SOURCES)
+    compile_command.append(str(repo_root / RTL_TB))
     compile_result = subprocess.run(
-        [
-            _tool("iverilog"),
-            "-g2012",
-            "-s",
-            "noc_sram_packet_mesh4x4_workload_tb",
-            "-o",
-            str(simulator),
-            *[str(repo_root / path) for path in RTL_SOURCES],
-            str(repo_root / RTL_TB),
-        ],
+        compile_command,
         cwd=repo_root,
         check=False,
         capture_output=True,
@@ -234,6 +263,7 @@ def run_rtl_replay(
         f"+EXPECTED_FLITS={expected_flits}",
         f"+TIMEOUT_CYCLES={timeout_cycles}",
         f"+DESC_MEM={memories.descriptors}",
+        f"+CMD_ORDER_MEM={memories.command_order}",
         f"+SRC_ORDER_MEM={memories.source_order}",
         f"+DST_ORDER_MEM={memories.destination_order}",
         f"+SRC_META_MEM={memories.source_meta}",
@@ -306,6 +336,7 @@ def run_performance_replay(
     packets: list[WorkloadPacket],
     *,
     max_cycles: int,
+    descriptor_scheduler: str = "endpoint_parallel",
 ) -> JsonDict:
     result = simulate_packet_mesh(
         [
@@ -324,6 +355,7 @@ def run_performance_replay(
             )
             for packet in packets
         ],
+        descriptor_scheduler=descriptor_scheduler,
         max_cycles=max_cycles,
         fast_forward_idle=True,
     )
@@ -389,7 +421,11 @@ def build_and_run(args: argparse.Namespace) -> JsonDict:
     packet_specs: list[PacketSpec] = []
     schedule = build_report(_schedule_args(args), packet_spec_output=packet_specs)
     packets = descriptors_from_packet_specs(packet_specs)
-    performance = run_performance_replay(packets, max_cycles=args.rtl_timeout_cycles)
+    performance = run_performance_replay(
+        packets,
+        max_cycles=args.rtl_timeout_cycles,
+        descriptor_scheduler=args.descriptor_scheduler,
+    )
     with tempfile.TemporaryDirectory(prefix="rtlgen-phase2-endpoint-rtl-") as temporary:
         replay = run_rtl_replay(
             repo_root=args.repo_root.resolve(),
@@ -397,6 +433,7 @@ def build_and_run(args: argparse.Namespace) -> JsonDict:
             work_dir=Path(temporary),
             timeout_cycles=args.rtl_timeout_cycles,
             wall_timeout_seconds=args.wall_timeout_seconds,
+            descriptor_scheduler=args.descriptor_scheduler,
         )
     counters = replay["counters"]
     compared_fields = ("packets", "flits", "cycles", "contention", "input_stalls", "max_occupancy")
@@ -409,7 +446,8 @@ def build_and_run(args: argparse.Namespace) -> JsonDict:
         raise ValueError(f"endpoint-aware performance/RTL mismatch: {mismatches}")
     return {
         "profile": "decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence",
-        "version": 1,
+        "version": 2,
+        "descriptor_scheduler": args.descriptor_scheduler,
         "coverage": schedule["source_contract"]["coverage"],
         "source_schedule": {
             "packet_count": schedule["simulation"]["scheduled_packet_count"],
@@ -434,7 +472,14 @@ def build_and_run(args: argparse.Namespace) -> JsonDict:
         },
         "remaining_abstractions": [
             "SRAM arrays are transaction-accurate one-cycle ports; bitcells and macro placement remain external.",
-            "The command scheduler is embodied by the deterministic paired-descriptor testbench driver, not yet synthesized RTL.",
+            "The 102-bit command records are supplied by an external command-memory/prefetch interface; its SRAM bitcells remain macro evidence.",
+            *(
+                []
+                if args.descriptor_scheduler == "serial_paired"
+                else [
+                    "The command scheduler is embodied by the deterministic paired-descriptor testbench driver, not synthesized RTL."
+                ]
+            ),
             "HBM/DRAM and its controller remain intentionally outside the design boundary.",
             "Workload-matched switching power requires a separate activity-capture run.",
         ],
@@ -449,6 +494,7 @@ def write_report(payload: JsonDict, path: Path) -> None:
         "# Llama7B Phase-2 Endpoint/RTL Equivalence",
         "",
         f"- coverage: `{payload['coverage']}`",
+        f"- descriptor scheduler: `{payload['descriptor_scheduler']}`",
         f"- packets/flits: `{rtl['packets']}` / `{rtl['flits']}`",
         f"- logical release-queue drain: `{source['logical_release_queue_cycles_to_drain']}` cycles",
         f"- finite endpoint/RTL drain: `{rtl['cycles']}` cycles",
@@ -476,6 +522,11 @@ def main() -> int:
     parser.add_argument("--schedule-max-cycles", type=int, default=1000000)
     parser.add_argument("--rtl-timeout-cycles", type=int, default=2000000)
     parser.add_argument("--wall-timeout-seconds", type=int, default=1800)
+    parser.add_argument(
+        "--descriptor-scheduler",
+        choices=("endpoint_parallel", "serial_paired"),
+        default="serial_paired",
+    )
     parser.add_argument("--out", type=Path, required=True)
     parser.add_argument("--report", type=Path, required=True)
     args = parser.parse_args()

--- a/npu/sim/perf/noc_sram_packet_mesh.py
+++ b/npu/sim/perf/noc_sram_packet_mesh.py
@@ -407,6 +407,7 @@ def _ordered_indices(descriptors: Sequence[PacketDescriptor]) -> tuple[int, ...]
 def simulate_packet_mesh(
     descriptors: Iterable[PacketDescriptor],
     *,
+    descriptor_scheduler: str = "endpoint_parallel",
     destination_sram_ready_schedule: ReadySchedule = None,
     source_sram_request_ready_schedule: ReadySchedule = None,
     completion_ready_schedule: ReadySchedule = None,
@@ -416,12 +417,18 @@ def simulate_packet_mesh(
 ) -> PacketMeshResult:
     """Simulate paired descriptors and the existing registered-credit mesh.
 
-    RX descriptors are scheduled one per destination endpoint per cycle.  A
-    TX descriptor is eligible only in a cycle strictly after its RX handshake,
-    and is scheduled one per source endpoint per cycle.  Ready schedules are
-    indexed as ``[cycle][endpoint]``; a callable may be used for large replay
-    workloads without materializing a matrix.
+    ``endpoint_parallel`` schedules one RX per destination and one TX per
+    source each cycle, preserving the original abstract scheduler.  The
+    synthesizable ``serial_paired`` policy holds one global command, installs
+    its RX descriptor first, and submits its TX descriptor on a later edge.
+    Ready schedules are indexed as ``[cycle][endpoint]``; a callable may be
+    used for large replay workloads without materializing a matrix.
     """
+
+    if descriptor_scheduler not in ("endpoint_parallel", "serial_paired"):
+        raise ValueError(
+            "descriptor_scheduler must be endpoint_parallel or serial_paired"
+        )
 
     packet_list = tuple(descriptors)
     if not packet_list:
@@ -454,6 +461,9 @@ def simulate_packet_mesh(
     rx_done: list[int | None] = [None] * len(packet_list)
     tx_done: list[int | None] = [None] * len(packet_list)
     ordered_indices = _ordered_indices(packet_list)
+    scheduler_pending = deque(ordered_indices)
+    scheduler_active: int | None = None
+    scheduler_receive_installed = False
     rx_queues = [deque() for _ in range(ENDPOINTS)]
     tx_queues = [deque() for _ in range(ENDPOINTS)]
     for index in ordered_indices:
@@ -489,9 +499,16 @@ def simulate_packet_mesh(
                 for state in states
             )
             if endpoints_idle and all(router.idle() for router in routers):
-                pending_releases = [
-                    packet_list[queue[0]].release_cycle for queue in rx_queues if queue
-                ]
+                if descriptor_scheduler == "serial_paired":
+                    pending_releases = (
+                        [packet_list[scheduler_active].release_cycle]
+                        if scheduler_active is not None
+                        else []
+                    )
+                else:
+                    pending_releases = [
+                        packet_list[queue[0]].release_cycle for queue in rx_queues if queue
+                    ]
                 if pending_releases:
                     next_release = min(pending_releases)
                     if next_release >= max_cycles:
@@ -502,29 +519,39 @@ def simulate_packet_mesh(
         # An RX handshake at this edge cannot make a same-edge TX release
         # legal, matching the RTL's registered descriptor state.
         rx_push: dict[int, int] = {}
-        for endpoint, queue in enumerate(rx_queues):
-            if not queue:
-                continue
-            index = queue[0]
-            descriptor = packet_list[index]
-            if (
-                descriptor.release_cycle <= cycle
-                and states[endpoint].rx_desc_ready(descriptor)
-            ):
-                rx_push[endpoint] = index
-
         tx_push: dict[int, int] = {}
-        for endpoint, queue in enumerate(tx_queues):
-            if not queue or not states[endpoint].tx_desc_ready():
-                continue
-            index = queue[0]
-            descriptor = packet_list[index]
-            if (
-                rx_done[index] is not None
-                and rx_done[index] < cycle
-                and descriptor.release_cycle <= cycle
-            ):
-                tx_push[endpoint] = index
+        if descriptor_scheduler == "serial_paired":
+            if scheduler_active is not None:
+                descriptor = packet_list[scheduler_active]
+                if descriptor.release_cycle <= cycle:
+                    if not scheduler_receive_installed:
+                        if states[descriptor.destination].rx_desc_ready(descriptor):
+                            rx_push[descriptor.destination] = scheduler_active
+                    elif states[descriptor.source].tx_desc_ready():
+                        tx_push[descriptor.source] = scheduler_active
+        else:
+            for endpoint, queue in enumerate(rx_queues):
+                if not queue:
+                    continue
+                index = queue[0]
+                descriptor = packet_list[index]
+                if (
+                    descriptor.release_cycle <= cycle
+                    and states[endpoint].rx_desc_ready(descriptor)
+                ):
+                    rx_push[endpoint] = index
+
+            for endpoint, queue in enumerate(tx_queues):
+                if not queue or not states[endpoint].tx_desc_ready():
+                    continue
+                index = queue[0]
+                descriptor = packet_list[index]
+                if (
+                    rx_done[index] is not None
+                    and rx_done[index] < cycle
+                    and descriptor.release_cycle <= cycle
+                ):
+                    tx_push[endpoint] = index
 
         tx_pop = [state.tx_pop_ready() for state in states]
         tx_requests_by_endpoint: list[SourceMemoryRequest | None] = [None] * ENDPOINTS
@@ -674,6 +701,10 @@ def simulate_packet_mesh(
                 rx_handshakes.append(
                     DescriptorHandshake(cycle, endpoint, "rx", index, packet_list[index])
                 )
+                if descriptor_scheduler == "serial_paired":
+                    if scheduler_active != index or scheduler_receive_installed:
+                        raise RuntimeError("serial RX scheduler state diverged")
+                    scheduler_receive_installed = True
             if endpoint in tx_push:
                 index = tx_push[endpoint]
                 if not tx_queues[endpoint] or tx_queues[endpoint][0] != index:
@@ -684,6 +715,11 @@ def simulate_packet_mesh(
                 tx_handshakes.append(
                     DescriptorHandshake(cycle, endpoint, "tx", index, packet_list[index])
                 )
+                if descriptor_scheduler == "serial_paired":
+                    if scheduler_active != index or not scheduler_receive_installed:
+                        raise RuntimeError("serial TX scheduler state diverged")
+                    scheduler_active = None
+                    scheduler_receive_installed = False
             if state.completion is not None and _ready(completion_ready_schedule, cycle, endpoint):
                 packet_index_completion, completion = state.completion
                 completion_handshakes.append(
@@ -699,6 +735,16 @@ def simulate_packet_mesh(
                 # The RTL clears the held completion at this edge.  A new
                 # final RX flit in the same edge may install the next event.
                 state.completion = None
+
+        # The external command memory can fill an empty scheduler or replace
+        # a command whose TX descriptor handshook on this edge.  Its newly
+        # accepted command cannot drive endpoint outputs until the next cycle.
+        if (
+            descriptor_scheduler == "serial_paired"
+            and scheduler_active is None
+            and scheduler_pending
+        ):
+            scheduler_active = scheduler_pending.popleft()
 
         for endpoint, event in enumerate(rx_flit_events):
             if event is None:

--- a/npu/sim/rtl/noc_descriptor_pair_scheduler.sv
+++ b/npu/sim/rtl/noc_descriptor_pair_scheduler.sv
@@ -1,0 +1,174 @@
+`timescale 1ns/1ps
+
+// Converts a producer-fed packet command stream into endpoint descriptors.
+// Receive state is installed before the corresponding transmit descriptor is
+// released, so packet arrival cannot race destination context allocation.
+module noc_descriptor_pair_scheduler #(
+  parameter integer NODES = 16,
+  parameter integer ENDPOINT_W = 4,
+  parameter integer VC_W = 2,
+  parameter integer TAG_W = 8,
+  parameter integer ADDR_W = 24,
+  parameter integer FLIT_COUNT_W = 4,
+  parameter integer RELEASE_W = 32,
+  parameter integer COUNTER_W = 32
+) (
+  input wire clk,
+  input wire rst_n,
+  input wire [RELEASE_W-1:0] current_cycle,
+
+  input wire cmd_valid,
+  output wire cmd_ready,
+  input wire [RELEASE_W-1:0] cmd_release_cycle,
+  input wire [ENDPOINT_W-1:0] cmd_source,
+  input wire [ENDPOINT_W-1:0] cmd_destination,
+  input wire [VC_W-1:0] cmd_vc,
+  input wire [TAG_W-1:0] cmd_tag,
+  input wire [ADDR_W-1:0] cmd_tx_base_addr,
+  input wire [ADDR_W-1:0] cmd_rx_base_addr,
+  input wire [FLIT_COUNT_W-1:0] cmd_flit_count,
+
+  output reg [NODES-1:0] tx_desc_valid,
+  input wire [NODES-1:0] tx_desc_ready,
+  output reg [NODES*ENDPOINT_W-1:0] tx_desc_destination,
+  output reg [NODES*VC_W-1:0] tx_desc_vc,
+  output reg [NODES*TAG_W-1:0] tx_desc_tag,
+  output reg [NODES*ADDR_W-1:0] tx_desc_base_addr,
+  output reg [NODES*FLIT_COUNT_W-1:0] tx_desc_flit_count,
+
+  output reg [NODES-1:0] rx_desc_valid,
+  input wire [NODES-1:0] rx_desc_ready,
+  output reg [NODES*ENDPOINT_W-1:0] rx_desc_source,
+  output reg [NODES*VC_W-1:0] rx_desc_vc,
+  output reg [NODES*TAG_W-1:0] rx_desc_tag,
+  output reg [NODES*ADDR_W-1:0] rx_desc_base_addr,
+  output reg [NODES*FLIT_COUNT_W-1:0] rx_desc_flit_count,
+
+  output reg [COUNTER_W-1:0] accepted_command_count,
+  output reg [COUNTER_W-1:0] installed_receive_count,
+  output reg [COUNTER_W-1:0] submitted_transmit_count,
+  output reg [COUNTER_W-1:0] release_wait_cycles,
+  output reg [COUNTER_W-1:0] endpoint_stall_cycles,
+  output reg protocol_error
+);
+  reg command_active;
+  reg receive_installed;
+  reg [RELEASE_W-1:0] active_release_cycle;
+  reg [ENDPOINT_W-1:0] active_source;
+  reg [ENDPOINT_W-1:0] active_destination;
+  reg [VC_W-1:0] active_vc;
+  reg [TAG_W-1:0] active_tag;
+  reg [ADDR_W-1:0] active_tx_base_addr;
+  reg [ADDR_W-1:0] active_rx_base_addr;
+  reg [FLIT_COUNT_W-1:0] active_flit_count;
+
+  wire command_released = command_active && current_cycle >= active_release_cycle;
+  wire receive_valid = command_released && !receive_installed;
+  wire transmit_valid = command_released && receive_installed;
+  wire receive_fire = receive_valid && rx_desc_ready[active_destination];
+  wire transmit_fire = transmit_valid && tx_desc_ready[active_source];
+  wire command_fields_valid =
+    cmd_flit_count != {FLIT_COUNT_W{1'b0}} &&
+    cmd_source < NODES && cmd_destination < NODES;
+
+  // A completing transmit can be replaced without an idle queue cycle.
+  assign cmd_ready = !command_active || transmit_fire;
+
+  always @(*) begin
+    tx_desc_valid = {NODES{1'b0}};
+    tx_desc_destination = {(NODES*ENDPOINT_W){1'b0}};
+    tx_desc_vc = {(NODES*VC_W){1'b0}};
+    tx_desc_tag = {(NODES*TAG_W){1'b0}};
+    tx_desc_base_addr = {(NODES*ADDR_W){1'b0}};
+    tx_desc_flit_count = {(NODES*FLIT_COUNT_W){1'b0}};
+    rx_desc_valid = {NODES{1'b0}};
+    rx_desc_source = {(NODES*ENDPOINT_W){1'b0}};
+    rx_desc_vc = {(NODES*VC_W){1'b0}};
+    rx_desc_tag = {(NODES*TAG_W){1'b0}};
+    rx_desc_base_addr = {(NODES*ADDR_W){1'b0}};
+    rx_desc_flit_count = {(NODES*FLIT_COUNT_W){1'b0}};
+
+    if (receive_valid) begin
+      rx_desc_valid[active_destination] = 1'b1;
+      rx_desc_source[(active_destination*ENDPOINT_W) +: ENDPOINT_W] = active_source;
+      rx_desc_vc[(active_destination*VC_W) +: VC_W] = active_vc;
+      rx_desc_tag[(active_destination*TAG_W) +: TAG_W] = active_tag;
+      rx_desc_base_addr[(active_destination*ADDR_W) +: ADDR_W] = active_rx_base_addr;
+      rx_desc_flit_count[(active_destination*FLIT_COUNT_W) +: FLIT_COUNT_W] = active_flit_count;
+    end
+    if (transmit_valid) begin
+      tx_desc_valid[active_source] = 1'b1;
+      tx_desc_destination[(active_source*ENDPOINT_W) +: ENDPOINT_W] = active_destination;
+      tx_desc_vc[(active_source*VC_W) +: VC_W] = active_vc;
+      tx_desc_tag[(active_source*TAG_W) +: TAG_W] = active_tag;
+      tx_desc_base_addr[(active_source*ADDR_W) +: ADDR_W] = active_tx_base_addr;
+      tx_desc_flit_count[(active_source*FLIT_COUNT_W) +: FLIT_COUNT_W] = active_flit_count;
+    end
+  end
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      command_active <= 1'b0;
+      receive_installed <= 1'b0;
+      active_release_cycle <= {RELEASE_W{1'b0}};
+      active_source <= {ENDPOINT_W{1'b0}};
+      active_destination <= {ENDPOINT_W{1'b0}};
+      active_vc <= {VC_W{1'b0}};
+      active_tag <= {TAG_W{1'b0}};
+      active_tx_base_addr <= {ADDR_W{1'b0}};
+      active_rx_base_addr <= {ADDR_W{1'b0}};
+      active_flit_count <= {FLIT_COUNT_W{1'b0}};
+      accepted_command_count <= {COUNTER_W{1'b0}};
+      installed_receive_count <= {COUNTER_W{1'b0}};
+      submitted_transmit_count <= {COUNTER_W{1'b0}};
+      release_wait_cycles <= {COUNTER_W{1'b0}};
+      endpoint_stall_cycles <= {COUNTER_W{1'b0}};
+      protocol_error <= 1'b0;
+    end else begin
+      if (command_active && current_cycle < active_release_cycle)
+        release_wait_cycles <= release_wait_cycles + 1'b1;
+      if ((receive_valid && !rx_desc_ready[active_destination]) ||
+          (transmit_valid && !tx_desc_ready[active_source]))
+        endpoint_stall_cycles <= endpoint_stall_cycles + 1'b1;
+
+      if (receive_fire) begin
+        receive_installed <= 1'b1;
+        installed_receive_count <= installed_receive_count + 1'b1;
+      end
+      if (transmit_fire) begin
+        command_active <= 1'b0;
+        receive_installed <= 1'b0;
+        submitted_transmit_count <= submitted_transmit_count + 1'b1;
+      end
+
+      if (cmd_valid && cmd_ready) begin
+        accepted_command_count <= accepted_command_count + 1'b1;
+        if (!command_fields_valid) begin
+          command_active <= 1'b0;
+          receive_installed <= 1'b0;
+          protocol_error <= 1'b1;
+        end else begin
+          command_active <= 1'b1;
+          receive_installed <= 1'b0;
+          active_release_cycle <= cmd_release_cycle;
+          active_source <= cmd_source;
+          active_destination <= cmd_destination;
+          active_vc <= cmd_vc;
+          active_tag <= cmd_tag;
+          active_tx_base_addr <= cmd_tx_base_addr;
+          active_rx_base_addr <= cmd_rx_base_addr;
+          active_flit_count <= cmd_flit_count;
+        end
+      end
+    end
+  end
+
+`ifndef SYNTHESIS
+  initial begin
+    if (NODES <= 1 || (1 << ENDPOINT_W) < NODES) begin
+      $error("noc_descriptor_pair_scheduler endpoint width cannot represent NODES");
+      $finish(1);
+    end
+  end
+`endif
+endmodule

--- a/npu/sim/rtl/noc_descriptor_pair_scheduler_ppa_harness.sv
+++ b/npu/sim/rtl/noc_descriptor_pair_scheduler_ppa_harness.sv
@@ -1,0 +1,137 @@
+`timescale 1ns/1ps
+
+module noc_descriptor_pair_scheduler_ppa_harness #(
+  parameter integer NODES = 16,
+  parameter integer DATA_W = 256,
+  parameter integer COUNTER_W = 32
+) (
+  input wire clk,
+  input wire rst_n,
+  output wire [COUNTER_W-1:0] accepted_command_count,
+  output wire [COUNTER_W-1:0] installed_receive_count,
+  output wire [COUNTER_W-1:0] submitted_transmit_count,
+  output wire [COUNTER_W-1:0] endpoint_stall_cycles,
+  output wire protocol_error,
+  output wire [DATA_W-1:0] observed_state
+);
+  reg [31:0] current_cycle;
+  reg cmd_valid;
+  wire cmd_ready;
+  reg [31:0] cmd_release_cycle;
+  reg [3:0] cmd_source;
+  reg [3:0] cmd_destination;
+  reg [1:0] cmd_vc;
+  reg [7:0] cmd_tag;
+  reg [23:0] cmd_tx_base_addr;
+  reg [23:0] cmd_rx_base_addr;
+  reg [3:0] cmd_flit_count;
+  wire [NODES-1:0] tx_desc_valid;
+  reg [NODES-1:0] tx_desc_ready;
+  wire [NODES*4-1:0] tx_desc_destination;
+  wire [NODES*2-1:0] tx_desc_vc;
+  wire [NODES*8-1:0] tx_desc_tag;
+  wire [NODES*24-1:0] tx_desc_base_addr;
+  wire [NODES*4-1:0] tx_desc_flit_count;
+  wire [NODES-1:0] rx_desc_valid;
+  reg [NODES-1:0] rx_desc_ready;
+  wire [NODES*4-1:0] rx_desc_source;
+  wire [NODES*2-1:0] rx_desc_vc;
+  wire [NODES*8-1:0] rx_desc_tag;
+  wire [NODES*24-1:0] rx_desc_base_addr;
+  wire [NODES*4-1:0] rx_desc_flit_count;
+  wire [COUNTER_W-1:0] release_wait_cycles;
+  reg [DATA_W-1:0] observed_state_r;
+  reg [3:0] tx_observed_index;
+  reg [3:0] rx_observed_index;
+  integer observed_i;
+
+  assign observed_state = observed_state_r;
+
+  always @(*) begin
+    tx_observed_index = 4'b0;
+    rx_observed_index = 4'b0;
+    for (observed_i = 0; observed_i < NODES; observed_i = observed_i + 1) begin
+      if (tx_desc_valid[observed_i] && tx_desc_ready[observed_i])
+        tx_observed_index = observed_i[3:0];
+      if (rx_desc_valid[observed_i] && rx_desc_ready[observed_i])
+        rx_observed_index = observed_i[3:0];
+    end
+  end
+
+  noc_descriptor_pair_scheduler #(
+    .NODES(NODES),
+    .COUNTER_W(COUNTER_W)
+  ) scheduler (
+    .clk(clk), .rst_n(rst_n), .current_cycle(current_cycle),
+    .cmd_valid(cmd_valid), .cmd_ready(cmd_ready),
+    .cmd_release_cycle(cmd_release_cycle), .cmd_source(cmd_source),
+    .cmd_destination(cmd_destination), .cmd_vc(cmd_vc), .cmd_tag(cmd_tag),
+    .cmd_tx_base_addr(cmd_tx_base_addr), .cmd_rx_base_addr(cmd_rx_base_addr),
+    .cmd_flit_count(cmd_flit_count),
+    .tx_desc_valid(tx_desc_valid), .tx_desc_ready(tx_desc_ready),
+    .tx_desc_destination(tx_desc_destination), .tx_desc_vc(tx_desc_vc),
+    .tx_desc_tag(tx_desc_tag), .tx_desc_base_addr(tx_desc_base_addr),
+    .tx_desc_flit_count(tx_desc_flit_count),
+    .rx_desc_valid(rx_desc_valid), .rx_desc_ready(rx_desc_ready),
+    .rx_desc_source(rx_desc_source), .rx_desc_vc(rx_desc_vc),
+    .rx_desc_tag(rx_desc_tag), .rx_desc_base_addr(rx_desc_base_addr),
+    .rx_desc_flit_count(rx_desc_flit_count),
+    .accepted_command_count(accepted_command_count),
+    .installed_receive_count(installed_receive_count),
+    .submitted_transmit_count(submitted_transmit_count),
+    .release_wait_cycles(release_wait_cycles),
+    .endpoint_stall_cycles(endpoint_stall_cycles),
+    .protocol_error(protocol_error)
+  );
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      current_cycle <= 0;
+      cmd_valid <= 0;
+      cmd_release_cycle <= 0;
+      cmd_source <= 0;
+      cmd_destination <= 1;
+      cmd_vc <= 0;
+      cmd_tag <= 8'h1d;
+      cmd_tx_base_addr <= 24'h010000;
+      cmd_rx_base_addr <= 24'h020000;
+      cmd_flit_count <= 1;
+      tx_desc_ready <= {NODES{1'b1}};
+      rx_desc_ready <= {NODES{1'b1}};
+      observed_state_r <= {DATA_W{1'b0}};
+    end else begin
+      current_cycle <= current_cycle + 1'b1;
+      tx_desc_ready <= {NODES{1'b1}} ^
+        ({{(NODES-1){1'b0}}, current_cycle[2]} << current_cycle[7:4]);
+      rx_desc_ready <= {NODES{1'b1}} ^
+        ({{(NODES-1){1'b0}}, current_cycle[3]} << current_cycle[11:8]);
+      cmd_valid <= 1'b1;
+      if (cmd_valid && cmd_ready) begin
+        cmd_source <= cmd_source + 1'b1;
+        cmd_destination <= cmd_destination + 4'd3;
+        cmd_vc <= cmd_vc + 1'b1;
+        cmd_tag <= {cmd_tag[6:0], cmd_tag[7] ^ cmd_tag[5]};
+        cmd_tx_base_addr <= cmd_tx_base_addr + 24'h000120;
+        cmd_rx_base_addr <= cmd_rx_base_addr + 24'h000220;
+        cmd_flit_count <= cmd_flit_count == 4'd8 ? 4'd1 : cmd_flit_count + 1'b1;
+        cmd_release_cycle <= current_cycle + {28'b0, cmd_tag[3:0]};
+      end
+      if (|(tx_desc_valid & tx_desc_ready))
+        observed_state_r <= {observed_state_r[DATA_W-2:0], observed_state_r[DATA_W-1]} ^
+          {{(DATA_W-42){1'b0}},
+           tx_desc_tag[(tx_observed_index*8) +: 8],
+           tx_desc_base_addr[(tx_observed_index*24) +: 24],
+           tx_desc_destination[(tx_observed_index*4) +: 4],
+           tx_desc_vc[(tx_observed_index*2) +: 2],
+           tx_desc_flit_count[(tx_observed_index*4) +: 4]};
+      if (|(rx_desc_valid & rx_desc_ready))
+        observed_state_r <= {observed_state_r[DATA_W-3:0], observed_state_r[DATA_W-1:DATA_W-2]} ^
+          {{(DATA_W-42){1'b0}},
+           rx_desc_tag[(rx_observed_index*8) +: 8],
+           rx_desc_base_addr[(rx_observed_index*24) +: 24],
+           rx_desc_source[(rx_observed_index*4) +: 4],
+           rx_desc_vc[(rx_observed_index*2) +: 2],
+           rx_desc_flit_count[(rx_observed_index*4) +: 4]};
+    end
+  end
+endmodule

--- a/runs/campaigns/noc/l1_descriptor_pair_scheduler/sweeps/nangate45_macro_frontier.json
+++ b/runs/campaigns/noc/l1_descriptor_pair_scheduler/sweeps/nangate45_macro_frontier.json
@@ -1,0 +1,8 @@
+{
+  "tag_prefix": "l1_descriptor_pair_scheduler_nangate45_macro_frontier",
+  "flow_params": {
+    "CLOCK_PERIOD": [1.0, 1.5],
+    "CORE_UTILIZATION": [40, 50, 60],
+    "PLACE_DENSITY": [0.52]
+  }
+}

--- a/runs/designs/noc/l1_noc_descriptor_pair_scheduler_n16_wrapper/config_l1_noc_descriptor_pair_scheduler_n16.json
+++ b/runs/designs/noc/l1_noc_descriptor_pair_scheduler_n16_wrapper/config_l1_noc_descriptor_pair_scheduler_n16.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "descriptor_state",
+      "dimensions": 1,
+      "bit_width": 256,
+      "signed": false,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "l1_memory_noc_primitive",
+      "module_name": "l1_noc_descriptor_pair_scheduler_n16",
+      "operand": "descriptor_state",
+      "options": {
+        "primitive": "descriptor_pair_scheduler",
+        "flit_bits": 256,
+        "depth": 4,
+        "ports": 16,
+        "banks": 16,
+        "counter_bits": 32
+      }
+    }
+  ]
+}

--- a/scripts/generate_design.py
+++ b/scripts/generate_design.py
@@ -451,10 +451,12 @@ def identify_design(config):
             "segmented_mesh4x4",
             "sram_packet_endpoint",
             "sram_packet_mesh4x4",
+            "descriptor_pair_scheduler",
         ):
             raise ValueError(
                 "l1_memory_noc_primitive primitive must be fifo, router, endpoint, segmented_router, "
-                "segmented_mesh4x4, sram_packet_endpoint, or sram_packet_mesh4x4"
+                "segmented_mesh4x4, sram_packet_endpoint, sram_packet_mesh4x4, or "
+                "descriptor_pair_scheduler"
             )
         if flit_bits <= 0:
             raise ValueError("l1_memory_noc_primitive flit_bits must be positive")
@@ -515,6 +517,15 @@ def identify_design(config):
                 )
             if local_endpoint_id < 0 or local_endpoint_id >= (1 << source_bits):
                 raise ValueError("l1_memory_noc_primitive local_endpoint_id is out of range")
+        if primitive == "descriptor_pair_scheduler":
+            if ports != 16:
+                raise ValueError(
+                    "l1_memory_noc_primitive descriptor_pair_scheduler requires 16 endpoints"
+                )
+            if flit_bits < 42:
+                raise ValueError(
+                    "l1_memory_noc_primitive descriptor_pair_scheduler requires at least 42 observation bits"
+                )
         return {
             "kind": "l1_memory_noc_primitive",
             "module_name": module_name,
@@ -968,6 +979,17 @@ def generate_l1_memory_noc_design(src_dir, design):
             "noc_sram_packet_endpoint.sv",
             "noc_sram_packet_mesh4x4.sv",
             "noc_sram_packet_mesh4x4_ppa_harness.sv",
+        ):
+            rtl_path = repo_root / "npu" / "sim" / "rtl" / filename
+            Path(src_dir, Path(filename).with_suffix(".v")).write_text(
+                rtl_path.read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+    elif design["primitive"] == "descriptor_pair_scheduler":
+        text = _emit_l1_descriptor_pair_scheduler(module_name, design)
+        for filename in (
+            "noc_descriptor_pair_scheduler.sv",
+            "noc_descriptor_pair_scheduler_ppa_harness.sv",
         ):
             rtl_path = repo_root / "npu" / "sim" / "rtl" / filename
             Path(src_dir, Path(filename).with_suffix(".v")).write_text(
@@ -1692,6 +1714,38 @@ module {module_name}(
     .issued_packet_count(issued_packet_count),
     .completed_packet_count(completed_packet_count),
     .protocol_error(protocol_error)
+  );
+endmodule
+"""
+
+
+def _emit_l1_descriptor_pair_scheduler(module_name, design):
+    return f"""
+`timescale 1ns/1ps
+
+module {module_name}(
+  input clk,
+  input rst_n,
+  output [{design['counter_bits']-1}:0] accepted_command_count,
+  output [{design['counter_bits']-1}:0] installed_receive_count,
+  output [{design['counter_bits']-1}:0] submitted_transmit_count,
+  output [{design['counter_bits']-1}:0] endpoint_stall_cycles,
+  output protocol_error,
+  output [{design['flit_bits']-1}:0] observed_state
+);
+  noc_descriptor_pair_scheduler_ppa_harness #(
+    .NODES({design['ports']}),
+    .DATA_W({design['flit_bits']}),
+    .COUNTER_W({design['counter_bits']})
+  ) harness (
+    .clk(clk),
+    .rst_n(rst_n),
+    .accepted_command_count(accepted_command_count),
+    .installed_receive_count(installed_receive_count),
+    .submitted_transmit_count(submitted_transmit_count),
+    .endpoint_stall_cycles(endpoint_stall_cycles),
+    .protocol_error(protocol_error),
+    .observed_state(observed_state)
   );
 endmodule
 """
@@ -2559,6 +2613,32 @@ module {wrapper_name}(
 
 endmodule
 """
+        elif design["primitive"] == "descriptor_pair_scheduler":
+            wrapper_content = f"""
+module {wrapper_name}(
+  input clk,
+  input rst_n,
+  output [{counter_bits-1}:0] accepted_command_count,
+  output [{counter_bits-1}:0] installed_receive_count,
+  output [{counter_bits-1}:0] submitted_transmit_count,
+  output [{counter_bits-1}:0] endpoint_stall_cycles,
+  output protocol_error,
+  output [{flit_bits-1}:0] observed_state
+);
+
+  {module_name} dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .accepted_command_count(accepted_command_count),
+    .installed_receive_count(installed_receive_count),
+    .submitted_transmit_count(submitted_transmit_count),
+    .endpoint_stall_cycles(endpoint_stall_cycles),
+    .protocol_error(protocol_error),
+    .observed_state(observed_state)
+  );
+
+endmodule
+"""
         else:
             wrapper_content = f"""
 module {wrapper_name}(
@@ -2604,6 +2684,16 @@ def generate_config_mk(platform_dir, platform, design):
     ]
     if design["include_mg_cpa"]:
         verilog_files.append(f"$(DESIGN_HOME)/src/{wrapper_name}/MG_CPA.v")
+    if (
+        design["kind"] == "l1_memory_noc_primitive"
+        and design["primitive"] == "descriptor_pair_scheduler"
+    ):
+        verilog_files.extend(
+            [
+                f"$(DESIGN_HOME)/src/{wrapper_name}/noc_descriptor_pair_scheduler.v",
+                f"$(DESIGN_HOME)/src/{wrapper_name}/noc_descriptor_pair_scheduler_ppa_harness.v",
+            ]
+        )
 
     content = f"""
 export PLATFORM = {platform}

--- a/tests/noc_descriptor_pair_scheduler_tb.sv
+++ b/tests/noc_descriptor_pair_scheduler_tb.sv
@@ -1,0 +1,164 @@
+`timescale 1ns/1ps
+
+module noc_descriptor_pair_scheduler_tb;
+  localparam integer NODES = 16;
+  reg clk = 0;
+  reg rst_n = 0;
+  reg [31:0] current_cycle = 0;
+  reg cmd_valid = 0;
+  wire cmd_ready;
+  reg [31:0] cmd_release_cycle = 0;
+  reg [3:0] cmd_source = 0;
+  reg [3:0] cmd_destination = 0;
+  reg [1:0] cmd_vc = 0;
+  reg [7:0] cmd_tag = 0;
+  reg [23:0] cmd_tx_base_addr = 0;
+  reg [23:0] cmd_rx_base_addr = 0;
+  reg [3:0] cmd_flit_count = 0;
+  wire [NODES-1:0] tx_desc_valid;
+  reg [NODES-1:0] tx_desc_ready = {NODES{1'b1}};
+  wire [NODES*4-1:0] tx_desc_destination;
+  wire [NODES*2-1:0] tx_desc_vc;
+  wire [NODES*8-1:0] tx_desc_tag;
+  wire [NODES*24-1:0] tx_desc_base_addr;
+  wire [NODES*4-1:0] tx_desc_flit_count;
+  wire [NODES-1:0] rx_desc_valid;
+  reg [NODES-1:0] rx_desc_ready = {NODES{1'b1}};
+  wire [NODES*4-1:0] rx_desc_source;
+  wire [NODES*2-1:0] rx_desc_vc;
+  wire [NODES*8-1:0] rx_desc_tag;
+  wire [NODES*24-1:0] rx_desc_base_addr;
+  wire [NODES*4-1:0] rx_desc_flit_count;
+  wire [31:0] accepted_command_count;
+  wire [31:0] installed_receive_count;
+  wire [31:0] submitted_transmit_count;
+  wire [31:0] release_wait_cycles;
+  wire [31:0] endpoint_stall_cycles;
+  wire protocol_error;
+  integer rx_cycle [0:1];
+  integer tx_cycle [0:1];
+  integer rx_seen = 0;
+  integer tx_seen = 0;
+
+  noc_descriptor_pair_scheduler dut (
+    .clk(clk), .rst_n(rst_n), .current_cycle(current_cycle),
+    .cmd_valid(cmd_valid), .cmd_ready(cmd_ready),
+    .cmd_release_cycle(cmd_release_cycle), .cmd_source(cmd_source),
+    .cmd_destination(cmd_destination), .cmd_vc(cmd_vc), .cmd_tag(cmd_tag),
+    .cmd_tx_base_addr(cmd_tx_base_addr), .cmd_rx_base_addr(cmd_rx_base_addr),
+    .cmd_flit_count(cmd_flit_count),
+    .tx_desc_valid(tx_desc_valid), .tx_desc_ready(tx_desc_ready),
+    .tx_desc_destination(tx_desc_destination), .tx_desc_vc(tx_desc_vc),
+    .tx_desc_tag(tx_desc_tag), .tx_desc_base_addr(tx_desc_base_addr),
+    .tx_desc_flit_count(tx_desc_flit_count),
+    .rx_desc_valid(rx_desc_valid), .rx_desc_ready(rx_desc_ready),
+    .rx_desc_source(rx_desc_source), .rx_desc_vc(rx_desc_vc),
+    .rx_desc_tag(rx_desc_tag), .rx_desc_base_addr(rx_desc_base_addr),
+    .rx_desc_flit_count(rx_desc_flit_count),
+    .accepted_command_count(accepted_command_count),
+    .installed_receive_count(installed_receive_count),
+    .submitted_transmit_count(submitted_transmit_count),
+    .release_wait_cycles(release_wait_cycles),
+    .endpoint_stall_cycles(endpoint_stall_cycles),
+    .protocol_error(protocol_error)
+  );
+
+  always #1 clk = ~clk;
+  always @(posedge clk) begin
+    if (rst_n)
+      current_cycle <= current_cycle + 1;
+    if (rst_n && |(rx_desc_valid & rx_desc_ready)) begin
+      $display("RX_FIRE cycle=%0d valid=%h ready=%h", current_cycle, rx_desc_valid, rx_desc_ready);
+      rx_cycle[rx_seen] = current_cycle;
+      rx_seen = rx_seen + 1;
+    end
+    if (rst_n && |(tx_desc_valid & tx_desc_ready)) begin
+      $display("TX_FIRE cycle=%0d valid=%h ready=%h", current_cycle, tx_desc_valid, tx_desc_ready);
+      tx_cycle[tx_seen] = current_cycle;
+      tx_seen = tx_seen + 1;
+    end
+  end
+
+  task submit;
+    input [31:0] release_cycle;
+    input [3:0] source;
+    input [3:0] destination;
+    input [7:0] tag;
+    begin
+      @(negedge clk);
+      cmd_release_cycle = release_cycle;
+      cmd_source = source;
+      cmd_destination = destination;
+      cmd_vc = tag[1:0];
+      cmd_tag = tag;
+      cmd_tx_base_addr = {tag, 8'h10, 8'h00};
+      cmd_rx_base_addr = {tag, 8'h20, 8'h00};
+      cmd_flit_count = 4;
+      cmd_valid = 1;
+      @(posedge clk);
+      while (!cmd_ready)
+        @(posedge clk);
+      @(negedge clk);
+      cmd_valid = 0;
+    end
+  endtask
+
+  initial begin
+    repeat (3) @(negedge clk);
+    rst_n = 1;
+
+    fork
+      begin
+        submit(8, 2, 7, 8'h31);
+        submit(8, 3, 9, 8'h52);
+      end
+      begin
+        wait (rx_desc_valid[7]);
+        if (rx_desc_source[(7*4) +: 4] !== 2 ||
+            rx_desc_tag[(7*8) +: 8] !== 8'h31 ||
+            rx_desc_flit_count[(7*4) +: 4] !== 4)
+          $fatal(1, "first RX descriptor payload mismatch");
+        rx_desc_ready[7] = 0;
+        repeat (2) @(negedge clk);
+        rx_desc_ready[7] = 1;
+        wait (tx_desc_valid[2]);
+        if (tx_desc_destination[(2*4) +: 4] !== 7 ||
+            tx_desc_tag[(2*8) +: 8] !== 8'h31)
+          $fatal(1, "first TX descriptor payload mismatch");
+        tx_desc_ready[2] = 0;
+        repeat (2) @(negedge clk);
+        tx_desc_ready[2] = 1;
+      end
+    join
+
+    wait (submitted_transmit_count == 2);
+    repeat (2) @(negedge clk);
+    if (rx_seen != 2 || tx_seen != 2)
+      $fatal(1, "descriptor event count mismatch rx=%0d tx=%0d", rx_seen, tx_seen);
+    if (rx_cycle[0] < 8 || tx_cycle[0] <= rx_cycle[0] || tx_cycle[1] <= rx_cycle[1])
+      $fatal(1, "RX-before-TX/release ordering mismatch");
+    if (accepted_command_count != 2 || installed_receive_count != 2 ||
+        submitted_transmit_count != 2 || protocol_error)
+      $fatal(1, "scheduler counters/error mismatch");
+    if (endpoint_stall_cycles < 2)
+      $fatal(1, "backpressure stalls were not counted");
+
+    @(negedge clk);
+    cmd_release_cycle = current_cycle;
+    cmd_source = 1;
+    cmd_destination = 4;
+    cmd_flit_count = 0;
+    cmd_valid = 1;
+    @(negedge clk);
+    cmd_valid = 0;
+    repeat (2) @(negedge clk);
+    if (!protocol_error || accepted_command_count != 3 ||
+        submitted_transmit_count != 2)
+      $fatal(1, "invalid command was not rejected");
+
+    $display("PASS accepted=%0d rx=%0d tx=%0d release_wait=%0d stalls=%0d",
+      accepted_command_count, installed_receive_count,
+      submitted_transmit_count, release_wait_cycles, endpoint_stall_cycles);
+    $finish;
+  end
+endmodule

--- a/tests/noc_sram_packet_mesh4x4_workload_tb.sv
+++ b/tests/noc_sram_packet_mesh4x4_workload_tb.sv
@@ -42,6 +42,7 @@ module noc_sram_packet_mesh4x4_workload_tb;
   reg [15:0] completion_shadow_valid = 0;
 
   reg [95:0] descriptors [0:MAX_PACKETS-1];
+  reg [15:0] command_order [0:MAX_PACKETS-1];
   reg [15:0] source_order [0:MAX_PACKETS-1];
   reg [15:0] destination_order [0:MAX_PACKETS-1];
   reg [31:0] source_queue_meta [0:15];
@@ -54,13 +55,25 @@ module noc_sram_packet_mesh4x4_workload_tb;
   reg [127:0] live_context_valid = 0;
   integer live_context_packet [0:127];
 
+`ifdef SERIAL_PAIRED_SCHEDULER
+  wire [15:0] tx_desc_valid;
+`else
   reg [15:0] tx_desc_valid = 0;
+`endif
   wire [15:0] tx_desc_ready;
+`ifdef SERIAL_PAIRED_SCHEDULER
+  wire [63:0] tx_desc_destination;
+  wire [31:0] tx_desc_vc;
+  wire [127:0] tx_desc_tag;
+  wire [16*ADDR_W-1:0] tx_desc_base_addr;
+  wire [63:0] tx_desc_flit_count;
+`else
   reg [63:0] tx_desc_destination = 0;
   reg [31:0] tx_desc_vc = 0;
   reg [127:0] tx_desc_tag = 0;
   reg [16*ADDR_W-1:0] tx_desc_base_addr = 0;
   reg [63:0] tx_desc_flit_count = 0;
+`endif
   wire [15:0] tx_mem_req_valid;
   wire [15:0] tx_mem_req_ready;
   wire [16*ADDR_W-1:0] tx_mem_req_addr;
@@ -72,13 +85,25 @@ module noc_sram_packet_mesh4x4_workload_tb;
   integer pending_read_wr [0:15];
   integer pending_read_count [0:15];
 
+`ifdef SERIAL_PAIRED_SCHEDULER
+  wire [15:0] rx_desc_valid;
+`else
   reg [15:0] rx_desc_valid = 0;
+`endif
   wire [15:0] rx_desc_ready;
+`ifdef SERIAL_PAIRED_SCHEDULER
+  wire [63:0] rx_desc_source;
+  wire [31:0] rx_desc_vc;
+  wire [127:0] rx_desc_tag;
+  wire [16*ADDR_W-1:0] rx_desc_base_addr;
+  wire [63:0] rx_desc_flit_count;
+`else
   reg [63:0] rx_desc_source = 0;
   reg [31:0] rx_desc_vc = 0;
   reg [127:0] rx_desc_tag = 0;
   reg [16*ADDR_W-1:0] rx_desc_base_addr = 0;
   reg [63:0] rx_desc_flit_count = 0;
+`endif
   wire [15:0] rx_mem_write_valid;
   reg [15:0] rx_mem_write_ready = 16'hffff;
   wire [16*ADDR_W-1:0] rx_mem_write_addr;
@@ -100,10 +125,53 @@ module noc_sram_packet_mesh4x4_workload_tb;
   wire [16*5*32-1:0] router_route_flit_count;
 
   string descriptor_mem;
+  string command_order_mem;
   string source_order_mem;
   string destination_order_mem;
   string source_meta_mem;
   string destination_meta_mem;
+
+`ifdef SERIAL_PAIRED_SCHEDULER
+  integer command_position = 0;
+  wire [15:0] scheduler_packet_index = command_position < packet_count ?
+    command_order[command_position] : 16'b0;
+  wire [95:0] scheduler_command = descriptors[scheduler_packet_index];
+  wire scheduler_cmd_valid = rst_n && command_position < packet_count;
+  wire scheduler_cmd_ready;
+  wire [31:0] scheduler_accepted_command_count;
+  wire [31:0] scheduler_installed_receive_count;
+  wire [31:0] scheduler_submitted_transmit_count;
+  wire [31:0] scheduler_release_wait_cycles;
+  wire [31:0] scheduler_endpoint_stall_cycles;
+  wire scheduler_protocol_error;
+
+  noc_descriptor_pair_scheduler scheduler (
+    .clk(clk), .rst_n(rst_n), .current_cycle(cycle),
+    .cmd_valid(scheduler_cmd_valid), .cmd_ready(scheduler_cmd_ready),
+    .cmd_release_cycle(scheduler_command[31:0]),
+    .cmd_source(scheduler_command[35:32]),
+    .cmd_destination(scheduler_command[39:36]),
+    .cmd_vc(scheduler_command[41:40]),
+    .cmd_tag(scheduler_command[49:42]),
+    .cmd_tx_base_addr({scheduler_packet_index, 8'b0}),
+    .cmd_rx_base_addr({scheduler_packet_index, 8'b0}),
+    .cmd_flit_count(scheduler_command[53:50]),
+    .tx_desc_valid(tx_desc_valid), .tx_desc_ready(tx_desc_ready),
+    .tx_desc_destination(tx_desc_destination), .tx_desc_vc(tx_desc_vc),
+    .tx_desc_tag(tx_desc_tag), .tx_desc_base_addr(tx_desc_base_addr),
+    .tx_desc_flit_count(tx_desc_flit_count),
+    .rx_desc_valid(rx_desc_valid), .rx_desc_ready(rx_desc_ready),
+    .rx_desc_source(rx_desc_source), .rx_desc_vc(rx_desc_vc),
+    .rx_desc_tag(rx_desc_tag), .rx_desc_base_addr(rx_desc_base_addr),
+    .rx_desc_flit_count(rx_desc_flit_count),
+    .accepted_command_count(scheduler_accepted_command_count),
+    .installed_receive_count(scheduler_installed_receive_count),
+    .submitted_transmit_count(scheduler_submitted_transmit_count),
+    .release_wait_cycles(scheduler_release_wait_cycles),
+    .endpoint_stall_cycles(scheduler_endpoint_stall_cycles),
+    .protocol_error(scheduler_protocol_error)
+  );
+`endif
 
   function [DATA_W-1:0] memory_data;
     input [3:0] source;
@@ -169,6 +237,7 @@ module noc_sram_packet_mesh4x4_workload_tb;
   // Select at most one released descriptor per source and destination. The
   // receive side must handshake first; the transmit side observes that state
   // no earlier than the following cycle.
+`ifndef SERIAL_PAIRED_SCHEDULER
   always @(*) begin
     tx_desc_valid = 0;
     tx_desc_destination = 0;
@@ -230,6 +299,7 @@ module noc_sram_packet_mesh4x4_workload_tb;
       end
     end
   end
+`endif
 
   always @(posedge clk or negedge rst_n) begin
     if (!rst_n) begin
@@ -244,6 +314,9 @@ module noc_sram_packet_mesh4x4_workload_tb;
       packet_completed <= 0;
       live_context_valid <= 0;
       completion_shadow_valid <= 0;
+`ifdef SERIAL_PAIRED_SCHEDULER
+      command_position <= 0;
+`endif
       for (seq_endpoint_i = 0; seq_endpoint_i < 16; seq_endpoint_i = seq_endpoint_i + 1) begin
         source_position[seq_endpoint_i] <= 0;
         destination_position[seq_endpoint_i] <= 0;
@@ -254,6 +327,10 @@ module noc_sram_packet_mesh4x4_workload_tb;
       end
     end else begin
       cycle <= cycle + 1;
+`ifdef SERIAL_PAIRED_SCHEDULER
+      if (scheduler_cmd_valid && scheduler_cmd_ready)
+        command_position <= command_position + 1;
+`endif
       tx_fire_count = 0;
       completion_fire_count = 0;
       write_fire_count = 0;
@@ -290,11 +367,15 @@ module noc_sram_packet_mesh4x4_workload_tb;
         end
 
         if (rx_desc_valid[seq_endpoint_i] && rx_desc_ready[seq_endpoint_i]) begin
+`ifdef SERIAL_PAIRED_SCHEDULER
+          selected_packet = rx_desc_base_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W] >> 8;
+`else
           selected_index = destination_queue_meta[seq_endpoint_i][15:0] +
             destination_position[seq_endpoint_i];
           selected_packet = destination_order[selected_index];
-          rx_installed[selected_packet] <= 1'b1;
           destination_position[seq_endpoint_i] <= destination_position[seq_endpoint_i] + 1;
+`endif
+          rx_installed[selected_packet] <= 1'b1;
           free_context = -1;
           for (seq_context_i = 0; seq_context_i < RX_CONTEXTS;
                seq_context_i = seq_context_i + 1)
@@ -307,12 +388,16 @@ module noc_sram_packet_mesh4x4_workload_tb;
         end
 
         if (tx_desc_valid[seq_endpoint_i] && tx_desc_ready[seq_endpoint_i]) begin
+`ifdef SERIAL_PAIRED_SCHEDULER
+          selected_packet = tx_desc_base_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W] >> 8;
+`else
           selected_index = source_queue_meta[seq_endpoint_i][15:0] + source_position[seq_endpoint_i];
           selected_packet = source_order[selected_index];
+          source_position[seq_endpoint_i] <= source_position[seq_endpoint_i] + 1;
+`endif
           if (!rx_installed[selected_packet])
             $fatal(1, "TX descriptor accepted before RX descriptor for packet %0d", selected_packet);
           tx_submitted[selected_packet] <= 1'b1;
-          source_position[seq_endpoint_i] <= source_position[seq_endpoint_i] + 1;
           tx_fire_count = tx_fire_count + 1;
         end
 
@@ -368,6 +453,10 @@ module noc_sram_packet_mesh4x4_workload_tb;
 
       if (endpoint_protocol_error != 0)
         $fatal(1, "endpoint protocol error: %h", endpoint_protocol_error);
+`ifdef SERIAL_PAIRED_SCHEDULER
+      if (scheduler_protocol_error)
+        $fatal(1, "descriptor scheduler protocol error");
+`endif
       if (cycle > 0 && (cycle % 100000) == 0)
         $display("PROGRESS workload cycle=%0d submitted=%0d completed=%0d writes=%0d",
           cycle, submitted_packets, completed_packets, accepted_writes);
@@ -399,6 +488,15 @@ module noc_sram_packet_mesh4x4_workload_tb;
       if (accepted_writes != expected_flits)
         $fatal(1, "flit count mismatch expected=%0d writes=%0d",
           expected_flits, accepted_writes);
+`ifdef SERIAL_PAIRED_SCHEDULER
+      if (scheduler_accepted_command_count != packet_count ||
+          scheduler_installed_receive_count != packet_count ||
+          scheduler_submitted_transmit_count != packet_count)
+        $fatal(1,
+          "scheduler count mismatch accepted=%0d rx=%0d tx=%0d expected=%0d",
+          scheduler_accepted_command_count, scheduler_installed_receive_count,
+          scheduler_submitted_transmit_count, packet_count);
+`endif
       for (packet_i = 0; packet_i < packet_count; packet_i = packet_i + 1)
         if (!rx_installed[packet_i] || !tx_submitted[packet_i] || !packet_completed[packet_i])
           $fatal(1, "packet %0d did not traverse the complete endpoint path", packet_i);
@@ -418,12 +516,14 @@ module noc_sram_packet_mesh4x4_workload_tb;
       $fatal(1, "EXPECTED_FLITS must be positive");
     plusarg_status = $value$plusargs("TIMEOUT_CYCLES=%d", timeout_cycles);
     if (!$value$plusargs("DESC_MEM=%s", descriptor_mem) ||
+        !$value$plusargs("CMD_ORDER_MEM=%s", command_order_mem) ||
         !$value$plusargs("SRC_ORDER_MEM=%s", source_order_mem) ||
         !$value$plusargs("DST_ORDER_MEM=%s", destination_order_mem) ||
         !$value$plusargs("SRC_META_MEM=%s", source_meta_mem) ||
         !$value$plusargs("DST_META_MEM=%s", destination_meta_mem))
       $fatal(1, "all workload memory paths are required");
     $readmemh(descriptor_mem, descriptors, 0, packet_count - 1);
+    $readmemh(command_order_mem, command_order, 0, packet_count - 1);
     $readmemh(source_order_mem, source_order, 0, packet_count - 1);
     $readmemh(destination_order_mem, destination_order, 0, packet_count - 1);
     $readmemh(source_meta_mem, source_queue_meta);

--- a/tests/test_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py
+++ b/tests/test_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py
@@ -67,6 +67,10 @@ def test_workload_memories_encode_endpoint_queues_and_concrete_tags(
     descriptor_words = [int(line, 16) for line in paths.descriptors.read_text().splitlines()]
     assert [(word >> 42) & 0xFF for word in descriptor_words] == [255, 0]
     assert [(word >> 50) & 0xF for word in descriptor_words] == [8, 3]
+    assert [int(line, 16) for line in paths.command_order.read_text().splitlines()] == [
+        0,
+        1,
+    ]
 
     source_meta = [int(line, 16) for line in paths.source_meta.read_text().splitlines()]
     destination_meta = [
@@ -103,3 +107,38 @@ def test_composed_rtl_replays_paired_descriptors_and_all_flits(tmp_path: Path) -
         for key in ("packets", "flits", "cycles", "contention", "input_stalls", "max_occupancy")
     }
     assert "PASS workload" in result["simulation_stdout"]
+
+
+@pytest.mark.skipif(
+    not (shutil.which("iverilog") or Path("/oss-cad-suite/bin/iverilog").exists())
+    or not (shutil.which("vvp") or Path("/oss-cad-suite/bin/vvp").exists()),
+    reason="iverilog/vvp unavailable",
+)
+def test_serial_scheduler_rtl_matches_performance_replay(tmp_path: Path) -> None:
+    packets = _contention_packets()
+    performance = run_performance_replay(
+        packets,
+        max_cycles=10000,
+        descriptor_scheduler="serial_paired",
+    )
+    result = run_rtl_replay(
+        repo_root=REPO_ROOT,
+        packets=packets,
+        work_dir=tmp_path,
+        timeout_cycles=10000,
+        wall_timeout_seconds=60,
+        descriptor_scheduler="serial_paired",
+    )
+
+    assert result["counters"] == {
+        key: performance[key]
+        for key in (
+            "packets",
+            "flits",
+            "cycles",
+            "contention",
+            "input_stalls",
+            "max_occupancy",
+        )
+    }
+    assert result["counters"]["cycles"] == 88

--- a/tests/test_noc_descriptor_pair_scheduler.py
+++ b/tests/test_noc_descriptor_pair_scheduler.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.generate_design import (  # noqa: E402
+    generate_config_mk,
+    generate_l1_memory_noc_design,
+    generate_wrapper,
+    identify_design,
+)
+
+PPA_CONFIG = (
+    REPO_ROOT
+    / "runs/designs/noc/l1_noc_descriptor_pair_scheduler_n16_wrapper"
+    / "config_l1_noc_descriptor_pair_scheduler_n16.json"
+)
+
+
+def test_noc_descriptor_pair_scheduler_protocol() -> None:
+    iverilog = shutil.which("iverilog")
+    vvp = shutil.which("vvp")
+    assert iverilog is not None
+    assert vvp is not None
+
+    with tempfile.TemporaryDirectory() as temporary:
+        simulator = Path(temporary) / "scheduler.vvp"
+        compile_result = subprocess.run(
+            [
+                iverilog,
+                "-g2012",
+                "-s",
+                "noc_descriptor_pair_scheduler_tb",
+                "-o",
+                str(simulator),
+                str(REPO_ROOT / "npu/sim/rtl/noc_descriptor_pair_scheduler.sv"),
+                str(REPO_ROOT / "tests/noc_descriptor_pair_scheduler_tb.sv"),
+            ],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        simulation = subprocess.run(
+            [vvp, str(simulator)],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert simulation.returncode == 0, simulation.stderr
+        assert "PASS accepted=3 rx=2 tx=2" in simulation.stdout
+
+
+def test_noc_descriptor_pair_scheduler_generator_emits_exact_hierarchy(
+    tmp_path: Path,
+) -> None:
+    config = json.loads(PPA_CONFIG.read_text(encoding="utf-8"))
+    design = identify_design(config)
+    assert design["primitive"] == "descriptor_pair_scheduler"
+
+    source_dir = tmp_path / "src"
+    source_dir.mkdir()
+    generate_l1_memory_noc_design(str(source_dir), design)
+    generate_wrapper(config, str(source_dir), design)
+
+    expected_sources = {
+        "noc_descriptor_pair_scheduler.v",
+        "noc_descriptor_pair_scheduler_ppa_harness.v",
+        f"{design['module_name']}.v",
+        f"{design['wrapper_name']}.v",
+    }
+    assert expected_sources == {path.name for path in source_dir.glob("*.v")}
+
+    platform_dir = tmp_path / "platform"
+    platform_dir.mkdir()
+    generate_config_mk(str(platform_dir), "nangate45", design)
+    config_mk = (platform_dir / "config.mk").read_text(encoding="utf-8")
+    for filename in expected_sources:
+        assert f"/{filename}" in config_mk
+
+    iverilog = shutil.which("iverilog")
+    if iverilog is None:
+        return
+    compile_result = subprocess.run(
+        [
+            iverilog,
+            "-g2012",
+            "-s",
+            design["wrapper_name"],
+            "-t",
+            "null",
+            *[str(path) for path in sorted(source_dir.glob("*.v"))],
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert compile_result.returncode == 0, compile_result.stderr
+
+
+@pytest.mark.parametrize(
+    ("option", "value", "message"),
+    [
+        ("ports", 8, "requires 16 endpoints"),
+        ("flit_bits", 32, "requires at least 42 observation bits"),
+    ],
+)
+def test_noc_descriptor_pair_scheduler_rejects_unsupported_physical_shape(
+    option: str,
+    value: int,
+    message: str,
+) -> None:
+    config = json.loads(PPA_CONFIG.read_text(encoding="utf-8"))
+    config["operations"][0]["options"][option] = value
+    with pytest.raises(ValueError, match=message):
+        identify_design(config)

--- a/tests/test_noc_sram_packet_mesh_perf.py
+++ b/tests/test_noc_sram_packet_mesh_perf.py
@@ -179,3 +179,56 @@ def test_idle_fast_forward_respects_max_cycle_bound() -> None:
 
     with pytest.raises(RuntimeError, match="max_cycles=999"):
         simulate_packet_mesh([descriptor], max_cycles=999, fast_forward_idle=True)
+
+
+def test_serial_paired_scheduler_matches_synthesizable_issue_cadence() -> None:
+    descriptors = [
+        PacketDescriptor(
+            source=index,
+            destination=15 - index,
+            vc=index,
+            tag=index + 1,
+            flit_count=1,
+            release_cycle=release,
+            schedule_order=index,
+            packet_id=f"serial-{index}",
+        )
+        for index, release in enumerate((4, 4, 10))
+    ]
+
+    result = simulate_packet_mesh(
+        descriptors,
+        descriptor_scheduler="serial_paired",
+        max_cycles=100,
+    )
+    accelerated = simulate_packet_mesh(
+        descriptors,
+        descriptor_scheduler="serial_paired",
+        fast_forward_idle=True,
+        max_cycles=100,
+    )
+
+    assert [(event.packet_index, event.cycle) for event in result.rx_descriptor_handshakes] == [
+        (0, 4),
+        (1, 6),
+        (2, 10),
+    ]
+    assert [(event.packet_index, event.cycle) for event in result.tx_descriptor_handshakes] == [
+        (0, 5),
+        (1, 7),
+        (2, 11),
+    ]
+    assert accelerated == result
+    assert not result.protocol_errors
+
+
+def test_packet_mesh_rejects_unknown_descriptor_scheduler() -> None:
+    descriptor = PacketDescriptor(
+        source=0,
+        destination=1,
+        vc=0,
+        tag=1,
+        flit_count=1,
+    )
+    with pytest.raises(ValueError, match="descriptor_scheduler"):
+        simulate_packet_mesh([descriptor], descriptor_scheduler="imaginary")


### PR DESCRIPTION
## Summary
- replace the testbench-only Phase-2 descriptor issuer with synthesizable RX-before-TX scheduler RTL
- add exact serial-scheduler behavior to the packet-mesh performance model and full RTL replay
- add Nangate45 PPA generation plus remote L1/L2 evaluation contracts

## Llama7B result
The complete local replay matches RTL and performance simulation for 11,576 packets and 92,128 flits. Drain time is 397,227 cycles, 24 cycles above the 397,203-cycle parallel-issuer baseline. Contention/input stalls/peak occupancy improve from 30,285/46,504/11 to 8,736/11,816/7.

## Validation
- 15 focused scheduler, packet-mesh, and composed RTL tests passed
- 2 control-plane task-generator variants passed
- broader NoC regression: 18 passed; one existing real-ORFS generator test is blocked by the current container ownership defect under `/orfs/flow/designs/src`
- generated scheduler hierarchy passes Icarus and Yosys
- `python3 scripts/validate_runs.py --skip_eval_queue`

## Remaining physical evidence
- remote scheduler PPA sweep
- command SRAM macro/prefetch service
- previously queued router/endpoint/composed physical anchors after evaluator image repair