### PR TITLE
Embody NoC command prefetch control

### DIFF
--- a/docs/architecture/llama7b_attention_abstraction_closure_plan.md
+++ b/docs/architecture/llama7b_attention_abstraction_closure_plan.md
@@ -261,9 +261,11 @@ evidence gaps:
   baseline, while contention/input stalls/peak occupancy fall from
   30,285/46,504/11 to 8,736/11,816/7. The prepared L1 PPA item and remote L2
   reproduction are required before removing scheduler cost and cadence from
-  the abstraction list. Its external command record is 102 bits; command SRAM
-  bitcells and prefetch service remain separate macro/interface evidence
-  rather than hidden flops.
+  the abstraction list. Its command record is 102 bits. Sequential address
+  generation, one outstanding read, one-cycle response capture, and a
+  one-entry prefetch buffer are concrete RTL. Command SRAM bitcells, placement,
+  macro energy, and the command population/inter-wave refill producer remain
+  separate evidence rather than hidden flops.
 - Physical composition: the prepared
   `l1_noc_sram_packet_mesh4x4_composed_ppa_v1` item places the complete
   endpoint/mesh hierarchy at the same initial floorplan envelope as the

--- a/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/analysis_report.md
+++ b/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/analysis_report.md
@@ -3,8 +3,10 @@
 Measured PPA is pending. Functional evidence establishes one RX and one TX
 handshake per valid command with a two-cycle minimum issue cadence.
 
-The complete local Llama7B replay drained 11,576 packets and 92,128 flits in
-397,227 cycles with exact RTL/performance agreement. This is 24 cycles slower
-than the merged endpoint-parallel issuer result, while router contention fell
-from 30,285 to 8,736 cycles, input stalls from 46,504 to 11,816 cycles, and
-peak router occupancy from 11 to 7.
+The complete local Llama7B replay, including one-cycle command prefetch,
+drained 11,576 packets and 92,128 flits in 397,227 cycles with exact
+RTL/performance agreement. Prefetch requests, responses, delivered commands,
+scheduler accepts, RX installs, and TX submissions each equal 11,576. This is
+24 cycles slower than the merged endpoint-parallel issuer result, while router
+contention fell from 30,285 to 8,736 cycles, input stalls from 46,504 to 11,816
+cycles, and peak router occupancy from 11 to 7.

--- a/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/design_brief.md
+++ b/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/design_brief.md
@@ -7,5 +7,9 @@ descriptor until accepted. A completing TX may be replaced by the next command
 on the same edge. This gives a deterministic minimum cadence of two cycles per
 packet without allowing packet arrival to race RX context allocation.
 
-The command record is 102 bits (`32+4+4+2+8+24+24+4`). Its backing SRAM is not
-implemented as flops in this block; capacity is reported and costed separately.
+The command record is 102 bits (`32+4+4+2+8+24+24+4`). A concrete prefetch
+controller issues sequential SRAM addresses, permits one outstanding read,
+holds one returned record, and overlaps the next read with command acceptance.
+Its backing SRAM bitcells are not implemented as flops in this block; capacity
+and macro energy are reported and costed separately. Command population and
+inter-wave refill remain an explicit producer boundary for follow-on closure.

--- a/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/implementation_summary.md
@@ -1,8 +1,10 @@
 # Implementation Summary
 
 - Added synthesizable paired descriptor scheduler RTL.
+- Added a one-cycle SRAM request/response prefetch controller with one
+  outstanding read and one response buffer.
 - Added a PPA harness with varying commands, endpoint backpressure, counters,
   and active-lane observation.
 - Added direct-generator support, an exact source manifest, config, and sweep.
 - Added protocol and generated-hierarchy tests.
-- Added a matching serial policy to the endpoint/mesh performance model.
+- Added a matching serial-plus-prefetch policy to the endpoint/mesh performance model.

--- a/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/proposal.json
+++ b/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/proposal.json
@@ -11,6 +11,8 @@
     "primary_question": "What PPA and issue cadence replace the unmeasured deterministic testbench descriptor scheduler?",
     "include": [
       "one active 102-bit packet command",
+      "one-outstanding-read command SRAM prefetch control",
+      "one-entry command response buffer",
       "release-cycle gating",
       "receive descriptor installation before transmit submission",
       "endpoint backpressure",
@@ -19,6 +21,7 @@
     ],
     "exclude": [
       "external command SRAM bitcells",
+      "command population and inter-wave refill producer",
       "endpoint and router logic",
       "HBM/DRAM",
       "workload-matched switching power"
@@ -32,7 +35,7 @@
   "risks": [
     "global serialization may increase congestion or drain latency",
     "the physical harness contributes disclosed source, backpressure, and observation logic",
-    "command SRAM capacity and macro energy remain separate physical evidence"
+    "command SRAM bitcell capacity and macro energy remain separate physical evidence"
   ],
   "required_evaluations": [
     {

--- a/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/quality_gate.md
@@ -1,9 +1,10 @@
 # Quality Gate
 
-- `pytest -q tests/test_noc_descriptor_pair_scheduler.py`
+- `pytest -q tests/test_noc_descriptor_command_prefetch.py tests/test_noc_descriptor_pair_scheduler.py`
 - Require valid-command RX-before-TX ordering and held-valid backpressure.
 - Require invalid commands to set sticky `protocol_error` without submission.
 - Require all generated scheduler sources in OpenROAD `VERILOG_FILES`.
+- Require one-cycle command-memory response buffering and in-order delivery.
 - Require generated wrapper elaboration with Icarus Verilog.
 
 Status: passed locally; physical evaluation pending.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/analysis_report.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/analysis_report.md
@@ -3,7 +3,8 @@
 The 8-packet contention case matches exactly at 88 cycles, 171 contention
 cycles, 53 input stalls, and peak router occupancy 29.
 
-The complete local Llama7B replay also matches exactly:
+The complete local Llama7B replay, including one-cycle command prefetch, also
+matches exactly:
 
 - packets/flits: 11,576 / 92,128
 - serial scheduler drain: 397,227 cycles
@@ -12,5 +13,6 @@ The complete local Llama7B replay also matches exactly:
 - contention: 8,736 versus 30,285 baseline
 - input stalls: 11,816 versus 46,504 baseline
 - peak occupancy: 7 versus 11 baseline
+- prefetch requests/responses/deliveries: 11,576 / 11,576 / 11,576
 
 Remote reproduction remains the promotion evidence.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/design_brief.md
@@ -1,6 +1,7 @@
 # Design Brief
 
-The replay streams globally ordered 102-bit command records from an external
-memory model into the concrete scheduler. The scheduler alone drives endpoint
-RX/TX descriptors. All packet payload, SRAM-port, endpoint, router, and
-completion behavior remains identical to the merged finite endpoint baseline.
+The replay fetches globally ordered 102-bit command records through a concrete
+one-cycle SRAM request/response controller with one outstanding read and one
+response buffer. The paired scheduler alone drives endpoint RX/TX descriptors.
+All packet payload, SRAM-port, endpoint, router, and completion behavior remains
+identical to the merged finite endpoint baseline.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/implementation_summary.md
@@ -2,6 +2,7 @@
 
 - Added `serial_paired` scheduling to the packet-mesh performance model.
 - Added global command-order memory generation.
+- Added one-cycle command-SRAM request/response replay and prefetch counters.
 - Added selectable scheduler RTL composition to the full workload testbench.
 - Added remote task generation for a distinct serial-scheduler revision.
-- Preserved the historical endpoint-parallel replay as the default API mode.
+- Preserved the historical endpoint-parallel replay as an explicit API mode.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/proposal.json
@@ -18,6 +18,7 @@
     ],
     "exclude": [
       "command and packet SRAM bitcells",
+      "command population and inter-wave refill producer",
       "workload-derived switching power",
       "HBM/DRAM controller implementation"
     ]

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/quality_gate.md
@@ -5,3 +5,5 @@
 - Full replay must cover all eight waves, `11,576` packets, and `92,128` flits.
 - Every RX descriptor must precede its paired TX descriptor.
 - Endpoint and scheduler protocol-error vectors must remain zero.
+- Prefetch request, response, delivered, and scheduler-accepted counts must all
+  equal the workload packet count.

--- a/examples/about_config.md
+++ b/examples/about_config.md
@@ -492,8 +492,9 @@ draining, and synthetic producer/consumer backpressure.
 `primitive: "sram_packet_endpoint"` emits the finite descriptor-driven packet
 endpoint. `primitive: "sram_packet_mesh4x4"` emits its full 16-endpoint,
 16-router composition. `primitive: "descriptor_pair_scheduler"` emits the
-synthesizable sixteen-endpoint command controller that waits for release,
-installs each RX descriptor, and only then submits its paired TX descriptor.
+synthesizable sixteen-endpoint command controller with sequential one-cycle
+SRAM prefetch, one response buffer, release waiting, RX descriptor
+installation, and only then paired TX descriptor submission.
 
 Supported common options are `primitive`, `flit_bits`, `depth`, `ports`, and
 `counter_bits`. Segmented-router and segmented-mesh options are `vc_count`,

--- a/npu/eval/verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py
+++ b/npu/eval/verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py
@@ -41,6 +41,7 @@ RTL_SOURCES = (
     Path("npu/sim/rtl/noc_sram_packet_mesh4x4.sv"),
 )
 SCHEDULER_RTL_SOURCE = Path("npu/sim/rtl/noc_descriptor_pair_scheduler.sv")
+PREFETCH_RTL_SOURCE = Path("npu/sim/rtl/noc_descriptor_command_prefetch.sv")
 RTL_TB = Path("tests/noc_sram_packet_mesh4x4_workload_tb.sv")
 PASS_RE = re.compile(
     r"PASS workload packets=(?P<packets>\d+) flits=(?P<flits>\d+) "
@@ -238,7 +239,11 @@ def run_rtl_replay(
     ]
     if descriptor_scheduler == "serial_paired":
         compile_command.extend(
-            ["-DSERIAL_PAIRED_SCHEDULER", str(repo_root / SCHEDULER_RTL_SOURCE)]
+            [
+                "-DSERIAL_PAIRED_SCHEDULER",
+                str(repo_root / PREFETCH_RTL_SOURCE),
+                str(repo_root / SCHEDULER_RTL_SOURCE),
+            ]
         )
     compile_command.extend(str(repo_root / path) for path in RTL_SOURCES)
     compile_command.append(str(repo_root / RTL_TB))
@@ -472,7 +477,7 @@ def build_and_run(args: argparse.Namespace) -> JsonDict:
         },
         "remaining_abstractions": [
             "SRAM arrays are transaction-accurate one-cycle ports; bitcells and macro placement remain external.",
-            "The 102-bit command records are supplied by an external command-memory/prefetch interface; its SRAM bitcells remain macro evidence.",
+            "The 102-bit command records use concrete one-cycle prefetch control; command SRAM bitcells, macro placement, and command population/refill remain external evidence.",
             *(
                 []
                 if args.descriptor_scheduler == "serial_paired"

--- a/npu/sim/perf/noc_sram_packet_mesh.py
+++ b/npu/sim/perf/noc_sram_packet_mesh.py
@@ -419,8 +419,10 @@ def simulate_packet_mesh(
 
     ``endpoint_parallel`` schedules one RX per destination and one TX per
     source each cycle, preserving the original abstract scheduler.  The
-    synthesizable ``serial_paired`` policy holds one global command, installs
-    its RX descriptor first, and submits its TX descriptor on a later edge.
+    synthesizable ``serial_paired`` policy includes the one-cycle SRAM request
+    and response buffer, then holds one global command, installs its RX
+    descriptor first, and submits its TX descriptor on a later edge. Its
+    steady-state issue cadence is two cycles per command.
     Ready schedules are indexed as ``[cycle][endpoint]``; a callable may be
     used for large replay workloads without materializing a matrix.
     """
@@ -743,6 +745,7 @@ def simulate_packet_mesh(
             descriptor_scheduler == "serial_paired"
             and scheduler_active is None
             and scheduler_pending
+            and cycle >= 2
         ):
             scheduler_active = scheduler_pending.popleft()
 

--- a/npu/sim/rtl/noc_descriptor_command_prefetch.sv
+++ b/npu/sim/rtl/noc_descriptor_command_prefetch.sv
@@ -1,0 +1,104 @@
+`timescale 1ns/1ps
+
+// Streams fixed-width command records from a one-cycle SRAM-style interface.
+// One response buffer and one outstanding read are sufficient because the
+// paired descriptor scheduler consumes at most one command every two cycles.
+module noc_descriptor_command_prefetch #(
+  parameter integer COMMAND_W = 102,
+  parameter integer ADDR_W = 14,
+  parameter integer COUNT_W = 14,
+  parameter integer COUNTER_W = 32
+) (
+  input wire clk,
+  input wire rst_n,
+  input wire enable,
+  input wire [COUNT_W-1:0] command_count,
+
+  output wire mem_req_valid,
+  input wire mem_req_ready,
+  output wire [ADDR_W-1:0] mem_req_addr,
+  input wire mem_rsp_valid,
+  output wire mem_rsp_ready,
+  input wire [COMMAND_W-1:0] mem_rsp_data,
+
+  output wire cmd_valid,
+  input wire cmd_ready,
+  output wire [COMMAND_W-1:0] cmd_data,
+
+  output reg [COUNTER_W-1:0] request_count,
+  output reg [COUNTER_W-1:0] response_count,
+  output reg [COUNTER_W-1:0] delivered_command_count,
+  output reg [COUNTER_W-1:0] memory_stall_cycles,
+  output reg protocol_error
+);
+  reg [ADDR_W-1:0] next_request_addr;
+  reg request_outstanding;
+  reg response_buffer_valid;
+  reg [COMMAND_W-1:0] response_buffer_data;
+
+  wire command_fire = cmd_valid && cmd_ready;
+  wire response_fire = mem_rsp_valid && mem_rsp_ready;
+  wire can_reserve_response_slot = !response_buffer_valid || command_fire;
+  wire all_requests_issued = next_request_addr >= command_count;
+  wire request_fire = mem_req_valid && mem_req_ready;
+
+  assign mem_req_valid =
+    enable && !all_requests_issued && !request_outstanding &&
+    can_reserve_response_slot;
+  assign mem_req_addr = next_request_addr;
+  assign mem_rsp_ready = can_reserve_response_slot;
+  assign cmd_valid = response_buffer_valid;
+  assign cmd_data = response_buffer_data;
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      next_request_addr <= {ADDR_W{1'b0}};
+      request_outstanding <= 1'b0;
+      response_buffer_valid <= 1'b0;
+      response_buffer_data <= {COMMAND_W{1'b0}};
+      request_count <= {COUNTER_W{1'b0}};
+      response_count <= {COUNTER_W{1'b0}};
+      delivered_command_count <= {COUNTER_W{1'b0}};
+      memory_stall_cycles <= {COUNTER_W{1'b0}};
+      protocol_error <= 1'b0;
+    end else begin
+      if (mem_req_valid && !mem_req_ready)
+        memory_stall_cycles <= memory_stall_cycles + 1'b1;
+
+      if (request_fire) begin
+        next_request_addr <= next_request_addr + 1'b1;
+        request_outstanding <= 1'b1;
+        request_count <= request_count + 1'b1;
+      end
+
+      if (command_fire) begin
+        response_buffer_valid <= 1'b0;
+        delivered_command_count <= delivered_command_count + 1'b1;
+      end
+
+      if (response_fire) begin
+        response_buffer_valid <= 1'b1;
+        response_buffer_data <= mem_rsp_data;
+        request_outstanding <= 1'b0;
+        response_count <= response_count + 1'b1;
+        if (!request_outstanding)
+          protocol_error <= 1'b1;
+      end else if (mem_rsp_valid && !request_outstanding) begin
+        protocol_error <= 1'b1;
+      end
+    end
+  end
+
+`ifndef SYNTHESIS
+  initial begin
+    if (COMMAND_W <= 0 || ADDR_W <= 0 || COUNT_W <= 0) begin
+      $error("noc_descriptor_command_prefetch parameters must be positive");
+      $finish(1);
+    end
+    if (ADDR_W < COUNT_W) begin
+      $error("noc_descriptor_command_prefetch ADDR_W must represent command_count");
+      $finish(1);
+    end
+  end
+`endif
+endmodule

--- a/npu/sim/rtl/noc_descriptor_pair_scheduler.sv
+++ b/npu/sim/rtl/noc_descriptor_pair_scheduler.sv
@@ -67,9 +67,13 @@ module noc_descriptor_pair_scheduler #(
   wire transmit_valid = command_released && receive_installed;
   wire receive_fire = receive_valid && rx_desc_ready[active_destination];
   wire transmit_fire = transmit_valid && tx_desc_ready[active_source];
+  wire [ENDPOINT_W:0] command_source_extended = {1'b0, cmd_source};
+  wire [ENDPOINT_W:0] command_destination_extended = {1'b0, cmd_destination};
+  localparam [ENDPOINT_W:0] NODE_COUNT = NODES[ENDPOINT_W:0];
   wire command_fields_valid =
     cmd_flit_count != {FLIT_COUNT_W{1'b0}} &&
-    cmd_source < NODES && cmd_destination < NODES;
+    command_source_extended < NODE_COUNT &&
+    command_destination_extended < NODE_COUNT;
 
   // A completing transmit can be replaced without an idle queue cycle.
   assign cmd_ready = !command_active || transmit_fire;

--- a/npu/sim/rtl/noc_descriptor_pair_scheduler_ppa_harness.sv
+++ b/npu/sim/rtl/noc_descriptor_pair_scheduler_ppa_harness.sv
@@ -14,17 +14,33 @@ module noc_descriptor_pair_scheduler_ppa_harness #(
   output wire protocol_error,
   output wire [DATA_W-1:0] observed_state
 );
+  localparam integer COMMAND_W = 102;
   reg [31:0] current_cycle;
-  reg cmd_valid;
+  wire cmd_valid;
   wire cmd_ready;
-  reg [31:0] cmd_release_cycle;
-  reg [3:0] cmd_source;
-  reg [3:0] cmd_destination;
-  reg [1:0] cmd_vc;
-  reg [7:0] cmd_tag;
-  reg [23:0] cmd_tx_base_addr;
-  reg [23:0] cmd_rx_base_addr;
-  reg [3:0] cmd_flit_count;
+  wire [COMMAND_W-1:0] cmd_data;
+  wire [31:0] cmd_release_cycle = cmd_data[31:0];
+  wire [3:0] cmd_source = cmd_data[35:32];
+  wire [3:0] cmd_destination = cmd_data[39:36];
+  wire [1:0] cmd_vc = cmd_data[41:40];
+  wire [7:0] cmd_tag = cmd_data[49:42];
+  wire [23:0] cmd_tx_base_addr = cmd_data[73:50];
+  wire [23:0] cmd_rx_base_addr = cmd_data[97:74];
+  wire [3:0] cmd_flit_count = cmd_data[101:98];
+  wire command_mem_req_valid;
+  reg command_mem_req_ready;
+  wire [13:0] command_mem_req_addr;
+  wire command_mem_rsp_valid;
+  wire command_mem_rsp_ready;
+  wire [COMMAND_W-1:0] command_mem_rsp_data;
+  reg [13:0] pending_command_addr;
+  reg pending_command_valid;
+  wire [COUNTER_W-1:0] prefetch_request_count;
+  wire [COUNTER_W-1:0] prefetch_response_count;
+  wire [COUNTER_W-1:0] prefetch_delivered_count;
+  wire [COUNTER_W-1:0] prefetch_memory_stalls;
+  wire prefetch_protocol_error;
+  wire scheduler_protocol_error;
   wire [NODES-1:0] tx_desc_valid;
   reg [NODES-1:0] tx_desc_ready;
   wire [NODES*4-1:0] tx_desc_destination;
@@ -46,6 +62,31 @@ module noc_descriptor_pair_scheduler_ppa_harness #(
   integer observed_i;
 
   assign observed_state = observed_state_r;
+  assign protocol_error = prefetch_protocol_error | scheduler_protocol_error;
+  assign command_mem_rsp_valid = pending_command_valid;
+  assign command_mem_rsp_data = command_word(pending_command_addr);
+
+  function [COMMAND_W-1:0] command_word;
+    input [13:0] address;
+    reg [3:0] source;
+    reg [3:0] destination;
+    reg [3:0] flit_count;
+    begin
+      source = address[3:0];
+      destination = address[7:4] + address[3:0] + 1'b1;
+      flit_count = {1'b0, address[2:0]} + 1'b1;
+      command_word = {
+        flit_count,
+        {address, 10'h155},
+        {address, 10'h0aa},
+        address[7:0] ^ 8'h5a,
+        address[1:0],
+        destination,
+        source,
+        {18'b0, address}
+      };
+    end
+  endfunction
 
   always @(*) begin
     tx_observed_index = 4'b0;
@@ -57,6 +98,28 @@ module noc_descriptor_pair_scheduler_ppa_harness #(
         rx_observed_index = observed_i[3:0];
     end
   end
+
+  noc_descriptor_command_prefetch #(
+    .COMMAND_W(COMMAND_W),
+    .ADDR_W(14),
+    .COUNT_W(14),
+    .COUNTER_W(COUNTER_W)
+  ) prefetch (
+    .clk(clk), .rst_n(rst_n), .enable(1'b1),
+    .command_count(14'h3fff),
+    .mem_req_valid(command_mem_req_valid),
+    .mem_req_ready(command_mem_req_ready),
+    .mem_req_addr(command_mem_req_addr),
+    .mem_rsp_valid(command_mem_rsp_valid),
+    .mem_rsp_ready(command_mem_rsp_ready),
+    .mem_rsp_data(command_mem_rsp_data),
+    .cmd_valid(cmd_valid), .cmd_ready(cmd_ready), .cmd_data(cmd_data),
+    .request_count(prefetch_request_count),
+    .response_count(prefetch_response_count),
+    .delivered_command_count(prefetch_delivered_count),
+    .memory_stall_cycles(prefetch_memory_stalls),
+    .protocol_error(prefetch_protocol_error)
+  );
 
   noc_descriptor_pair_scheduler #(
     .NODES(NODES),
@@ -81,41 +144,31 @@ module noc_descriptor_pair_scheduler_ppa_harness #(
     .submitted_transmit_count(submitted_transmit_count),
     .release_wait_cycles(release_wait_cycles),
     .endpoint_stall_cycles(endpoint_stall_cycles),
-    .protocol_error(protocol_error)
+    .protocol_error(scheduler_protocol_error)
   );
 
   always @(posedge clk or negedge rst_n) begin
     if (!rst_n) begin
       current_cycle <= 0;
-      cmd_valid <= 0;
-      cmd_release_cycle <= 0;
-      cmd_source <= 0;
-      cmd_destination <= 1;
-      cmd_vc <= 0;
-      cmd_tag <= 8'h1d;
-      cmd_tx_base_addr <= 24'h010000;
-      cmd_rx_base_addr <= 24'h020000;
-      cmd_flit_count <= 1;
+      command_mem_req_ready <= 1'b1;
+      pending_command_addr <= 0;
+      pending_command_valid <= 1'b0;
       tx_desc_ready <= {NODES{1'b1}};
       rx_desc_ready <= {NODES{1'b1}};
       observed_state_r <= {DATA_W{1'b0}};
     end else begin
       current_cycle <= current_cycle + 1'b1;
+      command_mem_req_ready <= !current_cycle[4] || current_cycle[1];
+      if (pending_command_valid && command_mem_rsp_ready)
+        pending_command_valid <= 1'b0;
+      if (command_mem_req_valid && command_mem_req_ready) begin
+        pending_command_addr <= command_mem_req_addr;
+        pending_command_valid <= 1'b1;
+      end
       tx_desc_ready <= {NODES{1'b1}} ^
         ({{(NODES-1){1'b0}}, current_cycle[2]} << current_cycle[7:4]);
       rx_desc_ready <= {NODES{1'b1}} ^
         ({{(NODES-1){1'b0}}, current_cycle[3]} << current_cycle[11:8]);
-      cmd_valid <= 1'b1;
-      if (cmd_valid && cmd_ready) begin
-        cmd_source <= cmd_source + 1'b1;
-        cmd_destination <= cmd_destination + 4'd3;
-        cmd_vc <= cmd_vc + 1'b1;
-        cmd_tag <= {cmd_tag[6:0], cmd_tag[7] ^ cmd_tag[5]};
-        cmd_tx_base_addr <= cmd_tx_base_addr + 24'h000120;
-        cmd_rx_base_addr <= cmd_rx_base_addr + 24'h000220;
-        cmd_flit_count <= cmd_flit_count == 4'd8 ? 4'd1 : cmd_flit_count + 1'b1;
-        cmd_release_cycle <= current_cycle + {28'b0, cmd_tag[3:0]};
-      end
       if (|(tx_desc_valid & tx_desc_ready))
         observed_state_r <= {observed_state_r[DATA_W-2:0], observed_state_r[DATA_W-1]} ^
           {{(DATA_W-42){1'b0}},

--- a/scripts/generate_design.py
+++ b/scripts/generate_design.py
@@ -988,6 +988,7 @@ def generate_l1_memory_noc_design(src_dir, design):
     elif design["primitive"] == "descriptor_pair_scheduler":
         text = _emit_l1_descriptor_pair_scheduler(module_name, design)
         for filename in (
+            "noc_descriptor_command_prefetch.sv",
             "noc_descriptor_pair_scheduler.sv",
             "noc_descriptor_pair_scheduler_ppa_harness.sv",
         ):
@@ -2690,6 +2691,7 @@ def generate_config_mk(platform_dir, platform, design):
     ):
         verilog_files.extend(
             [
+                f"$(DESIGN_HOME)/src/{wrapper_name}/noc_descriptor_command_prefetch.v",
                 f"$(DESIGN_HOME)/src/{wrapper_name}/noc_descriptor_pair_scheduler.v",
                 f"$(DESIGN_HOME)/src/{wrapper_name}/noc_descriptor_pair_scheduler_ppa_harness.v",
             ]

--- a/tests/noc_descriptor_command_prefetch_tb.sv
+++ b/tests/noc_descriptor_command_prefetch_tb.sv
@@ -1,0 +1,95 @@
+`timescale 1ns/1ps
+
+module noc_descriptor_command_prefetch_tb;
+  localparam integer COMMAND_W = 102;
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  reg enable = 1'b0;
+  reg [13:0] command_count = 4;
+  wire mem_req_valid;
+  reg mem_req_ready = 1'b0;
+  wire [13:0] mem_req_addr;
+  reg pending_response = 1'b0;
+  reg [13:0] pending_addr = 0;
+  wire mem_rsp_valid = pending_response;
+  wire mem_rsp_ready;
+  wire [COMMAND_W-1:0] mem_rsp_data = command_word(pending_addr);
+  wire cmd_valid;
+  reg cmd_ready = 1'b0;
+  wire [COMMAND_W-1:0] cmd_data;
+  wire [31:0] request_count;
+  wire [31:0] response_count;
+  wire [31:0] delivered_command_count;
+  wire [31:0] memory_stall_cycles;
+  wire protocol_error;
+  integer observed_count = 0;
+
+  function [COMMAND_W-1:0] command_word;
+    input [13:0] address;
+    begin
+      command_word = {32'h1000 + address, 56'h123456789abcde, address};
+    end
+  endfunction
+
+  noc_descriptor_command_prefetch dut (
+    .clk(clk), .rst_n(rst_n), .enable(enable),
+    .command_count(command_count),
+    .mem_req_valid(mem_req_valid), .mem_req_ready(mem_req_ready),
+    .mem_req_addr(mem_req_addr),
+    .mem_rsp_valid(mem_rsp_valid), .mem_rsp_ready(mem_rsp_ready),
+    .mem_rsp_data(mem_rsp_data),
+    .cmd_valid(cmd_valid), .cmd_ready(cmd_ready), .cmd_data(cmd_data),
+    .request_count(request_count), .response_count(response_count),
+    .delivered_command_count(delivered_command_count),
+    .memory_stall_cycles(memory_stall_cycles),
+    .protocol_error(protocol_error)
+  );
+
+  always #1 clk = ~clk;
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      pending_response <= 1'b0;
+      pending_addr <= 0;
+    end else begin
+      if (pending_response && mem_rsp_ready)
+        pending_response <= 1'b0;
+      if (mem_req_valid && mem_req_ready) begin
+        if (pending_response && !mem_rsp_ready)
+          $fatal(1, "memory accepted a request while response was held");
+        pending_response <= 1'b1;
+        pending_addr <= mem_req_addr;
+      end
+      if (cmd_valid && cmd_ready) begin
+        if (cmd_data !== command_word(observed_count[13:0]))
+          $fatal(1, "command order/data mismatch at %0d", observed_count);
+        observed_count = observed_count + 1;
+      end
+    end
+  end
+
+  initial begin
+    repeat (3) @(negedge clk);
+    rst_n = 1'b1;
+    enable = 1'b1;
+    repeat (2) @(negedge clk);
+    mem_req_ready = 1'b1;
+    repeat (3) @(negedge clk);
+    cmd_ready = 1'b1;
+    repeat (3) @(negedge clk);
+    cmd_ready = 1'b0;
+    repeat (2) @(negedge clk);
+    cmd_ready = 1'b1;
+
+    wait (delivered_command_count == 4);
+    repeat (2) @(negedge clk);
+    if (observed_count != 4 || request_count != 4 || response_count != 4)
+      $fatal(1, "prefetch count mismatch observed=%0d req=%0d rsp=%0d delivered=%0d",
+        observed_count, request_count, response_count, delivered_command_count);
+    if (memory_stall_cycles < 2 || protocol_error)
+      $fatal(1, "stall/error accounting mismatch stalls=%0d error=%0d",
+        memory_stall_cycles, protocol_error);
+    $display("PASS prefetch commands=%0d stalls=%0d", observed_count, memory_stall_cycles);
+    $finish;
+  end
+endmodule

--- a/tests/noc_sram_packet_mesh4x4_workload_tb.sv
+++ b/tests/noc_sram_packet_mesh4x4_workload_tb.sv
@@ -132,18 +132,70 @@ module noc_sram_packet_mesh4x4_workload_tb;
   string destination_meta_mem;
 
 `ifdef SERIAL_PAIRED_SCHEDULER
-  integer command_position = 0;
-  wire [15:0] scheduler_packet_index = command_position < packet_count ?
-    command_order[command_position] : 16'b0;
-  wire [95:0] scheduler_command = descriptors[scheduler_packet_index];
-  wire scheduler_cmd_valid = rst_n && command_position < packet_count;
+  localparam integer COMMAND_W = 102;
+  wire command_mem_req_valid;
+  wire command_mem_req_ready = 1'b1;
+  wire [13:0] command_mem_req_addr;
+  reg command_mem_pending = 1'b0;
+  reg [13:0] command_mem_pending_addr = 0;
+  wire command_mem_rsp_valid = command_mem_pending;
+  wire command_mem_rsp_ready;
+  wire [COMMAND_W-1:0] command_mem_rsp_data =
+    workload_command(command_mem_pending_addr);
+  wire scheduler_cmd_valid;
   wire scheduler_cmd_ready;
+  wire [COMMAND_W-1:0] scheduler_command;
+  wire [31:0] prefetch_request_count;
+  wire [31:0] prefetch_response_count;
+  wire [31:0] prefetch_delivered_command_count;
+  wire [31:0] prefetch_memory_stall_cycles;
+  wire prefetch_protocol_error;
   wire [31:0] scheduler_accepted_command_count;
   wire [31:0] scheduler_installed_receive_count;
   wire [31:0] scheduler_submitted_transmit_count;
   wire [31:0] scheduler_release_wait_cycles;
   wire [31:0] scheduler_endpoint_stall_cycles;
   wire scheduler_protocol_error;
+
+  function [COMMAND_W-1:0] workload_command;
+    input [13:0] command_address;
+    reg [15:0] command_packet;
+    begin
+      command_packet = command_order[command_address];
+      workload_command = {
+        descriptors[command_packet][53:50],
+        {command_packet, 8'b0},
+        {command_packet, 8'b0},
+        descriptors[command_packet][49:42],
+        descriptors[command_packet][41:40],
+        descriptors[command_packet][39:36],
+        descriptors[command_packet][35:32],
+        descriptors[command_packet][31:0]
+      };
+    end
+  endfunction
+
+  noc_descriptor_command_prefetch #(
+    .COMMAND_W(COMMAND_W),
+    .ADDR_W(14),
+    .COUNT_W(14)
+  ) command_prefetch (
+    .clk(clk), .rst_n(rst_n), .enable(1'b1),
+    .command_count(packet_count[13:0]),
+    .mem_req_valid(command_mem_req_valid),
+    .mem_req_ready(command_mem_req_ready),
+    .mem_req_addr(command_mem_req_addr),
+    .mem_rsp_valid(command_mem_rsp_valid),
+    .mem_rsp_ready(command_mem_rsp_ready),
+    .mem_rsp_data(command_mem_rsp_data),
+    .cmd_valid(scheduler_cmd_valid), .cmd_ready(scheduler_cmd_ready),
+    .cmd_data(scheduler_command),
+    .request_count(prefetch_request_count),
+    .response_count(prefetch_response_count),
+    .delivered_command_count(prefetch_delivered_command_count),
+    .memory_stall_cycles(prefetch_memory_stall_cycles),
+    .protocol_error(prefetch_protocol_error)
+  );
 
   noc_descriptor_pair_scheduler scheduler (
     .clk(clk), .rst_n(rst_n), .current_cycle(cycle),
@@ -153,9 +205,9 @@ module noc_sram_packet_mesh4x4_workload_tb;
     .cmd_destination(scheduler_command[39:36]),
     .cmd_vc(scheduler_command[41:40]),
     .cmd_tag(scheduler_command[49:42]),
-    .cmd_tx_base_addr({scheduler_packet_index, 8'b0}),
-    .cmd_rx_base_addr({scheduler_packet_index, 8'b0}),
-    .cmd_flit_count(scheduler_command[53:50]),
+    .cmd_tx_base_addr(scheduler_command[73:50]),
+    .cmd_rx_base_addr(scheduler_command[97:74]),
+    .cmd_flit_count(scheduler_command[101:98]),
     .tx_desc_valid(tx_desc_valid), .tx_desc_ready(tx_desc_ready),
     .tx_desc_destination(tx_desc_destination), .tx_desc_vc(tx_desc_vc),
     .tx_desc_tag(tx_desc_tag), .tx_desc_base_addr(tx_desc_base_addr),
@@ -315,7 +367,8 @@ module noc_sram_packet_mesh4x4_workload_tb;
       live_context_valid <= 0;
       completion_shadow_valid <= 0;
 `ifdef SERIAL_PAIRED_SCHEDULER
-      command_position <= 0;
+      command_mem_pending <= 1'b0;
+      command_mem_pending_addr <= 0;
 `endif
       for (seq_endpoint_i = 0; seq_endpoint_i < 16; seq_endpoint_i = seq_endpoint_i + 1) begin
         source_position[seq_endpoint_i] <= 0;
@@ -328,8 +381,12 @@ module noc_sram_packet_mesh4x4_workload_tb;
     end else begin
       cycle <= cycle + 1;
 `ifdef SERIAL_PAIRED_SCHEDULER
-      if (scheduler_cmd_valid && scheduler_cmd_ready)
-        command_position <= command_position + 1;
+      if (command_mem_pending && command_mem_rsp_ready)
+        command_mem_pending <= 1'b0;
+      if (command_mem_req_valid && command_mem_req_ready) begin
+        command_mem_pending <= 1'b1;
+        command_mem_pending_addr <= command_mem_req_addr;
+      end
 `endif
       tx_fire_count = 0;
       completion_fire_count = 0;
@@ -454,8 +511,9 @@ module noc_sram_packet_mesh4x4_workload_tb;
       if (endpoint_protocol_error != 0)
         $fatal(1, "endpoint protocol error: %h", endpoint_protocol_error);
 `ifdef SERIAL_PAIRED_SCHEDULER
-      if (scheduler_protocol_error)
-        $fatal(1, "descriptor scheduler protocol error");
+      if (prefetch_protocol_error || scheduler_protocol_error)
+        $fatal(1, "descriptor command path protocol error prefetch=%0d scheduler=%0d",
+          prefetch_protocol_error, scheduler_protocol_error);
 `endif
       if (cycle > 0 && (cycle % 100000) == 0)
         $display("PROGRESS workload cycle=%0d submitted=%0d completed=%0d writes=%0d",
@@ -491,9 +549,14 @@ module noc_sram_packet_mesh4x4_workload_tb;
 `ifdef SERIAL_PAIRED_SCHEDULER
       if (scheduler_accepted_command_count != packet_count ||
           scheduler_installed_receive_count != packet_count ||
-          scheduler_submitted_transmit_count != packet_count)
+          scheduler_submitted_transmit_count != packet_count ||
+          prefetch_request_count != packet_count ||
+          prefetch_response_count != packet_count ||
+          prefetch_delivered_command_count != packet_count)
         $fatal(1,
-          "scheduler count mismatch accepted=%0d rx=%0d tx=%0d expected=%0d",
+          "command count mismatch req=%0d rsp=%0d delivered=%0d accepted=%0d rx=%0d tx=%0d expected=%0d",
+          prefetch_request_count, prefetch_response_count,
+          prefetch_delivered_command_count,
           scheduler_accepted_command_count, scheduler_installed_receive_count,
           scheduler_submitted_transmit_count, packet_count);
 `endif

--- a/tests/test_noc_descriptor_command_prefetch.py
+++ b/tests/test_noc_descriptor_command_prefetch.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.skipif(
+    not (shutil.which("iverilog") or Path("/oss-cad-suite/bin/iverilog").exists())
+    or not (shutil.which("vvp") or Path("/oss-cad-suite/bin/vvp").exists()),
+    reason="iverilog/vvp unavailable",
+)
+def test_noc_descriptor_command_prefetch_protocol(tmp_path: Path) -> None:
+    iverilog = shutil.which("iverilog") or "/oss-cad-suite/bin/iverilog"
+    vvp = shutil.which("vvp") or "/oss-cad-suite/bin/vvp"
+    simulator = tmp_path / "prefetch.vvp"
+    compile_result = subprocess.run(
+        [
+            iverilog,
+            "-g2012",
+            "-s",
+            "noc_descriptor_command_prefetch_tb",
+            "-o",
+            str(simulator),
+            str(REPO_ROOT / "npu/sim/rtl/noc_descriptor_command_prefetch.sv"),
+            str(REPO_ROOT / "tests/noc_descriptor_command_prefetch_tb.sv"),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert compile_result.returncode == 0, compile_result.stderr
+    simulation = subprocess.run(
+        [vvp, str(simulator)],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert simulation.returncode == 0, simulation.stderr
+    assert "PASS prefetch commands=4" in simulation.stdout

--- a/tests/test_noc_descriptor_pair_scheduler.py
+++ b/tests/test_noc_descriptor_pair_scheduler.py
@@ -78,6 +78,7 @@ def test_noc_descriptor_pair_scheduler_generator_emits_exact_hierarchy(
     generate_wrapper(config, str(source_dir), design)
 
     expected_sources = {
+        "noc_descriptor_command_prefetch.v",
         "noc_descriptor_pair_scheduler.v",
         "noc_descriptor_pair_scheduler_ppa_harness.v",
         f"{design['module_name']}.v",
@@ -130,3 +131,83 @@ def test_noc_descriptor_pair_scheduler_rejects_unsupported_physical_shape(
     config["operations"][0]["options"][option] = value
     with pytest.raises(ValueError, match=message):
         identify_design(config)
+
+
+def test_noc_descriptor_scheduler_prefetch_harness_makes_progress(
+    tmp_path: Path,
+) -> None:
+    iverilog = shutil.which("iverilog")
+    vvp = shutil.which("vvp")
+    if iverilog is None or vvp is None:
+        pytest.skip("iverilog/vvp unavailable")
+    testbench = tmp_path / "harness_tb.sv"
+    testbench.write_text(
+        """
+module harness_tb;
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  wire [31:0] accepted;
+  wire [31:0] installed;
+  wire [31:0] submitted;
+  wire [31:0] stalls;
+  wire protocol_error;
+  wire [255:0] observed;
+  always #1 clk = ~clk;
+  noc_descriptor_pair_scheduler_ppa_harness dut (
+    .clk(clk), .rst_n(rst_n),
+    .accepted_command_count(accepted),
+    .installed_receive_count(installed),
+    .submitted_transmit_count(submitted),
+    .endpoint_stall_cycles(stalls),
+    .protocol_error(protocol_error),
+    .observed_state(observed)
+  );
+  initial begin
+    repeat (3) @(negedge clk);
+    rst_n = 1'b1;
+    repeat (200) @(negedge clk);
+    if (accepted < 16 || installed < 16 || submitted < 16 || protocol_error)
+      $fatal(1, "harness did not progress accepted=%0d rx=%0d tx=%0d error=%0d",
+        accepted, installed, submitted, protocol_error);
+    if (observed == 0)
+      $fatal(1, "harness observation state did not change");
+    $display("PASS harness accepted=%0d rx=%0d tx=%0d", accepted, installed, submitted);
+    $finish;
+  end
+endmodule
+""",
+        encoding="ascii",
+    )
+    simulator = tmp_path / "harness.vvp"
+    sources = [
+        REPO_ROOT / "npu/sim/rtl/noc_descriptor_command_prefetch.sv",
+        REPO_ROOT / "npu/sim/rtl/noc_descriptor_pair_scheduler.sv",
+        REPO_ROOT / "npu/sim/rtl/noc_descriptor_pair_scheduler_ppa_harness.sv",
+        testbench,
+    ]
+    compile_result = subprocess.run(
+        [
+            iverilog,
+            "-g2012",
+            "-s",
+            "harness_tb",
+            "-o",
+            str(simulator),
+            *[str(path) for path in sources],
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert compile_result.returncode == 0, compile_result.stderr
+    simulation = subprocess.run(
+        [vvp, str(simulator)],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert simulation.returncode == 0, simulation.stderr
+    assert "PASS harness" in simulation.stdout

--- a/tests/test_noc_sram_packet_mesh_perf.py
+++ b/tests/test_noc_sram_packet_mesh_perf.py
@@ -232,3 +232,20 @@ def test_packet_mesh_rejects_unknown_descriptor_scheduler() -> None:
     )
     with pytest.raises(ValueError, match="descriptor_scheduler"):
         simulate_packet_mesh([descriptor], descriptor_scheduler="imaginary")
+
+
+def test_serial_scheduler_models_one_cycle_sram_cold_start() -> None:
+    descriptor = PacketDescriptor(
+        source=0,
+        destination=1,
+        vc=0,
+        tag=1,
+        flit_count=1,
+    )
+    result = simulate_packet_mesh(
+        [descriptor],
+        descriptor_scheduler="serial_paired",
+    )
+
+    assert result.rx_descriptor_handshakes[0].cycle == 3
+    assert result.tx_descriptor_handshakes[0].cycle == 4


### PR DESCRIPTION
## Summary
- add a synthesizable one-outstanding-read, one-entry-response command SRAM prefetch controller
- compose one-cycle command-memory timing into the paired scheduler PPA harness and full endpoint/mesh RTL replay
- update the performance model so `serial_paired` includes the concrete two-cycle cold start and steady two-cycle command cadence

## Llama7B result
The complete prefetch/scheduler/endpoint/mesh replay matches the performance model for 11,576 commands and 92,128 flits. Drain remains 397,227 cycles, only 24 cycles above the merged endpoint-parallel baseline. Contention/input stalls/peak occupancy remain 8,736/11,816/7 versus 30,285/46,504/11 for the baseline.

The RTL gate requires prefetch requests, responses, delivered commands, scheduler accepts, RX installs, and TX submissions all to equal 11,576.

## Validation
- 18 focused RTL, generator, performance-model, and composed replay tests passed
- 2 control-plane task-generator variants passed
- full workload RTL/performance equivalence passed
- generated physical hierarchy passes Icarus and Yosys
- Verilator has no width errors
- `python3 scripts/validate_runs.py --skip_eval_queue`

## Remaining abstraction
Command SRAM bitcells/macro placement and the command population/inter-wave refill producer remain explicit. HBM/DRAM remains outside the design boundary.