### PR TITLE
Embody Llama7B Phase-2 command generation

### DIFF
--- a/.github/workflows/npu-golden-sim.yml
+++ b/.github/workflows/npu-golden-sim.yml
@@ -99,6 +99,8 @@ jobs:
       - name: Run endpoint mesh equivalence tests
         run: |
           python3 -m pytest -q \
+            tests/test_noc_descriptor_pair_scheduler.py \
+            tests/test_noc_llama7b_phase2_command_generator.py \
             tests/test_noc_sram_packet_mesh_perf.py \
             tests/test_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py \
             tests/test_llm_decoder_attention_score32_noc_phase2_schedule.py

--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5574,6 +5574,10 @@ def _decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_evidence(
             "prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1",
             "serial_paired",
         ),
+        "l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_llama7b_v1": (
+            "prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1",
+            "serial_generated",
+        ),
     }
     variant = variants.get(item_id)
     if variant is None:
@@ -5656,11 +5660,14 @@ def _decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_evidence(
             "Use one-cycle in-order source SRAM responses, four-entry TX descriptor FIFOs, eight outstanding reads, and eight RX contexts",
             "Require exact performance/RTL agreement for packets, flits, drain cycles, contention, stalls, and occupancy",
             "Require zero endpoint protocol errors and concrete 8-bit wire tags",
-            (
-                "Require the serial paired command scheduler RTL in the composed replay"
-                if descriptor_scheduler == "serial_paired"
-                else "Keep synthesized command scheduler PPA explicit"
-            ),
+            {
+                "endpoint_parallel": "Keep synthesized command scheduler PPA explicit",
+                "serial_paired": "Require the serial paired command scheduler RTL in the composed replay",
+                "serial_generated": (
+                    "Require the counter-based Llama7B command generator and serial paired "
+                    "scheduler RTL to emit exactly 11576 commands in the composed replay"
+                ),
+            }[descriptor_scheduler],
             "Keep SRAM bitcells, workload activity power, and HBM/DRAM explicit",
             "Write exactly one JSON and one Markdown report",
         ],

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -14837,6 +14837,11 @@ def test_generate_l2_campaign_task_adds_score32_noc_composed_mesh_reroute() -> N
             "serial_scheduler_equivalence_v1",
             "serial_paired",
         ),
+        (
+            "generated_scheduler_equivalence_llama7b_v1",
+            "generated_scheduler_equivalence_v1",
+            "serial_generated",
+        ),
     ],
 )
 def test_generate_l2_campaign_task_adds_score32_endpoint_rtl_equivalence(

--- a/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/README.md
+++ b/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/README.md
@@ -1,0 +1,5 @@
+# Llama7B Phase-2 Generated Command Scheduler
+
+This proposal replaces the complete 11,576-record command image and its
+refill boundary with a synthesizable counter-based generator feeding the
+paired descriptor scheduler.

--- a/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/design_brief.md
+++ b/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/design_brief.md
@@ -1,0 +1,15 @@
+# Design Brief
+
+The checked Llama7B Phase-2 schedule contains eight waves, sixteen clusters,
+68 shared-payload packets for each remote tile, and 33 reduction packets for
+each non-root cluster. Shared-SRAM home wave 4 is local and emits no shared
+traffic. Nine release epochs, wave/class/cluster/packet counters, and simple
+route, tag, packet-ID, and base-address formulas therefore reproduce all
+11,576 102-bit commands exactly.
+
+The generator holds its output under backpressure and advances only when the
+paired scheduler accepts a command. It replaces a 1,180,752-bit (147,594-byte)
+static command image plus an unspecified refill producer. This is a
+workload-specific hardware point: changing the topology, packetization,
+precision, or schedule requires regeneration and a new exhaustive equivalence
+proof.

--- a/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/evaluation_gate.md
@@ -1,0 +1,6 @@
+# Evaluation Gate
+
+Run the 1.0/1.5 ns, 40/50/60 percent utilization Nangate45 macro sweep. Keep
+only timing-feasible rows with nonzero area and power. Compare placed area,
+critical path, and vectorless power directly with the earlier prefetch-backed
+paired scheduler; do not add a command SRAM estimate to the generated point.

--- a/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/evaluation_requests.json
@@ -1,0 +1,31 @@
+{
+  "proposal_id": "prop_l1_noc_llama7b_phase2_command_scheduler_v1",
+  "source_commit": "TBD",
+  "requested_items": [
+    {
+      "item_id": "l1_noc_llama7b_phase2_command_scheduler_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the exact generated-command source plus sixteen-endpoint paired descriptor scheduler.",
+      "evaluation_mode": "ppa",
+      "abstraction_layer": "architecture_block",
+      "config_paths": [
+        "runs/designs/noc/l1_noc_llama7b_phase2_command_scheduler_n16_wrapper/config_l1_noc_llama7b_phase2_command_scheduler_n16.json"
+      ],
+      "sweep_path": "runs/campaigns/noc/l1_llama7b_phase2_command_scheduler/sweeps/nangate45_macro_frontier.json",
+      "expected_outputs": [
+        "runs/designs/noc/l1_noc_llama7b_phase2_command_scheduler_n16_wrapper/metrics.csv"
+      ],
+      "status": "pending_after_proposal_merge",
+      "comparison_role": "phase2_generated_command_scheduler_physical_anchor",
+      "paired_baseline_item_id": "l1_noc_descriptor_pair_scheduler_v1",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "replace_command_image_with_exact_generation",
+        "reason": "Measure generator-plus-scheduler PPA without command SRAM or refill estimates."
+      },
+      "acceptance_notes": "Require exhaustive 11576-command equivalence, generated hierarchy selection, protocol_error=0, and timing/area/power rows. Treat vectorless power and payload SRAM macros as separate evidence."
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/implementation_summary.md
@@ -1,0 +1,9 @@
+# Implementation Summary
+
+- Added synthesizable wave/class/cluster/packet command generation RTL.
+- Proved every generated command against the independently built Python
+  schedule under output backpressure.
+- Added a generated-command option to the scheduler physical harness and
+  direct design generator.
+- Added a Nangate45 macro sweep directly comparable with the earlier
+  SRAM-prefetch scheduler point.

--- a/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/promotion_gate.md
+++ b/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/promotion_gate.md
@@ -1,0 +1,6 @@
+# Promotion Gate
+
+Promote only if exhaustive command equivalence and the full composed replay
+pass, and at least one physical row is timing-feasible. Report that command
+population/refill and command-image storage are removed only for this exact
+checked Llama7B schedule.

--- a/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/proposal.json
+++ b/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/proposal.json
@@ -1,0 +1,62 @@
+{
+  "proposal_id": "prop_l1_noc_llama7b_phase2_command_scheduler_v1",
+  "created_utc": "2026-08-18T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "abstraction_layer": "architecture_block",
+  "title": "Replace the Llama7B Phase-2 command image with exact RTL generation",
+  "hypothesis": "The regular complete Phase-2 command stream can be generated from small counters and constants with materially less area and energy than a 147594-byte command image while preserving exact packet ordering and cadence.",
+  "direct_comparison": {
+    "primary_question": "What PPA replaces the static command image, prefetch path, and unspecified refill producer for the checked Llama7B schedule?",
+    "include": [
+      "nine release epochs",
+      "wave, traffic-class, cluster, and packet counters",
+      "shared-home route generation",
+      "reduction route and modulo-256 tag generation",
+      "packet-ID and TX/RX base-address generation",
+      "paired RX-before-TX descriptor scheduler",
+      "sixteen endpoint descriptor interfaces"
+    ],
+    "exclude": [
+      "endpoint and router logic",
+      "payload SRAM bitcells",
+      "HBM/DRAM",
+      "workload-matched switching power"
+    ]
+  },
+  "expected_benefit": [
+    "remove 1180752 bits of static command records",
+    "remove the command refill producer abstraction for this exact workload",
+    "retain exact two-cycle paired descriptor cadence"
+  ],
+  "risks": [
+    "the generator is specialized to one checked schedule",
+    "constant arithmetic may create an unexpected timing path",
+    "vectorless power does not represent workload activity"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l1_noc_llama7b_phase2_command_scheduler_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the exact generated-command source plus sixteen-endpoint paired descriptor scheduler.",
+      "evaluation_mode": "ppa",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "phase2_generated_command_scheduler_physical_anchor",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "config_paths": [
+        "runs/designs/noc/l1_noc_llama7b_phase2_command_scheduler_n16_wrapper/config_l1_noc_llama7b_phase2_command_scheduler_n16.json"
+      ],
+      "sweep_path": "runs/campaigns/noc/l1_llama7b_phase2_command_scheduler/sweeps/nangate45_macro_frontier.json",
+      "expected_outputs": [
+        "runs/designs/noc/l1_noc_llama7b_phase2_command_scheduler_n16_wrapper/metrics.csv"
+      ]
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l1_noc_descriptor_pair_scheduler_v1/proposal.json",
+    "npu/sim/rtl/noc_llama7b_phase2_command_generator.sv"
+  ]
+}

--- a/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/quality_gate.md
@@ -1,6 +1,8 @@
 # Quality Gate
 
 - Require exact equality for all 11,576 packed 102-bit commands.
+- Require the runtime generated-mode guard to match the canonical packed-stream
+  SHA-256 and reject same-length mutations before RTL replay.
 - Require command stability while `valid && !ready`.
 - Require generated hierarchy to select `GENERATED_SOURCE=1` and include the
   generator, paired scheduler, and observation harness RTL explicitly.

--- a/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/quality_gate.md
@@ -1,0 +1,11 @@
+# Quality Gate
+
+- Require exact equality for all 11,576 packed 102-bit commands.
+- Require command stability while `valid && !ready`.
+- Require generated hierarchy to select `GENERATED_SOURCE=1` and include the
+  generator, paired scheduler, and observation harness RTL explicitly.
+- Require composed endpoint/mesh replay to complete every packet and flit
+  without protocol errors.
+
+Status: exhaustive command comparison, composed replay, and generated-hierarchy
+synthesis passed locally; physical evaluation pending.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/README.md
@@ -1,0 +1,5 @@
+# Generated Scheduler Composed Equivalence
+
+This proposal proves the complete Llama7B Phase-2 command generator, paired
+descriptor scheduler, finite SRAM endpoints, and 4x4 mesh against the cycle
+performance model.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/design_brief.md
@@ -1,0 +1,11 @@
+# Design Brief
+
+The counter-based generator directly drives the synthesized RX-before-TX
+paired scheduler. Every generated command traverses finite endpoint descriptor
+queues, one-cycle source-SRAM ports, bounded receive contexts, and the exact
+segmented 4x4 mesh. The comparison covers packet/flit counts, drain cycles,
+router contention, input stalls, and maximum occupancy.
+
+The current packet-ID-derived base addresses are an identity-proof mechanism.
+Compact per-endpoint payload allocation and lifetime reuse remain a follow-on
+memory-controller closure item.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/evaluation_gate.md
@@ -1,0 +1,6 @@
+# Evaluation Gate
+
+Run the workload-complete eight-wave replay on the remote evaluator with
+`--descriptor-scheduler serial_generated`. The result must contain exactly one
+JSON and one Markdown report and must not claim payload SRAM bitcells,
+workload-activity power, or HBM/DRAM controller closure.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/evaluation_requests.json
@@ -1,0 +1,29 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1",
+  "source_commit": "TBD",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Replay every generated command and packet through finite endpoint and mesh RTL and require exact performance-model counters.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence",
+      "config_paths": [],
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence__l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_llama7b_v1.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence__l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_llama7b_v1.md"
+      ],
+      "status": "pending_after_proposal_merge",
+      "comparison_role": "phase2_generated_scheduler_composed_equivalence",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_llama7b_v1",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "exact_generated_command_equivalence",
+        "reason": "Close command-image and refill abstractions without changing packet or cycle behavior."
+      },
+      "acceptance_notes": "Require 11576 generated commands, 92128 flits, exact RTL/performance packet/flit/cycle/contention/stall/occupancy counters, and zero protocol errors."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/implementation_summary.md
@@ -1,0 +1,6 @@
+# Implementation Summary
+
+- Added `serial_generated` to the RTL and performance replay contracts.
+- Connected generated commands directly to the paired scheduler.
+- Added count and protocol gates for all 11,576 commands.
+- Removed command SRAM and refill from the generated-mode abstraction list.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/promotion_gate.md
@@ -1,0 +1,5 @@
+# Promotion Gate
+
+Promote only when command generation through final packet completion is
+cycle-exact with the performance model and the generated-command scheduler
+physical anchor is available for frontier recosting.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/proposal.json
@@ -1,0 +1,57 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1",
+  "created_utc": "2026-08-18T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "validation",
+  "abstraction_layer": "decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence",
+  "title": "Prove generated Llama7B commands through the finite endpoint and mesh RTL",
+  "hypothesis": "Counter-generated commands preserve the complete Phase-2 packet stream and cycle behavior while removing the command image and refill boundary.",
+  "direct_comparison": {
+    "primary_question": "Does generated command control remain exactly equivalent through finite endpoints and the composed mesh?",
+    "include": [
+      "complete eight-wave and 128-tile schedule",
+      "11576 generated command records",
+      "paired RX-before-TX scheduler RTL",
+      "one-cycle source SRAM response control",
+      "finite TX queues and RX contexts",
+      "exact 4x4 segmented mesh RTL"
+    ],
+    "exclude": [
+      "payload SRAM bitcells and macro placement",
+      "HBM/DRAM controller",
+      "workload-matched switching power"
+    ]
+  },
+  "expected_benefit": [
+    "close command population and refill abstraction",
+    "prove command-to-delivery cycle equivalence",
+    "retain an explicit short list of physical-only abstractions"
+  ],
+  "risks": [
+    "full detailed RTL replay is computationally expensive",
+    "specialization is valid only for the checked schedule contract"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Replay every generated command and packet through finite endpoint and mesh RTL and require exact performance-model counters.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence",
+      "comparison_role": "phase2_generated_scheduler_composed_equivalence",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "config_paths": [],
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence__l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_llama7b_v1.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence__l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_llama7b_v1.md"
+      ]
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_v1/proposal.json",
+    "docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/proposal.json"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/quality_gate.md
@@ -1,0 +1,9 @@
+# Quality Gate
+
+- Require all 11,576 commands and 92,128 flits.
+- Require exact RTL/performance equality for cycle and router counters.
+- Require every RX descriptor before its paired TX descriptor.
+- Require zero generator, scheduler, endpoint, and mesh protocol errors.
+
+Status: passed locally. All 11,576 commands and 92,128 flits completed in
+397,227 cycles with exact performance/RTL counter equality.

--- a/npu/eval/verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py
+++ b/npu/eval/verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import re
 import shutil
@@ -33,6 +34,10 @@ from npu.sim.perf.noc_sram_packet_mesh import (  # noqa: E402
 
 JsonDict = dict[str, Any]
 MAX_PACKETS = 12000
+GENERATED_COMMAND_COUNT = 11576
+GENERATED_COMMAND_SHA256 = (
+    "624c39e542c05fa76a480c173d39323adba58ac75ee12951139d8893929df483"
+)
 RTL_SOURCES = (
     Path("npu/sim/rtl/noc_ready_valid_fifo.sv"),
     Path("npu/sim/rtl/noc_segmented_mesh_router.sv"),
@@ -176,6 +181,24 @@ def command_words_from_packets(packets: list[WorkloadPacket]) -> list[int]:
     return words
 
 
+def _require_canonical_generated_commands(packets: list[WorkloadPacket]) -> None:
+    if len(packets) != GENERATED_COMMAND_COUNT:
+        raise ValueError(
+            "serial_generated is specialized to the complete 11576-command "
+            "Llama7B Phase-2 schedule"
+        )
+    digest = hashlib.sha256()
+    for word in command_words_from_packets(packets):
+        digest.update(word.to_bytes(13, byteorder="big"))
+    observed = digest.hexdigest()
+    if observed != GENERATED_COMMAND_SHA256:
+        raise ValueError(
+            "serial_generated command stream does not match the canonical "
+            f"Llama7B Phase-2 schedule: expected sha256={GENERATED_COMMAND_SHA256}, "
+            f"observed sha256={observed}"
+        )
+
+
 def write_workload_memories(
     packets: list[WorkloadPacket],
     output_dir: Path,
@@ -260,11 +283,8 @@ def run_rtl_replay(
             "descriptor_scheduler must be endpoint_parallel, serial_paired, or "
             "serial_generated"
         )
-    if descriptor_scheduler == "serial_generated" and len(packets) != 11576:
-        raise ValueError(
-            "serial_generated is specialized to the complete 11576-command "
-            "Llama7B Phase-2 schedule"
-        )
+    if descriptor_scheduler == "serial_generated":
+        _require_canonical_generated_commands(packets)
     memories = write_workload_memories(packets, work_dir)
     simulator = work_dir / "phase2_endpoint_mesh.vvp"
     compile_command = [

--- a/npu/eval/verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py
+++ b/npu/eval/verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py
@@ -42,6 +42,9 @@ RTL_SOURCES = (
 )
 SCHEDULER_RTL_SOURCE = Path("npu/sim/rtl/noc_descriptor_pair_scheduler.sv")
 PREFETCH_RTL_SOURCE = Path("npu/sim/rtl/noc_descriptor_command_prefetch.sv")
+COMMAND_GENERATOR_RTL_SOURCE = Path(
+    "npu/sim/rtl/noc_llama7b_phase2_command_generator.sv"
+)
 RTL_TB = Path("tests/noc_sram_packet_mesh4x4_workload_tb.sv")
 PASS_RE = re.compile(
     r"PASS workload packets=(?P<packets>\d+) flits=(?P<flits>\d+) "
@@ -148,6 +151,31 @@ def _queue_order_and_meta(
     return order, meta
 
 
+def command_words_from_packets(packets: list[WorkloadPacket]) -> list[int]:
+    """Pack the authoritative global command stream consumed by scheduler RTL."""
+
+    words: list[int] = []
+    for packet in sorted(
+        packets,
+        key=lambda item: (
+            item.release_cycle,
+            item.schedule_order,
+            item.packet_id,
+        ),
+    ):
+        base_addr = packet.packet_id << 8
+        word = packet.release_cycle
+        word |= packet.source << 32
+        word |= packet.destination << 36
+        word |= packet.vc << 40
+        word |= packet.tag << 42
+        word |= base_addr << 50
+        word |= base_addr << 74
+        word |= packet.flit_count << 98
+        words.append(word)
+    return words
+
+
 def write_workload_memories(
     packets: list[WorkloadPacket],
     output_dir: Path,
@@ -223,9 +251,19 @@ def run_rtl_replay(
     wall_timeout_seconds: int,
     descriptor_scheduler: str = "endpoint_parallel",
 ) -> JsonDict:
-    if descriptor_scheduler not in ("endpoint_parallel", "serial_paired"):
+    if descriptor_scheduler not in (
+        "endpoint_parallel",
+        "serial_paired",
+        "serial_generated",
+    ):
         raise ValueError(
-            "descriptor_scheduler must be endpoint_parallel or serial_paired"
+            "descriptor_scheduler must be endpoint_parallel, serial_paired, or "
+            "serial_generated"
+        )
+    if descriptor_scheduler == "serial_generated" and len(packets) != 11576:
+        raise ValueError(
+            "serial_generated is specialized to the complete 11576-command "
+            "Llama7B Phase-2 schedule"
         )
     memories = write_workload_memories(packets, work_dir)
     simulator = work_dir / "phase2_endpoint_mesh.vvp"
@@ -237,14 +275,22 @@ def run_rtl_replay(
         "-o",
         str(simulator),
     ]
-    if descriptor_scheduler == "serial_paired":
+    if descriptor_scheduler in ("serial_paired", "serial_generated"):
         compile_command.extend(
             [
                 "-DSERIAL_PAIRED_SCHEDULER",
-                str(repo_root / PREFETCH_RTL_SOURCE),
                 str(repo_root / SCHEDULER_RTL_SOURCE),
             ]
         )
+        if descriptor_scheduler == "serial_generated":
+            compile_command.extend(
+                [
+                    "-DGENERATED_COMMAND_SOURCE",
+                    str(repo_root / COMMAND_GENERATOR_RTL_SOURCE),
+                ]
+            )
+        else:
+            compile_command.append(str(repo_root / PREFETCH_RTL_SOURCE))
     compile_command.extend(str(repo_root / path) for path in RTL_SOURCES)
     compile_command.append(str(repo_root / RTL_TB))
     compile_result = subprocess.run(
@@ -477,10 +523,18 @@ def build_and_run(args: argparse.Namespace) -> JsonDict:
         },
         "remaining_abstractions": [
             "SRAM arrays are transaction-accurate one-cycle ports; bitcells and macro placement remain external.",
-            "The 102-bit command records use concrete one-cycle prefetch control; command SRAM bitcells, macro placement, and command population/refill remain external evidence.",
+            "Packet-ID-derived TX/RX addresses prove ordering and data integrity but do not yet embody compact per-endpoint payload allocation or lifetime reuse.",
+            *(
+                [
+                    "The 102-bit command records use concrete one-cycle prefetch control; command SRAM bitcells, macro placement, and command population/refill remain external evidence."
+                ]
+                if args.descriptor_scheduler == "serial_paired"
+                else []
+            ),
             *(
                 []
-                if args.descriptor_scheduler == "serial_paired"
+                if args.descriptor_scheduler
+                in ("serial_paired", "serial_generated")
                 else [
                     "The command scheduler is embodied by the deterministic paired-descriptor testbench driver, not synthesized RTL."
                 ]
@@ -529,8 +583,8 @@ def main() -> int:
     parser.add_argument("--wall-timeout-seconds", type=int, default=1800)
     parser.add_argument(
         "--descriptor-scheduler",
-        choices=("endpoint_parallel", "serial_paired"),
-        default="serial_paired",
+        choices=("endpoint_parallel", "serial_paired", "serial_generated"),
+        default="serial_generated",
     )
     parser.add_argument("--out", type=Path, required=True)
     parser.add_argument("--report", type=Path, required=True)

--- a/npu/sim/perf/noc_sram_packet_mesh.py
+++ b/npu/sim/perf/noc_sram_packet_mesh.py
@@ -420,17 +420,25 @@ def simulate_packet_mesh(
     ``endpoint_parallel`` schedules one RX per destination and one TX per
     source each cycle, preserving the original abstract scheduler.  The
     synthesizable ``serial_paired`` policy includes the one-cycle SRAM request
-    and response buffer, then holds one global command, installs its RX
-    descriptor first, and submits its TX descriptor on a later edge. Its
-    steady-state issue cadence is two cycles per command.
+    and response buffer. ``serial_generated`` feeds the same scheduler from a
+    direct ready/valid command generator. Both hold one global command,
+    install its RX descriptor first, and submit its TX descriptor on a later
+    edge; steady-state issue cadence is two cycles per command.
     Ready schedules are indexed as ``[cycle][endpoint]``; a callable may be
     used for large replay workloads without materializing a matrix.
     """
 
-    if descriptor_scheduler not in ("endpoint_parallel", "serial_paired"):
+    if descriptor_scheduler not in (
+        "endpoint_parallel",
+        "serial_paired",
+        "serial_generated",
+    ):
         raise ValueError(
-            "descriptor_scheduler must be endpoint_parallel or serial_paired"
+            "descriptor_scheduler must be endpoint_parallel, serial_paired, or "
+            "serial_generated"
         )
+
+    serial_scheduler = descriptor_scheduler in ("serial_paired", "serial_generated")
 
     packet_list = tuple(descriptors)
     if not packet_list:
@@ -501,7 +509,7 @@ def simulate_packet_mesh(
                 for state in states
             )
             if endpoints_idle and all(router.idle() for router in routers):
-                if descriptor_scheduler == "serial_paired":
+                if serial_scheduler:
                     pending_releases = (
                         [packet_list[scheduler_active].release_cycle]
                         if scheduler_active is not None
@@ -522,7 +530,7 @@ def simulate_packet_mesh(
         # legal, matching the RTL's registered descriptor state.
         rx_push: dict[int, int] = {}
         tx_push: dict[int, int] = {}
-        if descriptor_scheduler == "serial_paired":
+        if serial_scheduler:
             if scheduler_active is not None:
                 descriptor = packet_list[scheduler_active]
                 if descriptor.release_cycle <= cycle:
@@ -703,7 +711,7 @@ def simulate_packet_mesh(
                 rx_handshakes.append(
                     DescriptorHandshake(cycle, endpoint, "rx", index, packet_list[index])
                 )
-                if descriptor_scheduler == "serial_paired":
+                if serial_scheduler:
                     if scheduler_active != index or scheduler_receive_installed:
                         raise RuntimeError("serial RX scheduler state diverged")
                     scheduler_receive_installed = True
@@ -717,7 +725,7 @@ def simulate_packet_mesh(
                 tx_handshakes.append(
                     DescriptorHandshake(cycle, endpoint, "tx", index, packet_list[index])
                 )
-                if descriptor_scheduler == "serial_paired":
+                if serial_scheduler:
                     if scheduler_active != index or not scheduler_receive_installed:
                         raise RuntimeError("serial TX scheduler state diverged")
                     scheduler_active = None
@@ -742,10 +750,10 @@ def simulate_packet_mesh(
         # a command whose TX descriptor handshook on this edge.  Its newly
         # accepted command cannot drive endpoint outputs until the next cycle.
         if (
-            descriptor_scheduler == "serial_paired"
+            serial_scheduler
             and scheduler_active is None
             and scheduler_pending
-            and cycle >= 2
+            and cycle >= (2 if descriptor_scheduler == "serial_paired" else 0)
         ):
             scheduler_active = scheduler_pending.popleft()
 

--- a/npu/sim/rtl/noc_descriptor_pair_scheduler_ppa_harness.sv
+++ b/npu/sim/rtl/noc_descriptor_pair_scheduler_ppa_harness.sv
@@ -3,7 +3,8 @@
 module noc_descriptor_pair_scheduler_ppa_harness #(
   parameter integer NODES = 16,
   parameter integer DATA_W = 256,
-  parameter integer COUNTER_W = 32
+  parameter integer COUNTER_W = 32,
+  parameter bit GENERATED_SOURCE = 1'b0
 ) (
   input wire clk,
   input wire rst_n,
@@ -27,19 +28,7 @@ module noc_descriptor_pair_scheduler_ppa_harness #(
   wire [23:0] cmd_tx_base_addr = cmd_data[73:50];
   wire [23:0] cmd_rx_base_addr = cmd_data[97:74];
   wire [3:0] cmd_flit_count = cmd_data[101:98];
-  wire command_mem_req_valid;
-  reg command_mem_req_ready;
-  wire [13:0] command_mem_req_addr;
-  wire command_mem_rsp_valid;
-  wire command_mem_rsp_ready;
-  wire [COMMAND_W-1:0] command_mem_rsp_data;
-  reg [13:0] pending_command_addr;
-  reg pending_command_valid;
-  wire [COUNTER_W-1:0] prefetch_request_count;
-  wire [COUNTER_W-1:0] prefetch_response_count;
-  wire [COUNTER_W-1:0] prefetch_delivered_count;
-  wire [COUNTER_W-1:0] prefetch_memory_stalls;
-  wire prefetch_protocol_error;
+  wire command_source_protocol_error;
   wire scheduler_protocol_error;
   wire [NODES-1:0] tx_desc_valid;
   reg [NODES-1:0] tx_desc_ready;
@@ -62,31 +51,7 @@ module noc_descriptor_pair_scheduler_ppa_harness #(
   integer observed_i;
 
   assign observed_state = observed_state_r;
-  assign protocol_error = prefetch_protocol_error | scheduler_protocol_error;
-  assign command_mem_rsp_valid = pending_command_valid;
-  assign command_mem_rsp_data = command_word(pending_command_addr);
-
-  function [COMMAND_W-1:0] command_word;
-    input [13:0] address;
-    reg [3:0] source;
-    reg [3:0] destination;
-    reg [3:0] flit_count;
-    begin
-      source = address[3:0];
-      destination = address[7:4] + address[3:0] + 1'b1;
-      flit_count = {1'b0, address[2:0]} + 1'b1;
-      command_word = {
-        flit_count,
-        {address, 10'h155},
-        {address, 10'h0aa},
-        address[7:0] ^ 8'h5a,
-        address[1:0],
-        destination,
-        source,
-        {18'b0, address}
-      };
-    end
-  endfunction
+  assign protocol_error = command_source_protocol_error | scheduler_protocol_error;
 
   always @(*) begin
     tx_observed_index = 4'b0;
@@ -99,27 +64,101 @@ module noc_descriptor_pair_scheduler_ppa_harness #(
     end
   end
 
-  noc_descriptor_command_prefetch #(
-    .COMMAND_W(COMMAND_W),
-    .ADDR_W(14),
-    .COUNT_W(14),
-    .COUNTER_W(COUNTER_W)
-  ) prefetch (
-    .clk(clk), .rst_n(rst_n), .enable(1'b1),
-    .command_count(14'h3fff),
-    .mem_req_valid(command_mem_req_valid),
-    .mem_req_ready(command_mem_req_ready),
-    .mem_req_addr(command_mem_req_addr),
-    .mem_rsp_valid(command_mem_rsp_valid),
-    .mem_rsp_ready(command_mem_rsp_ready),
-    .mem_rsp_data(command_mem_rsp_data),
-    .cmd_valid(cmd_valid), .cmd_ready(cmd_ready), .cmd_data(cmd_data),
-    .request_count(prefetch_request_count),
-    .response_count(prefetch_response_count),
-    .delivered_command_count(prefetch_delivered_count),
-    .memory_stall_cycles(prefetch_memory_stalls),
-    .protocol_error(prefetch_protocol_error)
-  );
+  generate
+    if (GENERATED_SOURCE) begin : generated_command_source
+      wire generated_done;
+      wire [COUNTER_W-1:0] generated_command_count;
+      wire generated_protocol_error;
+      assign command_source_protocol_error = generated_protocol_error;
+      noc_llama7b_phase2_command_generator #(
+        .COMMAND_W(COMMAND_W),
+        .COUNTER_W(COUNTER_W)
+      ) generator (
+        .clk(clk), .rst_n(rst_n), .enable(1'b1),
+        .cmd_valid(cmd_valid), .cmd_ready(cmd_ready), .cmd_data(cmd_data),
+        .done(generated_done),
+        .generated_command_count(generated_command_count),
+        .protocol_error(generated_protocol_error)
+      );
+    end else begin : prefetched_command_source
+      wire command_mem_req_valid;
+      reg command_mem_req_ready;
+      wire [13:0] command_mem_req_addr;
+      wire command_mem_rsp_valid;
+      wire command_mem_rsp_ready;
+      wire [COMMAND_W-1:0] command_mem_rsp_data;
+      reg [13:0] pending_command_addr;
+      reg pending_command_valid;
+      wire [COUNTER_W-1:0] prefetch_request_count;
+      wire [COUNTER_W-1:0] prefetch_response_count;
+      wire [COUNTER_W-1:0] prefetch_delivered_count;
+      wire [COUNTER_W-1:0] prefetch_memory_stalls;
+      wire prefetch_protocol_error;
+      assign command_source_protocol_error = prefetch_protocol_error;
+      assign command_mem_rsp_valid = pending_command_valid;
+      assign command_mem_rsp_data = command_word(pending_command_addr);
+
+      function [COMMAND_W-1:0] command_word;
+        input [13:0] address;
+        reg [3:0] source;
+        reg [3:0] destination;
+        reg [3:0] flit_count;
+        begin
+          source = address[3:0];
+          destination = address[7:4] + address[3:0] + 1'b1;
+          flit_count = {1'b0, address[2:0]} + 1'b1;
+          command_word = {
+            flit_count,
+            {address, 10'h155},
+            {address, 10'h0aa},
+            address[7:0] ^ 8'h5a,
+            address[1:0],
+            destination,
+            source,
+            {18'b0, address}
+          };
+        end
+      endfunction
+
+      always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+          command_mem_req_ready <= 1'b1;
+          pending_command_addr <= 0;
+          pending_command_valid <= 1'b0;
+        end else begin
+          command_mem_req_ready <= !current_cycle[4] || current_cycle[1];
+          if (pending_command_valid && command_mem_rsp_ready)
+            pending_command_valid <= 1'b0;
+          if (command_mem_req_valid && command_mem_req_ready) begin
+            pending_command_addr <= command_mem_req_addr;
+            pending_command_valid <= 1'b1;
+          end
+        end
+      end
+
+      noc_descriptor_command_prefetch #(
+        .COMMAND_W(COMMAND_W),
+        .ADDR_W(14),
+        .COUNT_W(14),
+        .COUNTER_W(COUNTER_W)
+      ) prefetch (
+        .clk(clk), .rst_n(rst_n), .enable(1'b1),
+        .command_count(14'h3fff),
+        .mem_req_valid(command_mem_req_valid),
+        .mem_req_ready(command_mem_req_ready),
+        .mem_req_addr(command_mem_req_addr),
+        .mem_rsp_valid(command_mem_rsp_valid),
+        .mem_rsp_ready(command_mem_rsp_ready),
+        .mem_rsp_data(command_mem_rsp_data),
+        .cmd_valid(cmd_valid), .cmd_ready(cmd_ready), .cmd_data(cmd_data),
+        .request_count(prefetch_request_count),
+        .response_count(prefetch_response_count),
+        .delivered_command_count(prefetch_delivered_count),
+        .memory_stall_cycles(prefetch_memory_stalls),
+        .protocol_error(prefetch_protocol_error)
+      );
+    end
+  endgenerate
 
   noc_descriptor_pair_scheduler #(
     .NODES(NODES),
@@ -149,22 +188,12 @@ module noc_descriptor_pair_scheduler_ppa_harness #(
 
   always @(posedge clk or negedge rst_n) begin
     if (!rst_n) begin
-      current_cycle <= 0;
-      command_mem_req_ready <= 1'b1;
-      pending_command_addr <= 0;
-      pending_command_valid <= 1'b0;
+      current_cycle <= GENERATED_SOURCE ? 32'd400000 : 32'd0;
       tx_desc_ready <= {NODES{1'b1}};
       rx_desc_ready <= {NODES{1'b1}};
       observed_state_r <= {DATA_W{1'b0}};
     end else begin
       current_cycle <= current_cycle + 1'b1;
-      command_mem_req_ready <= !current_cycle[4] || current_cycle[1];
-      if (pending_command_valid && command_mem_rsp_ready)
-        pending_command_valid <= 1'b0;
-      if (command_mem_req_valid && command_mem_req_ready) begin
-        pending_command_addr <= command_mem_req_addr;
-        pending_command_valid <= 1'b1;
-      end
       tx_desc_ready <= {NODES{1'b1}} ^
         ({{(NODES-1){1'b0}}, current_cycle[2]} << current_cycle[7:4]);
       rx_desc_ready <= {NODES{1'b1}} ^

--- a/npu/sim/rtl/noc_llama7b_phase2_command_generator.sv
+++ b/npu/sim/rtl/noc_llama7b_phase2_command_generator.sv
@@ -1,0 +1,252 @@
+`timescale 1ns/1ps
+
+// Generates the complete command stream for the checked Llama7B Phase-2
+// schedule. The stream is represented by wave/class/cluster/packet counters;
+// no per-packet command image or refill engine is required.
+module noc_llama7b_phase2_command_generator #(
+  parameter integer COMMAND_W = 102,
+  parameter integer COUNTER_W = 32
+) (
+  input wire clk,
+  input wire rst_n,
+  input wire enable,
+
+  output wire cmd_valid,
+  input wire cmd_ready,
+  output wire [COMMAND_W-1:0] cmd_data,
+
+  output reg done,
+  output reg [COUNTER_W-1:0] generated_command_count,
+  output reg protocol_error
+);
+  localparam integer EXPECTED_COMMANDS = 11576;
+
+  localparam PHASE_REDUCTION = 1'b0;
+  localparam PHASE_SHARED = 1'b1;
+
+  reg [3:0] release_epoch;
+  reg phase;
+  reg [3:0] cluster;
+  reg [6:0] packet;
+
+  reg [31:0] command_release_cycle;
+  reg [3:0] command_source;
+  reg [3:0] command_destination;
+  reg [1:0] command_vc;
+  reg [7:0] command_tag;
+  reg [13:0] command_packet_id;
+  reg [3:0] command_flit_count;
+
+  wire command_fire = cmd_valid && cmd_ready;
+  wire [2:0] transfer_wave =
+    phase == PHASE_SHARED ? release_epoch[2:0] : release_epoch[2:0] - 1'b1;
+
+  function [31:0] epoch_release_cycle;
+    input [3:0] epoch;
+    begin
+      case (epoch)
+        4'd0: epoch_release_cycle = 32'd9341;
+        4'd1: epoch_release_cycle = 32'd57311;
+        4'd2: epoch_release_cycle = 32'd105281;
+        4'd3: epoch_release_cycle = 32'd153251;
+        4'd4: epoch_release_cycle = 32'd201221;
+        4'd5: epoch_release_cycle = 32'd249190;
+        4'd6: epoch_release_cycle = 32'd297160;
+        4'd7: epoch_release_cycle = 32'd345130;
+        4'd8: epoch_release_cycle = 32'd393100;
+        default: epoch_release_cycle = 32'd0;
+      endcase
+    end
+  endfunction
+
+  function [13:0] wave_packet_base;
+    input [2:0] wave;
+    begin
+      case (wave)
+        3'd0: wave_packet_base = 14'd0;
+        3'd1: wave_packet_base = 14'd1583;
+        3'd2: wave_packet_base = 14'd3166;
+        3'd3: wave_packet_base = 14'd4749;
+        3'd4: wave_packet_base = 14'd6332;
+        3'd5: wave_packet_base = 14'd6827;
+        3'd6: wave_packet_base = 14'd8410;
+        3'd7: wave_packet_base = 14'd9993;
+      endcase
+    end
+  endfunction
+
+  function [3:0] shared_home_shift;
+    input [2:0] wave;
+    begin
+      case (wave)
+        3'd0: shared_home_shift = 4'd4;
+        3'd1: shared_home_shift = 4'd7;
+        3'd2: shared_home_shift = 4'd10;
+        3'd3: shared_home_shift = 4'd13;
+        3'd4: shared_home_shift = 4'd0;
+        3'd5: shared_home_shift = 4'd3;
+        3'd6: shared_home_shift = 4'd6;
+        3'd7: shared_home_shift = 4'd9;
+      endcase
+    end
+  endfunction
+
+  function [13:0] full_cluster_offset;
+    input [3:0] cluster_index;
+    reg [13:0] value;
+    begin
+      value = {10'b0, cluster_index};
+      full_cluster_offset =
+        (value << 6) + (value << 5) + (value << 2) + value;
+    end
+  endfunction
+
+  function [13:0] reduction_cluster_offset;
+    input [3:0] cluster_index;
+    reg [13:0] value;
+    begin
+      value = {10'b0, cluster_index};
+      reduction_cluster_offset = (value << 5) + value;
+    end
+  endfunction
+
+  function [13:0] shared_packet_id;
+    input [2:0] wave;
+    input [3:0] cluster_index;
+    input [6:0] packet_index;
+    begin
+      shared_packet_id = wave_packet_base(wave) +
+        full_cluster_offset(cluster_index) + {7'b0, packet_index};
+    end
+  endfunction
+
+  function [13:0] reduction_packet_id;
+    input [2:0] wave;
+    input [3:0] cluster_index;
+    input [6:0] packet_index;
+    begin
+      if (wave == 3'd4)
+        reduction_packet_id = wave_packet_base(wave) +
+          reduction_cluster_offset(cluster_index) + {7'b0, packet_index};
+      else
+        reduction_packet_id = wave_packet_base(wave) +
+          full_cluster_offset(cluster_index) + 14'd68 +
+          {7'b0, packet_index};
+    end
+  endfunction
+
+  function [7:0] reduction_tag;
+    input [2:0] wave;
+    input [6:0] packet_index;
+    reg [7:0] wave_tag_base;
+    begin
+      case (wave)
+        3'd0: wave_tag_base = 8'd0;
+        3'd1: wave_tag_base = 8'd33;
+        3'd2: wave_tag_base = 8'd66;
+        3'd3: wave_tag_base = 8'd99;
+        3'd4: wave_tag_base = 8'd132;
+        3'd5: wave_tag_base = 8'd165;
+        3'd6: wave_tag_base = 8'd198;
+        3'd7: wave_tag_base = 8'd231;
+      endcase
+      reduction_tag = wave_tag_base + {1'b0, packet_index};
+    end
+  endfunction
+
+  always @(*) begin
+    command_release_cycle = epoch_release_cycle(release_epoch);
+    command_source = 4'd0;
+    command_destination = 4'd0;
+    command_vc = 2'd0;
+    command_tag = 8'd0;
+    command_packet_id = 14'd0;
+    command_flit_count = 4'd8;
+
+    if (phase == PHASE_SHARED) begin
+      command_source = cluster + shared_home_shift(transfer_wave);
+      command_destination = cluster;
+      command_vc = 2'd0;
+      command_tag = {1'b0, packet};
+      command_packet_id = shared_packet_id(transfer_wave, cluster, packet);
+    end else begin
+      command_source = cluster;
+      command_destination = 4'd15;
+      command_vc = 2'd1;
+      command_tag = reduction_tag(transfer_wave, packet);
+      command_packet_id = reduction_packet_id(transfer_wave, cluster, packet);
+      if (packet == 7'd32)
+        command_flit_count = 4'd4;
+    end
+  end
+
+  assign cmd_valid = enable && !done;
+  assign cmd_data = {
+    command_flit_count,
+    2'b0, command_packet_id, 8'b0,
+    2'b0, command_packet_id, 8'b0,
+    command_tag,
+    command_vc,
+    command_destination,
+    command_source,
+    command_release_cycle
+  };
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      release_epoch <= 4'd0;
+      phase <= PHASE_SHARED;
+      cluster <= 4'd0;
+      packet <= 7'd0;
+      done <= 1'b0;
+      generated_command_count <= {COUNTER_W{1'b0}};
+      protocol_error <= 1'b0;
+    end else if (command_fire) begin
+      generated_command_count <= generated_command_count + 1'b1;
+      if (phase == PHASE_SHARED) begin
+        if (packet == 7'd67) begin
+          packet <= 7'd0;
+          if (cluster == 4'd15) begin
+            cluster <= 4'd0;
+            release_epoch <= release_epoch + 1'b1;
+            phase <= PHASE_REDUCTION;
+          end else begin
+            cluster <= cluster + 1'b1;
+          end
+        end else begin
+          packet <= packet + 1'b1;
+        end
+      end else begin
+        if (packet == 7'd32) begin
+          packet <= 7'd0;
+          if (cluster == 4'd14) begin
+            cluster <= 4'd0;
+            if (release_epoch == 4'd8) begin
+              done <= 1'b1;
+              if (generated_command_count + 1'b1 != EXPECTED_COMMANDS)
+                protocol_error <= 1'b1;
+            end else if (release_epoch == 4'd4) begin
+              release_epoch <= release_epoch + 1'b1;
+              phase <= PHASE_REDUCTION;
+            end else begin
+              phase <= PHASE_SHARED;
+            end
+          end else begin
+            cluster <= cluster + 1'b1;
+          end
+        end else begin
+          packet <= packet + 1'b1;
+        end
+      end
+    end
+  end
+
+`ifndef SYNTHESIS
+  initial begin
+    if (COMMAND_W != 102) begin
+      $error("noc_llama7b_phase2_command_generator COMMAND_W must be 102");
+      $finish(1);
+    end
+  end
+`endif
+endmodule

--- a/runs/campaigns/noc/l1_llama7b_phase2_command_scheduler/sweeps/nangate45_macro_frontier.json
+++ b/runs/campaigns/noc/l1_llama7b_phase2_command_scheduler/sweeps/nangate45_macro_frontier.json
@@ -1,0 +1,8 @@
+{
+  "tag_prefix": "l1_llama7b_phase2_command_scheduler_nangate45_macro_frontier",
+  "flow_params": {
+    "CLOCK_PERIOD": [1.0, 1.5],
+    "CORE_UTILIZATION": [40, 50, 60],
+    "PLACE_DENSITY": [0.52]
+  }
+}

--- a/runs/designs/noc/l1_noc_llama7b_phase2_command_scheduler_n16_wrapper/config_l1_noc_llama7b_phase2_command_scheduler_n16.json
+++ b/runs/designs/noc/l1_noc_llama7b_phase2_command_scheduler_n16_wrapper/config_l1_noc_llama7b_phase2_command_scheduler_n16.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "descriptor_state",
+      "dimensions": 1,
+      "bit_width": 256,
+      "signed": false,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "l1_memory_noc_primitive",
+      "module_name": "l1_noc_llama7b_phase2_command_scheduler_n16",
+      "operand": "descriptor_state",
+      "options": {
+        "primitive": "descriptor_pair_scheduler",
+        "command_source": "llama7b_generated",
+        "flit_bits": 256,
+        "depth": 4,
+        "ports": 16,
+        "banks": 16,
+        "counter_bits": 32
+      }
+    }
+  ]
+}

--- a/scripts/generate_design.py
+++ b/scripts/generate_design.py
@@ -437,6 +437,7 @@ def identify_design(config):
         fragment_bits = int(options.get("fragment_bits", 3))
         addr_bits = int(options.get("addr_bits", 24))
         flit_count_bits = int(options.get("flit_count_bits", 4))
+        command_source = str(options.get("command_source", "prefetch"))
         tx_desc_depth = int(options.get("tx_desc_depth", depth))
         tx_outstanding = int(options.get("tx_outstanding", max(depth, 8)))
         rx_contexts = int(options.get("rx_contexts", max(depth, 8)))
@@ -526,6 +527,11 @@ def identify_design(config):
                 raise ValueError(
                     "l1_memory_noc_primitive descriptor_pair_scheduler requires at least 42 observation bits"
                 )
+            if command_source not in ("prefetch", "llama7b_generated"):
+                raise ValueError(
+                    "l1_memory_noc_primitive descriptor_pair_scheduler command_source "
+                    "must be prefetch or llama7b_generated"
+                )
         return {
             "kind": "l1_memory_noc_primitive",
             "module_name": module_name,
@@ -545,6 +551,7 @@ def identify_design(config):
             "fragment_bits": fragment_bits,
             "addr_bits": addr_bits,
             "flit_count_bits": flit_count_bits,
+            "command_source": command_source,
             "tx_desc_depth": tx_desc_depth,
             "tx_outstanding": tx_outstanding,
             "rx_contexts": rx_contexts,
@@ -989,6 +996,7 @@ def generate_l1_memory_noc_design(src_dir, design):
         text = _emit_l1_descriptor_pair_scheduler(module_name, design)
         for filename in (
             "noc_descriptor_command_prefetch.sv",
+            "noc_llama7b_phase2_command_generator.sv",
             "noc_descriptor_pair_scheduler.sv",
             "noc_descriptor_pair_scheduler_ppa_harness.sv",
         ):
@@ -1737,7 +1745,8 @@ module {module_name}(
   noc_descriptor_pair_scheduler_ppa_harness #(
     .NODES({design['ports']}),
     .DATA_W({design['flit_bits']}),
-    .COUNTER_W({design['counter_bits']})
+    .COUNTER_W({design['counter_bits']}),
+    .GENERATED_SOURCE({1 if design['command_source'] == 'llama7b_generated' else 0})
   ) harness (
     .clk(clk),
     .rst_n(rst_n),
@@ -2692,6 +2701,7 @@ def generate_config_mk(platform_dir, platform, design):
         verilog_files.extend(
             [
                 f"$(DESIGN_HOME)/src/{wrapper_name}/noc_descriptor_command_prefetch.v",
+                f"$(DESIGN_HOME)/src/{wrapper_name}/noc_llama7b_phase2_command_generator.v",
                 f"$(DESIGN_HOME)/src/{wrapper_name}/noc_descriptor_pair_scheduler.v",
                 f"$(DESIGN_HOME)/src/{wrapper_name}/noc_descriptor_pair_scheduler_ppa_harness.v",
             ]

--- a/tests/noc_llama7b_phase2_command_generator_tb.sv
+++ b/tests/noc_llama7b_phase2_command_generator_tb.sv
@@ -1,0 +1,76 @@
+`timescale 1ns/1ps
+
+module noc_llama7b_phase2_command_generator_tb;
+  localparam integer COMMAND_W = 102;
+  localparam integer COMMAND_COUNT = 11576;
+
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  reg enable = 1'b0;
+  reg cmd_ready = 1'b0;
+  wire cmd_valid;
+  wire [COMMAND_W-1:0] cmd_data;
+  wire done;
+  wire [31:0] generated_command_count;
+  wire protocol_error;
+
+  reg [COMMAND_W-1:0] expected [0:COMMAND_COUNT-1];
+  reg [COMMAND_W-1:0] held_command = {COMMAND_W{1'b0}};
+  reg held_valid = 1'b0;
+  integer observed = 0;
+  integer cycle = 0;
+  string expected_mem;
+
+  noc_llama7b_phase2_command_generator dut (
+    .clk(clk), .rst_n(rst_n), .enable(enable),
+    .cmd_valid(cmd_valid), .cmd_ready(cmd_ready), .cmd_data(cmd_data),
+    .done(done), .generated_command_count(generated_command_count),
+    .protocol_error(protocol_error)
+  );
+
+  always #1 clk = ~clk;
+
+  always @(posedge clk) begin
+    if (rst_n) begin
+      cycle = cycle + 1;
+      cmd_ready <= (cycle % 7 != 2) && (cycle % 11 != 5);
+      if (cmd_valid && !cmd_ready) begin
+        if (held_valid && cmd_data !== held_command)
+          $fatal(1, "command changed under backpressure at index %0d", observed);
+        held_command <= cmd_data;
+        held_valid <= 1'b1;
+      end else begin
+        held_valid <= 1'b0;
+      end
+      if (cmd_valid && cmd_ready) begin
+        if (observed >= COMMAND_COUNT)
+          $fatal(1, "generator emitted too many commands");
+        if (cmd_data !== expected[observed])
+          $fatal(1,
+            "command mismatch index=%0d expected=%026h observed=%026h",
+            observed, expected[observed], cmd_data);
+        observed = observed + 1;
+      end
+    end
+  end
+
+  initial begin
+    if (!$value$plusargs("EXPECTED_COMMAND_MEM=%s", expected_mem))
+      $fatal(1, "EXPECTED_COMMAND_MEM is required");
+    $readmemh(expected_mem, expected);
+    repeat (3) @(negedge clk);
+    rst_n = 1'b1;
+    enable = 1'b1;
+    wait (done);
+    repeat (2) @(negedge clk);
+    if (observed != COMMAND_COUNT ||
+        generated_command_count != COMMAND_COUNT || protocol_error)
+      $fatal(1,
+        "generator completion mismatch observed=%0d generated=%0d error=%0d",
+        observed, generated_command_count, protocol_error);
+    if (cmd_valid)
+      $fatal(1, "cmd_valid remained asserted after completion");
+    $display("PASS commands=%0d cycles=%0d", observed, cycle);
+    $finish;
+  end
+endmodule

--- a/tests/noc_sram_packet_mesh4x4_workload_tb.sv
+++ b/tests/noc_sram_packet_mesh4x4_workload_tb.sv
@@ -133,6 +133,10 @@ module noc_sram_packet_mesh4x4_workload_tb;
 
 `ifdef SERIAL_PAIRED_SCHEDULER
   localparam integer COMMAND_W = 102;
+  wire scheduler_cmd_valid;
+  wire scheduler_cmd_ready;
+  wire [COMMAND_W-1:0] scheduler_command;
+`ifndef GENERATED_COMMAND_SOURCE
   wire command_mem_req_valid;
   wire command_mem_req_ready = 1'b1;
   wire [13:0] command_mem_req_addr;
@@ -142,14 +146,16 @@ module noc_sram_packet_mesh4x4_workload_tb;
   wire command_mem_rsp_ready;
   wire [COMMAND_W-1:0] command_mem_rsp_data =
     workload_command(command_mem_pending_addr);
-  wire scheduler_cmd_valid;
-  wire scheduler_cmd_ready;
-  wire [COMMAND_W-1:0] scheduler_command;
   wire [31:0] prefetch_request_count;
   wire [31:0] prefetch_response_count;
   wire [31:0] prefetch_delivered_command_count;
   wire [31:0] prefetch_memory_stall_cycles;
   wire prefetch_protocol_error;
+`else
+  wire command_generator_done;
+  wire [31:0] generated_command_count;
+  wire command_generator_protocol_error;
+`endif
   wire [31:0] scheduler_accepted_command_count;
   wire [31:0] scheduler_installed_receive_count;
   wire [31:0] scheduler_submitted_transmit_count;
@@ -157,6 +163,7 @@ module noc_sram_packet_mesh4x4_workload_tb;
   wire [31:0] scheduler_endpoint_stall_cycles;
   wire scheduler_protocol_error;
 
+`ifndef GENERATED_COMMAND_SOURCE
   function [COMMAND_W-1:0] workload_command;
     input [13:0] command_address;
     reg [15:0] command_packet;
@@ -196,6 +203,15 @@ module noc_sram_packet_mesh4x4_workload_tb;
     .memory_stall_cycles(prefetch_memory_stall_cycles),
     .protocol_error(prefetch_protocol_error)
   );
+`else
+  noc_llama7b_phase2_command_generator command_generator (
+    .clk(clk), .rst_n(rst_n), .enable(1'b1),
+    .cmd_valid(scheduler_cmd_valid), .cmd_ready(scheduler_cmd_ready),
+    .cmd_data(scheduler_command), .done(command_generator_done),
+    .generated_command_count(generated_command_count),
+    .protocol_error(command_generator_protocol_error)
+  );
+`endif
 
   noc_descriptor_pair_scheduler scheduler (
     .clk(clk), .rst_n(rst_n), .current_cycle(cycle),
@@ -367,8 +383,10 @@ module noc_sram_packet_mesh4x4_workload_tb;
       live_context_valid <= 0;
       completion_shadow_valid <= 0;
 `ifdef SERIAL_PAIRED_SCHEDULER
+`ifndef GENERATED_COMMAND_SOURCE
       command_mem_pending <= 1'b0;
       command_mem_pending_addr <= 0;
+`endif
 `endif
       for (seq_endpoint_i = 0; seq_endpoint_i < 16; seq_endpoint_i = seq_endpoint_i + 1) begin
         source_position[seq_endpoint_i] <= 0;
@@ -381,12 +399,14 @@ module noc_sram_packet_mesh4x4_workload_tb;
     end else begin
       cycle <= cycle + 1;
 `ifdef SERIAL_PAIRED_SCHEDULER
+`ifndef GENERATED_COMMAND_SOURCE
       if (command_mem_pending && command_mem_rsp_ready)
         command_mem_pending <= 1'b0;
       if (command_mem_req_valid && command_mem_req_ready) begin
         command_mem_pending <= 1'b1;
         command_mem_pending_addr <= command_mem_req_addr;
       end
+`endif
 `endif
       tx_fire_count = 0;
       completion_fire_count = 0;
@@ -511,9 +531,15 @@ module noc_sram_packet_mesh4x4_workload_tb;
       if (endpoint_protocol_error != 0)
         $fatal(1, "endpoint protocol error: %h", endpoint_protocol_error);
 `ifdef SERIAL_PAIRED_SCHEDULER
+`ifdef GENERATED_COMMAND_SOURCE
+      if (command_generator_protocol_error || scheduler_protocol_error)
+        $fatal(1, "descriptor command path protocol error generator=%0d scheduler=%0d",
+          command_generator_protocol_error, scheduler_protocol_error);
+`else
       if (prefetch_protocol_error || scheduler_protocol_error)
         $fatal(1, "descriptor command path protocol error prefetch=%0d scheduler=%0d",
           prefetch_protocol_error, scheduler_protocol_error);
+`endif
 `endif
       if (cycle > 0 && (cycle % 100000) == 0)
         $display("PROGRESS workload cycle=%0d submitted=%0d completed=%0d writes=%0d",
@@ -547,6 +573,17 @@ module noc_sram_packet_mesh4x4_workload_tb;
         $fatal(1, "flit count mismatch expected=%0d writes=%0d",
           expected_flits, accepted_writes);
 `ifdef SERIAL_PAIRED_SCHEDULER
+`ifdef GENERATED_COMMAND_SOURCE
+      if (!command_generator_done || generated_command_count != packet_count ||
+          scheduler_accepted_command_count != packet_count ||
+          scheduler_installed_receive_count != packet_count ||
+          scheduler_submitted_transmit_count != packet_count)
+        $fatal(1,
+          "command count mismatch generated=%0d accepted=%0d rx=%0d tx=%0d expected=%0d done=%0d",
+          generated_command_count, scheduler_accepted_command_count,
+          scheduler_installed_receive_count, scheduler_submitted_transmit_count,
+          packet_count, command_generator_done);
+`else
       if (scheduler_accepted_command_count != packet_count ||
           scheduler_installed_receive_count != packet_count ||
           scheduler_submitted_transmit_count != packet_count ||
@@ -559,6 +596,7 @@ module noc_sram_packet_mesh4x4_workload_tb;
           prefetch_delivered_command_count,
           scheduler_accepted_command_count, scheduler_installed_receive_count,
           scheduler_submitted_transmit_count, packet_count);
+`endif
 `endif
       for (packet_i = 0; packet_i < packet_count; packet_i = packet_i + 1)
         if (!rx_installed[packet_i] || !tx_submitted[packet_i] || !packet_completed[packet_i])

--- a/tests/test_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py
+++ b/tests/test_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py
@@ -142,3 +142,15 @@ def test_serial_scheduler_rtl_matches_performance_replay(tmp_path: Path) -> None
         )
     }
     assert result["counters"]["cycles"] == 88
+
+
+def test_generated_scheduler_rejects_noncanonical_workload(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="complete 11576-command"):
+        run_rtl_replay(
+            repo_root=REPO_ROOT,
+            packets=_contention_packets(),
+            work_dir=tmp_path,
+            timeout_cycles=10000,
+            wall_timeout_seconds=60,
+            descriptor_scheduler="serial_generated",
+        )

--- a/tests/test_noc_descriptor_pair_scheduler.py
+++ b/tests/test_noc_descriptor_pair_scheduler.py
@@ -26,6 +26,11 @@ PPA_CONFIG = (
     / "runs/designs/noc/l1_noc_descriptor_pair_scheduler_n16_wrapper"
     / "config_l1_noc_descriptor_pair_scheduler_n16.json"
 )
+GENERATED_PPA_CONFIG = (
+    REPO_ROOT
+    / "runs/designs/noc/l1_noc_llama7b_phase2_command_scheduler_n16_wrapper"
+    / "config_l1_noc_llama7b_phase2_command_scheduler_n16.json"
+)
 
 
 def test_noc_descriptor_pair_scheduler_protocol() -> None:
@@ -79,6 +84,7 @@ def test_noc_descriptor_pair_scheduler_generator_emits_exact_hierarchy(
 
     expected_sources = {
         "noc_descriptor_command_prefetch.v",
+        "noc_llama7b_phase2_command_generator.v",
         "noc_descriptor_pair_scheduler.v",
         "noc_descriptor_pair_scheduler_ppa_harness.v",
         f"{design['module_name']}.v",
@@ -115,11 +121,55 @@ def test_noc_descriptor_pair_scheduler_generator_emits_exact_hierarchy(
     assert compile_result.returncode == 0, compile_result.stderr
 
 
+def test_generated_command_scheduler_emits_generator_selected_hierarchy(
+    tmp_path: Path,
+) -> None:
+    config = json.loads(GENERATED_PPA_CONFIG.read_text(encoding="utf-8"))
+    design = identify_design(config)
+    assert design["primitive"] == "descriptor_pair_scheduler"
+    assert design["command_source"] == "llama7b_generated"
+
+    source_dir = tmp_path / "src"
+    source_dir.mkdir()
+    generate_l1_memory_noc_design(str(source_dir), design)
+    generate_wrapper(config, str(source_dir), design)
+    top = (source_dir / f"{design['module_name']}.v").read_text(encoding="utf-8")
+    assert ".GENERATED_SOURCE(1)" in top
+
+    platform_dir = tmp_path / "platform"
+    platform_dir.mkdir()
+    generate_config_mk(str(platform_dir), "nangate45", design)
+    config_mk = (platform_dir / "config.mk").read_text(encoding="utf-8")
+    assert "/noc_llama7b_phase2_command_generator.v" in config_mk
+
+    iverilog = shutil.which("iverilog")
+    if iverilog is None:
+        return
+    compile_result = subprocess.run(
+        [
+            iverilog,
+            "-g2012",
+            "-s",
+            design["wrapper_name"],
+            "-t",
+            "null",
+            *[str(path) for path in sorted(source_dir.glob("*.v"))],
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert compile_result.returncode == 0, compile_result.stderr
+
+
 @pytest.mark.parametrize(
     ("option", "value", "message"),
     [
         ("ports", 8, "requires 16 endpoints"),
         ("flit_bits", 32, "requires at least 42 observation bits"),
+        ("command_source", "unknown", "must be prefetch or llama7b_generated"),
     ],
 )
 def test_noc_descriptor_pair_scheduler_rejects_unsupported_physical_shape(
@@ -181,6 +231,7 @@ endmodule
     simulator = tmp_path / "harness.vvp"
     sources = [
         REPO_ROOT / "npu/sim/rtl/noc_descriptor_command_prefetch.sv",
+        REPO_ROOT / "npu/sim/rtl/noc_llama7b_phase2_command_generator.sv",
         REPO_ROOT / "npu/sim/rtl/noc_descriptor_pair_scheduler.sv",
         REPO_ROOT / "npu/sim/rtl/noc_descriptor_pair_scheduler_ppa_harness.sv",
         testbench,

--- a/tests/test_noc_llama7b_phase2_command_generator.py
+++ b/tests/test_noc_llama7b_phase2_command_generator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from dataclasses import replace
 import shutil
 import subprocess
 from pathlib import Path
@@ -14,6 +15,7 @@ from npu.eval.measure_llm_decoder_attention_score32_noc_phase2_schedule import (
 )
 from npu.eval.verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl import (
     _schedule_args,
+    _require_canonical_generated_commands,
     command_words_from_packets,
     descriptors_from_packet_specs,
 )
@@ -52,6 +54,12 @@ def test_generator_matches_all_authoritative_commands_under_backpressure(
     packets = descriptors_from_packet_specs(packet_specs)
     words = command_words_from_packets(packets)
     assert len(words) == 11576
+    _require_canonical_generated_commands(packets)
+
+    mutated_packets = list(packets)
+    mutated_packets[0] = replace(mutated_packets[0], tag=1)
+    with pytest.raises(ValueError, match="does not match the canonical"):
+        _require_canonical_generated_commands(mutated_packets)
 
     expected_mem = tmp_path / "expected_commands.mem"
     expected_mem.write_text(

--- a/tests/test_noc_llama7b_phase2_command_generator.py
+++ b/tests/test_noc_llama7b_phase2_command_generator.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from npu.eval.measure_llm_decoder_attention_score32_noc_phase2_schedule import (
+    DEFAULT_MEASURED_L1_COSTS,
+    DEFAULT_SOURCE_JSON,
+    build_report,
+)
+from npu.eval.verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl import (
+    _schedule_args,
+    command_words_from_packets,
+    descriptors_from_packet_specs,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _tool(name: str) -> str:
+    candidate = shutil.which(name)
+    if candidate:
+        return candidate
+    bundled = Path("/oss-cad-suite/bin") / name
+    if bundled.exists():
+        return str(bundled)
+    raise RuntimeError(f"{name} unavailable")
+
+
+@pytest.mark.skipif(
+    not (shutil.which("iverilog") or Path("/oss-cad-suite/bin/iverilog").exists())
+    or not (shutil.which("vvp") or Path("/oss-cad-suite/bin/vvp").exists()),
+    reason="iverilog/vvp unavailable",
+)
+def test_generator_matches_all_authoritative_commands_under_backpressure(
+    tmp_path: Path,
+) -> None:
+    args = argparse.Namespace(
+        repo_root=REPO_ROOT,
+        source_json=DEFAULT_SOURCE_JSON,
+        measured_l1_costs=DEFAULT_MEASURED_L1_COSTS,
+        wave_limit=None,
+        noc_clock_ns=1.0,
+        schedule_max_cycles=1_000_000,
+    )
+    packet_specs = []
+    build_report(_schedule_args(args), packet_spec_output=packet_specs)
+    packets = descriptors_from_packet_specs(packet_specs)
+    words = command_words_from_packets(packets)
+    assert len(words) == 11576
+
+    expected_mem = tmp_path / "expected_commands.mem"
+    expected_mem.write_text(
+        "".join(f"{word:026x}\n" for word in words), encoding="ascii"
+    )
+    simulator = tmp_path / "command_generator.vvp"
+    compile_result = subprocess.run(
+        [
+            _tool("iverilog"),
+            "-g2012",
+            "-s",
+            "noc_llama7b_phase2_command_generator_tb",
+            "-o",
+            str(simulator),
+            str(
+                REPO_ROOT
+                / "npu/sim/rtl/noc_llama7b_phase2_command_generator.sv"
+            ),
+            str(REPO_ROOT / "tests/noc_llama7b_phase2_command_generator_tb.sv"),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert compile_result.returncode == 0, compile_result.stderr
+    run_result = subprocess.run(
+        [
+            _tool("vvp"),
+            str(simulator),
+            f"+EXPECTED_COMMAND_MEM={expected_mem}",
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert run_result.returncode == 0, run_result.stdout + run_result.stderr
+    assert "PASS commands=11576" in run_result.stdout

--- a/tests/test_noc_sram_packet_mesh_perf.py
+++ b/tests/test_noc_sram_packet_mesh_perf.py
@@ -249,3 +249,21 @@ def test_serial_scheduler_models_one_cycle_sram_cold_start() -> None:
 
     assert result.rx_descriptor_handshakes[0].cycle == 3
     assert result.tx_descriptor_handshakes[0].cycle == 4
+
+
+def test_serial_generated_scheduler_removes_command_sram_cold_start() -> None:
+    descriptor = PacketDescriptor(
+        source=0,
+        destination=1,
+        vc=0,
+        tag=1,
+        flit_count=1,
+    )
+    result = simulate_packet_mesh(
+        [descriptor],
+        descriptor_scheduler="serial_generated",
+    )
+
+    assert result.rx_descriptor_handshakes[0].cycle == 1
+    assert result.tx_descriptor_handshakes[0].cycle == 2
+    assert not result.protocol_errors


### PR DESCRIPTION
## Summary
- replace the 11,576-record Phase-2 command image/refill boundary with a counter/ROM RTL generator
- add direct generated-command scheduling to the performance model and full endpoint/mesh RTL replay
- add a directly comparable Nangate45 generator-plus-scheduler physical point and remote task contracts

## Evidence
- exhaustive equality for all 11,576 packed 102-bit commands under backpressure
- full composed replay: 11,576 packets, 92,128 flits, 397,227 cycles
- exact RTL/performance equality: contention 8,736, input stalls 11,816, max occupancy 7
- generated hierarchy passes Icarus and Yosys; prefetch hierarchy is eliminated from the selected top
- focused NoC/controller tests and `scripts/validate_runs.py --skip_eval_queue` pass

## Remaining boundaries
- packet-ID-derived payload addresses still need compact per-endpoint allocation and lifetime reuse
- SRAM bitcells/macro placement, workload activity power, and HBM/DRAM remain explicit

Physical jobs are intentionally not dispatched until the remote evaluator image/source refresh is confirmed.
