### PR TITLE
Bound Llama7B NoC payload addresses

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5665,7 +5665,9 @@ def _decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence_evidence(
                 "serial_paired": "Require the serial paired command scheduler RTL in the composed replay",
                 "serial_generated": (
                     "Require the counter-based Llama7B command generator and serial paired "
-                    "scheduler RTL to emit exactly 11576 commands in the composed replay"
+                    "scheduler RTL to emit exactly 11576 commands with 563 bounded "
+                    "endpoint-local packet slots; prove every TX/RX slot reuse collision-free "
+                    "through final SRAM response/write"
                 ),
             }[descriptor_scheduler],
             "Keep SRAM bitcells, workload activity power, and HBM/DRAM explicit",

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -14897,6 +14897,11 @@ def test_generate_l2_campaign_task_adds_score32_endpoint_rtl_equivalence(
             assert f"--descriptor-scheduler {descriptor_scheduler}" in run
             assert work_item.input_manifest["worker_resources"]["exclusive_worker"] is True
             assert work_item.input_manifest["worker_resources"]["stall_timeout_seconds"] == 1200
+            if descriptor_scheduler == "serial_generated":
+                assert any(
+                    "563 bounded" in str(rule)
+                    for rule in work_item.acceptance_rules
+                )
             assert work_item.expected_outputs[0].endswith(
                 "decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence__"
                 f"l2_decoder_attention_score32_noc_phase2_{item_suffix}.json"

--- a/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/design_brief.md
+++ b/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/design_brief.md
@@ -4,8 +4,12 @@ The checked Llama7B Phase-2 schedule contains eight waves, sixteen clusters,
 68 shared-payload packets for each remote tile, and 33 reduction packets for
 each non-root cluster. Shared-SRAM home wave 4 is local and emits no shared
 traffic. Nine release epochs, wave/class/cluster/packet counters, and simple
-route, tag, packet-ID, and base-address formulas therefore reproduce all
-11,576 102-bit commands exactly.
+route, tag, and bounded endpoint-local base-address formulas therefore
+reproduce all 11,576 102-bit commands exactly. Shared payloads use slots
+0..67, reduction sources use slots 68..100, and root reduction receive
+payloads use source-indexed slots 68..562. Each slot is 256 bytes, so the
+largest endpoint-visible address extent is 144,128 bytes rather than the
+global packet-ID-derived extent.
 
 The generator holds its output under backpressure and advances only when the
 paired scheduler accepts a command. It replaces a 1,180,752-bit (147,594-byte)

--- a/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/evaluation_requests.json
@@ -25,7 +25,7 @@
         "direction": "replace_command_image_with_exact_generation",
         "reason": "Measure generator-plus-scheduler PPA without command SRAM or refill estimates."
       },
-      "acceptance_notes": "Require exhaustive 11576-command equivalence, generated hierarchy selection, protocol_error=0, and timing/area/power rows. Treat vectorless power and payload SRAM macros as separate evidence."
+      "acceptance_notes": "Require exhaustive 11576-command equivalence including bounded TX/RX addresses, generated hierarchy selection, protocol_error=0, and timing/area/power rows. Require maximum RX base address 143872 bytes (slot 562). Treat vectorless power and payload SRAM macros as separate evidence."
     }
   ]
 }

--- a/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/implementation_summary.md
@@ -1,6 +1,8 @@
 # Implementation Summary
 
 - Added synthesizable wave/class/cluster/packet command generation RTL.
+- Replaced global packet-ID-derived payload addresses with fixed shared,
+  reduction-source, and source-indexed root-reduction packet slots.
 - Proved every generated command against the independently built Python
   schedule under output backpressure.
 - Added a generated-command option to the scheduler physical harness and

--- a/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/proposal.json
+++ b/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/proposal.json
@@ -6,7 +6,7 @@
   "kind": "circuit_block",
   "abstraction_layer": "architecture_block",
   "title": "Replace the Llama7B Phase-2 command image with exact RTL generation",
-  "hypothesis": "The regular complete Phase-2 command stream can be generated from small counters and constants with materially less area and energy than a 147594-byte command image while preserving exact packet ordering and cadence.",
+  "hypothesis": "The regular complete Phase-2 command stream and bounded endpoint-local payload addresses can be generated from small counters and constants with materially less area and energy than a 147594-byte command image while preserving exact packet ordering and cadence.",
   "direct_comparison": {
     "primary_question": "What PPA replaces the static command image, prefetch path, and unspecified refill producer for the checked Llama7B schedule?",
     "include": [
@@ -14,7 +14,7 @@
       "wave, traffic-class, cluster, and packet counters",
       "shared-home route generation",
       "reduction route and modulo-256 tag generation",
-      "packet-ID and TX/RX base-address generation",
+      "bounded class-local TX/RX packet-slot address generation",
       "paired RX-before-TX descriptor scheduler",
       "sixteen endpoint descriptor interfaces"
     ],
@@ -28,6 +28,7 @@
   "expected_benefit": [
     "remove 1180752 bits of static command records",
     "remove the command refill producer abstraction for this exact workload",
+    "replace sparse global packet-ID addressing with at most 563 endpoint-local 256-byte slots",
     "retain exact two-cycle paired descriptor cadence"
   ],
   "risks": [

--- a/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/quality_gate.md
@@ -1,6 +1,8 @@
 # Quality Gate
 
 - Require exact equality for all 11,576 packed 102-bit commands.
+- Require every generated address to be 256-byte aligned and within slots
+  0..562; require exact class/source slot formulas.
 - Require the runtime generated-mode guard to match the canonical packed-stream
   SHA-256 and reject same-length mutations before RTL replay.
 - Require command stability while `valid && !ready`.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/design_brief.md
@@ -6,6 +6,10 @@ queues, one-cycle source-SRAM ports, bounded receive contexts, and the exact
 segmented 4x4 mesh. The comparison covers packet/flit counts, drain cycles,
 router contention, input stalls, and maximum occupancy.
 
-The current packet-ID-derived base addresses are an identity-proof mechanism.
-Compact per-endpoint payload allocation and lifetime reuse remain a follow-on
-memory-controller closure item.
+Generated commands use bounded endpoint-local addresses: shared slots 0..67,
+reduction-source slots 68..100, and source-indexed root reduction receive
+slots 68..562. The performance model certifies descriptor-to-final-memory-
+operation lifetimes, while the RTL scoreboard maintains independent per-
+endpoint live-slot bitmaps and rejects premature reuse. Producer fill and
+consumer drain handshakes remain a follow-on composition item; SRAM bitcells
+and macro placement remain physical evidence.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/evaluation_requests.json
@@ -23,7 +23,7 @@
         "direction": "exact_generated_command_equivalence",
         "reason": "Close command-image and refill abstractions without changing packet or cycle behavior."
       },
-      "acceptance_notes": "Require 11576 generated commands, 92128 flits, exact RTL/performance packet/flit/cycle/contention/stall/occupancy counters, and zero protocol errors."
+      "acceptance_notes": "Require 11576 generated commands, 92128 flits, exact RTL/performance packet/flit/cycle/contention/stall/occupancy counters, zero protocol errors, 563 bounded 256-byte packet slots, and collision-free model plus RTL lifetime checks for every reused TX/RX slot."
     }
   ]
 }

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/implementation_summary.md
@@ -3,4 +3,6 @@
 - Added `serial_generated` to the RTL and performance replay contracts.
 - Connected generated commands directly to the paired scheduler.
 - Added count and protocol gates for all 11,576 commands.
+- Added bounded source/destination packet-slot formulas, model lifetime
+  certificates, and RTL live-slot collision checks.
 - Removed command SRAM and refill from the generated-mode abstraction list.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/proposal.json
@@ -6,7 +6,7 @@
   "kind": "validation",
   "abstraction_layer": "decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence",
   "title": "Prove generated Llama7B commands through the finite endpoint and mesh RTL",
-  "hypothesis": "Counter-generated commands preserve the complete Phase-2 packet stream and cycle behavior while removing the command image and refill boundary.",
+  "hypothesis": "Counter-generated commands preserve the complete Phase-2 packet stream and cycle behavior while removing the command image, refill boundary, and sparse global packet-address abstraction.",
   "direct_comparison": {
     "primary_question": "Does generated command control remain exactly equivalent through finite endpoints and the composed mesh?",
     "include": [
@@ -15,6 +15,7 @@
       "paired RX-before-TX scheduler RTL",
       "one-cycle source SRAM response control",
       "finite TX queues and RX contexts",
+      "bounded endpoint-local packet slots with cross-wave lifetime checks",
       "exact 4x4 segmented mesh RTL"
     ],
     "exclude": [
@@ -25,6 +26,7 @@
   },
   "expected_benefit": [
     "close command population and refill abstraction",
+    "close sparse packet-ID-derived address allocation for network lifetimes",
     "prove command-to-delivery cycle equivalence",
     "retain an explicit short list of physical-only abstractions"
   ],

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/quality_gate.md
@@ -4,6 +4,8 @@
 - Require exact RTL/performance equality for cycle and router counters.
 - Require every RX descriptor before its paired TX descriptor.
 - Require zero generator, scheduler, endpoint, and mesh protocol errors.
+- Require TX and RX slot lifetimes to be collision-free in both the model and
+  RTL, with all addresses confined to the 144,128-byte endpoint extent.
 
 Status: passed locally. All 11,576 commands and 92,128 flits completed in
 397,227 cycles with exact performance/RTL counter equality.

--- a/npu/eval/verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py
+++ b/npu/eval/verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl.py
@@ -36,7 +36,14 @@ JsonDict = dict[str, Any]
 MAX_PACKETS = 12000
 GENERATED_COMMAND_COUNT = 11576
 GENERATED_COMMAND_SHA256 = (
-    "624c39e542c05fa76a480c173d39323adba58ac75ee12951139d8893929df483"
+    "db8b0502bd3848a305f088ec94f74b97b6dc29bfce44d453e3d4b508e7ba6a4a"
+)
+PACKET_SLOT_BYTES = 256
+SHARED_PACKET_SLOTS = 68
+REDUCTION_PACKET_SLOTS = 33
+ROOT_REDUCTION_SOURCES = 15
+BOUNDED_PACKET_SLOTS = (
+    SHARED_PACKET_SLOTS + ROOT_REDUCTION_SOURCES * REDUCTION_PACKET_SLOTS
 )
 RTL_SOURCES = (
     Path("npu/sim/rtl/noc_ready_valid_fifo.sv"),
@@ -168,17 +175,136 @@ def command_words_from_packets(packets: list[WorkloadPacket]) -> list[int]:
             item.packet_id,
         ),
     ):
-        base_addr = packet.packet_id << 8
+        tx_base_addr, rx_base_addr = bounded_local_addresses(packet)
         word = packet.release_cycle
         word |= packet.source << 32
         word |= packet.destination << 36
         word |= packet.vc << 40
         word |= packet.tag << 42
-        word |= base_addr << 50
-        word |= base_addr << 74
+        word |= tx_base_addr << 50
+        word |= rx_base_addr << 74
         word |= packet.flit_count << 98
         words.append(word)
     return words
+
+
+def bounded_local_addresses(packet: WorkloadPacket) -> tuple[int, int]:
+    """Map a canonical packet to bounded source- and destination-local slots."""
+
+    match = re.fullmatch(
+        r"(?P<kind>shared|reduction)_w\d+_c\d+::p(?P<packet>\d+)",
+        packet.label,
+    )
+    if match is None:
+        raise ValueError(f"unsupported Phase-2 packet label: {packet.label}")
+    packet_index = int(match.group("packet"))
+    if match.group("kind") == "shared":
+        if packet_index not in range(SHARED_PACKET_SLOTS):
+            raise ValueError(f"shared packet index is outside bounded slots: {packet.label}")
+        tx_slot = packet_index
+        rx_slot = packet_index
+    else:
+        if packet_index not in range(REDUCTION_PACKET_SLOTS):
+            raise ValueError(f"reduction packet index is outside bounded slots: {packet.label}")
+        if packet.source not in range(ROOT_REDUCTION_SOURCES):
+            raise ValueError(f"reduction source is outside bounded slots: {packet.label}")
+        tx_slot = SHARED_PACKET_SLOTS + packet_index
+        rx_slot = (
+            SHARED_PACKET_SLOTS
+            + packet.source * REDUCTION_PACKET_SLOTS
+            + packet_index
+        )
+    if tx_slot >= BOUNDED_PACKET_SLOTS or rx_slot >= BOUNDED_PACKET_SLOTS:
+        raise AssertionError("bounded packet slot calculation exceeded its declared extent")
+    return tx_slot * PACKET_SLOT_BYTES, rx_slot * PACKET_SLOT_BYTES
+
+
+def _bounded_slot_lifetime_audit(result: Any) -> JsonDict:
+    """Prove that generated endpoint-local slots are never simultaneously live."""
+
+    tx_start = {item.packet_index: item.cycle for item in result.tx_descriptor_handshakes}
+    rx_start = {item.packet_index: item.cycle for item in result.rx_descriptor_handshakes}
+    tx_end: dict[int, int] = {}
+    rx_end: dict[int, int] = {}
+    for item in result.source_memory_responses:
+        tx_end[item.packet_index] = max(tx_end.get(item.packet_index, -1), item.cycle)
+    for item in result.destination_memory_writes:
+        rx_end[item.packet_index] = max(rx_end.get(item.packet_index, -1), item.cycle)
+
+    direction_summary: dict[str, JsonDict] = {}
+    maximum_slot_by_endpoint = {endpoint: -1 for endpoint in range(16)}
+    for direction, starts, ends, address_field in (
+        ("tx", tx_start, tx_end, "tx_base_addr"),
+        ("rx", rx_start, rx_end, "rx_base_addr"),
+    ):
+        by_endpoint_slot: dict[tuple[int, int], list[tuple[int, int, int]]] = {}
+        events_by_endpoint: dict[int, list[tuple[int, int]]] = {}
+        for packet_index, descriptor in enumerate(result.descriptors):
+            if packet_index not in starts or packet_index not in ends:
+                raise ValueError(f"bounded {direction} slot lacks a complete lifetime")
+            address = int(getattr(descriptor, address_field))
+            if address % PACKET_SLOT_BYTES:
+                raise ValueError(f"bounded {direction} address is not packet-slot aligned")
+            slot = address // PACKET_SLOT_BYTES
+            if slot not in range(BOUNDED_PACKET_SLOTS):
+                raise ValueError(f"bounded {direction} slot exceeds declared storage: {slot}")
+            endpoint = descriptor.source if direction == "tx" else descriptor.destination
+            maximum_slot_by_endpoint[endpoint] = max(
+                maximum_slot_by_endpoint[endpoint], slot
+            )
+            start = starts[packet_index]
+            end = ends[packet_index]
+            if end < start:
+                raise ValueError(f"bounded {direction} slot lifetime ends before it starts")
+            by_endpoint_slot.setdefault((endpoint, slot), []).append(
+                (start, end, packet_index)
+            )
+            events_by_endpoint.setdefault(endpoint, []).extend(((start, 1), (end + 1, -1)))
+
+        minimum_reuse_gap: int | None = None
+        reuse_count = 0
+        for (endpoint, slot), intervals in by_endpoint_slot.items():
+            intervals.sort()
+            for prior, following in zip(intervals, intervals[1:]):
+                reuse_count += 1
+                if following[0] <= prior[1]:
+                    raise ValueError(
+                        f"bounded {direction} slot overlap endpoint={endpoint} slot={slot}: "
+                        f"packet {prior[2]} ends {prior[1]}, packet {following[2]} starts {following[0]}"
+                    )
+                gap = following[0] - prior[1]
+                minimum_reuse_gap = gap if minimum_reuse_gap is None else min(minimum_reuse_gap, gap)
+
+        peak_live_by_endpoint: dict[str, int] = {}
+        for endpoint, events in events_by_endpoint.items():
+            live = 0
+            peak = 0
+            for _, delta in sorted(events):
+                live += delta
+                peak = max(peak, live)
+            peak_live_by_endpoint[str(endpoint)] = peak
+        direction_summary[direction] = {
+            "collision_free": True,
+            "reuse_count": reuse_count,
+            "minimum_reuse_gap_cycles": minimum_reuse_gap,
+            "peak_live_slots_by_endpoint": peak_live_by_endpoint,
+            "maximum_peak_live_slots": max(peak_live_by_endpoint.values(), default=0),
+        }
+    return {
+        "mapping": "shared slot=p; reduction TX slot=68+p; reduction root RX slot=68+33*source+p",
+        "packet_slot_bytes": PACKET_SLOT_BYTES,
+        "maximum_packet_slots_at_root_endpoint": BOUNDED_PACKET_SLOTS,
+        "maximum_addressed_bytes_at_root_endpoint": (
+            BOUNDED_PACKET_SLOTS * PACKET_SLOT_BYTES
+        ),
+        "required_address_extent_bytes_by_endpoint": {
+            str(endpoint): (maximum_slot + 1) * PACKET_SLOT_BYTES
+            for endpoint, maximum_slot in maximum_slot_by_endpoint.items()
+        },
+        "tx": direction_summary["tx"],
+        "rx": direction_summary["rx"],
+        "scope": "descriptor acceptance through final SRAM response/write; producer fill and consumer drain are separate interfaces",
+    }
 
 
 def _require_canonical_generated_commands(packets: list[WorkloadPacket]) -> None:
@@ -409,23 +535,30 @@ def run_performance_replay(
     max_cycles: int,
     descriptor_scheduler: str = "endpoint_parallel",
 ) -> JsonDict:
-    result = simulate_packet_mesh(
-        [
+    descriptors: list[PacketDescriptor] = []
+    for packet in packets:
+        if descriptor_scheduler == "serial_generated":
+            tx_base_addr, rx_base_addr = bounded_local_addresses(packet)
+        else:
+            tx_base_addr = packet.packet_id << 8
+            rx_base_addr = packet.packet_id << 8
+        descriptors.append(
             PacketDescriptor(
                 source=packet.source,
                 destination=packet.destination,
                 vc=packet.vc,
                 tag=packet.tag,
                 flit_count=packet.flit_count,
-                tx_base_addr=packet.packet_id << 8,
-                rx_base_addr=packet.packet_id << 8,
+                tx_base_addr=tx_base_addr,
+                rx_base_addr=rx_base_addr,
                 release_cycle=packet.release_cycle,
                 schedule_order=packet.schedule_order,
                 data_seed=packet.packet_id,
                 packet_id=packet.label,
             )
-            for packet in packets
-        ],
+        )
+    result = simulate_packet_mesh(
+        descriptors,
         descriptor_scheduler=descriptor_scheduler,
         max_cycles=max_cycles,
         fast_forward_idle=True,
@@ -468,6 +601,8 @@ def run_performance_replay(
             "endpoint-aware performance replay failed: "
             f"count_mismatches={mismatches}, protocol_errors={counters['protocol_errors']}"
         )
+    if descriptor_scheduler == "serial_generated":
+        counters["bounded_packet_slots"] = _bounded_slot_lifetime_audit(result)
     return counters
 
 
@@ -540,10 +675,21 @@ def build_and_run(args: argparse.Namespace) -> JsonDict:
             "tx_outstanding_limit": 8,
             "wire_tag_width_bits": 8,
             "cycle_and_router_counter_match": True,
+            "bounded_packet_slot_lifetime_match": (
+                args.descriptor_scheduler == "serial_generated"
+            ),
         },
         "remaining_abstractions": [
             "SRAM arrays are transaction-accurate one-cycle ports; bitcells and macro placement remain external.",
-            "Packet-ID-derived TX/RX addresses prove ordering and data integrity but do not yet embody compact per-endpoint payload allocation or lifetime reuse.",
+            *(
+                [
+                    "Generated commands use 563 bounded endpoint-local 256-byte packet slots; model and RTL prove network-lifetime reuse, while producer fill and consumer drain handshakes remain to be composed."
+                ]
+                if args.descriptor_scheduler == "serial_generated"
+                else [
+                    "Packet-ID-derived TX/RX addresses prove ordering and data integrity but do not embody compact per-endpoint payload allocation or lifetime reuse."
+                ]
+            ),
             *(
                 [
                     "The 102-bit command records use concrete one-cycle prefetch control; command SRAM bitcells, macro placement, and command population/refill remain external evidence."
@@ -582,10 +728,17 @@ def write_report(payload: JsonDict, path: Path) -> None:
         f"- maximum router occupancy: `{rtl['max_occupancy']}`",
         f"- maximum RX contexts used per endpoint: `{performance['max_rx_context_occupancy_per_endpoint']}`",
         "- cycle and router counter equivalence: `true`",
-        "",
-        "## Remaining Abstractions",
-        "",
     ]
+    bounded_slots = performance.get("bounded_packet_slots")
+    if isinstance(bounded_slots, dict):
+        lines.extend(
+            [
+                f"- bounded root packet slots/address extent: `{bounded_slots['maximum_packet_slots_at_root_endpoint']}` / `{bounded_slots['maximum_addressed_bytes_at_root_endpoint']}` bytes",
+                f"- TX peak live slots/minimum reuse gap: `{bounded_slots['tx']['maximum_peak_live_slots']}` / `{bounded_slots['tx']['minimum_reuse_gap_cycles']}` cycles",
+                f"- RX peak live slots/minimum reuse gap: `{bounded_slots['rx']['maximum_peak_live_slots']}` / `{bounded_slots['rx']['minimum_reuse_gap_cycles']}` cycles",
+            ]
+        )
+    lines.extend(["", "## Remaining Abstractions", ""])
     lines.extend(f"- {item}" for item in payload["remaining_abstractions"])
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/npu/sim/rtl/noc_llama7b_phase2_command_generator.sv
+++ b/npu/sim/rtl/noc_llama7b_phase2_command_generator.sv
@@ -34,7 +34,8 @@ module noc_llama7b_phase2_command_generator #(
   reg [3:0] command_destination;
   reg [1:0] command_vc;
   reg [7:0] command_tag;
-  reg [13:0] command_packet_id;
+  reg [23:0] command_tx_base_addr;
+  reg [23:0] command_rx_base_addr;
   reg [3:0] command_flit_count;
 
   wire command_fire = cmd_valid && cmd_ready;
@@ -59,22 +60,6 @@ module noc_llama7b_phase2_command_generator #(
     end
   endfunction
 
-  function [13:0] wave_packet_base;
-    input [2:0] wave;
-    begin
-      case (wave)
-        3'd0: wave_packet_base = 14'd0;
-        3'd1: wave_packet_base = 14'd1583;
-        3'd2: wave_packet_base = 14'd3166;
-        3'd3: wave_packet_base = 14'd4749;
-        3'd4: wave_packet_base = 14'd6332;
-        3'd5: wave_packet_base = 14'd6827;
-        3'd6: wave_packet_base = 14'd8410;
-        3'd7: wave_packet_base = 14'd9993;
-      endcase
-    end
-  endfunction
-
   function [3:0] shared_home_shift;
     input [2:0] wave;
     begin
@@ -88,50 +73,6 @@ module noc_llama7b_phase2_command_generator #(
         3'd6: shared_home_shift = 4'd6;
         3'd7: shared_home_shift = 4'd9;
       endcase
-    end
-  endfunction
-
-  function [13:0] full_cluster_offset;
-    input [3:0] cluster_index;
-    reg [13:0] value;
-    begin
-      value = {10'b0, cluster_index};
-      full_cluster_offset =
-        (value << 6) + (value << 5) + (value << 2) + value;
-    end
-  endfunction
-
-  function [13:0] reduction_cluster_offset;
-    input [3:0] cluster_index;
-    reg [13:0] value;
-    begin
-      value = {10'b0, cluster_index};
-      reduction_cluster_offset = (value << 5) + value;
-    end
-  endfunction
-
-  function [13:0] shared_packet_id;
-    input [2:0] wave;
-    input [3:0] cluster_index;
-    input [6:0] packet_index;
-    begin
-      shared_packet_id = wave_packet_base(wave) +
-        full_cluster_offset(cluster_index) + {7'b0, packet_index};
-    end
-  endfunction
-
-  function [13:0] reduction_packet_id;
-    input [2:0] wave;
-    input [3:0] cluster_index;
-    input [6:0] packet_index;
-    begin
-      if (wave == 3'd4)
-        reduction_packet_id = wave_packet_base(wave) +
-          reduction_cluster_offset(cluster_index) + {7'b0, packet_index};
-      else
-        reduction_packet_id = wave_packet_base(wave) +
-          full_cluster_offset(cluster_index) + 14'd68 +
-          {7'b0, packet_index};
     end
   endfunction
 
@@ -154,13 +95,36 @@ module noc_llama7b_phase2_command_generator #(
     end
   endfunction
 
+  // Packet payloads use endpoint-local slots rather than the global packet
+  // identity. Shared traffic occupies slots 0..67. A reduction source uses
+  // slots 68..100, while root endpoint 15 gives each of the 15 sources a
+  // disjoint 33-slot receive window (68..562).
+  function [23:0] packet_slot_addr;
+    input [9:0] slot;
+    begin
+      packet_slot_addr = {6'b0, slot, 8'b0};
+    end
+  endfunction
+
+  function [9:0] reduction_root_slot;
+    input [3:0] source;
+    input [6:0] packet_index;
+    reg [9:0] source_value;
+    begin
+      source_value = {6'b0, source};
+      reduction_root_slot = 10'd68 + (source_value << 5) + source_value +
+        {3'b0, packet_index};
+    end
+  endfunction
+
   always @(*) begin
     command_release_cycle = epoch_release_cycle(release_epoch);
     command_source = 4'd0;
     command_destination = 4'd0;
     command_vc = 2'd0;
     command_tag = 8'd0;
-    command_packet_id = 14'd0;
+    command_tx_base_addr = 24'd0;
+    command_rx_base_addr = 24'd0;
     command_flit_count = 4'd8;
 
     if (phase == PHASE_SHARED) begin
@@ -168,13 +132,16 @@ module noc_llama7b_phase2_command_generator #(
       command_destination = cluster;
       command_vc = 2'd0;
       command_tag = {1'b0, packet};
-      command_packet_id = shared_packet_id(transfer_wave, cluster, packet);
+      command_tx_base_addr = packet_slot_addr({3'b0, packet});
+      command_rx_base_addr = packet_slot_addr({3'b0, packet});
     end else begin
       command_source = cluster;
       command_destination = 4'd15;
       command_vc = 2'd1;
       command_tag = reduction_tag(transfer_wave, packet);
-      command_packet_id = reduction_packet_id(transfer_wave, cluster, packet);
+      command_tx_base_addr = packet_slot_addr(10'd68 + {3'b0, packet});
+      command_rx_base_addr = packet_slot_addr(
+        reduction_root_slot(cluster, packet));
       if (packet == 7'd32)
         command_flit_count = 4'd4;
     end
@@ -183,8 +150,8 @@ module noc_llama7b_phase2_command_generator #(
   assign cmd_valid = enable && !done;
   assign cmd_data = {
     command_flit_count,
-    2'b0, command_packet_id, 8'b0,
-    2'b0, command_packet_id, 8'b0,
+    command_rx_base_addr,
+    command_tx_base_addr,
     command_tag,
     command_vc,
     command_destination,

--- a/tests/noc_sram_packet_mesh4x4_workload_tb.sv
+++ b/tests/noc_sram_packet_mesh4x4_workload_tb.sv
@@ -8,6 +8,7 @@ module noc_sram_packet_mesh4x4_workload_tb;
   localparam integer ADDR_W = 24;
   localparam integer MAX_PACKETS = 12000;
   localparam integer RX_CONTEXTS = 8;
+  localparam integer BOUNDED_PACKET_SLOTS = 563;
 
   reg clk = 1'b0;
   reg rst_n = 1'b0;
@@ -35,6 +36,12 @@ module noc_sram_packet_mesh4x4_workload_tb;
   integer comb_free_context;
   integer comb_duplicate_context;
   integer write_fragment;
+  integer request_packet;
+  integer request_fragment;
+  integer request_slot;
+  integer response_packet;
+  integer response_fragment;
+  integer descriptor_slot;
   integer tx_fire_count;
   integer completion_fire_count;
   integer write_fire_count;
@@ -84,6 +91,20 @@ module noc_sram_packet_mesh4x4_workload_tb;
   integer pending_read_rd [0:15];
   integer pending_read_wr [0:15];
   integer pending_read_count [0:15];
+  integer pending_read_packet [0:16*8-1];
+
+`ifdef GENERATED_COMMAND_SOURCE
+  integer serial_rx_position = 0;
+  integer serial_tx_position = 0;
+  integer tx_packet_queue [0:16*MAX_PACKETS-1];
+  integer tx_packet_rd [0:15];
+  integer tx_packet_wr [0:15];
+  integer tx_packet_fragment [0:15];
+  reg [ADDR_W-1:0] packet_tx_base [0:MAX_PACKETS-1];
+  reg [ADDR_W-1:0] packet_rx_base [0:MAX_PACKETS-1];
+  reg [BOUNDED_PACKET_SLOTS-1:0] tx_slot_live [0:15];
+  reg [BOUNDED_PACKET_SLOTS-1:0] rx_slot_live [0:15];
+`endif
 
 `ifdef SERIAL_PAIRED_SCHEDULER
   wire [15:0] rx_desc_valid;
@@ -243,12 +264,9 @@ module noc_sram_packet_mesh4x4_workload_tb;
 
   function [DATA_W-1:0] memory_data;
     input [3:0] source;
-    input [ADDR_W-1:0] address;
-    reg [15:0] packet_id;
-    reg [2:0] fragment;
+    input [15:0] packet_id;
+    input [2:0] fragment;
     begin
-      packet_id = address[23:8];
-      fragment = address[7:5];
       memory_data = {DATA_W{1'b0}};
       memory_data[3:0] = source;
       memory_data[19:4] = packet_id;
@@ -382,6 +400,10 @@ module noc_sram_packet_mesh4x4_workload_tb;
       packet_completed <= 0;
       live_context_valid <= 0;
       completion_shadow_valid <= 0;
+`ifdef GENERATED_COMMAND_SOURCE
+      serial_rx_position <= 0;
+      serial_tx_position <= 0;
+`endif
 `ifdef SERIAL_PAIRED_SCHEDULER
 `ifndef GENERATED_COMMAND_SOURCE
       command_mem_pending <= 1'b0;
@@ -395,6 +417,13 @@ module noc_sram_packet_mesh4x4_workload_tb;
         pending_read_rd[seq_endpoint_i] <= 0;
         pending_read_wr[seq_endpoint_i] <= 0;
         pending_read_count[seq_endpoint_i] <= 0;
+`ifdef GENERATED_COMMAND_SOURCE
+        tx_packet_rd[seq_endpoint_i] <= 0;
+        tx_packet_wr[seq_endpoint_i] <= 0;
+        tx_packet_fragment[seq_endpoint_i] <= 0;
+        tx_slot_live[seq_endpoint_i] <= 0;
+        rx_slot_live[seq_endpoint_i] <= 0;
+`endif
       end
     end else begin
       cycle <= cycle + 1;
@@ -413,16 +442,58 @@ module noc_sram_packet_mesh4x4_workload_tb;
       write_fire_count = 0;
 
       for (seq_endpoint_i = 0; seq_endpoint_i < 16; seq_endpoint_i = seq_endpoint_i + 1) begin
+`ifdef GENERATED_COMMAND_SOURCE
+        if (tx_mem_rsp_valid[seq_endpoint_i] && tx_mem_rsp_ready[seq_endpoint_i]) begin
+          response_packet =
+            tx_mem_rsp_data[(seq_endpoint_i*DATA_W) + 4 +: 16];
+          response_fragment =
+            tx_mem_rsp_data[(seq_endpoint_i*DATA_W) + 20 +: 3];
+          if (response_fragment + 1 == descriptors[response_packet][53:50]) begin
+            request_slot = packet_tx_base[response_packet] >> 8;
+            tx_slot_live[seq_endpoint_i][request_slot] <= 1'b0;
+          end
+        end
+`endif
+        request_packet = -1;
+        request_fragment = -1;
+        if (tx_mem_req_valid[seq_endpoint_i] && tx_mem_req_ready[seq_endpoint_i]) begin
+`ifdef GENERATED_COMMAND_SOURCE
+          request_packet = tx_packet_queue[
+            seq_endpoint_i*MAX_PACKETS + tx_packet_rd[seq_endpoint_i]];
+          request_fragment = tx_packet_fragment[seq_endpoint_i];
+          if (tx_mem_req_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W] !==
+              packet_tx_base[request_packet] + request_fragment*32)
+            $fatal(1,
+              "TX packet-slot address mismatch endpoint=%0d packet=%0d fragment=%0d address=%h base=%h",
+              seq_endpoint_i, request_packet, request_fragment,
+              tx_mem_req_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W],
+              packet_tx_base[request_packet]);
+          if (request_fragment + 1 == descriptors[request_packet][53:50]) begin
+            tx_packet_rd[seq_endpoint_i] <= tx_packet_rd[seq_endpoint_i] + 1;
+            tx_packet_fragment[seq_endpoint_i] <= 0;
+          end else begin
+            tx_packet_fragment[seq_endpoint_i] <= request_fragment + 1;
+          end
+`else
+          request_packet = tx_mem_req_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W] >> 8;
+          request_fragment =
+            (tx_mem_req_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W] >> 5) & 7;
+`endif
+        end
+
         if (!tx_mem_rsp_valid[seq_endpoint_i] || tx_mem_rsp_ready[seq_endpoint_i]) begin
           if (pending_read_count[seq_endpoint_i] > 0) begin
             tx_mem_rsp_valid[seq_endpoint_i] <= 1'b1;
             tx_mem_rsp_data[(seq_endpoint_i*DATA_W) +: DATA_W] <= memory_data(
               seq_endpoint_i[3:0],
-              pending_read_addr[seq_endpoint_i*8 + pending_read_rd[seq_endpoint_i]]);
+              pending_read_packet[seq_endpoint_i*8 + pending_read_rd[seq_endpoint_i]],
+              (pending_read_addr[seq_endpoint_i*8 + pending_read_rd[seq_endpoint_i]] >> 5) & 7);
             pending_read_rd[seq_endpoint_i] <= (pending_read_rd[seq_endpoint_i] + 1) % 8;
             if (tx_mem_req_valid[seq_endpoint_i] && tx_mem_req_ready[seq_endpoint_i]) begin
               pending_read_addr[seq_endpoint_i*8 + pending_read_wr[seq_endpoint_i]] <=
                 tx_mem_req_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W];
+              pending_read_packet[seq_endpoint_i*8 + pending_read_wr[seq_endpoint_i]] <=
+                request_packet;
               pending_read_wr[seq_endpoint_i] <= (pending_read_wr[seq_endpoint_i] + 1) % 8;
             end else begin
               pending_read_count[seq_endpoint_i] <= pending_read_count[seq_endpoint_i] - 1;
@@ -432,20 +503,44 @@ module noc_sram_packet_mesh4x4_workload_tb;
             // response consumed at the following edge.
             tx_mem_rsp_valid[seq_endpoint_i] <= 1'b1;
             tx_mem_rsp_data[(seq_endpoint_i*DATA_W) +: DATA_W] <= memory_data(
-              seq_endpoint_i[3:0], tx_mem_req_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W]);
+              seq_endpoint_i[3:0], request_packet, request_fragment[2:0]);
           end else begin
             tx_mem_rsp_valid[seq_endpoint_i] <= 1'b0;
           end
         end else if (tx_mem_req_valid[seq_endpoint_i] && tx_mem_req_ready[seq_endpoint_i]) begin
           pending_read_addr[seq_endpoint_i*8 + pending_read_wr[seq_endpoint_i]] <=
             tx_mem_req_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W];
+          pending_read_packet[seq_endpoint_i*8 + pending_read_wr[seq_endpoint_i]] <=
+            request_packet;
           pending_read_wr[seq_endpoint_i] <= (pending_read_wr[seq_endpoint_i] + 1) % 8;
           pending_read_count[seq_endpoint_i] <= pending_read_count[seq_endpoint_i] + 1;
         end
 
         if (rx_desc_valid[seq_endpoint_i] && rx_desc_ready[seq_endpoint_i]) begin
 `ifdef SERIAL_PAIRED_SCHEDULER
+`ifdef GENERATED_COMMAND_SOURCE
+          selected_packet = command_order[serial_rx_position];
+          serial_rx_position <= serial_rx_position + 1;
+          if (descriptors[selected_packet][39:36] != seq_endpoint_i[3:0] ||
+              rx_desc_source[(seq_endpoint_i*4) +: 4] !== descriptors[selected_packet][35:32] ||
+              rx_desc_vc[(seq_endpoint_i*2) +: 2] !== descriptors[selected_packet][41:40] ||
+              rx_desc_tag[(seq_endpoint_i*8) +: 8] !== descriptors[selected_packet][49:42] ||
+              rx_desc_flit_count[(seq_endpoint_i*4) +: 4] !== descriptors[selected_packet][53:50])
+            $fatal(1, "generated RX descriptor metadata mismatch for packet %0d", selected_packet);
+          packet_rx_base[selected_packet] <=
+            rx_desc_base_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W];
+          descriptor_slot =
+            rx_desc_base_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W] >> 8;
+          if (descriptor_slot < 0 || descriptor_slot >= BOUNDED_PACKET_SLOTS)
+            $fatal(1, "generated RX descriptor slot is out of bounds: %0d", descriptor_slot);
+          if (rx_slot_live[seq_endpoint_i][descriptor_slot])
+            $fatal(1,
+              "generated RX descriptor reuses live slot endpoint=%0d slot=%0d packet=%0d",
+              seq_endpoint_i, descriptor_slot, selected_packet);
+          rx_slot_live[seq_endpoint_i][descriptor_slot] <= 1'b1;
+`else
           selected_packet = rx_desc_base_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W] >> 8;
+`endif
 `else
           selected_index = destination_queue_meta[seq_endpoint_i][15:0] +
             destination_position[seq_endpoint_i];
@@ -466,7 +561,32 @@ module noc_sram_packet_mesh4x4_workload_tb;
 
         if (tx_desc_valid[seq_endpoint_i] && tx_desc_ready[seq_endpoint_i]) begin
 `ifdef SERIAL_PAIRED_SCHEDULER
+`ifdef GENERATED_COMMAND_SOURCE
+          selected_packet = command_order[serial_tx_position];
+          serial_tx_position <= serial_tx_position + 1;
+          if (descriptors[selected_packet][35:32] != seq_endpoint_i[3:0] ||
+              tx_desc_destination[(seq_endpoint_i*4) +: 4] !== descriptors[selected_packet][39:36] ||
+              tx_desc_vc[(seq_endpoint_i*2) +: 2] !== descriptors[selected_packet][41:40] ||
+              tx_desc_tag[(seq_endpoint_i*8) +: 8] !== descriptors[selected_packet][49:42] ||
+              tx_desc_flit_count[(seq_endpoint_i*4) +: 4] !== descriptors[selected_packet][53:50])
+            $fatal(1, "generated TX descriptor metadata mismatch for packet %0d", selected_packet);
+          packet_tx_base[selected_packet] <=
+            tx_desc_base_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W];
+          descriptor_slot =
+            tx_desc_base_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W] >> 8;
+          if (descriptor_slot < 0 || descriptor_slot >= BOUNDED_PACKET_SLOTS)
+            $fatal(1, "generated TX descriptor slot is out of bounds: %0d", descriptor_slot);
+          if (tx_slot_live[seq_endpoint_i][descriptor_slot])
+            $fatal(1,
+              "generated TX descriptor reuses live slot endpoint=%0d slot=%0d packet=%0d",
+              seq_endpoint_i, descriptor_slot, selected_packet);
+          tx_slot_live[seq_endpoint_i][descriptor_slot] <= 1'b1;
+          tx_packet_queue[seq_endpoint_i*MAX_PACKETS + tx_packet_wr[seq_endpoint_i]] <=
+            selected_packet;
+          tx_packet_wr[seq_endpoint_i] <= tx_packet_wr[seq_endpoint_i] + 1;
+`else
           selected_packet = tx_desc_base_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W] >> 8;
+`endif
 `else
           selected_index = source_queue_meta[seq_endpoint_i][15:0] + source_position[seq_endpoint_i];
           selected_packet = source_order[selected_index];
@@ -494,17 +614,32 @@ module noc_sram_packet_mesh4x4_workload_tb;
         end
 
         if (rx_mem_write_valid[seq_endpoint_i] && rx_mem_write_ready[seq_endpoint_i]) begin
+`ifdef GENERATED_COMMAND_SOURCE
+          selected_packet =
+            rx_mem_write_data[(seq_endpoint_i*DATA_W) + 4 +: 16];
+          write_fragment =
+            rx_mem_write_data[(seq_endpoint_i*DATA_W) + 20 +: 3];
+`else
           selected_packet = rx_mem_write_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W] >> 8;
           write_fragment =
             (rx_mem_write_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W] >> 5) & 7;
+`endif
           if (selected_packet < 0 || selected_packet >= packet_count)
             $fatal(1, "destination write names invalid packet %0d", selected_packet);
           if (descriptors[selected_packet][39:36] != seq_endpoint_i[3:0])
             $fatal(1, "packet %0d written at wrong endpoint %0d", selected_packet, seq_endpoint_i);
+`ifdef GENERATED_COMMAND_SOURCE
+          if (rx_mem_write_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W] !==
+              packet_rx_base[selected_packet] + write_fragment*32)
+            $fatal(1,
+              "RX packet-slot address mismatch endpoint=%0d packet=%0d fragment=%0d address=%h base=%h",
+              seq_endpoint_i, selected_packet, write_fragment,
+              rx_mem_write_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W],
+              packet_rx_base[selected_packet]);
+`endif
           if (rx_mem_write_data[(seq_endpoint_i*DATA_W) +: DATA_W] !== memory_data(
                 descriptors[selected_packet][35:32],
-                (selected_packet << 8) |
-                  ((rx_mem_write_addr[(seq_endpoint_i*ADDR_W) +: ADDR_W] & 24'h0000ff))))
+                selected_packet[15:0], write_fragment[2:0]))
             $fatal(1, "packet %0d destination data mismatch", selected_packet);
           write_fire_count = write_fire_count + 1;
 
@@ -518,6 +653,10 @@ module noc_sram_packet_mesh4x4_workload_tb;
             if (free_context < 0)
               $fatal(1, "completed packet %0d has no live context", selected_packet);
             live_context_valid[seq_endpoint_i*RX_CONTEXTS + free_context] <= 1'b0;
+`ifdef GENERATED_COMMAND_SOURCE
+            descriptor_slot = packet_rx_base[selected_packet] >> 8;
+            rx_slot_live[seq_endpoint_i][descriptor_slot] <= 1'b0;
+`endif
             completion_packet[seq_endpoint_i] <= selected_packet;
             completion_shadow_valid[seq_endpoint_i] <= 1'b1;
           end
@@ -577,12 +716,21 @@ module noc_sram_packet_mesh4x4_workload_tb;
       if (!command_generator_done || generated_command_count != packet_count ||
           scheduler_accepted_command_count != packet_count ||
           scheduler_installed_receive_count != packet_count ||
-          scheduler_submitted_transmit_count != packet_count)
+          scheduler_submitted_transmit_count != packet_count ||
+          serial_rx_position != packet_count || serial_tx_position != packet_count)
         $fatal(1,
-          "command count mismatch generated=%0d accepted=%0d rx=%0d tx=%0d expected=%0d done=%0d",
+          "command count mismatch generated=%0d accepted=%0d rx=%0d tx=%0d rx_pos=%0d tx_pos=%0d expected=%0d done=%0d",
           generated_command_count, scheduler_accepted_command_count,
           scheduler_installed_receive_count, scheduler_submitted_transmit_count,
-          packet_count, command_generator_done);
+          serial_rx_position, serial_tx_position, packet_count, command_generator_done);
+      for (queue_i = 0; queue_i < 16; queue_i = queue_i + 1) begin
+        if (tx_slot_live[queue_i] != 0 || rx_slot_live[queue_i] != 0)
+          $fatal(1, "bounded packet slots remain live at endpoint %0d tx=%h rx=%h",
+            queue_i, tx_slot_live[queue_i], rx_slot_live[queue_i]);
+        if (tx_packet_rd[queue_i] != tx_packet_wr[queue_i])
+          $fatal(1, "TX packet-slot queue did not drain at endpoint %0d rd=%0d wr=%0d",
+            queue_i, tx_packet_rd[queue_i], tx_packet_wr[queue_i]);
+      end
 `else
       if (scheduler_accepted_command_count != packet_count ||
           scheduler_installed_receive_count != packet_count ||

--- a/tests/test_noc_llama7b_phase2_command_generator.py
+++ b/tests/test_noc_llama7b_phase2_command_generator.py
@@ -14,8 +14,11 @@ from npu.eval.measure_llm_decoder_attention_score32_noc_phase2_schedule import (
     build_report,
 )
 from npu.eval.verify_llm_decoder_attention_score32_noc_phase2_endpoint_rtl import (
+    BOUNDED_PACKET_SLOTS,
+    PACKET_SLOT_BYTES,
     _schedule_args,
     _require_canonical_generated_commands,
+    bounded_local_addresses,
     command_words_from_packets,
     descriptors_from_packet_specs,
 )
@@ -54,6 +57,12 @@ def test_generator_matches_all_authoritative_commands_under_backpressure(
     packets = descriptors_from_packet_specs(packet_specs)
     words = command_words_from_packets(packets)
     assert len(words) == 11576
+    addresses = [bounded_local_addresses(packet) for packet in packets]
+    assert min(tx for tx, _ in addresses) == 0
+    assert max(tx for tx, _ in addresses) == 100 * PACKET_SLOT_BYTES
+    assert max(rx for _, rx in addresses) == (
+        BOUNDED_PACKET_SLOTS - 1
+    ) * PACKET_SLOT_BYTES
     _require_canonical_generated_commands(packets)
 
     mutated_packets = list(packets)


### PR DESCRIPTION
## Summary
- replace global packet-ID-derived Phase-2 payload addresses with bounded endpoint-local shared and reduction packet slots
- prove all cross-wave TX/RX slot reuse in the performance model and full composed RTL replay
- amend the pending generated-scheduler evaluation contracts to require bounded-address evidence

## Result
- non-root endpoint address extent: 25,856 bytes (101 x 256-byte slots)
- root endpoint address extent: 144,128 bytes (563 x 256-byte slots)
- TX peak live slots / minimum reuse gap: 6 / 46,032 cycles
- RX peak live slots / minimum reuse gap: 8 / 47,720 cycles
- full RTL/performance result unchanged: 11,576 packets, 92,128 flits, 397,227 cycles, 8,736 contention cycles, 11,816 input stalls, max occupancy 7

## Verification
- exhaustive 11,576-command generator comparison under backpressure
- strict full RTL replay with per-endpoint TX/RX live-slot bitmaps through final SRAM response/write
- 25 focused tests passed
- `scripts/validate_runs.py --skip_eval_queue`
- generated physical hierarchy Yosys import/process/check

## Remaining boundary
SRAM bitcells/macro placement, producer fill and consumer drain handshakes, HBM/DRAM controller, and workload-activity power remain explicit. The next architecture job will compose actual local-reducer payloads through the NoC into the root reducer.
