### PR TITLE
Ignore control-plane runtime logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,5 @@ control_plane/.venv/
 control_plane/**/__pycache__/
 control_plane/*.egg-info/
 control_plane/logs/
+control_plane/runtime_logs/
 control_plane/shadow_exports/


### PR DESCRIPTION
Normal API and resolver startup creates PID and log files under `control_plane/runtime_logs/`. Ignore that runtime-only directory so daemon restarts do not dirty the developer worktree.