### PR TITLE
Revise Phase-2 exact reduction transport

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -5278,6 +5278,101 @@ def _decoder_attention_score32_noc_phase2_schedule_evidence(
     }
 
 
+def _decoder_attention_score32_noc_phase2_exact_transport_revision_evidence(
+    *,
+    item_id: str,
+    depends_on_item_ids: list[str] | None,
+    proposal_id: str | None,
+    proposal_path: str | None,
+) -> dict[str, Any]:
+    expected_item_id = (
+        "l2_decoder_attention_score32_noc_phase2_exact_transport_revision_llama7b_v1"
+    )
+    expected_proposal_id = (
+        "prop_l2_decoder_attention_score32_noc_phase2_exact_transport_revision_v1"
+    )
+    if item_id != expected_item_id:
+        raise Layer2TaskGenerationError(
+            "score32 Phase-2 exact transport revision only permits its registered item"
+        )
+    if str(proposal_id or "").strip() != expected_proposal_id:
+        raise Layer2TaskGenerationError("score32 Phase-2 exact transport proposal_id mismatch")
+    if str(proposal_path or "").strip() != (
+        f"docs/proposals/{expected_proposal_id}/proposal.json"
+    ):
+        raise Layer2TaskGenerationError("score32 Phase-2 exact transport proposal_path mismatch")
+    if list(depends_on_item_ids or []):
+        raise Layer2TaskGenerationError(
+            "score32 Phase-2 exact transport revision reads merged artifacts directly"
+        )
+
+    base = "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1"
+    exact_manifest = (
+        "runs/designs/npu_blocks/"
+        "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_"
+        "p54x8_p53x8_c16_r2_l8_b59/verilog/"
+        "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_manifest.json"
+    )
+    prior_schedule = (
+        f"{base}/decoder_attention_score32_noc_phase2_schedule__"
+        "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1.json"
+    )
+    out = f"{base}/decoder_attention_score32_noc_phase2_exact_transport_revision__{item_id}.json"
+    report = f"{base}/decoder_attention_score32_noc_phase2_exact_transport_revision__{item_id}.md"
+    command = _bounded_launcher_command(
+        memory_high="1G",
+        memory_max="2G",
+        cpu_quota="100%",
+        tasks_max=64,
+        runtime_max_sec=120,
+        child_command=[
+            "python3",
+            "npu/eval/revise_llm_decoder_attention_score32_noc_phase2_exact_transport.py",
+            "--exact-manifest",
+            exact_manifest,
+            "--prior-schedule",
+            prior_schedule,
+            "--out",
+            out,
+            "--report",
+            report,
+        ],
+    )
+    return {
+        "inputs": {
+            "attention_score32_exact_manifest": exact_manifest,
+            "attention_score32_prior_phase2_schedule": prior_schedule,
+            "attention_score32_exact_transport_revision_out": out,
+            "attention_score32_exact_transport_revision_report": report,
+        },
+        "commands": [
+            {
+                "name": "revise_attention_score32_noc_phase2_exact_transport",
+                "run": command,
+            }
+        ],
+        "expected_outputs": [out, report],
+        "evidence_only": True,
+        "worker_resources": {
+            "exclusive_worker": False,
+            "memory_high": "1G",
+            "memory_max": "2G",
+            "cpu_quota": "100%",
+            "tasks_max": 64,
+            "outer_timeout_seconds": 180,
+            "stall_timeout_seconds": 90,
+        },
+        "acceptance": [
+            "Require the merged exact manifest to declare 16 clusters and 419-bit partial links",
+            "Require four groups, eight local waves, and 128 aggregate beats per group",
+            "Compare aligned, packed, and stats-once transports without narrowing 41-bit numerators",
+            "Record revision metadata for every invalidated Phase-2 schedule descendant",
+            "Do not claim cycle closure before producer and root ready/valid composition",
+            "Write exactly one JSON and one Markdown report",
+        ],
+    }
+
+
 def _validate_score32_noc_closure_request(
     *,
     item_id: str,
@@ -13068,6 +13163,7 @@ def _build_payload(
         "decoder_attention_kv_endpoint_sram_noc_full_search_softmax_recip_lut_schedule",
         "decoder_attention_kv_onchip_service_schedule",
         "decoder_attention_score32_noc_phase2_schedule",
+        "decoder_attention_score32_noc_phase2_exact_transport",
         "decoder_attention_score32_noc_phase2_measured_router_closure",
         "decoder_attention_score32_noc_phase2_measured_router_clock_reroute",
         "decoder_attention_score32_noc_phase2_composed_mesh_reroute",
@@ -13303,6 +13399,15 @@ def _build_payload(
                 item_id=item_id,
                 proposal_id=proposal_id,
                 proposal_path=proposal_path,
+            )
+        elif abstraction_layer_name == "decoder_attention_score32_noc_phase2_exact_transport":
+            decoder_evidence = (
+                _decoder_attention_score32_noc_phase2_exact_transport_revision_evidence(
+                    item_id=item_id,
+                    depends_on_item_ids=depends_on_item_ids,
+                    proposal_id=proposal_id,
+                    proposal_path=proposal_path,
+                )
             )
         elif abstraction_layer_name == "decoder_attention_score32_noc_phase2_measured_router_closure":
             decoder_evidence = _decoder_attention_score32_noc_phase2_measured_router_closure_evidence(

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -14641,6 +14641,58 @@ def test_generate_l2_campaign_task_adds_score32_noc_phase2_full_schedule_evidenc
             assert any("compute_clock_ns/noc_clock_ns" in entry for entry in acceptance)
 
 
+def test_generate_l2_campaign_task_adds_score32_phase2_exact_transport_revision() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        campaign_path = _write_campaign(repo_root)
+        source_commit = _init_git_repo(repo_root)
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        create_all(engine)
+
+        with Session(engine) as session:
+            result = generate_l2_campaign_task(
+                session,
+                _make_l2_request(
+                    repo_root=str(repo_root),
+                    campaign_path=campaign_path,
+                    item_id=(
+                        "l2_decoder_attention_score32_noc_phase2_"
+                        "exact_transport_revision_llama7b_v1"
+                    ),
+                    requested_by="@tester",
+                    source_commit=source_commit,
+                    proposal_id=(
+                        "prop_l2_decoder_attention_score32_noc_phase2_"
+                        "exact_transport_revision_v1"
+                    ),
+                    proposal_path=(
+                        "docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_"
+                        "exact_transport_revision_v1/proposal.json"
+                    ),
+                    abstraction_layer=(
+                        "decoder_attention_score32_noc_phase2_exact_transport"
+                    ),
+                    evaluation_mode="frontier_detail",
+                    depends_on_item_ids=[],
+                    run_physical=False,
+                ),
+            )
+
+            work_item = session.query(WorkItem).filter_by(item_id=result.item_id).one()
+            run = work_item.command_manifest[0]["run"]
+            assert work_item.state == WorkItemState.DISPATCH_PENDING
+            assert "revise_llm_decoder_attention_score32_noc_phase2_exact_transport.py" in run
+            assert "partial_producer" not in run
+            assert "--runtime-max-sec 120" in run
+            assert work_item.input_manifest["worker_resources"]["exclusive_worker"] is False
+            assert any("419-bit" in str(rule) for rule in work_item.acceptance_rules)
+            assert work_item.expected_outputs[0].endswith(
+                "decoder_attention_score32_noc_phase2_exact_transport_revision__"
+                "l2_decoder_attention_score32_noc_phase2_exact_transport_revision_llama7b_v1.json"
+            )
+
+
 def test_generate_l2_campaign_task_rejects_noncanonical_score32_noc_phase2_item() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_noc_llama7b_phase2_command_scheduler_v1/evaluation_requests.json
@@ -15,7 +15,7 @@
       "expected_outputs": [
         "runs/designs/noc/l1_noc_llama7b_phase2_command_scheduler_n16_wrapper/metrics.csv"
       ],
-      "status": "pending_after_proposal_merge",
+      "status": "retracted",
       "comparison_role": "phase2_generated_command_scheduler_physical_anchor",
       "paired_baseline_item_id": "l1_noc_descriptor_pair_scheduler_v1",
       "depends_on_item_ids": [],
@@ -25,7 +25,9 @@
         "direction": "replace_command_image_with_exact_generation",
         "reason": "Measure generator-plus-scheduler PPA without command SRAM or refill estimates."
       },
-      "acceptance_notes": "Require exhaustive 11576-command equivalence including bounded TX/RX addresses, generated hierarchy selection, protocol_error=0, and timing/area/power rows. Require maximum RX base address 143872 bytes (slot 562). Treat vectorless power and payload SRAM macros as separate evidence."
+      "acceptance_notes": "Do not dispatch. The 11576-command source uses the invalidated per-wave 16-bit reduction contract.",
+      "retracted_by_item_id": "l2_decoder_attention_score32_noc_phase2_exact_transport_revision_llama7b_v1",
+      "retraction_reason": "wrong_precision_and_release_contract"
     }
   ]
 }

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_exact_transport_revision_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_exact_transport_revision_v1/README.md
@@ -1,0 +1,5 @@
+# Phase-2 Exact Transport Revision
+
+This proposal retracts the 16-bit per-wave reduction heuristic from the active
+Llama7B frontier and derives replacement traffic from the embodied exact
+local16/global-tree RTL contract.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_exact_transport_revision_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_exact_transport_revision_v1/design_brief.md
@@ -1,0 +1,12 @@
+# Design Brief
+
+The prior schedule emits 8,320 reduction bytes per cluster after every tile
+wave. That quantity assumes 16-bit reduction scalars. The embodied exact local
+temporal reducer instead accumulates eight waves and emits 128 structured
+419-bit beats for each of four eight-head groups.
+
+The revision compares three lossless transports over the existing 256-bit
+flit: direct two-flit beat alignment, contiguous group bit packing, and an
+ordered stats-once format that transmits each head's 32-bit maximum and 33-bit
+sum once while retaining every 41-bit numerator. Metadata in the stats-once
+format is reconstructed from the already checked group/head/slice order.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_exact_transport_revision_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_exact_transport_revision_v1/evaluation_gate.md
@@ -1,0 +1,6 @@
+# Evaluation Gate
+
+Reject the revision if the checked manifest no longer declares 16 clusters,
+419-bit partial links, 328-bit numerator payloads, or group-major wave
+scheduling. Require all three exact mode quantities and preserve the old
+artifact as retracted audit evidence rather than deleting it.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_exact_transport_revision_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_exact_transport_revision_v1/evaluation_requests.json
@@ -1,0 +1,43 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_noc_phase2_exact_transport_revision_v1",
+  "source_commit": "TBD",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_noc_phase2_exact_transport_revision_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Retract the invalid per-wave 16-bit reduction schedule and quantify precision-exact transport modes from the checked local16/global-tree RTL manifest.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_noc_phase2_exact_transport",
+      "config_paths": [],
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_exact_transport_revision__l2_decoder_attention_score32_noc_phase2_exact_transport_revision_llama7b_v1.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_exact_transport_revision__l2_decoder_attention_score32_noc_phase2_exact_transport_revision_llama7b_v1.md"
+      ],
+      "status": "pending_after_proposal_merge",
+      "comparison_role": "phase2_exact_transport_revision",
+      "paired_baseline_item_id": "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "revision": {
+        "reason": "wrong_precision_and_release_contract",
+        "invalidates_item_ids": [
+          "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1",
+          "l1_noc_llama7b_phase2_command_scheduler_v1",
+          "l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_llama7b_v1",
+          "l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1",
+          "l2_decoder_attention_score32_finite_endpoint_final_frontier_llama7b_v1"
+        ],
+        "invalidates": {
+          "artifact": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_schedule__l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1.json",
+          "prior_contract": "8320 bytes per cluster after each tile wave"
+        }
+      },
+      "expected_result": {
+        "direction": "retract_and_replace_phase2_reduction_transport",
+        "reason": "Use actual 419-bit exact aggregate beats and group-major release before any NoC PPA or frontier recost."
+      },
+      "acceptance_notes": "Require the checked exact manifest fields clusters=16, partial_link_bits_per_beat=419, partial_payload_bits_per_beat=328, four groups, eight local waves, and 128 aggregate beats per group. Record aligned, packed, and stats-once exact quantities and explicit revision metadata."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_exact_transport_revision_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_exact_transport_revision_v1/implementation_summary.md
@@ -1,0 +1,6 @@
+# Implementation Summary
+
+- Added a manifest-guarded exact transport revision calculator.
+- Quantified aligned, packed, and stats-once group transport over 256-bit
+  flits and eight-flit packets.
+- Declared the invalidated Phase-2 schedule subtree explicitly.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_exact_transport_revision_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_exact_transport_revision_v1/promotion_gate.md
@@ -1,0 +1,5 @@
+# Promotion Gate
+
+Use this revision to remove invalid Phase-2 schedule descendants from active
+ranking. The next promoted architecture must first pass direct aligned codec
+equivalence, then compare stats-once codec PPA and producer/root backpressure.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_exact_transport_revision_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_exact_transport_revision_v1/proposal.json
@@ -1,0 +1,64 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_noc_phase2_exact_transport_revision_v1",
+  "created_utc": "2026-08-18T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "revision",
+  "abstraction_layer": "decoder_attention_score32_noc_phase2_exact_transport",
+  "title": "Revise Phase-2 reduction traffic from the embodied exact reducer contract",
+  "hypothesis": "Replacing the per-wave 16-bit reduction heuristic with the actual 419-bit exact aggregate stream and group-major release contract will preserve precision while reducing total Phase-2 traffic because each cluster emits only after eight local waves.",
+  "direct_comparison": {
+    "primary_question": "What exact packet traffic must connect the embodied local temporal reducers to the root global reducer?",
+    "include": [
+      "four head groups",
+      "eight persistent local waves per group",
+      "128 exact aggregate beats per group and cluster",
+      "419-bit direct link beats",
+      "aligned, packed, and stats-once lossless transport modes",
+      "existing 256-bit flit and eight-flit packet contract"
+    ],
+    "exclude": [
+      "serializer and depacketizer PPA",
+      "dynamic producer/root backpressure",
+      "shared SRAM residency release",
+      "HBM/DRAM controller"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_noc_phase2_exact_transport_revision_llama7b_v1",
+      "task_type": "l2_campaign",
+      "objective": "Retract the invalid per-wave 16-bit reduction schedule and quantify precision-exact transport modes from the checked local16/global-tree RTL manifest.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_noc_phase2_exact_transport",
+      "comparison_role": "phase2_exact_transport_revision",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "config_paths": [],
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_exact_transport_revision__l2_decoder_attention_score32_noc_phase2_exact_transport_revision_llama7b_v1.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_exact_transport_revision__l2_decoder_attention_score32_noc_phase2_exact_transport_revision_llama7b_v1.md"
+      ],
+      "revision": {
+        "reason": "wrong_precision_and_release_contract",
+        "invalidates_item_ids": [
+          "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1",
+          "l1_noc_llama7b_phase2_command_scheduler_v1",
+          "l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_llama7b_v1",
+          "l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1",
+          "l2_decoder_attention_score32_finite_endpoint_final_frontier_llama7b_v1"
+        ],
+        "invalidates": {
+          "artifact": "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_schedule__l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1.json",
+          "prior_contract": "8320 bytes per cluster after each tile wave"
+        }
+      }
+    }
+  ],
+  "baseline_refs": [
+    "npu/docs/attention_score32_exact_local16_global_tree_gqa8_contract.md",
+    "runs/designs/npu_blocks/attention_score32_exact_local16_global_tree_cluster_sram_gqa8_p54x8_p53x8_c16_r2_l8_b59/verilog/attention_score32_exact_local16_global_tree_cluster_sram_gqa8_manifest.json",
+    "docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_schedule_v1/proposal.json"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_exact_transport_revision_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_exact_transport_revision_v1/quality_gate.md
@@ -1,0 +1,8 @@
+# Quality Gate
+
+- No numerator may be narrowed below signed 41 bits.
+- Maximum and sum state must remain 32 and 33 bits.
+- Stats-once metadata reconstruction is legal only for the checked ordered
+  eight-head, sixteen-slice group stream.
+- Do not claim cycle closure before actual producer and root ready/valid
+  interfaces are composed.

--- a/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_v1/evaluation_requests.json
@@ -13,7 +13,7 @@
         "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence__l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_llama7b_v1.json",
         "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_noc_phase2_endpoint_rtl_equivalence__l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_llama7b_v1.md"
       ],
-      "status": "pending_after_proposal_merge",
+      "status": "retracted",
       "comparison_role": "phase2_generated_scheduler_composed_equivalence",
       "paired_baseline_item_id": "l2_decoder_attention_score32_noc_phase2_serial_scheduler_equivalence_llama7b_v1",
       "depends_on_item_ids": [],
@@ -23,7 +23,9 @@
         "direction": "exact_generated_command_equivalence",
         "reason": "Close command-image and refill abstractions without changing packet or cycle behavior."
       },
-      "acceptance_notes": "Require 11576 generated commands, 92128 flits, exact RTL/performance packet/flit/cycle/contention/stall/occupancy counters, zero protocol errors, 563 bounded 256-byte packet slots, and collision-free model plus RTL lifetime checks for every reused TX/RX slot."
+      "acceptance_notes": "Do not dispatch. The 11576-command/92128-flit workload uses the invalidated per-wave 16-bit reduction contract.",
+      "retracted_by_item_id": "l2_decoder_attention_score32_noc_phase2_exact_transport_revision_llama7b_v1",
+      "retraction_reason": "wrong_precision_and_release_contract"
     }
   ]
 }

--- a/npu/eval/revise_llm_decoder_attention_score32_noc_phase2_exact_transport.py
+++ b/npu/eval/revise_llm_decoder_attention_score32_noc_phase2_exact_transport.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Revise Phase-2 reduction traffic from the embodied exact RTL contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+DEFAULT_EXACT_MANIFEST = Path(
+    "runs/designs/npu_blocks/"
+    "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_"
+    "p54x8_p53x8_c16_r2_l8_b59/verilog/"
+    "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_manifest.json"
+)
+DEFAULT_PRIOR_SCHEDULE = Path(
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+    "decoder_attention_score32_noc_phase2_schedule__"
+    "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1.json"
+)
+
+INVALIDATED_ITEM_IDS = [
+    "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1",
+    "l1_noc_llama7b_phase2_command_scheduler_v1",
+    "l2_decoder_attention_score32_noc_phase2_generated_scheduler_equivalence_llama7b_v1",
+    "l2_decoder_attention_score32_noc_phase2_finite_endpoint_composed_recost_llama7b_v1",
+    "l2_decoder_attention_score32_finite_endpoint_final_frontier_llama7b_v1",
+]
+
+
+def _load(path: Path) -> JsonDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _ceil_div(numerator: int, denominator: int) -> int:
+    return (numerator + denominator - 1) // denominator
+
+
+def _mode(
+    *,
+    name: str,
+    bits_per_group: int,
+    groups: int,
+    remote_clusters: int,
+    flit_bits: int,
+    packet_flits: int,
+    shared_packets: int,
+    shared_flits: int,
+) -> JsonDict:
+    flits_per_group = _ceil_div(bits_per_group, flit_bits)
+    packets_per_group = _ceil_div(flits_per_group, packet_flits)
+    flits_per_cluster = flits_per_group * groups
+    packets_per_cluster = packets_per_group * groups
+    reduction_flits = flits_per_cluster * remote_clusters
+    reduction_packets = packets_per_cluster * remote_clusters
+    return {
+        "name": name,
+        "bits_per_group": bits_per_group,
+        "flits_per_group": flits_per_group,
+        "packets_per_group": packets_per_group,
+        "flits_per_cluster_layer": flits_per_cluster,
+        "packets_per_cluster_layer": packets_per_cluster,
+        "remote_reduction_flits": reduction_flits,
+        "remote_reduction_packets": reduction_packets,
+        "total_phase2_flits": shared_flits + reduction_flits,
+        "total_phase2_commands": shared_packets + reduction_packets,
+    }
+
+
+def build_report(*, exact_manifest: Path, prior_schedule: Path) -> JsonDict:
+    manifest = _load(exact_manifest)
+    prior = _load(prior_schedule)
+    service = manifest.get("service_model")
+    if not isinstance(service, dict):
+        raise ValueError("exact manifest lacks service_model")
+
+    expected = {
+        "clusters": 16,
+        "partial_link_bits_per_beat": 419,
+        "partial_payload_bits_per_beat": 328,
+    }
+    for key, value in expected.items():
+        if int(service.get(key, -1)) != value:
+            raise ValueError(
+                f"exact manifest {key} mismatch: expected {value}, observed {service.get(key)!r}"
+            )
+    if "group_major" not in str(service.get("command_wave_contract", "")):
+        raise ValueError("exact manifest does not declare group-major wave scheduling")
+
+    source = prior["source_contract"]
+    simulation = prior["simulation"]
+    flows = prior["flow_summary"]
+    traffic = prior["traffic_quantities"]
+    if int(source["attention_heads"]) != 32 or int(source["hidden_size"]) != 4096:
+        raise ValueError("prior schedule is not the checked Llama7B 32-head/4096-hidden point")
+    if int(source["declared_tile_waves"]) != 8:
+        raise ValueError("prior schedule does not contain eight tile waves")
+    if int(traffic["partial_reduction_payload_bytes"]) != 8320:
+        raise ValueError("prior schedule no longer contains the invalidated 8320-byte reduction")
+
+    clusters = int(service["clusters"])
+    remote_clusters = clusters - 1
+    groups = 4
+    heads_per_group = 8
+    slices_per_head = 16
+    beats_per_group = heads_per_group * slices_per_head
+    link_bits = int(service["partial_link_bits_per_beat"])
+    value_bits = int(service["partial_payload_bits_per_beat"])
+    stats_bits = 32 + 33
+    flit_bits = 256
+    packet_flits = 8
+    shared_packets = int(flows["remote_shared_packet_count"])
+    shared_flits = int(simulation["delivery_flit_count_by_class"]["shared"])
+
+    aligned_bits_per_group = beats_per_group * _ceil_div(link_bits, flit_bits) * flit_bits
+    packed_bits_per_group = beats_per_group * link_bits
+    stats_once_bits_per_group = heads_per_group * (
+        stats_bits + slices_per_head * value_bits
+    )
+    modes = [
+        _mode(
+            name="aligned_419b_two_flits_per_beat",
+            bits_per_group=aligned_bits_per_group,
+            groups=groups,
+            remote_clusters=remote_clusters,
+            flit_bits=flit_bits,
+            packet_flits=packet_flits,
+            shared_packets=shared_packets,
+            shared_flits=shared_flits,
+        ),
+        _mode(
+            name="packed_419b_group_bitstream",
+            bits_per_group=packed_bits_per_group,
+            groups=groups,
+            remote_clusters=remote_clusters,
+            flit_bits=flit_bits,
+            packet_flits=packet_flits,
+            shared_packets=shared_packets,
+            shared_flits=shared_flits,
+        ),
+        _mode(
+            name="stats_once_ordered_exact",
+            bits_per_group=stats_once_bits_per_group,
+            groups=groups,
+            remote_clusters=remote_clusters,
+            flit_bits=flit_bits,
+            packet_flits=packet_flits,
+            shared_packets=shared_packets,
+            shared_flits=shared_flits,
+        ),
+    ]
+    for mode in modes:
+        mode["flit_reduction_vs_prior"] = (
+            int(simulation["scheduled_flit_count"]) - int(mode["total_phase2_flits"])
+        )
+        mode["flit_ratio_vs_prior"] = round(
+            int(mode["total_phase2_flits"]) / int(simulation["scheduled_flit_count"]),
+            6,
+        )
+
+    return {
+        "version": 1,
+        "profile": "decoder_attention_score32_noc_phase2_exact_transport_revision",
+        "decision": "prior_phase2_reduction_contract_retracted_exact_transport_required",
+        "revision": {
+            "reason": "wrong_precision_and_release_contract",
+            "invalidates_item_ids": INVALIDATED_ITEM_IDS,
+            "invalidates": {
+                "prior_schedule": str(prior_schedule),
+                "prior_partial_reduction_payload_bytes": int(
+                    traffic["partial_reduction_payload_bytes"]
+                ),
+                "prior_reduction_release": "once_per_cluster_per_tile_wave",
+            },
+        },
+        "exact_source": {
+            "manifest": str(exact_manifest),
+            "clusters": clusters,
+            "head_groups": groups,
+            "heads_per_group": heads_per_group,
+            "persistent_local_waves_per_group": 8,
+            "slices_per_head": slices_per_head,
+            "aggregate_beats_per_group_per_cluster": beats_per_group,
+            "partial_link_bits_per_beat": link_bits,
+            "partial_payload_bits_per_beat": value_bits,
+            "stats_bits_per_head": stats_bits,
+            "release_contract": "one aggregate stream per head group after eight local waves",
+        },
+        "prior_quantities": {
+            "scheduled_commands": int(simulation["scheduled_packet_count"]),
+            "scheduled_flits": int(simulation["scheduled_flit_count"]),
+            "remote_shared_packets": shared_packets,
+            "remote_shared_flits": shared_flits,
+            "remote_reduction_packets": int(flows["remote_reduction_packet_count"]),
+            "remote_reduction_flits": int(
+                simulation["delivery_flit_count_by_class"]["reduction"]
+            ),
+        },
+        "exact_transport_modes": modes,
+        "recommended_first_implementation": "aligned_419b_two_flits_per_beat",
+        "recommended_frontier_candidate": "stats_once_ordered_exact",
+        "recommendation": (
+            "Implement aligned transport as the direct field-preserving equivalence anchor, "
+            "then implement stats-once ordered packing and compare codec PPA plus actual "
+            "producer/root backpressure before rebuilding the Phase-2 command schedule."
+        ),
+        "remaining_abstractions": [
+            "Mode quantities do not yet include measured serializer/depacketizer PPA.",
+            "Command release must be driven by actual local-reducer valid/ready events.",
+            "Shared-tile traffic still requires SRAM-residency-driven release.",
+            "HBM/DRAM control remains external by design.",
+        ],
+    }
+
+
+def write_markdown(report: JsonDict, path: Path) -> None:
+    prior = report["prior_quantities"]
+    lines = [
+        "# Llama7B Phase-2 Exact Transport Revision",
+        "",
+        f"- decision: `{report['decision']}`",
+        f"- prior commands/flits: `{prior['scheduled_commands']}` / `{prior['scheduled_flits']}`",
+        "- exact release: one aggregate stream per head group after eight local waves",
+        "",
+        "| Mode | Commands | Flits | Ratio vs prior | Reduction packets/cluster |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    for mode in report["exact_transport_modes"]:
+        lines.append(
+            f"| `{mode['name']}` | {mode['total_phase2_commands']} | "
+            f"{mode['total_phase2_flits']} | {mode['flit_ratio_vs_prior']:.3f} | "
+            f"{mode['packets_per_cluster_layer']} |"
+        )
+    lines.extend(["", "## Recommendation", "", report["recommendation"], ""])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--exact-manifest", type=Path, default=DEFAULT_EXACT_MANIFEST)
+    parser.add_argument("--prior-schedule", type=Path, default=DEFAULT_PRIOR_SCHEDULE)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--report", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_report(
+        exact_manifest=args.exact_manifest,
+        prior_schedule=args.prior_schedule,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(payload, args.report)
+    print(json.dumps({"decision": payload["decision"], "modes": payload["exact_transport_modes"]}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llm_decoder_attention_score32_noc_phase2_exact_transport_revision.py
+++ b/tests/test_llm_decoder_attention_score32_noc_phase2_exact_transport_revision.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from npu.eval.revise_llm_decoder_attention_score32_noc_phase2_exact_transport import (
+    DEFAULT_EXACT_MANIFEST,
+    DEFAULT_PRIOR_SCHEDULE,
+    build_report,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_revision_uses_embodied_exact_link_and_group_release_contract() -> None:
+    report = build_report(
+        exact_manifest=REPO_ROOT / DEFAULT_EXACT_MANIFEST,
+        prior_schedule=REPO_ROOT / DEFAULT_PRIOR_SCHEDULE,
+    )
+
+    assert report["decision"] == (
+        "prior_phase2_reduction_contract_retracted_exact_transport_required"
+    )
+    assert report["exact_source"] == {
+        "manifest": str(REPO_ROOT / DEFAULT_EXACT_MANIFEST),
+        "clusters": 16,
+        "head_groups": 4,
+        "heads_per_group": 8,
+        "persistent_local_waves_per_group": 8,
+        "slices_per_head": 16,
+        "aggregate_beats_per_group_per_cluster": 128,
+        "partial_link_bits_per_beat": 419,
+        "partial_payload_bits_per_beat": 328,
+        "stats_bits_per_head": 65,
+        "release_contract": (
+            "one aggregate stream per head group after eight local waves"
+        ),
+    }
+    modes = {mode["name"]: mode for mode in report["exact_transport_modes"]}
+    assert modes["aligned_419b_two_flits_per_beat"]["total_phase2_flits"] == 76288
+    assert modes["packed_419b_group_bitstream"]["total_phase2_flits"] == 73528
+    assert modes["stats_once_ordered_exact"] == {
+        "name": "stats_once_ordered_exact",
+        "bits_per_group": 42504,
+        "flits_per_group": 167,
+        "packets_per_group": 21,
+        "flits_per_cluster_layer": 668,
+        "packets_per_cluster_layer": 84,
+        "remote_reduction_flits": 10020,
+        "remote_reduction_packets": 1260,
+        "total_phase2_flits": 70948,
+        "total_phase2_commands": 8876,
+        "flit_reduction_vs_prior": 21180,
+        "flit_ratio_vs_prior": 0.770102,
+    }
+
+
+def test_revision_rejects_nonexact_manifest(tmp_path: Path) -> None:
+    manifest = json.loads((REPO_ROOT / DEFAULT_EXACT_MANIFEST).read_text())
+    manifest["service_model"]["partial_link_bits_per_beat"] = 418
+    bad_manifest = tmp_path / "manifest.json"
+    bad_manifest.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="partial_link_bits_per_beat mismatch"):
+        build_report(
+            exact_manifest=bad_manifest,
+            prior_schedule=REPO_ROOT / DEFAULT_PRIOR_SCHEDULE,
+        )


### PR DESCRIPTION
## Finding
The merged Phase-2 schedule uses an 8,320-byte 16-bit reduction payload after every tile wave. The embodied exact local16/global-tree manifest instead declares 419-bit aggregate links, 328-bit (8 x S41) numerator payloads, and group-major output only after eight local waves. The old reduction traffic is not the exact RTL contract.

## Revision
- add an explicit revision item invalidating the affected Phase-2 schedule subtree
- retract the two not-yet-run 11,576-command generated-scheduler jobs
- derive three precision-exact transport modes from the checked RTL manifest
- register the corrective item in the L2 task generator

## Exact quantities
| Mode | Total commands | Total flits | Ratio vs prior |
|---|---:|---:|---:|
| aligned 419-bit | 9,536 | 76,288 | 0.828 |
| packed 419-bit | 9,236 | 73,528 | 0.798 |
| stats-once ordered exact | 8,876 | 70,948 | 0.770 |

The exact modes reduce traffic despite wider state because each cluster emits four group aggregates per layer, not one reduction after each of eight tile waves.

## Verification
- revision calculator manifest guards and quantity tests
- L2 task generator test
- `scripts/validate_runs.py --skip_eval_queue`

## Next implementation
Build aligned two-flit codec equivalence first, then stats-once codec equivalence/PPA and actual local-reducer/root ready-valid composition before regenerating Phase-2 commands.
