### PR TITLE
Add exact aligned Phase-2 transport codec

### DIFF
--- a/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/README.md
+++ b/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/README.md
@@ -1,0 +1,4 @@
+# Score32 Exact Aligned Transport Codec PPA
+
+This proposal embodies the field-preserving 419-bit aggregate codec over two
+aligned 256-bit flits and measures its Nangate45 PPA.

--- a/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/analysis_report.md
+++ b/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/analysis_report.md
@@ -1,0 +1,4 @@
+# Analysis Report
+
+Functional evidence passes exact round-trip, malformed framing, reset, random
+backpressure, and bubble-free cadence checks. Nangate45 PPA is pending.

--- a/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/design_brief.md
+++ b/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/design_brief.md
@@ -1,0 +1,12 @@
+# Design Brief
+
+The encoder retains one 419-bit exact aggregate beat and emits two ordered
+256-bit flits. The decoder checks phase, last, and zero padding before
+reconstructing the identical beat. Both interfaces propagate ready/valid
+backpressure and sustain one flit per cycle without inter-beat bubbles after
+initial fill.
+
+The physical harness uses an internal 32-bit deterministic source and folded
+32-bit observation boundary. Its counters and source/sink support logic are
+included in measured PPA. Reducer arithmetic, endpoint descriptors, SRAM,
+router/mesh, global reduction, and HBM/DRAM are excluded.

--- a/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/design_brief.md
+++ b/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/design_brief.md
@@ -1,7 +1,7 @@
 # Design Brief
 
 The encoder retains one 419-bit exact aggregate beat and emits two ordered
-256-bit flits. The decoder checks phase, last, and zero padding before
+256-bit flits. The decoder checks phase, aggregate beat-last, and zero padding before
 reconstructing the identical beat. Both interfaces propagate ready/valid
 backpressure and sustain one flit per cycle without inter-beat bubbles after
 initial fill.

--- a/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/design_brief.md
+++ b/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/design_brief.md
@@ -6,7 +6,7 @@ reconstructing the identical beat. Both interfaces propagate ready/valid
 backpressure and sustain one flit per cycle without inter-beat bubbles after
 initial fill.
 
-The physical harness uses an internal 32-bit deterministic source and folded
-32-bit observation boundary. Its counters and source/sink support logic are
+The physical harness uses an internal 419-bit deterministic LFSR source and
+folds every decoded bit into a 32-bit observation boundary. Its counters and source/sink support logic are
 included in measured PPA. Reducer arithmetic, endpoint descriptors, SRAM,
 router/mesh, global reduction, and HBM/DRAM are excluded.

--- a/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/evaluation_gate.md
@@ -1,0 +1,4 @@
+# Evaluation Gate
+
+Pending remote Nangate45 sweep after the evaluator image passes the initializer
+hash and writable OpenROAD-runtime preflight in issue #1671.

--- a/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/evaluation_requests.json
@@ -1,0 +1,31 @@
+{
+  "proposal_id": "prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1",
+  "source_commit": "TBD",
+  "requested_items": [
+    {
+      "item_id": "l1_attention_score32_exact_aligned_transport_codec_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the exact 419-bit aggregate aligned two-flit codec.",
+      "evaluation_mode": "ppa",
+      "abstraction_layer": "architecture_block",
+      "config_paths": [
+        "runs/designs/noc/l1_attention_score32_exact_aligned_codec_w419_f256_wrapper/config_l1_attention_score32_exact_aligned_codec_w419_f256.json"
+      ],
+      "sweep_path": "runs/campaigns/noc/l1_attention_score32_exact_aligned_codec/sweeps/nangate45_macro_frontier.json",
+      "expected_outputs": [
+        "runs/designs/noc/l1_attention_score32_exact_aligned_codec_w419_f256_wrapper/metrics.csv"
+      ],
+      "status": "pending_after_proposal_merge",
+      "comparison_role": "phase2_exact_aligned_codec_physical_anchor",
+      "paired_baseline_item_id": "",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_exact_aligned_transport_codec",
+        "reason": "Establish the direct field-preserving codec PPA anchor before comparing denser exact packing."
+      },
+      "acceptance_notes": "Require exact round-trip and no-bubble cadence tests, generated hierarchy checks, and timing/area/power rows for the requested sweep. Treat PPA as codec-plus-compact-harness evidence, not endpoint, mesh, SRAM, reducer, or global-tree evidence."
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/implementation_summary.md
@@ -4,4 +4,4 @@
 - Added strict phase/beat-last/padding checks and reset-safe partial state.
 - Added same-edge replacement for bubble-free sustained flit cadence.
 - Added randomized-stall round-trip, malformed framing, reset, and Yosys tests.
-- Added compact PPA harness, direct-generator support, config, and sweep.
+- Added full-width live-cone PPA harness, direct-generator support, config, and sweep.

--- a/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/implementation_summary.md
@@ -1,0 +1,7 @@
+# Implementation Summary
+
+- Added exact 419-bit-to-two-flit encoder and decoder RTL.
+- Added strict phase/last/padding checks and reset-safe partial state.
+- Added same-edge replacement for bubble-free sustained flit cadence.
+- Added randomized-stall round-trip, malformed framing, reset, and Yosys tests.
+- Added compact PPA harness, direct-generator support, config, and sweep.

--- a/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/implementation_summary.md
@@ -1,7 +1,7 @@
 # Implementation Summary
 
 - Added exact 419-bit-to-two-flit encoder and decoder RTL.
-- Added strict phase/last/padding checks and reset-safe partial state.
+- Added strict phase/beat-last/padding checks and reset-safe partial state.
 - Added same-edge replacement for bubble-free sustained flit cadence.
 - Added randomized-stall round-trip, malformed framing, reset, and Yosys tests.
 - Added compact PPA harness, direct-generator support, config, and sweep.

--- a/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/promotion_decision.json
+++ b/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/promotion_decision.json
@@ -1,0 +1,9 @@
+{
+  "proposal_id": "prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1",
+  "candidate_id": "",
+  "decision": "iterate",
+  "reason": "Functional codec and compact physical harness are complete; remote PPA is pending.",
+  "evidence_refs": [],
+  "next_action": "run l1_attention_score32_exact_aligned_transport_codec_ppa_v1",
+  "requires_human_approval": false
+}

--- a/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/promotion_gate.md
+++ b/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/promotion_gate.md
@@ -1,0 +1,5 @@
+# Promotion Gate
+
+Promote as the field-preserving transport anchor only after timing-feasible PPA
+is recorded. Do not promote it as full Phase-2 closure until actual local
+reducer output, endpoint/mesh transport, and global-tree input are composed.

--- a/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/promotion_result.json
+++ b/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/promotion_result.json
@@ -1,0 +1,7 @@
+{
+  "proposal_id": "prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1",
+  "decision": "pending",
+  "pr_number": null,
+  "merge_commit": "",
+  "merged_utc": ""
+}

--- a/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/proposal.json
+++ b/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/proposal.json
@@ -16,7 +16,7 @@
       "419-bit retained decoder output",
       "phase, beat-last, and padding checks",
       "ready/valid backpressure",
-      "compact deterministic source and folded sink harness"
+      "full-width deterministic source and all-bit folded sink harness"
     ],
     "exclude": [
       "local reducer arithmetic",

--- a/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/proposal.json
+++ b/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/proposal.json
@@ -1,0 +1,66 @@
+{
+  "proposal_id": "prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1",
+  "created_utc": "2026-08-18T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "abstraction_layer": "architecture_block",
+  "title": "Embody the score32 exact aligned transport codec",
+  "hypothesis": "A field-preserving two-flit codec can sustain the 256-bit NoC payload cadence with small PPA relative to the exact reducer and mesh.",
+  "direct_comparison": {
+    "primary_question": "What PPA and cadence are required to transport one exact 419-bit aggregate beat without precision loss?",
+    "include": [
+      "419-bit retained encoder beat",
+      "two ordered 256-bit flits",
+      "256-bit decoder partial state",
+      "419-bit retained decoder output",
+      "phase, last, and padding checks",
+      "ready/valid backpressure",
+      "compact deterministic source and folded sink harness"
+    ],
+    "exclude": [
+      "local reducer arithmetic",
+      "packet endpoint and descriptor scheduler",
+      "SRAM bitcells",
+      "router and mesh wiring",
+      "global reduction tree",
+      "HBM/DRAM",
+      "workload-matched switching power"
+    ]
+  },
+  "expected_benefit": [
+    "remove exact aggregate field preservation from the Phase-2 abstraction list",
+    "establish a direct PPA baseline for packed and stats-once codecs",
+    "prove continuous one-flit-per-cycle transport under backpressure"
+  ],
+  "risks": [
+    "the retained 419-bit registers may dominate this small block",
+    "compact harness support logic is included in measured PPA",
+    "standalone PPA does not predict composed endpoint or routing timing"
+  ],
+  "required_evaluations": [
+    {
+      "item_id": "l1_attention_score32_exact_aligned_transport_codec_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure Nangate45 PPA for the exact 419-bit aggregate aligned two-flit codec.",
+      "evaluation_mode": "ppa",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "phase2_exact_aligned_codec_physical_anchor",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "config_paths": [
+        "runs/designs/noc/l1_attention_score32_exact_aligned_codec_w419_f256_wrapper/config_l1_attention_score32_exact_aligned_codec_w419_f256.json"
+      ],
+      "sweep_path": "runs/campaigns/noc/l1_attention_score32_exact_aligned_codec/sweeps/nangate45_macro_frontier.json",
+      "expected_outputs": [
+        "runs/designs/noc/l1_attention_score32_exact_aligned_codec_w419_f256_wrapper/metrics.csv"
+      ]
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_exact_transport_revision_v1/proposal.json",
+    "npu/docs/attention_score32_exact_aligned_transport_codec_contract.md",
+    "npu/eval/gqa8_compositional_exact.py"
+  ]
+}

--- a/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/proposal.json
+++ b/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/proposal.json
@@ -14,7 +14,7 @@
       "two ordered 256-bit flits",
       "256-bit decoder partial state",
       "419-bit retained decoder output",
-      "phase, last, and padding checks",
+      "phase, beat-last, and padding checks",
       "ready/valid backpressure",
       "compact deterministic source and folded sink harness"
     ],

--- a/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/quality_gate.md
@@ -1,0 +1,9 @@
+# Quality Gate
+
+- `pytest -q tests/test_local_reducer_aggregate_aligned_exact_codec.py`
+- Require exact 419-bit round-trip under arbitrary input and output stalls.
+- Require zero phase-1 padding and sticky malformed-framing detection.
+- Require no inter-beat flit bubble under always-ready operation.
+- Require generated hierarchy Icarus elaboration and Yosys process/check.
+
+Status: passed locally; physical evaluation pending.

--- a/examples/about_config.md
+++ b/examples/about_config.md
@@ -495,6 +495,9 @@ endpoint. `primitive: "sram_packet_mesh4x4"` emits its full 16-endpoint,
 synthesizable sixteen-endpoint command controller with sequential one-cycle
 SRAM prefetch, one response buffer, release waiting, RX descriptor
 installation, and only then paired TX descriptor submission.
+`primitive: "exact_aligned_codec"` emits the field-preserving 419-bit exact
+partial aggregate encoder/decoder over two aligned 256-bit flits, inside a
+compact activity harness for direct PPA measurement.
 
 Supported common options are `primitive`, `flit_bits`, `depth`, `ports`, and
 `counter_bits`. Segmented-router and segmented-mesh options are `vc_count`,

--- a/npu/docs/attention_score32_exact_aligned_transport_codec_contract.md
+++ b/npu/docs/attention_score32_exact_aligned_transport_codec_contract.md
@@ -33,7 +33,7 @@ the reducer interfaces.
   can no longer be overwritten.
 
 The decoder accepts exactly the same two phases, rejects nonzero padding or an
-invalid phase/last sequence with a sticky protocol error, and presents one
+invalid phase/beat-last sequence with a sticky protocol error, and presents one
 stable aggregate beat until its consumer accepts it. Reset discards any
 partially transferred beat on either side.
 
@@ -46,9 +46,12 @@ interface. Backpressure must propagate through every retained stage; a static
 release timestamp is not equivalent to this contract.
 
 The endpoint descriptor still provides packet identity, source, destination,
-VC, tag, fragment, and packet-last metadata. Codec phase is subordinate to that
-framing and must agree with fragment order. NoC transport must not infer a new
-aggregate boundary from payload values.
+VC, tag, fragment, and packet-last metadata. Codec `flit_beat_last` marks the
+second half of one aggregate only; it must never drive the endpoint's packet
+`flit_last`, which remains true only on the final fragment of the configured
+packet. Codec phase is subordinate to packet framing and must agree with
+fragment order. NoC transport must not infer a new aggregate boundary from
+payload values.
 
 ## Closure Limits
 

--- a/npu/docs/attention_score32_exact_aligned_transport_codec_contract.md
+++ b/npu/docs/attention_score32_exact_aligned_transport_codec_contract.md
@@ -1,0 +1,59 @@
+# Score32 Exact Aligned Transport Codec Contract
+
+This codec is the field-preserving transport anchor between one local temporal
+reducer output and the 256-bit segmented NoC payload path. It carries the full
+exact-partial aggregate state without narrowing or recomputation.
+
+## Aggregate Beat
+
+The canonical 419-bit aggregate beat uses the same least-significant-bit-first
+layout as `npu.eval.gqa8_compositional_exact`:
+
+| Bits | Field |
+|---|---|
+| `15:0` | command ID |
+| `20:16` | head ID |
+| `52:21` | signed global maximum |
+| `85:53` | exponential sum |
+| `89:86` | value slice |
+| `90` | last slice |
+| `418:91` | eight signed 41-bit weighted numerators |
+
+The field widths are therefore `16 + 5 + 32 + 33 + 4 + 1 + 328 = 419`.
+The codec treats the complete beat as bits; signed interpretation remains at
+the reducer interfaces.
+
+## Aligned Flits
+
+- Flit 0 carries aggregate bits `255:0`.
+- Flit 1 carries aggregate bits `418:256` in payload bits `162:0`.
+- Flit 1 payload bits `255:163` are zero.
+- Each accepted aggregate beat produces exactly two accepted flits in order.
+- A new aggregate beat is not accepted until the retained two-flit transfer
+  can no longer be overwritten.
+
+The decoder accepts exactly the same two phases, rejects nonzero padding or an
+invalid phase/last sequence with a sticky protocol error, and presents one
+stable aggregate beat until its consumer accepts it. Reset discards any
+partially transferred beat on either side.
+
+## Ready/Valid Composition
+
+The encoder input connects directly to the local temporal reducer `out_*`
+interface. Its output is packetized as an ordered two-flit payload. At the root,
+the depacketized decoder output connects directly to one global-tree `leaf_*`
+interface. Backpressure must propagate through every retained stage; a static
+release timestamp is not equivalent to this contract.
+
+The endpoint descriptor still provides packet identity, source, destination,
+VC, tag, fragment, and packet-last metadata. Codec phase is subordinate to that
+framing and must agree with fragment order. NoC transport must not infer a new
+aggregate boundary from payload values.
+
+## Closure Limits
+
+Standalone round-trip equivalence closes field preservation and backpressure,
+not the full Phase-2 schedule. The next composition must drive codec input from
+actual local-reducer validity, route through the endpoint/mesh, and drive the
+root tree under its actual readiness. Shared K/V traffic must separately use
+SRAM-residency-driven release. HBM/DRAM control remains external by design.

--- a/npu/sim/rtl/local_reducer_aggregate_aligned_exact_codec.sv
+++ b/npu/sim/rtl/local_reducer_aggregate_aligned_exact_codec.sv
@@ -8,7 +8,7 @@
 // - Phase 0 / last 0 carries beat_data[255:0].
 // - Phase 1 / last 1 carries beat_data[418:256] in flit_data[162:0].
 // - Phase 1 flit_data[255:163] is deterministically zero padded.
-// - Decoder rejects malformed phase/last ordering and nonzero phase-1 padding.
+// - Decoder rejects malformed phase/beat-last ordering and nonzero phase-1 padding.
 
 module local_reducer_aggregate_aligned_exact_encoder #(
   parameter integer BEAT_W = 419,
@@ -23,7 +23,7 @@ module local_reducer_aggregate_aligned_exact_encoder #(
   input  wire              flit_ready,
   output wire [FLIT_W-1:0] flit_data,
   output wire              flit_phase,
-  output wire              flit_last
+  output wire              flit_beat_last
 );
   localparam integer SECOND_PAYLOAD_W = BEAT_W - FLIT_W;
   localparam integer SECOND_PAD_W = FLIT_W - SECOND_PAYLOAD_W;
@@ -39,7 +39,7 @@ module local_reducer_aggregate_aligned_exact_encoder #(
   assign beat_ready = !active_r || release_fire;
   assign flit_valid = active_r;
   assign flit_phase = phase_r;
-  assign flit_last = phase_r;
+  assign flit_beat_last = phase_r;
   assign flit_data = !active_r ? {FLIT_W{1'b0}} :
     (phase_r ? {{SECOND_PAD_W{1'b0}}, beat_data_r[BEAT_W-1:FLIT_W]} :
                beat_data_r[FLIT_W-1:0]);
@@ -97,7 +97,7 @@ module local_reducer_aggregate_aligned_exact_decoder #(
   output wire              flit_ready,
   input  wire [FLIT_W-1:0] flit_data,
   input  wire              flit_phase,
-  input  wire              flit_last,
+  input  wire              flit_beat_last,
   output wire              beat_valid,
   input  wire              beat_ready,
   output wire [BEAT_W-1:0] beat_data,
@@ -115,8 +115,8 @@ module local_reducer_aggregate_aligned_exact_decoder #(
 
   wire flit_fire = flit_valid && flit_ready;
   wire beat_fire = beat_valid && beat_ready;
-  wire phase0_valid = !flit_phase && !flit_last;
-  wire phase1_valid = flit_phase && flit_last;
+  wire phase0_valid = !flit_phase && !flit_beat_last;
+  wire phase1_valid = flit_phase && flit_beat_last;
   wire phase1_padding_zero = flit_data[FLIT_W-1:SECOND_PAYLOAD_W] == {SECOND_PAD_W{1'b0}};
 
   assign flit_ready = !beat_valid_r || beat_ready;

--- a/npu/sim/rtl/local_reducer_aggregate_aligned_exact_codec.sv
+++ b/npu/sim/rtl/local_reducer_aggregate_aligned_exact_codec.sv
@@ -1,0 +1,179 @@
+`timescale 1ns/1ps
+
+// Aligned exact transport codec for one checked 419-bit local-reducer aggregate
+// beat over a 256-bit flit interface.
+//
+// Transport contract:
+// - One beat always maps to exactly two flits.
+// - Phase 0 / last 0 carries beat_data[255:0].
+// - Phase 1 / last 1 carries beat_data[418:256] in flit_data[162:0].
+// - Phase 1 flit_data[255:163] is deterministically zero padded.
+// - Decoder rejects malformed phase/last ordering and nonzero phase-1 padding.
+
+module local_reducer_aggregate_aligned_exact_encoder #(
+  parameter integer BEAT_W = 419,
+  parameter integer FLIT_W = 256
+) (
+  input  wire              clk,
+  input  wire              rst_n,
+  input  wire              beat_valid,
+  output wire              beat_ready,
+  input  wire [BEAT_W-1:0] beat_data,
+  output wire              flit_valid,
+  input  wire              flit_ready,
+  output wire [FLIT_W-1:0] flit_data,
+  output wire              flit_phase,
+  output wire              flit_last
+);
+  localparam integer SECOND_PAYLOAD_W = BEAT_W - FLIT_W;
+  localparam integer SECOND_PAD_W = FLIT_W - SECOND_PAYLOAD_W;
+
+  reg active_r;
+  reg phase_r;
+  reg [BEAT_W-1:0] beat_data_r;
+
+  wire flit_fire = flit_valid && flit_ready;
+  wire release_fire = active_r && phase_r && flit_ready;
+  wire beat_fire = beat_valid && beat_ready;
+
+  assign beat_ready = !active_r || release_fire;
+  assign flit_valid = active_r;
+  assign flit_phase = phase_r;
+  assign flit_last = phase_r;
+  assign flit_data = !active_r ? {FLIT_W{1'b0}} :
+    (phase_r ? {{SECOND_PAD_W{1'b0}}, beat_data_r[BEAT_W-1:FLIT_W]} :
+               beat_data_r[FLIT_W-1:0]);
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      active_r <= 1'b0;
+      phase_r <= 1'b0;
+      beat_data_r <= {BEAT_W{1'b0}};
+    end else begin
+      if (active_r) begin
+        if (flit_fire) begin
+          if (!phase_r) begin
+            phase_r <= 1'b1;
+          end else if (beat_fire) begin
+            active_r <= 1'b1;
+            phase_r <= 1'b0;
+            beat_data_r <= beat_data;
+          end else begin
+            active_r <= 1'b0;
+            phase_r <= 1'b0;
+            beat_data_r <= {BEAT_W{1'b0}};
+          end
+        end
+      end else if (beat_fire) begin
+        active_r <= 1'b1;
+        phase_r <= 1'b0;
+        beat_data_r <= beat_data;
+      end
+    end
+  end
+
+`ifndef SYNTHESIS
+  initial begin
+    if (BEAT_W != 419) begin
+      $error("local_reducer_aggregate_aligned_exact_encoder BEAT_W must be 419");
+      $finish(1);
+    end
+    if (FLIT_W != 256) begin
+      $error("local_reducer_aggregate_aligned_exact_encoder FLIT_W must be 256");
+      $finish(1);
+    end
+  end
+`endif
+endmodule
+
+
+module local_reducer_aggregate_aligned_exact_decoder #(
+  parameter integer BEAT_W = 419,
+  parameter integer FLIT_W = 256
+) (
+  input  wire              clk,
+  input  wire              rst_n,
+  input  wire              flit_valid,
+  output wire              flit_ready,
+  input  wire [FLIT_W-1:0] flit_data,
+  input  wire              flit_phase,
+  input  wire              flit_last,
+  output wire              beat_valid,
+  input  wire              beat_ready,
+  output wire [BEAT_W-1:0] beat_data,
+  output wire              partial_valid,
+  output wire              protocol_error
+) ;
+  localparam integer SECOND_PAYLOAD_W = BEAT_W - FLIT_W;
+  localparam integer SECOND_PAD_W = FLIT_W - SECOND_PAYLOAD_W;
+
+  reg partial_valid_r;
+  reg [FLIT_W-1:0] lower_flit_r;
+  reg beat_valid_r;
+  reg [BEAT_W-1:0] beat_data_r;
+  reg protocol_error_r;
+
+  wire flit_fire = flit_valid && flit_ready;
+  wire beat_fire = beat_valid && beat_ready;
+  wire phase0_valid = !flit_phase && !flit_last;
+  wire phase1_valid = flit_phase && flit_last;
+  wire phase1_padding_zero = flit_data[FLIT_W-1:SECOND_PAYLOAD_W] == {SECOND_PAD_W{1'b0}};
+
+  assign flit_ready = !beat_valid_r || beat_ready;
+  assign beat_valid = beat_valid_r;
+  assign beat_data = beat_data_r;
+  assign partial_valid = partial_valid_r;
+  assign protocol_error = protocol_error_r;
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      partial_valid_r <= 1'b0;
+      lower_flit_r <= {FLIT_W{1'b0}};
+      beat_valid_r <= 1'b0;
+      beat_data_r <= {BEAT_W{1'b0}};
+      protocol_error_r <= 1'b0;
+    end else begin
+      if (beat_fire) begin
+        beat_valid_r <= 1'b0;
+        beat_data_r <= {BEAT_W{1'b0}};
+      end
+
+      if (flit_fire) begin
+        if (!partial_valid_r) begin
+          if (phase0_valid) begin
+            lower_flit_r <= flit_data;
+            partial_valid_r <= 1'b1;
+          end else begin
+            protocol_error_r <= 1'b1;
+            partial_valid_r <= 1'b0;
+            lower_flit_r <= {FLIT_W{1'b0}};
+          end
+        end else begin
+          if (phase1_valid && phase1_padding_zero) begin
+            beat_data_r <= {flit_data[SECOND_PAYLOAD_W-1:0], lower_flit_r};
+            beat_valid_r <= 1'b1;
+            partial_valid_r <= 1'b0;
+            lower_flit_r <= {FLIT_W{1'b0}};
+          end else begin
+            protocol_error_r <= 1'b1;
+            partial_valid_r <= 1'b0;
+            lower_flit_r <= {FLIT_W{1'b0}};
+          end
+        end
+      end
+    end
+  end
+
+`ifndef SYNTHESIS
+  initial begin
+    if (BEAT_W != 419) begin
+      $error("local_reducer_aggregate_aligned_exact_decoder BEAT_W must be 419");
+      $finish(1);
+    end
+    if (FLIT_W != 256) begin
+      $error("local_reducer_aggregate_aligned_exact_decoder FLIT_W must be 256");
+      $finish(1);
+    end
+  end
+`endif
+endmodule

--- a/npu/sim/rtl/local_reducer_aggregate_aligned_exact_codec_ppa_harness.sv
+++ b/npu/sim/rtl/local_reducer_aggregate_aligned_exact_codec_ppa_harness.sv
@@ -17,7 +17,7 @@ module local_reducer_aggregate_aligned_exact_codec_ppa_harness #(
   localparam integer BEAT_W = 419;
   localparam integer FLIT_W = 256;
 
-  reg [31:0] source_state_q;
+  reg [BEAT_W-1:0] source_state_q;
   reg [COUNTER_W-1:0] cycle_count_q;
   reg [COUNTER_W-1:0] accepted_count_q;
   reg [COUNTER_W-1:0] emitted_count_q;
@@ -26,10 +26,7 @@ module local_reducer_aggregate_aligned_exact_codec_ppa_harness #(
 
   wire source_valid = cycle_count_q[2:0] != 3'b111;
   wire source_ready;
-  wire [BEAT_W-1:0] source_beat = {
-    source_state_q[2:0],
-    {13{source_state_q}}
-  };
+  wire [BEAT_W-1:0] source_beat = source_state_q;
   wire flit_valid;
   wire flit_ready;
   wire [FLIT_W-1:0] flit_data;
@@ -51,6 +48,17 @@ module local_reducer_aggregate_aligned_exact_codec_ppa_harness #(
   assign observed_data = observed_q;
   assign protocol_error = decoder_protocol_error;
 
+  function [31:0] fold_beat;
+    input [BEAT_W-1:0] value;
+    integer bit_i;
+    begin
+      fold_beat = 32'b0;
+      for (bit_i = 0; bit_i < BEAT_W; bit_i = bit_i + 1)
+        fold_beat[bit_i % 32] = fold_beat[bit_i % 32] ^ value[bit_i];
+    end
+  endfunction
+
+  (* keep_hierarchy = "yes" *)
   local_reducer_aggregate_aligned_exact_encoder u_encoder (
     .clk(clk),
     .rst_n(rst_n),
@@ -64,6 +72,7 @@ module local_reducer_aggregate_aligned_exact_codec_ppa_harness #(
     .flit_beat_last(flit_beat_last)
   );
 
+  (* keep_hierarchy = "yes" *)
   local_reducer_aggregate_aligned_exact_decoder u_decoder (
     .clk(clk),
     .rst_n(rst_n),
@@ -81,7 +90,10 @@ module local_reducer_aggregate_aligned_exact_codec_ppa_harness #(
 
   always @(posedge clk or negedge rst_n) begin
     if (!rst_n) begin
-      source_state_q <= 32'h1357_9bdf;
+      source_state_q <= {
+        {13{32'h1357_9bdf}},
+        3'b101
+      };
       cycle_count_q <= {COUNTER_W{1'b0}};
       accepted_count_q <= {COUNTER_W{1'b0}};
       emitted_count_q <= {COUNTER_W{1'b0}};
@@ -91,9 +103,9 @@ module local_reducer_aggregate_aligned_exact_codec_ppa_harness #(
       cycle_count_q <= cycle_count_q + 1'b1;
       if (source_fire) begin
         source_state_q <= {
-          source_state_q[30:0],
-          source_state_q[31] ^ source_state_q[21] ^
-          source_state_q[1] ^ source_state_q[0]
+          source_state_q[BEAT_W-2:0],
+          source_state_q[BEAT_W-1] ^ source_state_q[302] ^
+          source_state_q[171] ^ source_state_q[5]
         };
         accepted_count_q <= accepted_count_q + 1'b1;
       end
@@ -101,11 +113,17 @@ module local_reducer_aggregate_aligned_exact_codec_ppa_harness #(
         emitted_count_q <= emitted_count_q + 1'b1;
       if (decoded_fire) begin
         decoded_count_q <= decoded_count_q + 1'b1;
-        observed_q <=
-          decoded_data[31:0] ^ decoded_data[127:96] ^
-          decoded_data[255:224] ^ decoded_data[351:320] ^
-          {29'b0, decoded_data[418:416]};
+        observed_q <= fold_beat(decoded_data);
       end
     end
   end
+
+`ifndef SYNTHESIS
+  initial begin
+    if (COUNTER_W < 4) begin
+      $error("local_reducer_aggregate_aligned_exact_codec_ppa_harness COUNTER_W must be at least 4");
+      $finish(1);
+    end
+  end
+`endif
 endmodule

--- a/npu/sim/rtl/local_reducer_aggregate_aligned_exact_codec_ppa_harness.sv
+++ b/npu/sim/rtl/local_reducer_aggregate_aligned_exact_codec_ppa_harness.sv
@@ -1,0 +1,111 @@
+`timescale 1ns/1ps
+
+// Compact-boundary activity harness for the 419b <-> 2x256b aligned codec.
+// Source and sink folding are deterministic support logic; no NoC router,
+// endpoint, SRAM bitcell, local reducer, or global tree is included.
+module local_reducer_aggregate_aligned_exact_codec_ppa_harness #(
+  parameter integer COUNTER_W = 32
+) (
+  input wire clk,
+  input wire rst_n,
+  output wire [31:0] observed_data,
+  output wire [COUNTER_W-1:0] accepted_beat_count,
+  output wire [COUNTER_W-1:0] emitted_flit_count,
+  output wire [COUNTER_W-1:0] decoded_beat_count,
+  output wire protocol_error
+);
+  localparam integer BEAT_W = 419;
+  localparam integer FLIT_W = 256;
+
+  reg [31:0] source_state_q;
+  reg [COUNTER_W-1:0] cycle_count_q;
+  reg [COUNTER_W-1:0] accepted_count_q;
+  reg [COUNTER_W-1:0] emitted_count_q;
+  reg [COUNTER_W-1:0] decoded_count_q;
+  reg [31:0] observed_q;
+
+  wire source_valid = cycle_count_q[2:0] != 3'b111;
+  wire source_ready;
+  wire [BEAT_W-1:0] source_beat = {
+    source_state_q[2:0],
+    {13{source_state_q}}
+  };
+  wire flit_valid;
+  wire flit_ready;
+  wire [FLIT_W-1:0] flit_data;
+  wire flit_phase;
+  wire flit_last;
+  wire decoded_valid;
+  wire decoded_ready = cycle_count_q[3:1] != 3'b101;
+  wire [BEAT_W-1:0] decoded_data;
+  wire decoder_partial_valid;
+  wire decoder_protocol_error;
+
+  wire source_fire = source_valid && source_ready;
+  wire flit_fire = flit_valid && flit_ready;
+  wire decoded_fire = decoded_valid && decoded_ready;
+
+  assign accepted_beat_count = accepted_count_q;
+  assign emitted_flit_count = emitted_count_q;
+  assign decoded_beat_count = decoded_count_q;
+  assign observed_data = observed_q;
+  assign protocol_error = decoder_protocol_error;
+
+  local_reducer_aggregate_aligned_exact_encoder u_encoder (
+    .clk(clk),
+    .rst_n(rst_n),
+    .beat_valid(source_valid),
+    .beat_ready(source_ready),
+    .beat_data(source_beat),
+    .flit_valid(flit_valid),
+    .flit_ready(flit_ready),
+    .flit_data(flit_data),
+    .flit_phase(flit_phase),
+    .flit_last(flit_last)
+  );
+
+  local_reducer_aggregate_aligned_exact_decoder u_decoder (
+    .clk(clk),
+    .rst_n(rst_n),
+    .flit_valid(flit_valid),
+    .flit_ready(flit_ready),
+    .flit_data(flit_data),
+    .flit_phase(flit_phase),
+    .flit_last(flit_last),
+    .beat_valid(decoded_valid),
+    .beat_ready(decoded_ready),
+    .beat_data(decoded_data),
+    .partial_valid(decoder_partial_valid),
+    .protocol_error(decoder_protocol_error)
+  );
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      source_state_q <= 32'h1357_9bdf;
+      cycle_count_q <= {COUNTER_W{1'b0}};
+      accepted_count_q <= {COUNTER_W{1'b0}};
+      emitted_count_q <= {COUNTER_W{1'b0}};
+      decoded_count_q <= {COUNTER_W{1'b0}};
+      observed_q <= 32'b0;
+    end else begin
+      cycle_count_q <= cycle_count_q + 1'b1;
+      if (source_fire) begin
+        source_state_q <= {
+          source_state_q[30:0],
+          source_state_q[31] ^ source_state_q[21] ^
+          source_state_q[1] ^ source_state_q[0]
+        };
+        accepted_count_q <= accepted_count_q + 1'b1;
+      end
+      if (flit_fire)
+        emitted_count_q <= emitted_count_q + 1'b1;
+      if (decoded_fire) begin
+        decoded_count_q <= decoded_count_q + 1'b1;
+        observed_q <=
+          decoded_data[31:0] ^ decoded_data[127:96] ^
+          decoded_data[255:224] ^ decoded_data[351:320] ^
+          {29'b0, decoded_data[418:416]};
+      end
+    end
+  end
+endmodule

--- a/npu/sim/rtl/local_reducer_aggregate_aligned_exact_codec_ppa_harness.sv
+++ b/npu/sim/rtl/local_reducer_aggregate_aligned_exact_codec_ppa_harness.sv
@@ -34,7 +34,7 @@ module local_reducer_aggregate_aligned_exact_codec_ppa_harness #(
   wire flit_ready;
   wire [FLIT_W-1:0] flit_data;
   wire flit_phase;
-  wire flit_last;
+  wire flit_beat_last;
   wire decoded_valid;
   wire decoded_ready = cycle_count_q[3:1] != 3'b101;
   wire [BEAT_W-1:0] decoded_data;
@@ -61,7 +61,7 @@ module local_reducer_aggregate_aligned_exact_codec_ppa_harness #(
     .flit_ready(flit_ready),
     .flit_data(flit_data),
     .flit_phase(flit_phase),
-    .flit_last(flit_last)
+    .flit_beat_last(flit_beat_last)
   );
 
   local_reducer_aggregate_aligned_exact_decoder u_decoder (
@@ -71,7 +71,7 @@ module local_reducer_aggregate_aligned_exact_codec_ppa_harness #(
     .flit_ready(flit_ready),
     .flit_data(flit_data),
     .flit_phase(flit_phase),
-    .flit_last(flit_last),
+    .flit_beat_last(flit_beat_last),
     .beat_valid(decoded_valid),
     .beat_ready(decoded_ready),
     .beat_data(decoded_data),

--- a/runs/campaigns/noc/l1_attention_score32_exact_aligned_codec/sweeps/nangate45_macro_frontier.json
+++ b/runs/campaigns/noc/l1_attention_score32_exact_aligned_codec/sweeps/nangate45_macro_frontier.json
@@ -1,0 +1,8 @@
+{
+  "tag_prefix": "l1_attention_score32_exact_aligned_codec_nangate45_macro_frontier",
+  "flow_params": {
+    "CLOCK_PERIOD": [1.0, 1.5, 2.0],
+    "CORE_UTILIZATION": [40, 50, 60],
+    "PLACE_DENSITY": [0.52]
+  }
+}

--- a/runs/designs/noc/l1_attention_score32_exact_aligned_codec_w419_f256_wrapper/config_l1_attention_score32_exact_aligned_codec_w419_f256.json
+++ b/runs/designs/noc/l1_attention_score32_exact_aligned_codec_w419_f256_wrapper/config_l1_attention_score32_exact_aligned_codec_w419_f256.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "flit",
+      "dimensions": 1,
+      "bit_width": 256,
+      "signed": false,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "l1_memory_noc_primitive",
+      "module_name": "l1_attention_score32_exact_aligned_codec_w419_f256",
+      "operand": "flit",
+      "options": {
+        "primitive": "exact_aligned_codec",
+        "flit_bits": 256,
+        "depth": 2,
+        "ports": 2,
+        "banks": 2,
+        "counter_bits": 32
+      }
+    }
+  ]
+}

--- a/scripts/generate_design.py
+++ b/scripts/generate_design.py
@@ -537,6 +537,10 @@ def identify_design(config):
             raise ValueError(
                 "l1_memory_noc_primitive exact_aligned_codec requires 256-bit flits"
             )
+        if primitive == "exact_aligned_codec" and counter_bits < 4:
+            raise ValueError(
+                "l1_memory_noc_primitive exact_aligned_codec requires counter_bits >= 4"
+            )
         return {
             "kind": "l1_memory_noc_primitive",
             "module_name": module_name,

--- a/scripts/generate_design.py
+++ b/scripts/generate_design.py
@@ -453,11 +453,12 @@ def identify_design(config):
             "sram_packet_endpoint",
             "sram_packet_mesh4x4",
             "descriptor_pair_scheduler",
+            "exact_aligned_codec",
         ):
             raise ValueError(
                 "l1_memory_noc_primitive primitive must be fifo, router, endpoint, segmented_router, "
-                "segmented_mesh4x4, sram_packet_endpoint, sram_packet_mesh4x4, or "
-                "descriptor_pair_scheduler"
+                "segmented_mesh4x4, sram_packet_endpoint, sram_packet_mesh4x4, "
+                "descriptor_pair_scheduler, or exact_aligned_codec"
             )
         if flit_bits <= 0:
             raise ValueError("l1_memory_noc_primitive flit_bits must be positive")
@@ -532,6 +533,10 @@ def identify_design(config):
                     "l1_memory_noc_primitive descriptor_pair_scheduler command_source "
                     "must be prefetch or llama7b_generated"
                 )
+        if primitive == "exact_aligned_codec" and flit_bits != 256:
+            raise ValueError(
+                "l1_memory_noc_primitive exact_aligned_codec requires 256-bit flits"
+            )
         return {
             "kind": "l1_memory_noc_primitive",
             "module_name": module_name,
@@ -999,6 +1004,17 @@ def generate_l1_memory_noc_design(src_dir, design):
             "noc_llama7b_phase2_command_generator.sv",
             "noc_descriptor_pair_scheduler.sv",
             "noc_descriptor_pair_scheduler_ppa_harness.sv",
+        ):
+            rtl_path = repo_root / "npu" / "sim" / "rtl" / filename
+            Path(src_dir, Path(filename).with_suffix(".v")).write_text(
+                rtl_path.read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+    elif design["primitive"] == "exact_aligned_codec":
+        text = _emit_l1_exact_aligned_codec(module_name, design)
+        for filename in (
+            "local_reducer_aggregate_aligned_exact_codec.sv",
+            "local_reducer_aggregate_aligned_exact_codec_ppa_harness.sv",
         ):
             rtl_path = repo_root / "npu" / "sim" / "rtl" / filename
             Path(src_dir, Path(filename).with_suffix(".v")).write_text(
@@ -1756,6 +1772,34 @@ module {module_name}(
     .endpoint_stall_cycles(endpoint_stall_cycles),
     .protocol_error(protocol_error),
     .observed_state(observed_state)
+  );
+endmodule
+"""
+
+
+def _emit_l1_exact_aligned_codec(module_name, design):
+    return f"""
+`timescale 1ns/1ps
+
+module {module_name}(
+  input clk,
+  input rst_n,
+  output [31:0] observed_data,
+  output [{design['counter_bits']-1}:0] accepted_beat_count,
+  output [{design['counter_bits']-1}:0] emitted_flit_count,
+  output [{design['counter_bits']-1}:0] decoded_beat_count,
+  output protocol_error
+);
+  local_reducer_aggregate_aligned_exact_codec_ppa_harness #(
+    .COUNTER_W({design['counter_bits']})
+  ) harness (
+    .clk(clk),
+    .rst_n(rst_n),
+    .observed_data(observed_data),
+    .accepted_beat_count(accepted_beat_count),
+    .emitted_flit_count(emitted_flit_count),
+    .decoded_beat_count(decoded_beat_count),
+    .protocol_error(protocol_error)
   );
 endmodule
 """
@@ -2649,6 +2693,30 @@ module {wrapper_name}(
 
 endmodule
 """
+        elif design["primitive"] == "exact_aligned_codec":
+            wrapper_content = f"""
+module {wrapper_name}(
+  input clk,
+  input rst_n,
+  output [31:0] observed_data,
+  output [{counter_bits-1}:0] accepted_beat_count,
+  output [{counter_bits-1}:0] emitted_flit_count,
+  output [{counter_bits-1}:0] decoded_beat_count,
+  output protocol_error
+);
+
+  {module_name} dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .observed_data(observed_data),
+    .accepted_beat_count(accepted_beat_count),
+    .emitted_flit_count(emitted_flit_count),
+    .decoded_beat_count(decoded_beat_count),
+    .protocol_error(protocol_error)
+  );
+
+endmodule
+"""
         else:
             wrapper_content = f"""
 module {wrapper_name}(
@@ -2704,6 +2772,16 @@ def generate_config_mk(platform_dir, platform, design):
                 f"$(DESIGN_HOME)/src/{wrapper_name}/noc_llama7b_phase2_command_generator.v",
                 f"$(DESIGN_HOME)/src/{wrapper_name}/noc_descriptor_pair_scheduler.v",
                 f"$(DESIGN_HOME)/src/{wrapper_name}/noc_descriptor_pair_scheduler_ppa_harness.v",
+            ]
+        )
+    if (
+        design["kind"] == "l1_memory_noc_primitive"
+        and design["primitive"] == "exact_aligned_codec"
+    ):
+        verilog_files.extend(
+            [
+                f"$(DESIGN_HOME)/src/{wrapper_name}/local_reducer_aggregate_aligned_exact_codec.v",
+                f"$(DESIGN_HOME)/src/{wrapper_name}/local_reducer_aggregate_aligned_exact_codec_ppa_harness.v",
             ]
         )
 

--- a/tests/local_reducer_aggregate_aligned_exact_codec_tb.sv
+++ b/tests/local_reducer_aggregate_aligned_exact_codec_tb.sv
@@ -1,0 +1,467 @@
+`timescale 1ns/1ps
+
+module local_reducer_aggregate_aligned_exact_codec_tb;
+  localparam integer BEAT_W = 419;
+  localparam integer FLIT_W = 256;
+  localparam integer SECOND_PAYLOAD_W = BEAT_W - FLIT_W;
+  localparam integer SECOND_PAD_W = FLIT_W - SECOND_PAYLOAD_W;
+  localparam integer ENCODER_VECTOR_COUNT = 12;
+  localparam integer CADENCE_VECTOR_COUNT = 6;
+  localparam integer LOOPBACK_VECTOR_COUNT = 10;
+  localparam integer MODE_IDLE = 0;
+  localparam integer MODE_ENCODER = 1;
+  localparam integer MODE_LOOPBACK = 2;
+  localparam integer MODE_MANUAL_DECODER = 3;
+  localparam integer MODE_CADENCE = 4;
+
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  integer cycle_count = 0;
+
+  reg enc_beat_valid = 1'b0;
+  wire enc_beat_ready;
+  reg [BEAT_W-1:0] enc_beat_data = {BEAT_W{1'b0}};
+  wire enc_flit_valid;
+  wire enc_flit_ready;
+  wire [FLIT_W-1:0] enc_flit_data;
+  wire enc_flit_phase;
+  wire enc_flit_last;
+
+  reg dec_flit_valid = 1'b0;
+  wire dec_flit_ready;
+  reg [FLIT_W-1:0] dec_flit_data = {FLIT_W{1'b0}};
+  reg dec_flit_phase = 1'b0;
+  reg dec_flit_last = 1'b0;
+  wire dec_beat_valid;
+  wire dec_beat_ready;
+  wire [BEAT_W-1:0] dec_beat_data;
+  wire dec_partial_valid;
+  wire dec_protocol_error;
+
+  reg manual_flit_valid = 1'b0;
+  reg [FLIT_W-1:0] manual_flit_data = {FLIT_W{1'b0}};
+  reg manual_flit_phase = 1'b0;
+  reg manual_flit_last = 1'b0;
+  reg [2:0] mode = MODE_IDLE[2:0];
+
+  reg [31:0] stall_state = 32'h1badf00d;
+  reg [BEAT_W-1:0] encoder_vectors [0:ENCODER_VECTOR_COUNT-1];
+  reg [BEAT_W-1:0] cadence_vectors [0:CADENCE_VECTOR_COUNT-1];
+  reg [BEAT_W-1:0] loopback_vectors [0:LOOPBACK_VECTOR_COUNT-1];
+  reg manual_dec_ready = 1'b0;
+
+  integer encoder_flit_count = 0;
+  integer cadence_encoder_beat_count = 0;
+  integer cadence_flit_count = 0;
+  integer cadence_decoder_beat_count = 0;
+  integer loopback_beat_count = 0;
+  integer encoder_hold_checks = 0;
+  integer decoder_hold_checks = 0;
+  integer cadence_encoder_beat_cycles [0:CADENCE_VECTOR_COUNT-1];
+  integer cadence_flit_cycles [0:(CADENCE_VECTOR_COUNT*2)-1];
+  integer cadence_decoder_beat_cycles [0:CADENCE_VECTOR_COUNT-1];
+
+  reg held_encoder_valid = 1'b0;
+  reg [FLIT_W+1:0] held_encoder_flit = {(FLIT_W+2){1'b0}};
+  reg held_decoder_valid = 1'b0;
+  reg [BEAT_W-1:0] held_decoder_beat = {BEAT_W{1'b0}};
+
+  assign enc_flit_ready =
+    (mode == MODE_ENCODER) ? stall_state[0] :
+    ((mode == MODE_LOOPBACK || mode == MODE_CADENCE) ? dec_flit_ready : 1'b0);
+  assign dec_beat_ready =
+    (mode == MODE_LOOPBACK) ? stall_state[1] :
+    ((mode == MODE_CADENCE) ? 1'b1 :
+     ((mode == MODE_MANUAL_DECODER) ? manual_dec_ready : 1'b0));
+
+  local_reducer_aggregate_aligned_exact_encoder #(
+    .BEAT_W(BEAT_W),
+    .FLIT_W(FLIT_W)
+  ) encoder_dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .beat_valid(enc_beat_valid),
+    .beat_ready(enc_beat_ready),
+    .beat_data(enc_beat_data),
+    .flit_valid(enc_flit_valid),
+    .flit_ready(enc_flit_ready),
+    .flit_data(enc_flit_data),
+    .flit_phase(enc_flit_phase),
+    .flit_last(enc_flit_last)
+  );
+
+  local_reducer_aggregate_aligned_exact_decoder #(
+    .BEAT_W(BEAT_W),
+    .FLIT_W(FLIT_W)
+  ) decoder_dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .flit_valid(dec_flit_valid),
+    .flit_ready(dec_flit_ready),
+    .flit_data(dec_flit_data),
+    .flit_phase(dec_flit_phase),
+    .flit_last(dec_flit_last),
+    .beat_valid(dec_beat_valid),
+    .beat_ready(dec_beat_ready),
+    .beat_data(dec_beat_data),
+    .partial_valid(dec_partial_valid),
+    .protocol_error(dec_protocol_error)
+  );
+
+  always #5 clk = ~clk;
+
+  always @(posedge clk) begin
+    if (!rst_n)
+      cycle_count <= 0;
+    else
+      cycle_count <= cycle_count + 1;
+  end
+
+  function automatic [31:0] next_state;
+    input [31:0] state;
+    begin
+      next_state = {state[30:0], state[31] ^ state[21] ^ state[1] ^ state[0]};
+    end
+  endfunction
+
+  function automatic [BEAT_W-1:0] make_beat;
+    input integer index;
+    reg [447:0] tmp;
+    reg [31:0] state;
+    integer chunk;
+    begin
+      case (index)
+        0: make_beat = {BEAT_W{1'b0}};
+        1: make_beat = {BEAT_W{1'b1}};
+        2: begin
+          make_beat = {BEAT_W{1'b0}};
+          make_beat[0] = 1'b1;
+          make_beat[255] = 1'b1;
+          make_beat[256] = 1'b1;
+          make_beat[418] = 1'b1;
+        end
+        3: begin
+          for (chunk = 0; chunk < BEAT_W; chunk = chunk + 1)
+            make_beat[chunk] = chunk[0];
+        end
+        default: begin
+          tmp = {448{1'b0}};
+          state = 32'h6d2b79f5 ^ (index * 32'h9e3779b9);
+          for (chunk = 0; chunk < 14; chunk = chunk + 1) begin
+            state = state * 32'h45d9f3b + 32'h27100001;
+            tmp[(chunk * 32) +: 32] = state ^ {state[15:0], state[31:16]};
+          end
+          make_beat = tmp[BEAT_W-1:0];
+        end
+      endcase
+    end
+  endfunction
+
+  function automatic [FLIT_W-1:0] expected_flit;
+    input [BEAT_W-1:0] beat;
+    input integer phase;
+    begin
+      if (phase == 0)
+        expected_flit = beat[FLIT_W-1:0];
+      else
+        expected_flit = {{SECOND_PAD_W{1'b0}}, beat[BEAT_W-1:FLIT_W]};
+    end
+  endfunction
+
+  task automatic apply_reset;
+    integer hold_cycles;
+    begin
+      rst_n = 1'b0;
+      enc_beat_valid = 1'b0;
+      enc_beat_data = {BEAT_W{1'b0}};
+      dec_flit_valid = 1'b0;
+      dec_flit_data = {FLIT_W{1'b0}};
+      dec_flit_phase = 1'b0;
+      dec_flit_last = 1'b0;
+      manual_flit_valid = 1'b0;
+      manual_flit_data = {FLIT_W{1'b0}};
+      manual_flit_phase = 1'b0;
+      manual_flit_last = 1'b0;
+      manual_dec_ready = 1'b0;
+      held_encoder_valid = 1'b0;
+      held_decoder_valid = 1'b0;
+      stall_state = 32'h1badf00d;
+      for (hold_cycles = 0; hold_cycles < 3; hold_cycles = hold_cycles + 1)
+        @(posedge clk);
+      rst_n = 1'b1;
+      @(posedge clk);
+    end
+  endtask
+
+  task automatic load_vectors;
+    integer i;
+    begin
+      for (i = 0; i < ENCODER_VECTOR_COUNT; i = i + 1)
+        encoder_vectors[i] = make_beat(i);
+      for (i = 0; i < CADENCE_VECTOR_COUNT; i = i + 1)
+        cadence_vectors[i] = make_beat(i + 64);
+      for (i = 0; i < LOOPBACK_VECTOR_COUNT; i = i + 1)
+        loopback_vectors[i] = make_beat(i + 32);
+    end
+  endtask
+
+  task automatic send_encoder_beat;
+    input [BEAT_W-1:0] beat;
+    begin
+      @(negedge clk);
+      enc_beat_valid = 1'b1;
+      enc_beat_data = beat;
+      while (!enc_beat_ready)
+        @(posedge clk);
+      @(posedge clk);
+      @(negedge clk);
+      enc_beat_valid = 1'b0;
+      enc_beat_data = {BEAT_W{1'b0}};
+    end
+  endtask
+
+  task automatic send_manual_flit;
+    input [FLIT_W-1:0] data;
+    input phase;
+    input last;
+    begin
+      @(negedge clk);
+      manual_flit_valid = 1'b1;
+      manual_flit_data = data;
+      manual_flit_phase = phase;
+      manual_flit_last = last;
+      while (!dec_flit_ready)
+        @(posedge clk);
+      @(posedge clk);
+      @(negedge clk);
+      manual_flit_valid = 1'b0;
+      manual_flit_data = {FLIT_W{1'b0}};
+      manual_flit_phase = 1'b0;
+      manual_flit_last = 1'b0;
+    end
+  endtask
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      stall_state <= 32'h1badf00d;
+    end else begin
+      stall_state <= next_state(stall_state);
+    end
+  end
+
+  always @(*) begin
+    if (mode == MODE_LOOPBACK || mode == MODE_CADENCE) begin
+      dec_flit_valid = enc_flit_valid;
+      dec_flit_data = enc_flit_data;
+      dec_flit_phase = enc_flit_phase;
+      dec_flit_last = enc_flit_last;
+    end else if (mode == MODE_MANUAL_DECODER) begin
+      dec_flit_valid = manual_flit_valid;
+      dec_flit_data = manual_flit_data;
+      dec_flit_phase = manual_flit_phase;
+      dec_flit_last = manual_flit_last;
+    end else begin
+      dec_flit_valid = 1'b0;
+      dec_flit_data = {FLIT_W{1'b0}};
+      dec_flit_phase = 1'b0;
+      dec_flit_last = 1'b0;
+    end
+  end
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      held_encoder_valid <= 1'b0;
+      held_encoder_flit <= {(FLIT_W+2){1'b0}};
+      held_decoder_valid <= 1'b0;
+      held_decoder_beat <= {BEAT_W{1'b0}};
+    end else begin
+      if (mode != MODE_MANUAL_DECODER && enc_flit_valid && !enc_flit_ready) begin
+        if (held_encoder_valid &&
+            held_encoder_flit !== {enc_flit_phase, enc_flit_last, enc_flit_data})
+          $fatal(1, "encoder output changed under backpressure");
+        held_encoder_valid <= 1'b1;
+        held_encoder_flit <= {enc_flit_phase, enc_flit_last, enc_flit_data};
+        encoder_hold_checks <= encoder_hold_checks + 1;
+      end else begin
+        held_encoder_valid <= 1'b0;
+      end
+
+      if (dec_beat_valid && !dec_beat_ready) begin
+        if (held_decoder_valid && held_decoder_beat !== dec_beat_data)
+          $fatal(1, "decoder beat changed under backpressure");
+        held_decoder_valid <= 1'b1;
+        held_decoder_beat <= dec_beat_data;
+        decoder_hold_checks <= decoder_hold_checks + 1;
+      end else begin
+        held_decoder_valid <= 1'b0;
+      end
+    end
+  end
+
+  always @(posedge clk) begin
+    integer beat_index;
+    integer phase_index;
+    if (rst_n && mode == MODE_ENCODER && enc_flit_valid && enc_flit_ready) begin
+      beat_index = encoder_flit_count / 2;
+      phase_index = encoder_flit_count % 2;
+      if (beat_index >= ENCODER_VECTOR_COUNT)
+        $fatal(1, "encoder emitted too many flits");
+      if (enc_flit_phase !== phase_index[0])
+        $fatal(1, "encoder phase mismatch for flit %0d", encoder_flit_count);
+      if (enc_flit_last !== phase_index[0])
+        $fatal(1, "encoder last mismatch for flit %0d", encoder_flit_count);
+      if (enc_flit_data !== expected_flit(encoder_vectors[beat_index], phase_index))
+        $fatal(1, "encoder flit payload mismatch for beat %0d phase %0d", beat_index, phase_index);
+      if (phase_index == 1 && enc_flit_data[FLIT_W-1:SECOND_PAYLOAD_W] !== {SECOND_PAD_W{1'b0}})
+        $fatal(1, "encoder phase-1 padding was not zero");
+      encoder_flit_count <= encoder_flit_count + 1;
+    end
+    if (rst_n && mode == MODE_CADENCE && enc_flit_valid && enc_flit_ready) begin
+      cadence_flit_cycles[cadence_flit_count] = cycle_count;
+      cadence_flit_count <= cadence_flit_count + 1;
+    end
+    if (rst_n && mode == MODE_CADENCE && enc_beat_valid && enc_beat_ready) begin
+      cadence_encoder_beat_cycles[cadence_encoder_beat_count] = cycle_count;
+      cadence_encoder_beat_count <= cadence_encoder_beat_count + 1;
+    end
+  end
+
+  always @(posedge clk) begin
+    if (rst_n && mode == MODE_CADENCE && dec_beat_valid && dec_beat_ready) begin
+      if (cadence_decoder_beat_count >= CADENCE_VECTOR_COUNT)
+        $fatal(1, "cadence decoder emitted too many beats");
+      if (dec_beat_data !== cadence_vectors[cadence_decoder_beat_count])
+        $fatal(1, "cadence decoder beat mismatch for beat %0d", cadence_decoder_beat_count);
+      cadence_decoder_beat_cycles[cadence_decoder_beat_count] = cycle_count;
+      cadence_decoder_beat_count <= cadence_decoder_beat_count + 1;
+    end
+    if (rst_n && mode == MODE_LOOPBACK && dec_beat_valid && dec_beat_ready) begin
+      if (loopback_beat_count >= LOOPBACK_VECTOR_COUNT)
+        $fatal(1, "decoder emitted too many beats");
+      if (dec_beat_data !== loopback_vectors[loopback_beat_count])
+        $fatal(1, "decoder beat mismatch for beat %0d", loopback_beat_count);
+      loopback_beat_count <= loopback_beat_count + 1;
+    end
+  end
+
+  initial begin
+    load_vectors();
+
+    mode = MODE_ENCODER[2:0];
+    encoder_flit_count = 0;
+    loopback_beat_count = 0;
+    encoder_hold_checks = 0;
+    decoder_hold_checks = 0;
+    apply_reset();
+    repeat (2) @(posedge clk);
+    begin : encoder_phase
+      integer i;
+      for (i = 0; i < ENCODER_VECTOR_COUNT; i = i + 1)
+        send_encoder_beat(encoder_vectors[i]);
+    end
+    wait (encoder_flit_count == (ENCODER_VECTOR_COUNT * 2));
+    repeat (4) @(posedge clk);
+    if (encoder_hold_checks == 0)
+      $fatal(1, "encoder never experienced backpressure");
+
+    mode = MODE_CADENCE[2:0];
+    cadence_encoder_beat_count = 0;
+    cadence_flit_count = 0;
+    cadence_decoder_beat_count = 0;
+    apply_reset();
+    repeat (2) @(posedge clk);
+    begin : cadence_phase
+      integer c;
+      for (c = 0; c < CADENCE_VECTOR_COUNT; c = c + 1)
+        send_encoder_beat(cadence_vectors[c]);
+    end
+    wait (cadence_decoder_beat_count == CADENCE_VECTOR_COUNT);
+    repeat (3) @(posedge clk);
+    begin : cadence_checks
+      integer k;
+      if (cadence_encoder_beat_count != CADENCE_VECTOR_COUNT)
+        $fatal(1, "encoder cadence accepted %0d beats instead of %0d", cadence_encoder_beat_count, CADENCE_VECTOR_COUNT);
+      if (cadence_flit_count != (CADENCE_VECTOR_COUNT * 2))
+        $fatal(1, "cadence emitted %0d flits instead of %0d", cadence_flit_count, CADENCE_VECTOR_COUNT * 2);
+      for (k = 0; k < (CADENCE_VECTOR_COUNT * 2) - 1; k = k + 1)
+        if (cadence_flit_cycles[k+1] != (cadence_flit_cycles[k] + 1))
+          $fatal(1, "always-ready flit cadence bubbled between flits %0d and %0d", k, k + 1);
+      for (k = 0; k < CADENCE_VECTOR_COUNT - 1; k = k + 1) begin
+        if (cadence_encoder_beat_cycles[k+1] != cadence_flit_cycles[(2 * k) + 1])
+          $fatal(1, "encoder did not accept beat %0d on prior phase-1 acceptance cycle", k + 1);
+        if (cadence_flit_cycles[2 * (k + 1)] != cadence_decoder_beat_cycles[k])
+          $fatal(1, "decoder did not accept next phase-0 flit on prior beat-drain cycle for beat %0d", k);
+        if (cadence_decoder_beat_cycles[k+1] != (cadence_decoder_beat_cycles[k] + 2))
+          $fatal(1, "decoder output cadence bubbled between beats %0d and %0d", k, k + 1);
+      end
+    end
+
+    mode = MODE_LOOPBACK[2:0];
+    loopback_beat_count = 0;
+    apply_reset();
+    repeat (2) @(posedge clk);
+    begin : loopback_phase
+      integer j;
+      for (j = 0; j < LOOPBACK_VECTOR_COUNT; j = j + 1)
+        send_encoder_beat(loopback_vectors[j]);
+    end
+    wait (loopback_beat_count == LOOPBACK_VECTOR_COUNT);
+    repeat (4) @(posedge clk);
+    if (dec_protocol_error)
+      $fatal(1, "decoder protocol_error asserted during exact loopback");
+    if (decoder_hold_checks == 0)
+      $fatal(1, "decoder never experienced output backpressure");
+
+    mode = MODE_MANUAL_DECODER[2:0];
+    apply_reset();
+    repeat (2) @(posedge clk);
+    send_manual_flit(expected_flit(make_beat(80), 0), 1'b0, 1'b0);
+    @(negedge clk);
+    if (!dec_partial_valid)
+      $fatal(1, "decoder did not retain first flit as partial state");
+    if (dec_beat_valid)
+      $fatal(1, "decoder emitted a beat after only one flit");
+
+    rst_n = 1'b0;
+    repeat (2) @(posedge clk);
+    rst_n = 1'b1;
+    @(negedge clk);
+    if (dec_partial_valid)
+      $fatal(1, "reset did not clear decoder partial state");
+    if (dec_protocol_error)
+      $fatal(1, "reset did not clear decoder protocol_error");
+
+    send_manual_flit(expected_flit(make_beat(80), 1), 1'b1, 1'b1);
+    @(negedge clk);
+    if (!dec_protocol_error)
+      $fatal(1, "decoder failed to reject lone phase-1 flit after reset");
+    if (dec_beat_valid)
+      $fatal(1, "decoder emitted a beat from a half-beat sequence");
+
+    apply_reset();
+    mode = MODE_MANUAL_DECODER[2:0];
+    repeat (2) @(posedge clk);
+    manual_dec_ready = 1'b0;
+    send_manual_flit(expected_flit(make_beat(81), 0), 1'b0, 1'b0);
+    send_manual_flit(expected_flit(make_beat(81), 1), 1'b1, 1'b1);
+    repeat (3) @(posedge clk);
+    if (!dec_beat_valid)
+      $fatal(1, "decoder did not produce a full beat after two valid flits");
+    if (dec_beat_data !== make_beat(81))
+      $fatal(1, "decoder reconstructed the wrong beat after manual framing");
+    manual_dec_ready = 1'b1;
+    @(posedge clk);
+    @(negedge clk);
+    if (dec_beat_valid)
+      $fatal(1, "decoder beat did not drain after ready");
+
+    $display(
+      "PASS local_reducer_aggregate_aligned_exact_codec encoder_flits=%0d loopback_beats=%0d encoder_holds=%0d decoder_holds=%0d",
+      encoder_flit_count,
+      loopback_beat_count,
+      encoder_hold_checks,
+      decoder_hold_checks
+    );
+    $finish;
+  end
+endmodule

--- a/tests/local_reducer_aggregate_aligned_exact_codec_tb.sv
+++ b/tests/local_reducer_aggregate_aligned_exact_codec_tb.sv
@@ -25,13 +25,13 @@ module local_reducer_aggregate_aligned_exact_codec_tb;
   wire enc_flit_ready;
   wire [FLIT_W-1:0] enc_flit_data;
   wire enc_flit_phase;
-  wire enc_flit_last;
+  wire enc_flit_beat_last;
 
   reg dec_flit_valid = 1'b0;
   wire dec_flit_ready;
   reg [FLIT_W-1:0] dec_flit_data = {FLIT_W{1'b0}};
   reg dec_flit_phase = 1'b0;
-  reg dec_flit_last = 1'b0;
+  reg dec_flit_beat_last = 1'b0;
   wire dec_beat_valid;
   wire dec_beat_ready;
   wire [BEAT_W-1:0] dec_beat_data;
@@ -41,7 +41,7 @@ module local_reducer_aggregate_aligned_exact_codec_tb;
   reg manual_flit_valid = 1'b0;
   reg [FLIT_W-1:0] manual_flit_data = {FLIT_W{1'b0}};
   reg manual_flit_phase = 1'b0;
-  reg manual_flit_last = 1'b0;
+  reg manual_flit_beat_last = 1'b0;
   reg [2:0] mode = MODE_IDLE[2:0];
 
   reg [31:0] stall_state = 32'h1badf00d;
@@ -87,7 +87,7 @@ module local_reducer_aggregate_aligned_exact_codec_tb;
     .flit_ready(enc_flit_ready),
     .flit_data(enc_flit_data),
     .flit_phase(enc_flit_phase),
-    .flit_last(enc_flit_last)
+    .flit_beat_last(enc_flit_beat_last)
   );
 
   local_reducer_aggregate_aligned_exact_decoder #(
@@ -100,7 +100,7 @@ module local_reducer_aggregate_aligned_exact_codec_tb;
     .flit_ready(dec_flit_ready),
     .flit_data(dec_flit_data),
     .flit_phase(dec_flit_phase),
-    .flit_last(dec_flit_last),
+    .flit_beat_last(dec_flit_beat_last),
     .beat_valid(dec_beat_valid),
     .beat_ready(dec_beat_ready),
     .beat_data(dec_beat_data),
@@ -177,11 +177,11 @@ module local_reducer_aggregate_aligned_exact_codec_tb;
       dec_flit_valid = 1'b0;
       dec_flit_data = {FLIT_W{1'b0}};
       dec_flit_phase = 1'b0;
-      dec_flit_last = 1'b0;
+      dec_flit_beat_last = 1'b0;
       manual_flit_valid = 1'b0;
       manual_flit_data = {FLIT_W{1'b0}};
       manual_flit_phase = 1'b0;
-      manual_flit_last = 1'b0;
+      manual_flit_beat_last = 1'b0;
       manual_dec_ready = 1'b0;
       held_encoder_valid = 1'b0;
       held_decoder_valid = 1'b0;
@@ -229,7 +229,7 @@ module local_reducer_aggregate_aligned_exact_codec_tb;
       manual_flit_valid = 1'b1;
       manual_flit_data = data;
       manual_flit_phase = phase;
-      manual_flit_last = last;
+      manual_flit_beat_last = last;
       while (!dec_flit_ready)
         @(posedge clk);
       @(posedge clk);
@@ -237,7 +237,7 @@ module local_reducer_aggregate_aligned_exact_codec_tb;
       manual_flit_valid = 1'b0;
       manual_flit_data = {FLIT_W{1'b0}};
       manual_flit_phase = 1'b0;
-      manual_flit_last = 1'b0;
+      manual_flit_beat_last = 1'b0;
     end
   endtask
 
@@ -254,17 +254,17 @@ module local_reducer_aggregate_aligned_exact_codec_tb;
       dec_flit_valid = enc_flit_valid;
       dec_flit_data = enc_flit_data;
       dec_flit_phase = enc_flit_phase;
-      dec_flit_last = enc_flit_last;
+      dec_flit_beat_last = enc_flit_beat_last;
     end else if (mode == MODE_MANUAL_DECODER) begin
       dec_flit_valid = manual_flit_valid;
       dec_flit_data = manual_flit_data;
       dec_flit_phase = manual_flit_phase;
-      dec_flit_last = manual_flit_last;
+      dec_flit_beat_last = manual_flit_beat_last;
     end else begin
       dec_flit_valid = 1'b0;
       dec_flit_data = {FLIT_W{1'b0}};
       dec_flit_phase = 1'b0;
-      dec_flit_last = 1'b0;
+      dec_flit_beat_last = 1'b0;
     end
   end
 
@@ -277,10 +277,10 @@ module local_reducer_aggregate_aligned_exact_codec_tb;
     end else begin
       if (mode != MODE_MANUAL_DECODER && enc_flit_valid && !enc_flit_ready) begin
         if (held_encoder_valid &&
-            held_encoder_flit !== {enc_flit_phase, enc_flit_last, enc_flit_data})
+            held_encoder_flit !== {enc_flit_phase, enc_flit_beat_last, enc_flit_data})
           $fatal(1, "encoder output changed under backpressure");
         held_encoder_valid <= 1'b1;
-        held_encoder_flit <= {enc_flit_phase, enc_flit_last, enc_flit_data};
+        held_encoder_flit <= {enc_flit_phase, enc_flit_beat_last, enc_flit_data};
         encoder_hold_checks <= encoder_hold_checks + 1;
       end else begin
         held_encoder_valid <= 1'b0;
@@ -308,7 +308,7 @@ module local_reducer_aggregate_aligned_exact_codec_tb;
         $fatal(1, "encoder emitted too many flits");
       if (enc_flit_phase !== phase_index[0])
         $fatal(1, "encoder phase mismatch for flit %0d", encoder_flit_count);
-      if (enc_flit_last !== phase_index[0])
+      if (enc_flit_beat_last !== phase_index[0])
         $fatal(1, "encoder last mismatch for flit %0d", encoder_flit_count);
       if (enc_flit_data !== expected_flit(encoder_vectors[beat_index], phase_index))
         $fatal(1, "encoder flit payload mismatch for beat %0d phase %0d", beat_index, phase_index);

--- a/tests/test_local_reducer_aggregate_aligned_exact_codec.py
+++ b/tests/test_local_reducer_aggregate_aligned_exact_codec.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import shutil
 import subprocess
 import sys
@@ -11,8 +12,20 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from scripts.generate_design import (  # noqa: E402
+    generate_config_mk,
+    generate_l1_memory_noc_design,
+    generate_wrapper,
+    identify_design,
+)
+
 RTL = REPO_ROOT / "npu/sim/rtl/local_reducer_aggregate_aligned_exact_codec.sv"
 TB = REPO_ROOT / "tests/local_reducer_aggregate_aligned_exact_codec_tb.sv"
+PPA_CONFIG = (
+    REPO_ROOT
+    / "runs/designs/noc/l1_attention_score32_exact_aligned_codec_w419_f256_wrapper"
+    / "config_l1_attention_score32_exact_aligned_codec_w419_f256.json"
+)
 
 
 def _tool(name: str) -> str | None:
@@ -73,6 +86,68 @@ def test_local_reducer_aggregate_aligned_exact_codec_yosys_import_process_check(
                 "-q",
                 "-p",
                 f"read_verilog -DSYNTHESIS -sv {RTL}; hierarchy -check -top {top}; proc; check",
+            ],
+            check=True,
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+
+def test_local_reducer_aggregate_aligned_exact_codec_ppa_hierarchy(tmp_path: Path) -> None:
+    config = json.loads(PPA_CONFIG.read_text(encoding="utf-8"))
+    design = identify_design(config)
+    assert design["primitive"] == "exact_aligned_codec"
+
+    source_dir = tmp_path / "src"
+    source_dir.mkdir()
+    generate_l1_memory_noc_design(str(source_dir), design)
+    generate_wrapper(config, str(source_dir), design)
+    expected_sources = {
+        "local_reducer_aggregate_aligned_exact_codec.v",
+        "local_reducer_aggregate_aligned_exact_codec_ppa_harness.v",
+        f"{design['module_name']}.v",
+        f"{design['wrapper_name']}.v",
+    }
+    assert expected_sources == {path.name for path in source_dir.glob("*.v")}
+
+    platform_dir = tmp_path / "platform"
+    platform_dir.mkdir()
+    generate_config_mk(str(platform_dir), "nangate45", design)
+    config_mk = (platform_dir / "config.mk").read_text(encoding="utf-8")
+    for filename in expected_sources:
+        assert f"/{filename}" in config_mk
+
+    iverilog = _tool("iverilog")
+    if iverilog is not None:
+        subprocess.run(
+            [
+                iverilog,
+                "-g2012",
+                "-s",
+                design["wrapper_name"],
+                "-t",
+                "null",
+                *[str(path) for path in sorted(source_dir.glob("*.v"))],
+            ],
+            check=True,
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+    yosys = _tool("yosys")
+    if yosys is not None:
+        subprocess.run(
+            [
+                yosys,
+                "-q",
+                "-p",
+                "read_verilog -DSYNTHESIS -sv "
+                + " ".join(str(path) for path in sorted(source_dir.glob("*.v")))
+                + f"; hierarchy -check -top {design['wrapper_name']}; proc; check",
             ],
             check=True,
             cwd=REPO_ROOT,

--- a/tests/test_local_reducer_aggregate_aligned_exact_codec.py
+++ b/tests/test_local_reducer_aggregate_aligned_exact_codec.py
@@ -155,3 +155,10 @@ def test_local_reducer_aggregate_aligned_exact_codec_ppa_hierarchy(tmp_path: Pat
             text=True,
             timeout=60,
         )
+
+
+def test_local_reducer_aggregate_aligned_exact_codec_rejects_narrow_counter() -> None:
+    config = json.loads(PPA_CONFIG.read_text(encoding="utf-8"))
+    config["operations"][0]["options"]["counter_bits"] = 3
+    with pytest.raises(ValueError, match="requires counter_bits >= 4"):
+        identify_design(config)

--- a/tests/test_local_reducer_aggregate_aligned_exact_codec.py
+++ b/tests/test_local_reducer_aggregate_aligned_exact_codec.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+RTL = REPO_ROOT / "npu/sim/rtl/local_reducer_aggregate_aligned_exact_codec.sv"
+TB = REPO_ROOT / "tests/local_reducer_aggregate_aligned_exact_codec_tb.sv"
+
+
+def _tool(name: str) -> str | None:
+    path = shutil.which(name)
+    if path is not None:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    if fallback.exists():
+        return str(fallback)
+    return None
+
+
+@pytest.mark.skipif(_tool("iverilog") is None or _tool("vvp") is None, reason="iverilog/vvp unavailable")
+def test_local_reducer_aggregate_aligned_exact_codec_roundtrip_and_cadence(tmp_path: Path) -> None:
+    simv = tmp_path / "local_reducer_aggregate_aligned_exact_codec.vvp"
+    subprocess.run(
+        [
+            str(_tool("iverilog")),
+            "-g2012",
+            "-s",
+            "local_reducer_aggregate_aligned_exact_codec_tb",
+            "-o",
+            str(simv),
+            str(RTL),
+            str(TB),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    run = subprocess.run(
+        [str(_tool("vvp")), str(simv)],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert (
+        "PASS local_reducer_aggregate_aligned_exact_codec"
+        in run.stdout
+    )
+    assert "encoder_flits=24" in run.stdout
+    assert "loopback_beats=10" in run.stdout
+
+
+@pytest.mark.skipif(_tool("yosys") is None, reason="yosys unavailable")
+def test_local_reducer_aggregate_aligned_exact_codec_yosys_import_process_check() -> None:
+    for top in (
+        "local_reducer_aggregate_aligned_exact_encoder",
+        "local_reducer_aggregate_aligned_exact_decoder",
+    ):
+        subprocess.run(
+            [
+                str(_tool("yosys")),
+                "-q",
+                "-p",
+                f"read_verilog -DSYNTHESIS -sv {RTL}; hierarchy -check -top {top}; proc; check",
+            ],
+            check=True,
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )


### PR DESCRIPTION
## Summary
- add a synthesizable 419-bit exact aggregate encoder/decoder over two aligned 256-bit flits
- prove exact round-trip, malformed-framing rejection, reset safety, arbitrary backpressure, and bubble-free sustained cadence
- add a compact-boundary PPA harness, direct-generator support, Nangate45 config/sweep, and an L1 measurement proposal
- document the canonical bit layout and remaining composition boundaries

## Why
The prior Phase-2 schedule narrowed and released reduction state incorrectly. This establishes the direct field-preserving transport anchor before implementing denser exact packing or rebuilding the producer-driven NoC schedule.

## Verification
- `PYTHONPATH=. /home/rtlgen/.venvs/rtlgen-control-plane/bin/pytest -q tests/test_local_reducer_aggregate_aligned_exact_codec.py tests/test_noc_sram_packet_endpoint.py tests/test_noc_descriptor_pair_scheduler.py`
- `scripts/validate_runs.py --skip_eval_queue`
- generated hierarchy Icarus elaboration and Yosys `proc; check`
