### PR TITLE
Add exact stats-once transport codec and matched PPA sweep

### DIFF
--- a/docs/proposals/prop_l1_attention_score32_exact_stats_once_transport_codec_ppa_v1/README.md
+++ b/docs/proposals/prop_l1_attention_score32_exact_stats_once_transport_codec_ppa_v1/README.md
@@ -1,0 +1,8 @@
+# Score32 Exact Stats-Once Transport Codec PPA
+
+This proposal compares the exact stats-once group codec against the aligned
+two-flit codec under one matched canonical source, sink, and stall harness.
+
+The dense codec carries one eight-head aggregate group in 167 256-bit flits
+instead of 256 flits while preserving every 41-bit value numerator and each
+head's exact maximum and exponential sum.

--- a/docs/proposals/prop_l1_attention_score32_exact_stats_once_transport_codec_ppa_v1/design_brief.md
+++ b/docs/proposals/prop_l1_attention_score32_exact_stats_once_transport_codec_ppa_v1/design_brief.md
@@ -1,0 +1,16 @@
+# Design Brief
+
+The source emits canonical 128-beat GQA8 groups. Each beat is 419 bits and the
+maximum and exponential sum remain constant across the 16 slices of one head.
+Both candidates consume the same sequence and use the same deterministic
+backpressure and all-bit output fold.
+
+The aligned candidate emits two 256-bit flits per beat, or 256 flits per group.
+The stats-once candidate sends each head's 65 statistics bits once followed by
+all sixteen 328-bit value vectors, or 42,504 bits and 167 flits per group. Its
+encoder and decoder use bounded 768-bit reservoirs; neither stores a group.
+
+The matched harness includes source, sink, counters, and both codec directions.
+It excludes endpoint descriptors, SRAM, routers, local-reducer arithmetic, the
+global reduction tree, and HBM/DRAM. The architecture uses 15 encoder/decoder
+pairs, so measured pair PPA must be scaled by 15 before Llama7B recosting.

--- a/docs/proposals/prop_l1_attention_score32_exact_stats_once_transport_codec_ppa_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l1_attention_score32_exact_stats_once_transport_codec_ppa_v1/evaluation_gate.md
@@ -1,0 +1,10 @@
+# Evaluation Gate
+
+Run both matched candidates at identical Nangate45 clock, utilization, density,
+seed, and flow settings. A comparison is valid only when both rows are timing
+feasible and their generated source commit and tool provenance match.
+
+Report the paired area, critical path, and vectorless power deltas. Also report
+the exact traffic reduction of 89 flits per group and scale codec pair PPA by 15
+for the current 16-cluster reduction topology. Do not interpret vectorless
+power as workload energy without adding measured flit transport energy.

--- a/docs/proposals/prop_l1_attention_score32_exact_stats_once_transport_codec_ppa_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_attention_score32_exact_stats_once_transport_codec_ppa_v1/evaluation_requests.json
@@ -1,0 +1,33 @@
+{
+  "proposal_id": "prop_l1_attention_score32_exact_stats_once_transport_codec_ppa_v1",
+  "source_commit": "TBD",
+  "requested_items": [
+    {
+      "item_id": "l1_attention_score32_exact_stats_once_transport_codec_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure paired Nangate45 PPA for exact aligned and stats-once aggregate codecs under an identical group source and sink.",
+      "evaluation_mode": "ppa",
+      "abstraction_layer": "architecture_block",
+      "config_paths": [
+        "runs/designs/noc/l1_attention_score32_exact_matched_aligned_codec_w419_f256_wrapper/config_l1_attention_score32_exact_matched_aligned_codec_w419_f256.json",
+        "runs/designs/noc/l1_attention_score32_exact_matched_stats_once_codec_w419_f256_wrapper/config_l1_attention_score32_exact_matched_stats_once_codec_w419_f256.json"
+      ],
+      "sweep_path": "runs/campaigns/noc/l1_attention_score32_exact_matched_codec/sweeps/nangate45_macro_frontier.json",
+      "expected_outputs": [
+        "runs/designs/noc/l1_attention_score32_exact_matched_aligned_codec_w419_f256_wrapper/metrics.csv",
+        "runs/designs/noc/l1_attention_score32_exact_matched_stats_once_codec_w419_f256_wrapper/metrics.csv"
+      ],
+      "status": "pending_after_proposal_merge",
+      "comparison_role": "phase2_exact_transport_matched_codec_tradeoff",
+      "paired_baseline_item_id": "l1_attention_score32_exact_aligned_transport_codec_ppa_v1",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "expected_result": {
+        "direction": "measure_exact_stats_once_codec_tradeoff",
+        "reason": "Determine whether 34.8 percent fewer exact transport flits outweigh bounded-reservoir codec cost at 15-pair architecture scale."
+      },
+      "acceptance_notes": "Require exact round-trip, matched generated hierarchy, and paired timing-feasible rows from the same source/tool settings. Keep endpoint, mesh, SRAM, reducer, root tree, and HBM outside this PPA claim."
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_attention_score32_exact_stats_once_transport_codec_ppa_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_attention_score32_exact_stats_once_transport_codec_ppa_v1/implementation_summary.md
@@ -1,0 +1,13 @@
+# Implementation Summary
+
+- Added a bounded 768-bit-reservoir exact stats-once encoder and decoder.
+- Added independent randomized round-trip and malformed-protocol tests.
+- Added a matched PPA harness with one canonical group source, deterministic
+  stalls, exact decoded-beat comparison, and an all-bit observation fold.
+- Added constant-elaborated aligned and stats-once generated PPA tops.
+- Added a paired Nangate45 sweep over 1.0/1.5/2.0 ns and 40/50/60 percent
+  utilization at placement density 0.52.
+
+Local verification: 13 focused tests pass and `validate_runs.py
+--skip_eval_queue` passes. Yosys removes the unselected codec hierarchy and
+contains no multiplier cells in the matched source support.

--- a/docs/proposals/prop_l1_attention_score32_exact_stats_once_transport_codec_ppa_v1/promotion_decision.json
+++ b/docs/proposals/prop_l1_attention_score32_exact_stats_once_transport_codec_ppa_v1/promotion_decision.json
@@ -1,0 +1,6 @@
+{
+  "proposal_id": "prop_l1_attention_score32_exact_stats_once_transport_codec_ppa_v1",
+  "decision": "pending_evaluation",
+  "reason": "Exact RTL exists, but the matched Nangate45 codec tradeoff has not been measured.",
+  "next_action": "run l1_attention_score32_exact_stats_once_transport_codec_ppa_v1"
+}

--- a/docs/proposals/prop_l1_attention_score32_exact_stats_once_transport_codec_ppa_v1/promotion_gate.md
+++ b/docs/proposals/prop_l1_attention_score32_exact_stats_once_transport_codec_ppa_v1/promotion_gate.md
@@ -1,0 +1,9 @@
+# Promotion Gate
+
+Promote stats-once transport only if exact equivalence remains green and its
+15-pair codec overhead is outweighed by the measured/specified cost of removing
+1,335 flits per 16-cluster wave (15 remote groups times 89 flits).
+
+The result closes codec packing PPA only. Full Phase-2 closure still requires
+composition with real reducer validity, packet endpoints and mesh scheduling,
+and root-tree readiness.

--- a/docs/proposals/prop_l1_attention_score32_exact_stats_once_transport_codec_ppa_v1/proposal.json
+++ b/docs/proposals/prop_l1_attention_score32_exact_stats_once_transport_codec_ppa_v1/proposal.json
@@ -1,0 +1,65 @@
+{
+  "proposal_id": "prop_l1_attention_score32_exact_stats_once_transport_codec_ppa_v1",
+  "created_utc": "2026-08-18T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit_block",
+  "abstraction_layer": "architecture_block",
+  "title": "Measure exact stats-once transport against a matched aligned codec",
+  "hypothesis": "Removing repeated aggregate metadata reduces exact Phase-2 traffic by 34.8 percent with codec PPA small enough that the 15-pair Llama7B hierarchy improves total transport area-energy and service time.",
+  "direct_comparison": {
+    "primary_question": "Does exact stats-once packing improve the measured codec-plus-transport frontier after its bounded reservoir cost is scaled to all 15 remote cluster links?",
+    "include": [
+      "one identical canonical 419-bit group source for both candidates",
+      "one identical all-bit sink and deterministic stall schedule",
+      "aligned exact two-flit encoder and decoder",
+      "stats-once exact bounded-reservoir encoder and decoder",
+      "128 beats and 256 versus 167 flits per group",
+      "paired Nangate45 timing, area, and vectorless power"
+    ],
+    "exclude": [
+      "local reducer arithmetic",
+      "packet endpoint and descriptor scheduler",
+      "SRAM bitcells",
+      "router and mesh wiring",
+      "global reduction tree",
+      "HBM/DRAM",
+      "workload-activity power"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l1_attention_score32_exact_stats_once_transport_codec_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure paired Nangate45 PPA for exact aligned and stats-once aggregate codecs under an identical group source and sink.",
+      "evaluation_mode": "ppa",
+      "abstraction_layer": "architecture_block",
+      "comparison_role": "phase2_exact_transport_matched_codec_tradeoff",
+      "paired_baseline_item_id": "l1_attention_score32_exact_aligned_transport_codec_ppa_v1",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "config_paths": [
+        "runs/designs/noc/l1_attention_score32_exact_matched_aligned_codec_w419_f256_wrapper/config_l1_attention_score32_exact_matched_aligned_codec_w419_f256.json",
+        "runs/designs/noc/l1_attention_score32_exact_matched_stats_once_codec_w419_f256_wrapper/config_l1_attention_score32_exact_matched_stats_once_codec_w419_f256.json"
+      ],
+      "sweep_path": "runs/campaigns/noc/l1_attention_score32_exact_matched_codec/sweeps/nangate45_macro_frontier.json",
+      "expected_outputs": [
+        "runs/designs/noc/l1_attention_score32_exact_matched_aligned_codec_w419_f256_wrapper/metrics.csv",
+        "runs/designs/noc/l1_attention_score32_exact_matched_stats_once_codec_w419_f256_wrapper/metrics.csv"
+      ]
+    }
+  ],
+  "baseline_refs": [
+    "docs/proposals/prop_l1_attention_score32_exact_aligned_transport_codec_ppa_v1/proposal.json",
+    "docs/proposals/prop_l2_decoder_attention_score32_noc_phase2_exact_transport_revision_v1/proposal.json",
+    "npu/docs/attention_score32_exact_aligned_transport_codec_contract.md",
+    "npu/docs/attention_score32_exact_stats_once_transport_codec_contract.md"
+  ],
+  "remaining_abstractions_after_this_step": [
+    "codec-to-packet endpoint integration",
+    "transport through the routed mesh under descriptor-owned packet boundaries",
+    "root decoder to global exact reduction readiness",
+    "workload-activity transport energy"
+  ]
+}

--- a/docs/proposals/prop_l1_attention_score32_exact_stats_once_transport_codec_ppa_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_attention_score32_exact_stats_once_transport_codec_ppa_v1/quality_gate.md
@@ -1,0 +1,12 @@
+# Quality Gate
+
+- Exact 419-bit round-trip for multiple canonical groups in both modes.
+- Arbitrary deterministic source, transport, and sink stalls.
+- Exactly 256 aligned or 167 stats-once flits per 128-beat group.
+- Stable ready/valid payloads and no protocol errors for valid traffic.
+- Invalid order, context, terminal marker, and padding are rejected.
+- Generated hierarchy passes Icarus elaboration and Yosys process/check.
+- Both PPA candidates use the same source, sink, counters, and stall schedule.
+
+Status: passed locally with 13 focused aligned/stats/matched RTL and generated-
+hierarchy tests; physical evaluation remains pending.

--- a/npu/docs/attention_score32_exact_stats_once_transport_codec_contract.md
+++ b/npu/docs/attention_score32_exact_stats_once_transport_codec_contract.md
@@ -1,0 +1,69 @@
+# Score32 Exact Stats-Once Transport Codec Contract
+
+This codec is the dense exact-transport candidate for one GQA8 aggregate group.
+It removes only metadata that the checked group-major order makes redundant;
+all signed 41-bit numerators and exact max/sum fields are preserved.
+
+## Input Group
+
+The encoder receives one group context before aggregate data:
+
+- `command_id[15:0]`
+- `head_base[4:0]`, restricted to `0`, `8`, `16`, or `24`
+
+It then accepts exactly 128 canonical 419-bit beats in this order:
+
+1. heads `head_base + 0` through `head_base + 7`
+2. slices `0` through `15` for each head
+3. `last=1` only on slice 15
+4. command ID constant across the group
+5. global maximum and exponential sum constant across all 16 slices of a head
+
+Any mismatch sets a sticky protocol error. The canonical aggregate layout is
+defined by `attention_score32_exact_aligned_transport_codec_contract.md`.
+
+## Packed Bitstream
+
+Bits are emitted least-significant first. For each head, in order, the stream
+contains:
+
+- signed global maximum: 32 bits
+- exponential sum: 33 bits
+- slice values 0 through 15: `16 x 328` bits
+
+One head therefore contributes `65 + 5248 = 5313` bits. One group contributes
+`8 x 5313 = 42504` bits, transported as 167 256-bit flits. Flits 0 through 165
+are full. Flit 166 carries the final 8 stream bits in payload bits `7:0`; bits
+`255:8` are zero.
+
+`flit_group_last` marks only flit 166. It must never drive the endpoint's
+packet `flit_last`: packet boundaries remain descriptor-owned and occur at up
+to eight flits, so one group spans 20 full packets plus one seven-flit packet.
+
+## Streaming Hardware
+
+The encoder and decoder use bounded bit reservoirs. They must not instantiate
+a 42,504-bit group register. Backpressure is legal at every context, aggregate,
+flit, and reconstructed-aggregate interface. Accepted output data remains
+stable until consumed.
+
+The decoder receives the same group context out of band from checked command
+or packet metadata. It reconstructs all 128 canonical 419-bit beats, repeating
+the transmitted max/sum for the 16 slices of each head and restoring inferred
+command ID, head ID, slice, and last fields.
+
+## Equivalence Gate
+
+For every valid group:
+
+- reconstructed 419-bit beats equal encoder input beats bit for bit
+- accepted flits equal 167
+- only final-flit zero padding is discarded
+- arbitrary stalls do not drop, duplicate, or reorder data
+- malformed order, early/late group-last, nonzero padding, or context mismatch
+  sets protocol error
+- reset discards partial group state
+
+Standalone equivalence and PPA do not close the local-reducer-to-root path.
+The follow-on composition must connect actual reducer validity through the
+endpoint/mesh to actual global-tree readiness.

--- a/npu/sim/rtl/local_reducer_aggregate_exact_codec_matched_ppa_harness.sv
+++ b/npu/sim/rtl/local_reducer_aggregate_exact_codec_matched_ppa_harness.sv
@@ -29,6 +29,8 @@ module local_reducer_aggregate_exact_codec_matched_ppa_harness #(
   reg [15:0] expected_group_id_q;
   reg [7:0] source_group_beat_q;
   reg [7:0] decoded_group_beat_q;
+  reg [VALUE_W-1:0] source_value_q;
+  reg [VALUE_W-1:0] expected_value_q;
   reg group_open_q;
   reg [31:0] observed_q;
   reg mismatch_q;
@@ -44,7 +46,7 @@ module local_reducer_aggregate_exact_codec_matched_ppa_harness #(
     (cycle_count_q[5:2] != 4'he);
 
   wire [BEAT_W-1:0] source_beat = make_canonical_beat(
-    group_id_q, source_group_beat_q);
+    group_id_q, source_group_beat_q, source_value_q);
   wire source_ready;
   wire encoder_flit_valid;
   wire encoder_flit_ready;
@@ -73,7 +75,7 @@ module local_reducer_aggregate_exact_codec_matched_ppa_harness #(
   wire decoded_fire = decoded_valid && decoded_ready;
   wire decoded_group_last = decoded_fire && (decoded_group_beat_q == 8'd127);
   wire [BEAT_W-1:0] expected_decoded_beat = make_canonical_beat(
-    expected_group_id_q, decoded_group_beat_q);
+    expected_group_id_q, decoded_group_beat_q, expected_value_q);
 
   assign accepted_beat_count = accepted_count_q;
   assign emitted_flit_count = emitted_count_q;
@@ -85,31 +87,26 @@ module local_reducer_aggregate_exact_codec_matched_ppa_harness #(
   assign protocol_error = encoder_protocol_error | decoder_protocol_error |
     mismatch_q;
 
-  function automatic [VALUE_W-1:0] canonical_value;
+  function automatic [VALUE_W-1:0] seed_value;
     input [15:0] group_id;
-    input [7:0] beat_index;
-    reg [31:0] state;
-    integer lane;
     begin
-      canonical_value = {VALUE_W{1'b0}};
-      for (lane = 0; lane < 10; lane = lane + 1) begin
-        state = 32'h6d2b79f5 ^ (group_id * 32'h9e3779b9) ^
-          (beat_index * 32'h45d9f3b) ^ (lane * 32'h27d4eb2d);
-        state = state ^ (state << 13);
-        state = state ^ (state >> 17);
-        state = state ^ (state << 5);
-        canonical_value[(lane * 32) +: 32] = state;
-      end
-      state = 32'hb5297a4d ^ (group_id * 32'h7f4a7c15) ^
-        (beat_index * 32'h94d049bb);
-      state = state ^ (state << 13) ^ (state >> 11);
-      canonical_value[320 +: 8] = state[7:0];
+      seed_value = {{10{32'h6d2b_79f5}}, 8'hb5} ^
+        {{20{group_id}}, group_id[7:0]};
+    end
+  endfunction
+
+  function automatic [VALUE_W-1:0] advance_value;
+    input [VALUE_W-1:0] value;
+    begin
+      advance_value = {value[VALUE_W-2:0],
+        value[VALUE_W-1] ^ value[211] ^ value[107] ^ value[0]};
     end
   endfunction
 
   function automatic [BEAT_W-1:0] make_canonical_beat;
     input [15:0] group_id;
     input [7:0] beat_index;
+    input [VALUE_W-1:0] value;
     reg [4:0] head;
     reg [3:0] slice;
     reg [31:0] head_max;
@@ -117,10 +114,10 @@ module local_reducer_aggregate_exact_codec_matched_ppa_harness #(
     begin
       head = {3'b000, group_id[1:0], 3'b000} + (beat_index >> 4);
       slice = beat_index[3:0];
-      head_max = 32'h1200_0000 ^ (group_id * 32'h0101_0101) ^
-        ((beat_index >> 4) * 32'h0011_1111);
-      head_sum = 33'h0_1a2b_3c4d ^ (group_id * 33'h0_0001_2345) ^
-        ((beat_index >> 4) * 33'h0_0000_1111);
+      head_max = 32'h1200_0000 ^ {group_id, group_id} ^
+        {24'b0, beat_index[7:4], beat_index[7:4]};
+      head_sum = 33'h0_1a2b_3c4d ^ {1'b0, group_id, group_id} ^
+        {25'b0, beat_index[7:4], beat_index[7:4]};
       make_canonical_beat = {BEAT_W{1'b0}};
       make_canonical_beat[15:0] = group_id;
       make_canonical_beat[20:16] = head;
@@ -128,7 +125,7 @@ module local_reducer_aggregate_exact_codec_matched_ppa_harness #(
       make_canonical_beat[85:53] = head_sum;
       make_canonical_beat[89:86] = slice;
       make_canonical_beat[90] = (slice == 4'd15);
-      make_canonical_beat[BEAT_W-1:91] = canonical_value(group_id, beat_index);
+      make_canonical_beat[BEAT_W-1:91] = value;
     end
   endfunction
 
@@ -242,6 +239,8 @@ module local_reducer_aggregate_exact_codec_matched_ppa_harness #(
       expected_group_id_q <= 16'b0;
       source_group_beat_q <= 8'b0;
       decoded_group_beat_q <= 8'b0;
+      source_value_q <= seed_value(16'b0);
+      expected_value_q <= seed_value(16'b0);
       group_open_q <= 1'b0;
       observed_q <= 32'b0;
       mismatch_q <= 1'b0;
@@ -253,10 +252,13 @@ module local_reducer_aggregate_exact_codec_matched_ppa_harness #(
         expected_group_id_q <= group_id_q;
         source_group_beat_q <= 8'b0;
         decoded_group_beat_q <= 8'b0;
+        source_value_q <= seed_value(group_id_q);
+        expected_value_q <= seed_value(group_id_q);
       end
 
       if (source_fire) begin
         accepted_count_q <= accepted_count_q + 1'b1;
+        source_value_q <= advance_value(source_value_q);
         if (source_group_beat_q < 8'd127)
           source_group_beat_q <= source_group_beat_q + 1'b1;
         else
@@ -268,6 +270,7 @@ module local_reducer_aggregate_exact_codec_matched_ppa_harness #(
 
       if (decoded_fire) begin
         decoded_count_q <= decoded_count_q + 1'b1;
+        expected_value_q <= advance_value(expected_value_q);
         observed_q <= observed_q ^ fold_all_bits(decoded_data);
         if (decoded_data != expected_decoded_beat)
           mismatch_q <= 1'b1;

--- a/npu/sim/rtl/local_reducer_aggregate_exact_codec_matched_ppa_harness.sv
+++ b/npu/sim/rtl/local_reducer_aggregate_exact_codec_matched_ppa_harness.sv
@@ -70,6 +70,7 @@ module local_reducer_aggregate_exact_codec_matched_ppa_harness #(
   wire decoder_group_ctx_ready;
   wire context_ready;
   wire context_fire = group_ctx_valid && context_ready;
+  wire paired_group_ctx_valid = group_ctx_valid && context_ready;
   wire source_fire = common_source_valid && source_ready;
   wire flit_fire = encoder_flit_valid && encoder_flit_ready;
   wire decoded_fire = decoded_valid && decoded_ready;
@@ -194,7 +195,7 @@ module local_reducer_aggregate_exact_codec_matched_ppa_harness #(
       local_reducer_aggregate_stats_once_exact_encoder u_encoder (
         .clk(clk),
         .rst_n(rst_n),
-        .group_ctx_valid(group_ctx_valid),
+        .group_ctx_valid(paired_group_ctx_valid),
         .group_ctx_ready(encoder_group_ctx_ready),
         .group_command_id(group_command_id),
         .group_head_base(group_head_base),
@@ -212,7 +213,7 @@ module local_reducer_aggregate_exact_codec_matched_ppa_harness #(
       local_reducer_aggregate_stats_once_exact_decoder u_decoder (
         .clk(clk),
         .rst_n(rst_n),
-        .group_ctx_valid(group_ctx_valid),
+        .group_ctx_valid(paired_group_ctx_valid),
         .group_ctx_ready(decoder_group_ctx_ready),
         .group_command_id(group_command_id),
         .group_head_base(group_head_base),

--- a/npu/sim/rtl/local_reducer_aggregate_exact_codec_matched_ppa_harness.sv
+++ b/npu/sim/rtl/local_reducer_aggregate_exact_codec_matched_ppa_harness.sv
@@ -36,7 +36,7 @@ module local_reducer_aggregate_exact_codec_matched_ppa_harness #(
   reg mismatch_q;
 
   wire [15:0] group_command_id = group_id_q;
-  wire [4:0] group_head_base = {3'b000, group_id_q[1:0], 3'b000};
+  wire [4:0] group_head_base = {group_id_q[1:0], 3'b000};
   wire group_ctx_valid = !group_open_q;
   wire common_source_valid = group_open_q &&
     (source_group_beat_q < 8'd128) && (cycle_count_q[2:0] != 3'b111);
@@ -112,7 +112,7 @@ module local_reducer_aggregate_exact_codec_matched_ppa_harness #(
     reg [31:0] head_max;
     reg [32:0] head_sum;
     begin
-      head = {3'b000, group_id[1:0], 3'b000} + (beat_index >> 4);
+      head = {group_id[1:0], 3'b000} + {1'b0, beat_index[7:4]};
       slice = beat_index[3:0];
       head_max = 32'h1200_0000 ^ {group_id, group_id} ^
         {24'b0, beat_index[7:4], beat_index[7:4]};

--- a/npu/sim/rtl/local_reducer_aggregate_exact_codec_matched_ppa_harness.sv
+++ b/npu/sim/rtl/local_reducer_aggregate_exact_codec_matched_ppa_harness.sv
@@ -1,0 +1,301 @@
+`timescale 1ns/1ps
+
+// Matched activity harness for the aligned and stats-once exact transports.
+// The source, stalls, counters, and full-bit sink are intentionally shared so
+// that a PPA comparison changes only the transport codec.
+module local_reducer_aggregate_exact_codec_matched_ppa_harness #(
+  parameter integer MODE_STATS_ONCE = 0,
+  parameter integer COUNTER_W = 32
+) (
+  input wire clk,
+  input wire rst_n,
+  output wire [31:0] observed_data,
+  output wire [COUNTER_W-1:0] accepted_beat_count,
+  output wire [COUNTER_W-1:0] emitted_flit_count,
+  output wire [COUNTER_W-1:0] decoded_beat_count,
+  output wire [COUNTER_W-1:0] completed_group_count,
+  output wire protocol_error
+);
+  localparam integer BEAT_W = 419;
+  localparam integer FLIT_W = 256;
+  localparam integer VALUE_W = 328;
+
+  reg [COUNTER_W-1:0] cycle_count_q;
+  reg [COUNTER_W-1:0] accepted_count_q;
+  reg [COUNTER_W-1:0] emitted_count_q;
+  reg [COUNTER_W-1:0] decoded_count_q;
+  reg [COUNTER_W-1:0] completed_group_count_q;
+  reg [15:0] group_id_q;
+  reg [15:0] expected_group_id_q;
+  reg [7:0] source_group_beat_q;
+  reg [7:0] decoded_group_beat_q;
+  reg group_open_q;
+  reg [31:0] observed_q;
+  reg mismatch_q;
+
+  wire [15:0] group_command_id = group_id_q;
+  wire [4:0] group_head_base = {3'b000, group_id_q[1:0], 3'b000};
+  wire group_ctx_valid = !group_open_q;
+  wire common_source_valid = group_open_q &&
+    (source_group_beat_q < 8'd128) && (cycle_count_q[2:0] != 3'b111);
+  wire common_flit_ready = (cycle_count_q[4:0] != 5'h03) &&
+    (cycle_count_q[4:0] != 5'h11) && (cycle_count_q[4:0] != 5'h1c);
+  wire common_decoded_ready = (cycle_count_q[5:2] != 4'hb) &&
+    (cycle_count_q[5:2] != 4'he);
+
+  wire [BEAT_W-1:0] source_beat = make_canonical_beat(
+    group_id_q, source_group_beat_q);
+  wire source_ready;
+  wire encoder_flit_valid;
+  wire encoder_flit_ready;
+  wire [FLIT_W-1:0] encoder_flit_data;
+  wire encoder_flit_phase;
+  wire encoder_flit_beat_last;
+  wire encoder_flit_group_last;
+  wire decoder_flit_valid;
+  wire decoder_flit_ready;
+  wire [FLIT_W-1:0] decoder_flit_data;
+  wire decoder_flit_phase;
+  wire decoder_flit_beat_last;
+  wire decoder_flit_group_last;
+  wire decoded_valid;
+  wire decoded_ready = common_decoded_ready;
+  wire [BEAT_W-1:0] decoded_data;
+  wire decoder_partial_valid;
+  wire encoder_protocol_error;
+  wire decoder_protocol_error;
+  wire encoder_group_ctx_ready;
+  wire decoder_group_ctx_ready;
+  wire context_ready;
+  wire context_fire = group_ctx_valid && context_ready;
+  wire source_fire = common_source_valid && source_ready;
+  wire flit_fire = encoder_flit_valid && encoder_flit_ready;
+  wire decoded_fire = decoded_valid && decoded_ready;
+  wire decoded_group_last = decoded_fire && (decoded_group_beat_q == 8'd127);
+  wire [BEAT_W-1:0] expected_decoded_beat = make_canonical_beat(
+    expected_group_id_q, decoded_group_beat_q);
+
+  assign accepted_beat_count = accepted_count_q;
+  assign emitted_flit_count = emitted_count_q;
+  assign decoded_beat_count = decoded_count_q;
+  assign completed_group_count = completed_group_count_q;
+  assign observed_data = observed_q;
+  // The exact decoded-beat comparison is part of the direct harness gate.
+  // Keep the public interface limited to the generator integration contract.
+  assign protocol_error = encoder_protocol_error | decoder_protocol_error |
+    mismatch_q;
+
+  function automatic [VALUE_W-1:0] canonical_value;
+    input [15:0] group_id;
+    input [7:0] beat_index;
+    reg [31:0] state;
+    integer lane;
+    begin
+      canonical_value = {VALUE_W{1'b0}};
+      for (lane = 0; lane < 10; lane = lane + 1) begin
+        state = 32'h6d2b79f5 ^ (group_id * 32'h9e3779b9) ^
+          (beat_index * 32'h45d9f3b) ^ (lane * 32'h27d4eb2d);
+        state = state ^ (state << 13);
+        state = state ^ (state >> 17);
+        state = state ^ (state << 5);
+        canonical_value[(lane * 32) +: 32] = state;
+      end
+      state = 32'hb5297a4d ^ (group_id * 32'h7f4a7c15) ^
+        (beat_index * 32'h94d049bb);
+      state = state ^ (state << 13) ^ (state >> 11);
+      canonical_value[320 +: 8] = state[7:0];
+    end
+  endfunction
+
+  function automatic [BEAT_W-1:0] make_canonical_beat;
+    input [15:0] group_id;
+    input [7:0] beat_index;
+    reg [4:0] head;
+    reg [3:0] slice;
+    reg [31:0] head_max;
+    reg [32:0] head_sum;
+    begin
+      head = {3'b000, group_id[1:0], 3'b000} + (beat_index >> 4);
+      slice = beat_index[3:0];
+      head_max = 32'h1200_0000 ^ (group_id * 32'h0101_0101) ^
+        ((beat_index >> 4) * 32'h0011_1111);
+      head_sum = 33'h0_1a2b_3c4d ^ (group_id * 33'h0_0001_2345) ^
+        ((beat_index >> 4) * 33'h0_0000_1111);
+      make_canonical_beat = {BEAT_W{1'b0}};
+      make_canonical_beat[15:0] = group_id;
+      make_canonical_beat[20:16] = head;
+      make_canonical_beat[52:21] = head_max;
+      make_canonical_beat[85:53] = head_sum;
+      make_canonical_beat[89:86] = slice;
+      make_canonical_beat[90] = (slice == 4'd15);
+      make_canonical_beat[BEAT_W-1:91] = canonical_value(group_id, beat_index);
+    end
+  endfunction
+
+  function automatic [31:0] fold_all_bits;
+    input [BEAT_W-1:0] value;
+    integer bit_i;
+    begin
+      fold_all_bits = 32'b0;
+      for (bit_i = 0; bit_i < BEAT_W; bit_i = bit_i + 1)
+        fold_all_bits[bit_i % 32] = fold_all_bits[bit_i % 32] ^ value[bit_i];
+    end
+  endfunction
+
+  generate
+    if (MODE_STATS_ONCE == 0) begin : g_aligned
+      assign context_ready = 1'b1;
+      assign encoder_group_ctx_ready = 1'b1;
+      assign decoder_group_ctx_ready = 1'b1;
+      assign encoder_flit_ready = common_flit_ready && decoder_flit_ready;
+      assign decoder_flit_valid = encoder_flit_valid && common_flit_ready;
+      assign decoder_flit_data = encoder_flit_data;
+      assign decoder_flit_phase = encoder_flit_phase;
+      assign decoder_flit_beat_last = encoder_flit_beat_last;
+      assign decoder_flit_group_last = 1'b0;
+
+      (* keep_hierarchy = "yes" *)
+      local_reducer_aggregate_aligned_exact_encoder u_encoder (
+        .clk(clk),
+        .rst_n(rst_n),
+        .beat_valid(common_source_valid),
+        .beat_ready(source_ready),
+        .beat_data(source_beat),
+        .flit_valid(encoder_flit_valid),
+        .flit_ready(encoder_flit_ready),
+        .flit_data(encoder_flit_data),
+        .flit_phase(encoder_flit_phase),
+        .flit_beat_last(encoder_flit_beat_last)
+      );
+
+      (* keep_hierarchy = "yes" *)
+      local_reducer_aggregate_aligned_exact_decoder u_decoder (
+        .clk(clk),
+        .rst_n(rst_n),
+        .flit_valid(decoder_flit_valid),
+        .flit_ready(decoder_flit_ready),
+        .flit_data(decoder_flit_data),
+        .flit_phase(decoder_flit_phase),
+        .flit_beat_last(decoder_flit_beat_last),
+        .beat_valid(decoded_valid),
+        .beat_ready(decoded_ready),
+        .beat_data(decoded_data),
+        .partial_valid(decoder_partial_valid),
+        .protocol_error(decoder_protocol_error)
+      );
+      assign encoder_protocol_error = 1'b0;
+    end else begin : g_stats_once
+      assign context_ready = encoder_group_ctx_ready && decoder_group_ctx_ready;
+      assign encoder_flit_ready = common_flit_ready && decoder_flit_ready;
+      assign decoder_flit_valid = encoder_flit_valid && common_flit_ready;
+      assign decoder_flit_data = encoder_flit_data;
+      assign decoder_flit_group_last = encoder_flit_group_last;
+      assign decoder_flit_phase = 1'b0;
+      assign decoder_flit_beat_last = 1'b0;
+
+      (* keep_hierarchy = "yes" *)
+      local_reducer_aggregate_stats_once_exact_encoder u_encoder (
+        .clk(clk),
+        .rst_n(rst_n),
+        .group_ctx_valid(group_ctx_valid),
+        .group_ctx_ready(encoder_group_ctx_ready),
+        .group_command_id(group_command_id),
+        .group_head_base(group_head_base),
+        .beat_valid(common_source_valid),
+        .beat_ready(source_ready),
+        .beat_data(source_beat),
+        .flit_valid(encoder_flit_valid),
+        .flit_ready(encoder_flit_ready),
+        .flit_data(encoder_flit_data),
+        .flit_group_last(encoder_flit_group_last),
+        .protocol_error(encoder_protocol_error)
+      );
+
+      (* keep_hierarchy = "yes" *)
+      local_reducer_aggregate_stats_once_exact_decoder u_decoder (
+        .clk(clk),
+        .rst_n(rst_n),
+        .group_ctx_valid(group_ctx_valid),
+        .group_ctx_ready(decoder_group_ctx_ready),
+        .group_command_id(group_command_id),
+        .group_head_base(group_head_base),
+        .flit_valid(decoder_flit_valid),
+        .flit_ready(decoder_flit_ready),
+        .flit_data(decoder_flit_data),
+        .flit_group_last(decoder_flit_group_last),
+        .beat_valid(decoded_valid),
+        .beat_ready(decoded_ready),
+        .beat_data(decoded_data),
+        .protocol_error(decoder_protocol_error)
+      );
+    end
+  endgenerate
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      cycle_count_q <= {COUNTER_W{1'b0}};
+      accepted_count_q <= {COUNTER_W{1'b0}};
+      emitted_count_q <= {COUNTER_W{1'b0}};
+      decoded_count_q <= {COUNTER_W{1'b0}};
+      completed_group_count_q <= {COUNTER_W{1'b0}};
+      group_id_q <= 16'b0;
+      expected_group_id_q <= 16'b0;
+      source_group_beat_q <= 8'b0;
+      decoded_group_beat_q <= 8'b0;
+      group_open_q <= 1'b0;
+      observed_q <= 32'b0;
+      mismatch_q <= 1'b0;
+    end else begin
+      cycle_count_q <= cycle_count_q + 1'b1;
+
+      if (context_fire) begin
+        group_open_q <= 1'b1;
+        expected_group_id_q <= group_id_q;
+        source_group_beat_q <= 8'b0;
+        decoded_group_beat_q <= 8'b0;
+      end
+
+      if (source_fire) begin
+        accepted_count_q <= accepted_count_q + 1'b1;
+        if (source_group_beat_q < 8'd127)
+          source_group_beat_q <= source_group_beat_q + 1'b1;
+        else
+          source_group_beat_q <= 8'd128;
+      end
+
+      if (flit_fire)
+        emitted_count_q <= emitted_count_q + 1'b1;
+
+      if (decoded_fire) begin
+        decoded_count_q <= decoded_count_q + 1'b1;
+        observed_q <= observed_q ^ fold_all_bits(decoded_data);
+        if (decoded_data != expected_decoded_beat)
+          mismatch_q <= 1'b1;
+        if (decoded_group_beat_q < 8'd127)
+          decoded_group_beat_q <= decoded_group_beat_q + 1'b1;
+        else
+          decoded_group_beat_q <= 8'd128;
+      end
+
+      if (decoded_group_last) begin
+        completed_group_count_q <= completed_group_count_q + 1'b1;
+        group_open_q <= 1'b0;
+        group_id_q <= group_id_q + 1'b1;
+        decoded_group_beat_q <= 8'b0;
+      end
+    end
+  end
+
+`ifndef SYNTHESIS
+  initial begin
+    if (!((MODE_STATS_ONCE == 0) || (MODE_STATS_ONCE == 1))) begin
+      $error("MODE_STATS_ONCE must be 0 or 1");
+      $finish(1);
+    end
+    if (COUNTER_W < 8) begin
+      $error("COUNTER_W must be at least 8");
+      $finish(1);
+    end
+  end
+`endif
+endmodule

--- a/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_codec.sv
+++ b/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_codec.sv
@@ -1,0 +1,407 @@
+`timescale 1ns/1ps
+
+// Exact stats-once transport for one GQA8 aggregate group.
+//
+// The stream is little-endian at the bit level.  Each head contributes
+// max[31:0], exp_sum[32:0], and sixteen 328-bit value slices.  The rolling
+// reservoirs are deliberately bounded; neither module stores a whole group.
+
+module local_reducer_aggregate_stats_once_exact_encoder #(
+  parameter integer BEAT_W = 419,
+  parameter integer FLIT_W = 256,
+  parameter integer RESERVOIR_W = 768
+) (
+  input  wire              clk,
+  input  wire              rst_n,
+  input  wire              group_ctx_valid,
+  output wire              group_ctx_ready,
+  input  wire [15:0]       group_command_id,
+  input  wire [4:0]        group_head_base,
+  input  wire              beat_valid,
+  output wire              beat_ready,
+  input  wire [BEAT_W-1:0] beat_data,
+  output wire              flit_valid,
+  input  wire              flit_ready,
+  output wire [FLIT_W-1:0] flit_data,
+  output wire              flit_group_last,
+  output wire              protocol_error
+);
+  localparam integer VALUE_W = 328;
+  localparam integer STATS_W = 65;
+  localparam integer FIRST_APPEND_W = STATS_W + VALUE_W;
+  localparam integer BEAT_COUNT_W = 7;
+  localparam integer HEAD_OFFSET_W = 3;
+  localparam integer SLICE_W = 4;
+
+  reg active_q;
+  reg input_done_q;
+  reg [15:0] command_q;
+  reg [4:0] head_base_q;
+  reg [HEAD_OFFSET_W-1:0] head_offset_q;
+  reg [SLICE_W-1:0] slice_q;
+  reg [BEAT_COUNT_W-1:0] beat_count_q;
+  reg head_stats_valid_q;
+  reg [31:0] head_max_q;
+  reg [32:0] head_sum_q;
+  reg [RESERVOIR_W-1:0] reservoir_q;
+  reg [10:0] reservoir_count_q;
+  reg protocol_error_q;
+
+  wire flit_is_valid = active_q &&
+    ((reservoir_count_q >= FLIT_W) ||
+     (input_done_q && (reservoir_count_q != 0)));
+  wire flit_fire = flit_is_valid && flit_ready;
+  wire expected_first_slice = (slice_q == 0);
+  wire [9:0] append_count = expected_first_slice ? FIRST_APPEND_W : VALUE_W;
+  wire [10:0] reservoir_after_pop_count =
+    reservoir_count_q - (flit_fire ? FLIT_W : 0);
+  wire append_fits =
+    (reservoir_after_pop_count + append_count) <= RESERVOIR_W;
+  wire beat_fire = beat_valid && beat_ready;
+  wire [4:0] expected_head = head_base_q + head_offset_q;
+  wire order_ok =
+    (beat_data[15:0] == command_q) &&
+    (beat_data[20:16] == expected_head) &&
+    (beat_data[89:86] == slice_q) &&
+    (beat_data[90] == (slice_q == 15));
+  wire stats_ok = expected_first_slice ||
+    ((beat_data[52:21] == head_max_q) &&
+     (beat_data[85:53] == head_sum_q));
+
+  reg [FIRST_APPEND_W-1:0] append_payload;
+  reg [RESERVOIR_W-1:0] append_payload_ext;
+  reg [RESERVOIR_W-1:0] reservoir_after_pop;
+  reg [RESERVOIR_W-1:0] reservoir_after_append;
+  integer append_base;
+
+  assign group_ctx_ready = !active_q;
+  assign beat_ready = active_q && !input_done_q && append_fits;
+  assign flit_valid = flit_is_valid;
+  assign flit_data = flit_is_valid ? reservoir_q[FLIT_W-1:0] : {FLIT_W{1'b0}};
+  assign flit_group_last = flit_is_valid && input_done_q &&
+    (reservoir_count_q <= FLIT_W);
+  assign protocol_error = protocol_error_q;
+
+  // Removing a flit and appending a beat may happen in the same cycle.  The
+  // append offset is therefore based on the post-pop reservoir occupancy.
+  always @* begin
+    append_payload = {FIRST_APPEND_W{1'b0}};
+    if (expected_first_slice) begin
+      // The stream starts with the 65 statistics bits, followed by the
+      // 328-bit value.  Both subfields are themselves LSB-first.
+      append_payload[STATS_W-1:0] = beat_data[85:21];
+      append_payload[FIRST_APPEND_W-1:STATS_W] = beat_data[BEAT_W-1:91];
+    end else begin
+      append_payload[VALUE_W-1:0] = beat_data[BEAT_W-1:91];
+    end
+
+    reservoir_after_pop = reservoir_q;
+    append_base = reservoir_count_q;
+    if (flit_fire) begin
+      reservoir_after_pop = reservoir_q >> FLIT_W;
+      append_base = reservoir_count_q - FLIT_W;
+    end
+
+    append_payload_ext = {RESERVOIR_W{1'b0}};
+    append_payload_ext[FIRST_APPEND_W-1:0] = append_payload;
+    reservoir_after_append = reservoir_after_pop;
+    if (beat_fire)
+      reservoir_after_append = reservoir_after_pop |
+        (append_payload_ext << append_base);
+  end
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      active_q <= 1'b0;
+      input_done_q <= 1'b0;
+      command_q <= 16'b0;
+      head_base_q <= 5'b0;
+      head_offset_q <= 3'b0;
+      slice_q <= 4'b0;
+      beat_count_q <= 7'b0;
+      head_stats_valid_q <= 1'b0;
+      head_max_q <= 32'b0;
+      head_sum_q <= 33'b0;
+      reservoir_q <= {RESERVOIR_W{1'b0}};
+      reservoir_count_q <= 11'b0;
+      protocol_error_q <= 1'b0;
+    end else begin
+      if (group_ctx_valid && group_ctx_ready) begin
+        active_q <= 1'b1;
+        input_done_q <= 1'b0;
+        command_q <= group_command_id;
+        head_base_q <= group_head_base;
+        head_offset_q <= 3'b0;
+        slice_q <= 4'b0;
+        beat_count_q <= 7'b0;
+        head_stats_valid_q <= 1'b0;
+        head_max_q <= 32'b0;
+        head_sum_q <= 33'b0;
+        reservoir_q <= {RESERVOIR_W{1'b0}};
+        reservoir_count_q <= 11'b0;
+        if (!((group_head_base == 0) || (group_head_base == 8) ||
+              (group_head_base == 16) || (group_head_base == 24)))
+          protocol_error_q <= 1'b1;
+      end else begin
+        reservoir_q <= reservoir_after_append;
+        reservoir_count_q <= reservoir_after_pop_count +
+          (beat_fire ? append_count : 0);
+
+        if (beat_fire) begin
+          if (!order_ok || !stats_ok)
+            protocol_error_q <= 1'b1;
+          if (expected_first_slice) begin
+            head_stats_valid_q <= 1'b1;
+            head_max_q <= beat_data[52:21];
+            head_sum_q <= beat_data[85:53];
+          end
+          beat_count_q <= beat_count_q + 1'b1;
+          if (beat_count_q == 7'd127) begin
+            input_done_q <= 1'b1;
+          end else if (slice_q == 4'd15) begin
+            head_offset_q <= head_offset_q + 1'b1;
+            slice_q <= 4'b0;
+            head_stats_valid_q <= 1'b0;
+          end else begin
+            slice_q <= slice_q + 1'b1;
+          end
+        end
+
+        if (flit_fire && input_done_q && (reservoir_count_q <= FLIT_W)) begin
+          active_q <= 1'b0;
+          input_done_q <= 1'b0;
+          head_stats_valid_q <= 1'b0;
+        end
+      end
+    end
+  end
+
+`ifndef SYNTHESIS
+  initial begin
+    if (BEAT_W != 419) begin
+      $error("stats-once encoder BEAT_W must be 419");
+      $finish(1);
+    end
+    if (FLIT_W != 256) begin
+      $error("stats-once encoder FLIT_W must be 256");
+      $finish(1);
+    end
+    if (RESERVOIR_W < 648) begin
+      $error("stats-once encoder RESERVOIR_W must be at least 648");
+      $finish(1);
+    end
+  end
+`endif
+endmodule
+
+
+module local_reducer_aggregate_stats_once_exact_decoder #(
+  parameter integer BEAT_W = 419,
+  parameter integer FLIT_W = 256,
+  parameter integer RESERVOIR_W = 768
+) (
+  input  wire              clk,
+  input  wire              rst_n,
+  input  wire              group_ctx_valid,
+  output wire              group_ctx_ready,
+  input  wire [15:0]       group_command_id,
+  input  wire [4:0]        group_head_base,
+  input  wire              flit_valid,
+  output wire              flit_ready,
+  input  wire [FLIT_W-1:0] flit_data,
+  input  wire              flit_group_last,
+  output wire              beat_valid,
+  input  wire              beat_ready,
+  output wire [BEAT_W-1:0] beat_data,
+  output wire              protocol_error
+);
+  localparam integer VALUE_W = 328;
+  localparam integer STATS_W = 65;
+  localparam integer FIRST_BITS = STATS_W + VALUE_W;
+
+  reg active_q;
+  reg input_done_q;
+  reg [15:0] command_q;
+  reg [4:0] head_base_q;
+  reg [2:0] head_offset_q;
+  reg [3:0] slice_q;
+  reg [7:0] flit_index_q;
+  reg [7:0] beat_count_q;
+  reg [31:0] head_max_q;
+  reg [32:0] head_sum_q;
+  reg [RESERVOIR_W-1:0] reservoir_q;
+  reg [10:0] reservoir_count_q;
+  reg beat_valid_q;
+  reg [BEAT_W-1:0] beat_data_q;
+  reg protocol_error_q;
+
+  wire first_slice = (slice_q == 0);
+  wire [9:0] needed_bits = first_slice ? FIRST_BITS : VALUE_W;
+  wire beat_fire = beat_valid_q && beat_ready;
+  wire beat_slot_available = !beat_valid_q || beat_fire;
+  wire flit_is_last_position = (flit_index_q == 8'd166);
+  wire [9:0] accepted_flit_bits = flit_is_last_position ? 10'd8 : FLIT_W;
+  wire flit_padding_zero = (flit_data[FLIT_W-1:8] == {(FLIT_W-8){1'b0}});
+  wire parse_fire = active_q && beat_slot_available &&
+    (beat_count_q < 128) && (reservoir_count_q >= needed_bits);
+  wire [10:0] reservoir_after_parse_count = reservoir_count_q -
+    (parse_fire ? needed_bits : 0);
+  wire flit_has_room =
+    (reservoir_after_parse_count + accepted_flit_bits) <= RESERVOIR_W;
+  wire flit_fire = flit_valid && flit_ready;
+
+  reg [BEAT_W-1:0] parsed_beat;
+  reg [VALUE_W-1:0] parsed_value;
+  reg [31:0] parsed_max;
+  reg [32:0] parsed_sum;
+  reg [RESERVOIR_W-1:0] shifted_reservoir;
+  reg [RESERVOIR_W-1:0] flit_payload_ext;
+  reg [RESERVOIR_W-1:0] reservoir_after_events;
+  integer flit_append_base;
+
+  assign group_ctx_ready = !active_q;
+  // A consumed output beat opens the output slot in the same cycle.  Parsing
+  // and flit reception may therefore overlap, with the flit appended after
+  // the parsed bits in the post-parse reservoir.
+  assign flit_ready = active_q && !input_done_q && flit_has_room;
+  assign beat_valid = beat_valid_q;
+  assign beat_data = beat_data_q;
+  assign protocol_error = protocol_error_q;
+
+  always @* begin
+    parsed_max = reservoir_q[31:0];
+    parsed_sum = reservoir_q[64:32];
+    if (first_slice)
+      parsed_value = reservoir_q >> STATS_W;
+    else
+      parsed_value = reservoir_q[VALUE_W-1:0];
+
+    parsed_beat = {BEAT_W{1'b0}};
+    parsed_beat[15:0] = command_q;
+    parsed_beat[20:16] = head_base_q + head_offset_q;
+    parsed_beat[52:21] = first_slice ? parsed_max : head_max_q;
+    parsed_beat[85:53] = first_slice ? parsed_sum : head_sum_q;
+    parsed_beat[89:86] = slice_q;
+    parsed_beat[90] = (slice_q == 15);
+    parsed_beat[BEAT_W-1:91] = parsed_value;
+    shifted_reservoir = reservoir_q >> needed_bits;
+
+    flit_payload_ext = {RESERVOIR_W{1'b0}};
+    if (flit_is_last_position)
+      flit_payload_ext[7:0] = flit_data[7:0];
+    else
+      flit_payload_ext[FLIT_W-1:0] = flit_data;
+    flit_append_base = reservoir_after_parse_count;
+    reservoir_after_events = shifted_reservoir;
+    if (!parse_fire)
+      reservoir_after_events = reservoir_q;
+    if (flit_fire)
+      reservoir_after_events = reservoir_after_events |
+        (flit_payload_ext << flit_append_base);
+  end
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      active_q <= 1'b0;
+      input_done_q <= 1'b0;
+      command_q <= 16'b0;
+      head_base_q <= 5'b0;
+      head_offset_q <= 3'b0;
+      slice_q <= 4'b0;
+      flit_index_q <= 8'b0;
+      beat_count_q <= 8'b0;
+      head_max_q <= 32'b0;
+      head_sum_q <= 33'b0;
+      reservoir_q <= {RESERVOIR_W{1'b0}};
+      reservoir_count_q <= 11'b0;
+      beat_valid_q <= 1'b0;
+      beat_data_q <= {BEAT_W{1'b0}};
+      protocol_error_q <= 1'b0;
+    end else begin
+      if (group_ctx_valid && group_ctx_ready) begin
+        active_q <= 1'b1;
+        input_done_q <= 1'b0;
+        command_q <= group_command_id;
+        head_base_q <= group_head_base;
+        head_offset_q <= 3'b0;
+        slice_q <= 4'b0;
+        flit_index_q <= 8'b0;
+        beat_count_q <= 8'b0;
+        head_max_q <= 32'b0;
+        head_sum_q <= 33'b0;
+        reservoir_q <= {RESERVOIR_W{1'b0}};
+        reservoir_count_q <= 11'b0;
+        beat_valid_q <= 1'b0;
+        beat_data_q <= {BEAT_W{1'b0}};
+        if (!((group_head_base == 0) || (group_head_base == 8) ||
+              (group_head_base == 16) || (group_head_base == 24)))
+          protocol_error_q <= 1'b1;
+      end else begin
+        if (beat_fire) begin
+          beat_valid_q <= 1'b0;
+          beat_data_q <= {BEAT_W{1'b0}};
+        end
+
+        reservoir_q <= reservoir_after_events;
+        reservoir_count_q <= reservoir_after_parse_count +
+          (flit_fire ? accepted_flit_bits : 0);
+
+        if (flit_fire) begin
+          if (flit_group_last != flit_is_last_position)
+            protocol_error_q <= 1'b1;
+          if (flit_is_last_position && !flit_padding_zero)
+            protocol_error_q <= 1'b1;
+          // An early group-last is an error marker only.  The decoder still
+          // requires the exact-position terminal flit and cannot close from
+          // the early marker.
+          if (flit_is_last_position)
+            input_done_q <= 1'b1;
+          if (!flit_is_last_position)
+            flit_index_q <= flit_index_q + 1'b1;
+        end
+
+        if (parse_fire) begin
+          beat_valid_q <= 1'b1;
+          beat_data_q <= parsed_beat;
+          beat_count_q <= beat_count_q + 1'b1;
+          if (first_slice) begin
+            head_max_q <= parsed_max;
+            head_sum_q <= parsed_sum;
+          end
+          if (slice_q == 4'd15) begin
+            head_offset_q <= head_offset_q + 1'b1;
+            slice_q <= 4'b0;
+          end else begin
+            slice_q <= slice_q + 1'b1;
+          end
+        end
+
+        // A valid group closes only after all 128 reconstructed beats have
+        // drained.  A malformed/truncated group can be abandoned once its
+        // reservoir is empty, while retaining the sticky error indication.
+        if (input_done_q && beat_count_q == 8'd128 && beat_fire &&
+            reservoir_after_parse_count == 0) begin
+          active_q <= 1'b0;
+          input_done_q <= 1'b0;
+        end
+      end
+    end
+  end
+
+`ifndef SYNTHESIS
+  initial begin
+    if (BEAT_W != 419) begin
+      $error("stats-once decoder BEAT_W must be 419");
+      $finish(1);
+    end
+    if (FLIT_W != 256) begin
+      $error("stats-once decoder FLIT_W must be 256");
+      $finish(1);
+    end
+    if (RESERVOIR_W < 584) begin
+      $error("stats-once decoder RESERVOIR_W must be at least 584");
+      $finish(1);
+    end
+  end
+`endif
+endmodule

--- a/runs/campaigns/noc/l1_attention_score32_exact_matched_codec/sweeps/nangate45_macro_frontier.json
+++ b/runs/campaigns/noc/l1_attention_score32_exact_matched_codec/sweeps/nangate45_macro_frontier.json
@@ -1,0 +1,8 @@
+{
+  "tag_prefix": "l1_attention_score32_exact_matched_codec_nangate45_macro_frontier",
+  "flow_params": {
+    "CLOCK_PERIOD": [1.0, 1.5, 2.0],
+    "CORE_UTILIZATION": [40, 50, 60],
+    "PLACE_DENSITY": [0.52]
+  }
+}

--- a/runs/designs/noc/l1_attention_score32_exact_matched_aligned_codec_w419_f256_wrapper/config_l1_attention_score32_exact_matched_aligned_codec_w419_f256.json
+++ b/runs/designs/noc/l1_attention_score32_exact_matched_aligned_codec_w419_f256_wrapper/config_l1_attention_score32_exact_matched_aligned_codec_w419_f256.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "flit",
+      "dimensions": 1,
+      "bit_width": 256,
+      "signed": false,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "l1_memory_noc_primitive",
+      "module_name": "l1_attention_score32_exact_matched_aligned_codec_w419_f256",
+      "operand": "flit",
+      "options": {
+        "primitive": "exact_matched_codec",
+        "codec_mode": "aligned",
+        "flit_bits": 256,
+        "depth": 2,
+        "ports": 2,
+        "banks": 2,
+        "counter_bits": 32
+      }
+    }
+  ]
+}

--- a/runs/designs/noc/l1_attention_score32_exact_matched_stats_once_codec_w419_f256_wrapper/config_l1_attention_score32_exact_matched_stats_once_codec_w419_f256.json
+++ b/runs/designs/noc/l1_attention_score32_exact_matched_stats_once_codec_w419_f256_wrapper/config_l1_attention_score32_exact_matched_stats_once_codec_w419_f256.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.1",
+  "operands": [
+    {
+      "name": "flit",
+      "dimensions": 1,
+      "bit_width": 256,
+      "signed": false,
+      "kind": "int"
+    }
+  ],
+  "operations": [
+    {
+      "type": "l1_memory_noc_primitive",
+      "module_name": "l1_attention_score32_exact_matched_stats_once_codec_w419_f256",
+      "operand": "flit",
+      "options": {
+        "primitive": "exact_matched_codec",
+        "codec_mode": "stats_once",
+        "flit_bits": 256,
+        "depth": 2,
+        "ports": 2,
+        "banks": 2,
+        "counter_bits": 32
+      }
+    }
+  ]
+}

--- a/scripts/generate_design.py
+++ b/scripts/generate_design.py
@@ -454,11 +454,12 @@ def identify_design(config):
             "sram_packet_mesh4x4",
             "descriptor_pair_scheduler",
             "exact_aligned_codec",
+            "exact_matched_codec",
         ):
             raise ValueError(
                 "l1_memory_noc_primitive primitive must be fifo, router, endpoint, segmented_router, "
                 "segmented_mesh4x4, sram_packet_endpoint, sram_packet_mesh4x4, "
-                "descriptor_pair_scheduler, or exact_aligned_codec"
+                "descriptor_pair_scheduler, exact_aligned_codec, or exact_matched_codec"
             )
         if flit_bits <= 0:
             raise ValueError("l1_memory_noc_primitive flit_bits must be positive")
@@ -541,6 +542,19 @@ def identify_design(config):
             raise ValueError(
                 "l1_memory_noc_primitive exact_aligned_codec requires counter_bits >= 4"
             )
+        codec_mode = str(options.get("codec_mode", "aligned"))
+        if primitive == "exact_matched_codec" and flit_bits != 256:
+            raise ValueError(
+                "l1_memory_noc_primitive exact_matched_codec requires 256-bit flits"
+            )
+        if primitive == "exact_matched_codec" and counter_bits < 8:
+            raise ValueError(
+                "l1_memory_noc_primitive exact_matched_codec requires counter_bits >= 8"
+            )
+        if primitive == "exact_matched_codec" and codec_mode not in ("aligned", "stats_once"):
+            raise ValueError(
+                "l1_memory_noc_primitive exact_matched_codec codec_mode must be aligned or stats_once"
+            )
         return {
             "kind": "l1_memory_noc_primitive",
             "module_name": module_name,
@@ -561,6 +575,7 @@ def identify_design(config):
             "addr_bits": addr_bits,
             "flit_count_bits": flit_count_bits,
             "command_source": command_source,
+            "codec_mode": codec_mode,
             "tx_desc_depth": tx_desc_depth,
             "tx_outstanding": tx_outstanding,
             "rx_contexts": rx_contexts,
@@ -1019,6 +1034,18 @@ def generate_l1_memory_noc_design(src_dir, design):
         for filename in (
             "local_reducer_aggregate_aligned_exact_codec.sv",
             "local_reducer_aggregate_aligned_exact_codec_ppa_harness.sv",
+        ):
+            rtl_path = repo_root / "npu" / "sim" / "rtl" / filename
+            Path(src_dir, Path(filename).with_suffix(".v")).write_text(
+                rtl_path.read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+    elif design["primitive"] == "exact_matched_codec":
+        text = _emit_l1_exact_matched_codec(module_name, design)
+        for filename in (
+            "local_reducer_aggregate_aligned_exact_codec.sv",
+            "local_reducer_aggregate_stats_once_exact_codec.sv",
+            "local_reducer_aggregate_exact_codec_matched_ppa_harness.sv",
         ):
             rtl_path = repo_root / "npu" / "sim" / "rtl" / filename
             Path(src_dir, Path(filename).with_suffix(".v")).write_text(
@@ -1803,6 +1830,38 @@ module {module_name}(
     .accepted_beat_count(accepted_beat_count),
     .emitted_flit_count(emitted_flit_count),
     .decoded_beat_count(decoded_beat_count),
+    .protocol_error(protocol_error)
+  );
+endmodule
+"""
+
+
+def _emit_l1_exact_matched_codec(module_name, design):
+    mode_stats_once = 1 if design["codec_mode"] == "stats_once" else 0
+    return f"""
+`timescale 1ns/1ps
+
+module {module_name}(
+  input clk,
+  input rst_n,
+  output [31:0] observed_data,
+  output [{design['counter_bits']-1}:0] accepted_beat_count,
+  output [{design['counter_bits']-1}:0] emitted_flit_count,
+  output [{design['counter_bits']-1}:0] decoded_beat_count,
+  output [{design['counter_bits']-1}:0] completed_group_count,
+  output protocol_error
+);
+  local_reducer_aggregate_exact_codec_matched_ppa_harness #(
+    .MODE_STATS_ONCE({mode_stats_once}),
+    .COUNTER_W({design['counter_bits']})
+  ) harness (
+    .clk(clk),
+    .rst_n(rst_n),
+    .observed_data(observed_data),
+    .accepted_beat_count(accepted_beat_count),
+    .emitted_flit_count(emitted_flit_count),
+    .decoded_beat_count(decoded_beat_count),
+    .completed_group_count(completed_group_count),
     .protocol_error(protocol_error)
   );
 endmodule
@@ -2721,6 +2780,32 @@ module {wrapper_name}(
 
 endmodule
 """
+        elif design["primitive"] == "exact_matched_codec":
+            wrapper_content = f"""
+module {wrapper_name}(
+  input clk,
+  input rst_n,
+  output [31:0] observed_data,
+  output [{counter_bits-1}:0] accepted_beat_count,
+  output [{counter_bits-1}:0] emitted_flit_count,
+  output [{counter_bits-1}:0] decoded_beat_count,
+  output [{counter_bits-1}:0] completed_group_count,
+  output protocol_error
+);
+
+  {module_name} dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .observed_data(observed_data),
+    .accepted_beat_count(accepted_beat_count),
+    .emitted_flit_count(emitted_flit_count),
+    .decoded_beat_count(decoded_beat_count),
+    .completed_group_count(completed_group_count),
+    .protocol_error(protocol_error)
+  );
+
+endmodule
+"""
         else:
             wrapper_content = f"""
 module {wrapper_name}(
@@ -2786,6 +2871,17 @@ def generate_config_mk(platform_dir, platform, design):
             [
                 f"$(DESIGN_HOME)/src/{wrapper_name}/local_reducer_aggregate_aligned_exact_codec.v",
                 f"$(DESIGN_HOME)/src/{wrapper_name}/local_reducer_aggregate_aligned_exact_codec_ppa_harness.v",
+            ]
+        )
+    if (
+        design["kind"] == "l1_memory_noc_primitive"
+        and design["primitive"] == "exact_matched_codec"
+    ):
+        verilog_files.extend(
+            [
+                f"$(DESIGN_HOME)/src/{wrapper_name}/local_reducer_aggregate_aligned_exact_codec.v",
+                f"$(DESIGN_HOME)/src/{wrapper_name}/local_reducer_aggregate_stats_once_exact_codec.v",
+                f"$(DESIGN_HOME)/src/{wrapper_name}/local_reducer_aggregate_exact_codec_matched_ppa_harness.v",
             ]
         )
 

--- a/tests/local_reducer_aggregate_exact_codec_matched_ppa_harness_tb.sv
+++ b/tests/local_reducer_aggregate_exact_codec_matched_ppa_harness_tb.sv
@@ -1,0 +1,114 @@
+`timescale 1ns/1ps
+
+module local_reducer_aggregate_exact_codec_matched_ppa_harness_tb;
+  localparam integer COUNTER_W = 32;
+  localparam integer REQUIRED_GROUPS = 3;
+  localparam integer MAX_CYCLES = 200000;
+
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  integer cycle_count = 0;
+
+  wire [31:0] aligned_observed;
+  wire [COUNTER_W-1:0] aligned_accepted;
+  wire [COUNTER_W-1:0] aligned_flits;
+  wire [COUNTER_W-1:0] aligned_decoded;
+  wire [COUNTER_W-1:0] aligned_groups;
+  wire aligned_error;
+
+  wire [31:0] stats_observed;
+  wire [COUNTER_W-1:0] stats_accepted;
+  wire [COUNTER_W-1:0] stats_flits;
+  wire [COUNTER_W-1:0] stats_decoded;
+  wire [COUNTER_W-1:0] stats_groups;
+  wire stats_error;
+
+  local_reducer_aggregate_exact_codec_matched_ppa_harness #(
+    .MODE_STATS_ONCE(0),
+    .COUNTER_W(COUNTER_W)
+  ) aligned_dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .observed_data(aligned_observed),
+    .accepted_beat_count(aligned_accepted),
+    .emitted_flit_count(aligned_flits),
+    .decoded_beat_count(aligned_decoded),
+    .completed_group_count(aligned_groups),
+    .protocol_error(aligned_error)
+  );
+
+  local_reducer_aggregate_exact_codec_matched_ppa_harness #(
+    .MODE_STATS_ONCE(1),
+    .COUNTER_W(COUNTER_W)
+  ) stats_dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .observed_data(stats_observed),
+    .accepted_beat_count(stats_accepted),
+    .emitted_flit_count(stats_flits),
+    .decoded_beat_count(stats_decoded),
+    .completed_group_count(stats_groups),
+    .protocol_error(stats_error)
+  );
+
+  always #5 clk = ~clk;
+
+  always @(posedge clk) begin
+    if (!rst_n)
+      cycle_count <= 0;
+    else
+      cycle_count <= cycle_count + 1;
+  end
+
+  initial begin
+    repeat (3) @(posedge clk);
+    rst_n = 1'b1;
+    while ((aligned_groups < REQUIRED_GROUPS) ||
+           (stats_groups < REQUIRED_GROUPS)) begin
+      @(posedge clk);
+      if (cycle_count >= MAX_CYCLES) begin
+        $display("FAIL timeout cycles=%0d aligned_groups=%0d stats_groups=%0d aligned_accepted=%0d aligned_flits=%0d aligned_decoded=%0d stats_accepted=%0d stats_flits=%0d stats_decoded=%0d aligned_error=%b stats_error=%b",
+          cycle_count, aligned_groups, stats_groups, aligned_accepted,
+          aligned_flits, aligned_decoded, stats_accepted, stats_flits,
+          stats_decoded, aligned_error, stats_error);
+        $finish(1);
+      end
+    end
+    #1;
+    if (aligned_error || stats_error) begin
+      $display("FAIL error aligned=%b stats=%b", aligned_error, stats_error);
+      $finish(1);
+    end
+    if (aligned_dut.mismatch_q || stats_dut.mismatch_q) begin
+      $display("FAIL exact decoded-beat comparison aligned=%b stats=%b",
+        aligned_dut.mismatch_q, stats_dut.mismatch_q);
+      $finish(1);
+    end
+    if (aligned_accepted < aligned_groups * 128 ||
+        aligned_accepted >= (aligned_groups + 1) * 128 ||
+        aligned_decoded < aligned_groups * 128 ||
+        aligned_decoded >= (aligned_groups + 1) * 128 ||
+        stats_accepted < stats_groups * 128 ||
+        stats_accepted >= (stats_groups + 1) * 128 ||
+        stats_decoded < stats_groups * 128 ||
+        stats_decoded >= (stats_groups + 1) * 128) begin
+      $display("FAIL group counters aligned accepted=%0d decoded=%0d groups=%0d stats accepted=%0d decoded=%0d groups=%0d",
+        aligned_accepted, aligned_decoded, aligned_groups, stats_accepted,
+        stats_decoded, stats_groups);
+      $finish(1);
+    end
+    if (aligned_groups < REQUIRED_GROUPS || stats_groups < REQUIRED_GROUPS ||
+        aligned_flits < aligned_groups * 256 ||
+        aligned_flits >= (aligned_groups + 1) * 256 ||
+        stats_flits < stats_groups * 167 ||
+        stats_flits >= (stats_groups + 1) * 167) begin
+      $display("FAIL counts aligned beats=%0d decoded=%0d flits=%0d stats_flits=%0d",
+        aligned_accepted, aligned_decoded, aligned_flits, stats_flits);
+      $finish(1);
+    end
+    $display("PASS local_reducer_aggregate_exact_codec_matched_ppa_harness groups=%0d beats=%0d aligned_flits=%0d stats_flits=%0d cycles=%0d observed=%h",
+      aligned_groups, aligned_decoded, aligned_flits, stats_flits,
+      cycle_count, aligned_observed);
+    $finish(0);
+  end
+endmodule

--- a/tests/local_reducer_aggregate_stats_once_exact_codec_tb.sv
+++ b/tests/local_reducer_aggregate_stats_once_exact_codec_tb.sv
@@ -1,0 +1,530 @@
+`timescale 1ns/1ps
+
+module local_reducer_aggregate_stats_once_exact_codec_tb;
+  localparam integer BEAT_W = 419;
+  localparam integer FLIT_W = 256;
+  localparam integer VALUE_W = 328;
+  localparam integer GROUP_BITS = 42504;
+  localparam integer GROUP_FLITS = 167;
+  localparam integer GROUP_BEATS = 128;
+
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  reg [31:0] stall_state = 32'h9e37_79b9;
+
+  reg normal_ctx_valid = 1'b0;
+  wire normal_enc_ctx_ready;
+  wire normal_dec_ctx_ready;
+  reg [15:0] normal_command = 16'b0;
+  reg [4:0] normal_head_base = 5'b0;
+  reg normal_beat_valid = 1'b0;
+  wire normal_beat_ready;
+  reg [BEAT_W-1:0] normal_beat_data = {BEAT_W{1'b0}};
+  wire normal_enc_flit_valid;
+  wire normal_enc_flit_ready;
+  wire [FLIT_W-1:0] normal_enc_flit_data;
+  wire normal_enc_flit_group_last;
+  wire normal_encoder_error;
+  wire normal_dec_flit_valid;
+  wire normal_dec_flit_ready;
+  wire [FLIT_W-1:0] normal_dec_flit_data;
+  wire normal_dec_flit_group_last;
+  wire normal_dec_beat_valid;
+  wire normal_dec_beat_ready;
+  wire [BEAT_W-1:0] normal_dec_beat_data;
+  wire normal_decoder_error;
+
+  reg bad_ctx_valid = 1'b0;
+  wire bad_ctx_ready;
+  reg [15:0] bad_command = 16'b0;
+  reg [4:0] bad_head_base = 5'b0;
+  reg bad_flit_valid = 1'b0;
+  wire bad_flit_ready;
+  reg [FLIT_W-1:0] bad_flit_data = {FLIT_W{1'b0}};
+  reg bad_flit_group_last = 1'b0;
+  wire bad_protocol_error;
+
+  reg [BEAT_W-1:0] expected_beats [0:GROUP_BEATS-1];
+  reg [GROUP_BITS-1:0] expected_stream;
+  integer normal_group_flit_count = 0;
+  integer normal_driver_input_count = 0;
+  integer normal_output_in_group = 0;
+  integer normal_groups_completed = 0;
+  integer valid_input_count_last = 0;
+  integer overlap_count = 0;
+  reg normal_monitor_enable = 1'b0;
+  reg flit_accept_q = 1'b0;
+  reg output_accept_q = 1'b0;
+  reg overlap_accept_q = 1'b0;
+  reg [FLIT_W-1:0] accepted_flit_data_q = {FLIT_W{1'b0}};
+  reg accepted_flit_last_q = 1'b0;
+  reg [BEAT_W-1:0] accepted_output_data_q = {BEAT_W{1'b0}};
+  reg enc_hold_valid = 1'b0;
+  reg [FLIT_W-1:0] enc_hold_data = {FLIT_W{1'b0}};
+  reg enc_hold_last = 1'b0;
+  reg dec_hold_valid = 1'b0;
+  reg [BEAT_W-1:0] dec_hold_data = {BEAT_W{1'b0}};
+
+  assign normal_enc_flit_ready = normal_dec_flit_ready && stall_state[0];
+  assign normal_dec_flit_valid = normal_enc_flit_valid && stall_state[0];
+  assign normal_dec_flit_data = normal_enc_flit_data;
+  assign normal_dec_flit_group_last = normal_enc_flit_group_last;
+  assign normal_dec_beat_ready = stall_state[1];
+  local_reducer_aggregate_stats_once_exact_encoder encoder_dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .group_ctx_valid(normal_ctx_valid),
+    .group_ctx_ready(normal_enc_ctx_ready),
+    .group_command_id(normal_command),
+    .group_head_base(normal_head_base),
+    .beat_valid(normal_beat_valid),
+    .beat_ready(normal_beat_ready),
+    .beat_data(normal_beat_data),
+    .flit_valid(normal_enc_flit_valid),
+    .flit_ready(normal_enc_flit_ready),
+    .flit_data(normal_enc_flit_data),
+    .flit_group_last(normal_enc_flit_group_last),
+    .protocol_error(normal_encoder_error)
+  );
+
+  local_reducer_aggregate_stats_once_exact_decoder decoder_dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .group_ctx_valid(normal_ctx_valid),
+    .group_ctx_ready(normal_dec_ctx_ready),
+    .group_command_id(normal_command),
+    .group_head_base(normal_head_base),
+    .flit_valid(normal_dec_flit_valid),
+    .flit_ready(normal_dec_flit_ready),
+    .flit_data(normal_dec_flit_data),
+    .flit_group_last(normal_dec_flit_group_last),
+    .beat_valid(normal_dec_beat_valid),
+    .beat_ready(normal_dec_beat_ready),
+    .beat_data(normal_dec_beat_data),
+    .protocol_error(normal_decoder_error)
+  );
+
+  wire bad_decoder_beat_valid;
+  local_reducer_aggregate_stats_once_exact_decoder bad_decoder_dut (
+    .clk(clk),
+    .rst_n(rst_n),
+    .group_ctx_valid(bad_ctx_valid),
+    .group_ctx_ready(bad_ctx_ready),
+    .group_command_id(bad_command),
+    .group_head_base(bad_head_base),
+    .flit_valid(bad_flit_valid),
+    .flit_ready(bad_flit_ready),
+    .flit_data(bad_flit_data),
+    .flit_group_last(bad_flit_group_last),
+    .beat_valid(bad_decoder_beat_valid),
+    .beat_ready(1'b1),
+    .beat_data(),
+    .protocol_error(bad_protocol_error)
+  );
+
+  always #5 clk = ~clk;
+
+  function automatic [31:0] next_stall_state;
+    input [31:0] state;
+    begin
+      next_stall_state = {state[30:0], state[31] ^ state[21] ^ state[1] ^ state[0]};
+    end
+  endfunction
+
+  function automatic [BEAT_W-1:0] make_beat;
+    input integer index;
+    input integer command_id;
+    input integer head_base;
+    input integer seed;
+    reg [BEAT_W-1:0] value;
+    integer head;
+    integer slice;
+    integer lane;
+    begin
+      value = {BEAT_W{1'b0}};
+      head = index / 16;
+      slice = index % 16;
+      value[15:0] = command_id[15:0];
+      value[20:16] = head_base + head;
+      value[52:21] = 32'h1200_0000 + seed * 32'h101 + head * 32'h31;
+      value[85:53] = 33'h1 + seed * 33'h1001 + head * 33'h71;
+      value[89:86] = slice[3:0];
+      value[90] = (slice == 15);
+      for (lane = 0; lane < 8; lane = lane + 1)
+        value[91 + lane * 41 +: 41] =
+          41'h10000 + seed * 41'h101 + index * 41'h13 + lane * 41'h7;
+      make_beat = value;
+    end
+  endfunction
+
+  function automatic [FLIT_W-1:0] expected_flit;
+    input integer flit_index;
+    reg [FLIT_W-1:0] result;
+    begin
+      result = {FLIT_W{1'b0}};
+      if (flit_index < 166)
+        result = expected_stream[flit_index * FLIT_W +: FLIT_W];
+      else
+        result[7:0] = expected_stream[166 * FLIT_W +: 8];
+      expected_flit = result;
+    end
+  endfunction
+
+  task automatic build_expected_stream;
+    integer index;
+    integer bit_position;
+    begin
+      expected_stream = {GROUP_BITS{1'b0}};
+      bit_position = 0;
+      for (index = 0; index < GROUP_BEATS; index = index + 1) begin
+        if ((index % 16) == 0) begin
+          expected_stream[bit_position +: 32] = expected_beats[index][52:21];
+          bit_position = bit_position + 32;
+          expected_stream[bit_position +: 33] = expected_beats[index][85:53];
+          bit_position = bit_position + 33;
+        end
+        expected_stream[bit_position +: VALUE_W] = expected_beats[index][BEAT_W-1:91];
+        bit_position = bit_position + VALUE_W;
+      end
+      if (bit_position != GROUP_BITS)
+        $fatal(1, "reference stream length mismatch: %0d", bit_position);
+    end
+  endtask
+
+  task automatic apply_reset;
+    begin
+      rst_n = 1'b0;
+      normal_ctx_valid = 1'b0;
+      normal_beat_valid = 1'b0;
+      normal_beat_data = {BEAT_W{1'b0}};
+      bad_ctx_valid = 1'b0;
+      bad_flit_valid = 1'b0;
+      bad_flit_data = {FLIT_W{1'b0}};
+      bad_flit_group_last = 1'b0;
+      stall_state = 32'h9e37_79b9;
+      enc_hold_valid = 1'b0;
+      dec_hold_valid = 1'b0;
+      repeat (3) @(posedge clk);
+      rst_n = 1'b1;
+      @(posedge clk);
+    end
+  endtask
+
+  task automatic send_context;
+    input integer command_id;
+    input integer head_base;
+    begin
+      @(negedge clk);
+      normal_command = command_id[15:0];
+      normal_head_base = head_base[4:0];
+      normal_ctx_valid = 1'b1;
+      while (1) begin
+        @(posedge clk);
+        if (normal_ctx_valid && normal_enc_ctx_ready && normal_dec_ctx_ready)
+          break;
+      end
+      @(negedge clk);
+      normal_ctx_valid = 1'b0;
+    end
+  endtask
+
+  task automatic send_normal_beat;
+    input [BEAT_W-1:0] value;
+    begin
+      @(negedge clk);
+      normal_beat_data = value;
+      normal_beat_valid = 1'b1;
+      while (1) begin
+        @(posedge clk);
+        if (normal_beat_valid && normal_beat_ready) begin
+          normal_driver_input_count = normal_driver_input_count + 1;
+          break;
+        end
+      end
+      @(negedge clk);
+      normal_beat_valid = 1'b0;
+      normal_beat_data = {BEAT_W{1'b0}};
+    end
+  endtask
+
+  task automatic send_normal_group;
+    input integer command_id;
+    input integer head_base;
+    input integer seed;
+    integer index;
+    integer timeout;
+    begin
+      for (index = 0; index < GROUP_BEATS; index = index + 1)
+        expected_beats[index] = make_beat(index, command_id, head_base, seed);
+      build_expected_stream();
+      normal_group_flit_count = 0;
+      normal_driver_input_count = 0;
+      normal_output_in_group = 0;
+      normal_monitor_enable = 1'b1;
+      send_context(command_id, head_base);
+      for (index = 0; index < GROUP_BEATS; index = index + 1) begin
+        send_normal_beat(expected_beats[index]);
+      end
+      timeout = 0;
+      while ((normal_group_flit_count != GROUP_FLITS) ||
+             (normal_output_in_group != GROUP_BEATS)) begin
+        @(posedge clk);
+        timeout = timeout + 1;
+        if (timeout > 200000)
+          $fatal(1, "normal group timed out flits=%0d beats=%0d",
+            normal_group_flit_count, normal_output_in_group);
+      end
+      normal_monitor_enable = 1'b0;
+      if (normal_driver_input_count != GROUP_BEATS)
+        $fatal(1, "valid group accepted %0d input beats", normal_driver_input_count);
+      valid_input_count_last = normal_driver_input_count;
+      repeat (3) @(posedge clk);
+      if (decoder_dut.active_q !== 1'b0 ||
+          decoder_dut.reservoir_count_q !== 0)
+        $fatal(1, "decoder did not close with an empty reservoir");
+      if (encoder_dut.active_q !== 1'b0)
+        $fatal(1, "encoder did not close after final group flit");
+      if (normal_encoder_error || normal_decoder_error)
+        $fatal(1, "valid group raised protocol error enc=%b dec=%b",
+          normal_encoder_error, normal_decoder_error);
+      normal_monitor_enable = 1'b0;
+      normal_groups_completed = normal_groups_completed + 1;
+    end
+  endtask
+
+  task automatic send_bad_context;
+    input integer command_id;
+    input integer head_base;
+    begin
+      @(negedge clk);
+      bad_command = command_id[15:0];
+      bad_head_base = head_base[4:0];
+      bad_ctx_valid = 1'b1;
+      while (1) begin
+        @(posedge clk);
+        if (bad_ctx_valid && bad_ctx_ready)
+          break;
+      end
+      @(negedge clk);
+      bad_ctx_valid = 1'b0;
+    end
+  endtask
+
+  task automatic send_bad_flit;
+    input [FLIT_W-1:0] data;
+    input last;
+    begin
+      @(negedge clk);
+      bad_flit_data = data;
+      bad_flit_group_last = last;
+      bad_flit_valid = 1'b1;
+      while (1) begin
+        @(posedge clk);
+        if (bad_flit_valid && bad_flit_ready)
+          break;
+      end
+      @(negedge clk);
+      bad_flit_valid = 1'b0;
+      bad_flit_data = {FLIT_W{1'b0}};
+      bad_flit_group_last = 1'b0;
+    end
+  endtask
+
+  task automatic check_early_group_last;
+    begin
+      apply_reset();
+      send_bad_context(16'h55aa, 0);
+      send_bad_flit({FLIT_W{1'b0}}, 1'b1);
+      repeat (3) @(posedge clk);
+      if (!bad_protocol_error)
+        $fatal(1, "early group-last was not rejected");
+      if (bad_decoder_dut.input_done_q !== 1'b0 || bad_ctx_ready !== 1'b0)
+        $fatal(1, "early group-last forced a clean decoder close");
+    end
+  endtask
+
+  task automatic check_invalid_context;
+    begin
+      apply_reset();
+      send_bad_context(16'h55ae, 1);
+      repeat (2) @(posedge clk);
+      if (!bad_protocol_error)
+        $fatal(1, "invalid head-base context was not rejected");
+    end
+  endtask
+
+  task automatic check_reset_mid_group;
+    reg [BEAT_W-1:0] partial_beat;
+    begin
+      apply_reset();
+      normal_monitor_enable = 1'b0;
+      send_context(16'h55af, 0);
+      partial_beat = make_beat(0, 16'h55af, 0, 19);
+      send_normal_beat(partial_beat);
+      repeat (2) @(posedge clk);
+      if (encoder_dut.active_q !== 1'b1 || decoder_dut.active_q !== 1'b1)
+        $fatal(1, "mid-group reset setup did not activate both codecs");
+      apply_reset();
+      if (encoder_dut.active_q !== 1'b0 || decoder_dut.active_q !== 1'b0 ||
+          normal_enc_ctx_ready !== 1'b1 || normal_dec_ctx_ready !== 1'b1)
+        $fatal(1, "reset did not discard partial group state");
+    end
+  endtask
+
+  task automatic check_late_group_last;
+    integer index;
+    reg [FLIT_W-1:0] data;
+    begin
+      apply_reset();
+      send_bad_context(16'h55ab, 8);
+      for (index = 0; index < GROUP_FLITS; index = index + 1) begin
+        data = {FLIT_W{1'b0}};
+        send_bad_flit(data, 1'b0);
+      end
+      if (!bad_protocol_error)
+        $fatal(1, "missing terminal group-last was not rejected");
+    end
+  endtask
+
+  task automatic check_nonzero_padding;
+    integer index;
+    reg [FLIT_W-1:0] data;
+    begin
+      apply_reset();
+      send_bad_context(16'h55ac, 16);
+      for (index = 0; index < GROUP_FLITS; index = index + 1) begin
+        data = {FLIT_W{1'b0}};
+        if (index == GROUP_FLITS - 1)
+          data[8] = 1'b1;
+        send_bad_flit(data, index == GROUP_FLITS - 1);
+      end
+      if (!bad_protocol_error)
+        $fatal(1, "nonzero final padding was not rejected");
+    end
+  endtask
+
+  task automatic check_encoder_order;
+    reg [BEAT_W-1:0] malformed;
+    begin
+      apply_reset();
+      normal_monitor_enable = 1'b0;
+      send_context(16'h55ad, 24);
+      malformed = make_beat(0, 16'h55ad, 24, 7);
+      malformed[89:86] = 4'd1;
+      normal_driver_input_count = 0;
+      send_normal_beat(malformed);
+      if (normal_driver_input_count != 1)
+        $fatal(1, "malformed order driver accepted %0d input beats",
+          normal_driver_input_count);
+      repeat (3) @(posedge clk);
+      if (!normal_encoder_error)
+        $fatal(1, "encoder order violation was not sticky");
+    end
+  endtask
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      stall_state <= 32'h9e37_79b9;
+    end else begin
+      stall_state <= next_stall_state(stall_state);
+    end
+  end
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      enc_hold_valid = 1'b0;
+      dec_hold_valid = 1'b0;
+    end else begin
+      if (enc_hold_valid && !normal_enc_flit_ready &&
+          (normal_enc_flit_data !== enc_hold_data ||
+           normal_enc_flit_group_last !== enc_hold_last))
+        $fatal(1, "encoder flit changed while stalled");
+      if (dec_hold_valid && !normal_dec_beat_ready &&
+          normal_dec_beat_data !== dec_hold_data)
+        $fatal(1, "decoder beat changed while stalled");
+      enc_hold_valid = normal_enc_flit_valid && !normal_enc_flit_ready;
+      if (enc_hold_valid) begin
+        enc_hold_data = normal_enc_flit_data;
+        enc_hold_last = normal_enc_flit_group_last;
+      end
+      dec_hold_valid = normal_dec_beat_valid && !normal_dec_beat_ready;
+      if (dec_hold_valid)
+        dec_hold_data = normal_dec_beat_data;
+    end
+  end
+
+  // Capture handshake events before either task changes its driven signals.
+  // Validation and counters are committed at the following negedge, which
+  // makes group completion independent of active-region scheduling order.
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      flit_accept_q <= 1'b0;
+      output_accept_q <= 1'b0;
+      overlap_accept_q <= 1'b0;
+    end else begin
+      flit_accept_q <= normal_monitor_enable &&
+        normal_enc_flit_valid && normal_enc_flit_ready;
+      output_accept_q <= normal_monitor_enable &&
+        normal_dec_beat_valid && normal_dec_beat_ready;
+      overlap_accept_q <= normal_monitor_enable &&
+        decoder_dut.parse_fire && decoder_dut.flit_fire;
+      if (normal_monitor_enable && normal_enc_flit_valid && normal_enc_flit_ready) begin
+        accepted_flit_data_q <= normal_enc_flit_data;
+        accepted_flit_last_q <= normal_enc_flit_group_last;
+      end
+      if (normal_monitor_enable && normal_dec_beat_valid && normal_dec_beat_ready)
+        accepted_output_data_q <= normal_dec_beat_data;
+    end
+  end
+
+  always @(negedge clk) begin
+    if (!rst_n) begin
+      normal_group_flit_count = 0;
+      normal_output_in_group = 0;
+    end else begin
+      if (flit_accept_q) begin
+        if (normal_group_flit_count >= GROUP_FLITS)
+          $fatal(1, "encoder emitted too many flits");
+        if (accepted_flit_data_q !== expected_flit(normal_group_flit_count))
+          $fatal(1, "independent stream mismatch at flit %0d",
+            normal_group_flit_count);
+        if (accepted_flit_last_q !==
+            (normal_group_flit_count == GROUP_FLITS - 1))
+          $fatal(1, "group-last mismatch at flit %0d", normal_group_flit_count);
+        normal_group_flit_count = normal_group_flit_count + 1;
+      end
+      if (output_accept_q) begin
+        if (normal_output_in_group >= GROUP_BEATS)
+          $fatal(1, "decoder emitted too many beats");
+        if (accepted_output_data_q !== expected_beats[normal_output_in_group])
+          $fatal(1, "decoded beat mismatch at beat %0d", normal_output_in_group);
+        normal_output_in_group = normal_output_in_group + 1;
+      end
+      if (overlap_accept_q)
+        overlap_count = overlap_count + 1;
+    end
+  end
+
+  initial begin
+    normal_group_flit_count = 0;
+    normal_output_in_group = 0;
+    normal_groups_completed = 0;
+    overlap_count = 0;
+    apply_reset();
+    send_normal_group(16'h1234, 0, 3);
+    send_normal_group(16'h2345, 24, 11);
+    if (normal_groups_completed != 2)
+      $fatal(1, "expected two valid groups");
+    if (overlap_count < 8)
+      $fatal(1, "decoder did not demonstrate sustained parse/receive overlap: %0d",
+        overlap_count);
+    check_reset_mid_group();
+    check_invalid_context();
+    check_early_group_last();
+    check_late_group_last();
+    check_nonzero_padding();
+    check_encoder_order();
+    $display("PASS local_reducer_aggregate_stats_once_exact_codec groups=%0d input_beats_per_group=%0d flits_per_group=%0d beats_per_group=%0d overlap=%0d", normal_groups_completed, valid_input_count_last, GROUP_FLITS, GROUP_BEATS, overlap_count);
+    $finish(0);
+  end
+endmodule

--- a/tests/test_exact_matched_codec_design_generator.py
+++ b/tests/test_exact_matched_codec_design_generator.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.generate_design import (  # noqa: E402
+    generate_config_mk,
+    generate_l1_memory_noc_design,
+    generate_wrapper,
+    identify_design,
+)
+
+
+CONFIGS = {
+    "aligned": REPO_ROOT
+    / "runs/designs/noc/l1_attention_score32_exact_matched_aligned_codec_w419_f256_wrapper"
+    / "config_l1_attention_score32_exact_matched_aligned_codec_w419_f256.json",
+    "stats_once": REPO_ROOT
+    / "runs/designs/noc/l1_attention_score32_exact_matched_stats_once_codec_w419_f256_wrapper"
+    / "config_l1_attention_score32_exact_matched_stats_once_codec_w419_f256.json",
+}
+
+
+def _tool(name: str) -> str | None:
+    path = shutil.which(name)
+    if path is not None:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    return str(fallback) if fallback.exists() else None
+
+
+@pytest.mark.parametrize(("mode", "mode_value"), [("aligned", 0), ("stats_once", 1)])
+def test_exact_matched_codec_generated_hierarchy(
+    mode: str, mode_value: int, tmp_path: Path
+) -> None:
+    config = json.loads(CONFIGS[mode].read_text(encoding="utf-8"))
+    design = identify_design(config)
+    assert design["primitive"] == "exact_matched_codec"
+    assert design["codec_mode"] == mode
+
+    source_dir = tmp_path / "src"
+    source_dir.mkdir()
+    generate_l1_memory_noc_design(str(source_dir), design)
+    generate_wrapper(config, str(source_dir), design)
+    expected_sources = {
+        "local_reducer_aggregate_aligned_exact_codec.v",
+        "local_reducer_aggregate_stats_once_exact_codec.v",
+        "local_reducer_aggregate_exact_codec_matched_ppa_harness.v",
+        f"{design['module_name']}.v",
+        f"{design['wrapper_name']}.v",
+    }
+    assert expected_sources == {path.name for path in source_dir.glob("*.v")}
+    generated_top = (source_dir / f"{design['module_name']}.v").read_text(
+        encoding="utf-8"
+    )
+    assert f".MODE_STATS_ONCE({mode_value})" in generated_top
+
+    platform_dir = tmp_path / "platform"
+    platform_dir.mkdir()
+    generate_config_mk(str(platform_dir), "nangate45", design)
+    config_mk = (platform_dir / "config.mk").read_text(encoding="utf-8")
+    for filename in expected_sources:
+        assert f"/{filename}" in config_mk
+
+    sources = [str(path) for path in sorted(source_dir.glob("*.v"))]
+    if (iverilog := _tool("iverilog")) is not None:
+        subprocess.run(
+            [iverilog, "-g2012", "-s", design["wrapper_name"], "-t", "null", *sources],
+            check=True,
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    if (yosys := _tool("yosys")) is not None:
+        subprocess.run(
+            [
+                yosys,
+                "-q",
+                "-p",
+                "read_verilog -DSYNTHESIS -sv "
+                + " ".join(sources)
+                + f"; hierarchy -check -top {design['wrapper_name']}; proc; check",
+            ],
+            check=True,
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("codec_mode", "lossy", "codec_mode must be aligned or stats_once"),
+        ("counter_bits", 7, "requires counter_bits >= 8"),
+        ("flit_bits", 128, "requires 256-bit flits"),
+    ],
+)
+def test_exact_matched_codec_rejects_invalid_options(
+    field: str, value: object, message: str
+) -> None:
+    config = json.loads(CONFIGS["aligned"].read_text(encoding="utf-8"))
+    config["operations"][0]["options"][field] = value
+    with pytest.raises(ValueError, match=message):
+        identify_design(config)

--- a/tests/test_local_reducer_aggregate_exact_codec_matched_ppa_harness.py
+++ b/tests/test_local_reducer_aggregate_exact_codec_matched_ppa_harness.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HARNESS = REPO_ROOT / "npu/sim/rtl/local_reducer_aggregate_exact_codec_matched_ppa_harness.sv"
+ALIGNED = REPO_ROOT / "npu/sim/rtl/local_reducer_aggregate_aligned_exact_codec.sv"
+STATS = REPO_ROOT / "npu/sim/rtl/local_reducer_aggregate_stats_once_exact_codec.sv"
+TB = REPO_ROOT / "tests/local_reducer_aggregate_exact_codec_matched_ppa_harness_tb.sv"
+
+
+def _tool(name: str) -> str | None:
+    path = shutil.which(name)
+    if path is not None:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    return str(fallback) if fallback.exists() else None
+
+
+@pytest.mark.skipif(
+    _tool("iverilog") is None or _tool("vvp") is None,
+    reason="iverilog/vvp unavailable",
+)
+def test_matched_harness_roundtrip_and_transport_counts(tmp_path: Path) -> None:
+    simv = tmp_path / "matched_ppa_harness.vvp"
+    subprocess.run(
+        [
+            str(_tool("iverilog")),
+            "-g2012",
+            "-s",
+            "local_reducer_aggregate_exact_codec_matched_ppa_harness_tb",
+            "-o",
+            str(simv),
+            str(ALIGNED),
+            str(STATS),
+            str(HARNESS),
+            str(TB),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    run = subprocess.run(
+        [str(_tool("vvp")), str(simv)],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert "PASS local_reducer_aggregate_exact_codec_matched_ppa_harness" in run.stdout
+    fields = dict(
+        field.split("=", 1)
+        for field in run.stdout.split()
+        if "=" in field
+    )
+    assert int(fields["groups"]) >= 3
+    assert int(fields["aligned_flits"]) >= int(fields["groups"]) * 256
+    assert int(fields["stats_flits"]) >= 3 * 167
+
+
+@pytest.mark.skipif(_tool("yosys") is None, reason="yosys unavailable")
+def test_matched_harness_yosys_check_both_modes() -> None:
+    yosys = str(_tool("yosys"))
+    for mode in (0, 1):
+        subprocess.run(
+            [
+                yosys,
+                "-q",
+                "-p",
+                "read_verilog -DSYNTHESIS -sv "
+                f"{ALIGNED} {STATS} {HARNESS}; "
+                f"chparam -set MODE_STATS_ONCE {mode} "
+                "local_reducer_aggregate_exact_codec_matched_ppa_harness; "
+                "hierarchy -check -top local_reducer_aggregate_exact_codec_matched_ppa_harness; "
+                "proc; check",
+            ],
+            check=True,
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )

--- a/tests/test_local_reducer_aggregate_stats_once_exact_codec.py
+++ b/tests/test_local_reducer_aggregate_stats_once_exact_codec.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RTL = REPO_ROOT / "npu/sim/rtl/local_reducer_aggregate_stats_once_exact_codec.sv"
+TB = REPO_ROOT / "tests/local_reducer_aggregate_stats_once_exact_codec_tb.sv"
+
+
+def _tool(name: str) -> str | None:
+    path = shutil.which(name)
+    if path is not None:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    if fallback.exists():
+        return str(fallback)
+    return None
+
+
+@pytest.mark.skipif(
+    _tool("iverilog") is None or _tool("vvp") is None,
+    reason="iverilog/vvp unavailable",
+)
+def test_stats_once_exact_codec_randomized_roundtrip_and_protocol_gate(
+    tmp_path: Path,
+) -> None:
+    simv = tmp_path / "local_reducer_aggregate_stats_once_exact_codec.vvp"
+    subprocess.run(
+        [
+            str(_tool("iverilog")),
+            "-g2012",
+            "-s",
+            "local_reducer_aggregate_stats_once_exact_codec_tb",
+            "-o",
+            str(simv),
+            str(RTL),
+            str(TB),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    run = subprocess.run(
+        [str(_tool("vvp")), str(simv)],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert "PASS local_reducer_aggregate_stats_once_exact_codec" in run.stdout
+    assert "input_beats_per_group=128" in run.stdout
+    assert "flits_per_group=167" in run.stdout
+    assert "beats_per_group=128" in run.stdout
+    overlap = int(run.stdout.split("overlap=")[-1].split()[0])
+    assert overlap >= 8
+
+
+@pytest.mark.skipif(_tool("yosys") is None, reason="yosys unavailable")
+def test_stats_once_exact_codec_yosys_import_process_check() -> None:
+    yosys = str(_tool("yosys"))
+    for top in (
+        "local_reducer_aggregate_stats_once_exact_encoder",
+        "local_reducer_aggregate_stats_once_exact_decoder",
+    ):
+        subprocess.run(
+            [
+                yosys,
+                "-q",
+                "-p",
+                "read_verilog -DSYNTHESIS -sv "
+                f"{RTL}; hierarchy -check -top {top}; proc; check",
+            ],
+            check=True,
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )


### PR DESCRIPTION
## Summary
- implement an exact bounded-reservoir stats-once codec for 419-bit score32 aggregates
- prove 128-beat round-trip over 167 256-bit flits with protocol and backpressure checks
- add matched aligned/stats PPA harnesses and a paired Nangate45 sweep

## Architecture impact
- preserves every 41-bit value numerator and exact per-head max/sum
- reduces one GQA8 group from 256 to 167 flits (34.8%)
- measures the codec pair under identical canonical source, sink, and stall support
- leaves endpoint/mesh/root composition explicitly unresolved

## Verification
- `python -m pytest -q tests/test_local_reducer_aggregate_aligned_exact_codec.py tests/test_local_reducer_aggregate_stats_once_exact_codec.py tests/test_local_reducer_aggregate_exact_codec_matched_ppa_harness.py tests/test_exact_matched_codec_design_generator.py` (13 passed)
- `python3 scripts/validate_runs.py --skip_eval_queue`
- Yosys confirms the unselected codec is removed and matched source support contains no multiplier cells
