### PR TITLE
Add exact stats-once packet bridge and mesh equivalence

### DIFF
--- a/npu/docs/attention_score32_exact_stats_once_packet_bridge_contract.md
+++ b/npu/docs/attention_score32_exact_stats_once_packet_bridge_contract.md
@@ -1,0 +1,61 @@
+# Score32 Exact Stats-Once Packet Bridge Contract
+
+This bridge connects one exact stats-once codec stream to one 256-bit segmented
+NoC endpoint port. It embodies packet boundaries and checked transport metadata
+without changing the 42,504-bit group payload.
+
+## Group Context
+
+Before accepting payload, the transmit bridge accepts:
+
+- `command_id[15:0]`
+- `head_base[4:0]`, restricted to `0`, `8`, `16`, or `24`
+- `source[3:0]` and `destination[3:0]`
+- `vc[1:0]`
+- `group_epoch[2:0]`
+
+The receive bridge is armed independently with the same expected context. The
+command scheduler is responsible for installing receive context before transmit
+release. Command ID and head base remain scheduler metadata for the root codec;
+they are not redundantly inserted into every payload flit.
+
+## Packet Mapping
+
+One group is exactly 167 flits:
+
+- packets 0 through 19 contain eight flits each
+- packet 20 contains seven flits
+- `fragment` runs from 0 through 7, or 0 through 6 on packet 20
+- packet `last` is asserted on fragment 7 or on the final group flit
+- `tag = {group_epoch[2:0], packet_index[4:0]}`
+
+Only one group per source may be in flight for a given epoch. A source must not
+reuse an epoch until the scheduler has observed completion, preventing the
+eight-epoch tag space from aliasing live traffic.
+
+`group_last` belongs to the codec stream and is asserted only on group flit
+166. NoC `last` belongs to each packet. The bridge must never directly connect
+these two signals.
+
+## Ready/Valid and Validation
+
+Both directions are fully backpressured. Metadata and payload remain stable
+while valid is asserted and ready is low. The transmit bridge rejects early or
+late codec `group_last`. The receive bridge checks destination, source, VC,
+tag, fragment, packet-last position, packet order, and the exact 167-flit group
+length. Violations set a sticky protocol error and cannot create a clean group
+completion.
+
+The receive output reconstructs the original flit stream bit for bit, emits
+`group_last` only for flit 166, and retains `command_id` and `head_base` as
+stable outputs for the root codec. Context becomes reusable only after that
+output flit is consumed.
+
+## Scope Boundary
+
+The first composition drives these bridges directly into
+`noc_segmented_mesh4x4` to prove packet and route equivalence. It does not yet
+claim SRAM endpoint closure. The follow-on must place packet-sized inferred
+SRAM buffers and `noc_sram_packet_endpoint` descriptor/read/write control at
+the same boundary, then scale from one checked source to the 15 remote sources
+feeding the root exact reduction tree.

--- a/npu/docs/attention_score32_exact_stats_once_sram_endpoint_bridge_contract.md
+++ b/npu/docs/attention_score32_exact_stats_once_sram_endpoint_bridge_contract.md
@@ -1,0 +1,61 @@
+# Score32 Exact Stats-Once SRAM Endpoint Bridge Contract
+
+This follow-on composes the stats-once codec packet stream with
+`noc_sram_packet_endpoint`. It replaces direct mesh injection with finite
+packet storage, descriptor queues, SRAM request/response timing, receive
+contexts, and completion-driven reclamation.
+
+## Source Side
+
+The source bridge owns at least two packet slots of eight 256-bit words each.
+It fills one slot from the codec while the endpoint drains another. A TX
+descriptor becomes visible only after every payload word for that packet has
+been written. Its base address is the slot base, and its flit count is eight or
+seven for the terminal packet.
+
+The endpoint may issue several reads before their responses return. The memory
+adapter captures the addressed payload at each accepted read request and holds
+responses in order. A source slot is reusable only after all of its read
+requests have been accepted and their payload values have entered that response
+storage. Descriptor acceptance alone is not a release event.
+
+## Destination Side
+
+The root scheduler reserves a receive slot and installs the exact
+`(source, VC, tag, base, count)` context before releasing the matching TX
+descriptor. The endpoint writes each accepted fragment directly into the slot.
+The slot becomes readable only after the registered packet completion is
+accepted, which proves the terminal SRAM write was accepted.
+
+Completed packets are retired to the decoder in packet-index order for each
+source and group epoch. A slot is reusable only after its final word is accepted
+by the stats-once decoder. If no receive slot is available, the scheduler must
+withhold the TX release; sending a packet without a live receive context is a
+protocol error, not a legal backpressure mechanism.
+
+## Ordering and Capacity
+
+- one group contains 21 packets and 167 flits
+- packet slots are parameterized; two is the minimum ping-pong implementation
+- descriptors and completions carry the packet tag from the packet bridge
+- one group per source/epoch may be live
+- different sources may interleave at the root, but packets from one source
+  remain ordered
+- one decoder is retained per remote source in the 16-cluster architecture, so
+  15 streams can advance independently until global reduction backpressure
+
+The minimum slot count is a functional point, not an assumed optimum. The
+composed performance model and RTL must sweep source and destination slot depth
+under the measured global-reducer ready schedule.
+
+## Equivalence Gate
+
+For every accepted group, the decoder output must equal the local reducer's 128
+canonical 419-bit beats exactly. The test records descriptor handshakes, SRAM
+requests and responses, writes, packet completions, codec flits, and output
+beats. RTL and the finite endpoint performance model must agree on packet/flit
+counts, completion order, stalls, and maximum slot occupancy.
+
+SRAM is initially an inferred synchronous word array for control and schedule
+closure. Its bitcell area and energy must later be substituted from a cited
+macro model; the inferred array is not itself a physical SRAM PPA claim.

--- a/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_packet_bridge.sv
+++ b/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_packet_bridge.sv
@@ -39,8 +39,6 @@ module local_reducer_aggregate_stats_once_exact_packet_tx_framer #(
   reg active_q;
   reg input_done_q;
   reg [7:0] flit_index_q;
-  reg [15:0] command_q;
-  reg [4:0] head_base_q;
   reg [3:0] source_q;
   reg [3:0] destination_q;
   reg [VC_W-1:0] vc_q;
@@ -83,8 +81,6 @@ module local_reducer_aggregate_stats_once_exact_packet_tx_framer #(
       active_q <= 1'b0;
       input_done_q <= 1'b0;
       flit_index_q <= 8'b0;
-      command_q <= 16'b0;
-      head_base_q <= 5'b0;
       source_q <= 4'b0;
       destination_q <= 4'b0;
       vc_q <= {VC_W{1'b0}};
@@ -106,8 +102,6 @@ module local_reducer_aggregate_stats_once_exact_packet_tx_framer #(
         active_q <= 1'b1;
         input_done_q <= 1'b0;
         flit_index_q <= 8'b0;
-        command_q <= group_command_id;
-        head_base_q <= group_head_base;
         source_q <= group_source;
         destination_q <= group_destination;
         vc_q <= group_vc;
@@ -198,6 +192,8 @@ module local_reducer_aggregate_stats_once_exact_packet_rx_deframer #(
   input  wire                         codec_flit_ready,
   output wire [DATA_W-1:0]             codec_flit_data,
   output wire                         codec_flit_group_last,
+  output wire [15:0]                  codec_group_command_id,
+  output wire [4:0]                   codec_group_head_base,
   output wire                         protocol_error,
   output wire                         clean_group_complete
 );
@@ -243,6 +239,8 @@ module local_reducer_aggregate_stats_once_exact_packet_rx_deframer #(
   assign codec_flit_valid = output_valid_q;
   assign codec_flit_data = output_data_q;
   assign codec_flit_group_last = output_group_last_q;
+  assign codec_group_command_id = command_q;
+  assign codec_group_head_base = head_base_q;
   assign protocol_error = protocol_error_q;
   assign clean_group_complete = clean_group_complete_q;
 

--- a/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_packet_bridge.sv
+++ b/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_packet_bridge.sv
@@ -1,0 +1,325 @@
+`timescale 1ns/1ps
+
+// Packetizes one exact stats-once group for the segmented mesh.  The codec
+// group stream and the mesh packet stream have independent last markers.
+module local_reducer_aggregate_stats_once_exact_packet_tx_framer #(
+  parameter integer DATA_W = 256,
+  parameter integer TAG_W = 8,
+  parameter integer FRAGMENT_W = 3,
+  parameter integer VC_W = 2
+) (
+  input  wire                         clk,
+  input  wire                         rst_n,
+  input  wire                         group_ctx_valid,
+  output wire                         group_ctx_ready,
+  input  wire [15:0]                  group_command_id,
+  input  wire [4:0]                   group_head_base,
+  input  wire [3:0]                   group_source,
+  input  wire [3:0]                   group_destination,
+  input  wire [VC_W-1:0]              group_vc,
+  input  wire [2:0]                   group_epoch,
+  input  wire                         codec_flit_valid,
+  output wire                         codec_flit_ready,
+  input  wire [DATA_W-1:0]             codec_flit_data,
+  input  wire                         codec_flit_group_last,
+  output wire                         mesh_flit_valid,
+  input  wire                         mesh_flit_ready,
+  output wire [3:0]                   mesh_flit_destination,
+  output wire [3:0]                   mesh_flit_source,
+  output wire [TAG_W-1:0]             mesh_flit_tag,
+  output wire [FRAGMENT_W-1:0]        mesh_flit_fragment,
+  output wire                         mesh_flit_last,
+  output wire [VC_W-1:0]              mesh_flit_vc,
+  output wire [DATA_W-1:0]             mesh_flit_data,
+  output wire                         clean_group_complete,
+  output wire                         protocol_error
+);
+  localparam integer GROUP_FLITS = 167;
+
+  reg active_q;
+  reg input_done_q;
+  reg [7:0] flit_index_q;
+  reg [15:0] command_q;
+  reg [4:0] head_base_q;
+  reg [3:0] source_q;
+  reg [3:0] destination_q;
+  reg [VC_W-1:0] vc_q;
+  reg [2:0] epoch_q;
+  reg output_valid_q;
+  reg [3:0] output_destination_q;
+  reg [3:0] output_source_q;
+  reg [TAG_W-1:0] output_tag_q;
+  reg [FRAGMENT_W-1:0] output_fragment_q;
+  reg output_last_q;
+  reg [VC_W-1:0] output_vc_q;
+  reg [DATA_W-1:0] output_data_q;
+  reg group_error_q;
+  reg protocol_error_q;
+  reg clean_group_complete_q;
+
+  wire output_fire = output_valid_q && mesh_flit_ready;
+  wire codec_fire = codec_flit_valid && codec_flit_ready;
+  wire expected_group_last = (flit_index_q == 8'd166);
+  wire valid_head_base = (group_head_base == 5'd0) ||
+    (group_head_base == 5'd8) || (group_head_base == 5'd16) ||
+    (group_head_base == 5'd24);
+
+  assign group_ctx_ready = !active_q;
+  assign codec_flit_ready = active_q && !input_done_q &&
+    (!output_valid_q || mesh_flit_ready);
+  assign mesh_flit_valid = output_valid_q;
+  assign mesh_flit_destination = output_destination_q;
+  assign mesh_flit_source = output_source_q;
+  assign mesh_flit_tag = output_tag_q;
+  assign mesh_flit_fragment = output_fragment_q;
+  assign mesh_flit_last = output_last_q;
+  assign mesh_flit_vc = output_vc_q;
+  assign mesh_flit_data = output_data_q;
+  assign clean_group_complete = clean_group_complete_q;
+  assign protocol_error = protocol_error_q;
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      active_q <= 1'b0;
+      input_done_q <= 1'b0;
+      flit_index_q <= 8'b0;
+      command_q <= 16'b0;
+      head_base_q <= 5'b0;
+      source_q <= 4'b0;
+      destination_q <= 4'b0;
+      vc_q <= {VC_W{1'b0}};
+      epoch_q <= 3'b0;
+      output_valid_q <= 1'b0;
+      output_destination_q <= 4'b0;
+      output_source_q <= 4'b0;
+      output_tag_q <= {TAG_W{1'b0}};
+      output_fragment_q <= {FRAGMENT_W{1'b0}};
+      output_last_q <= 1'b0;
+      output_vc_q <= {VC_W{1'b0}};
+      output_data_q <= {DATA_W{1'b0}};
+      group_error_q <= 1'b0;
+      protocol_error_q <= 1'b0;
+      clean_group_complete_q <= 1'b0;
+    end else begin
+      clean_group_complete_q <= 1'b0;
+      if (group_ctx_valid && group_ctx_ready) begin
+        active_q <= 1'b1;
+        input_done_q <= 1'b0;
+        flit_index_q <= 8'b0;
+        command_q <= group_command_id;
+        head_base_q <= group_head_base;
+        source_q <= group_source;
+        destination_q <= group_destination;
+        vc_q <= group_vc;
+        epoch_q <= group_epoch;
+        output_valid_q <= 1'b0;
+        group_error_q <= !valid_head_base;
+        if (!valid_head_base)
+          protocol_error_q <= 1'b1;
+      end else begin
+        if (codec_fire) begin
+          output_valid_q <= 1'b1;
+          output_destination_q <= destination_q;
+          output_source_q <= source_q;
+          output_tag_q <= {epoch_q, flit_index_q[7:3]};
+          output_fragment_q <= flit_index_q[2:0];
+          output_last_q <= (flit_index_q[2:0] == 3'd7) || expected_group_last;
+          output_vc_q <= vc_q;
+          output_data_q <= codec_flit_data;
+
+          if (codec_flit_group_last != expected_group_last) begin
+            group_error_q <= 1'b1;
+            protocol_error_q <= 1'b1;
+          end
+
+          if (expected_group_last) begin
+            input_done_q <= 1'b1;
+          end else begin
+            flit_index_q <= flit_index_q + 1'b1;
+          end
+        end else if (output_fire) begin
+          output_valid_q <= 1'b0;
+        end
+
+        if (output_fire && input_done_q) begin
+          if (!group_error_q)
+            clean_group_complete_q <= 1'b1;
+          active_q <= 1'b0;
+          input_done_q <= 1'b0;
+          output_valid_q <= 1'b0;
+          flit_index_q <= 8'b0;
+          group_error_q <= 1'b0;
+        end
+      end
+    end
+  end
+
+`ifndef SYNTHESIS
+  initial begin
+    if (DATA_W != 256 || TAG_W != 8 || FRAGMENT_W != 3 || VC_W != 2) begin
+      $error("packet TX bridge widths must be DATA=256 TAG=8 FRAGMENT=3 VC=2");
+      $finish(1);
+    end
+    if (GROUP_FLITS != 167)
+      $error("packet TX bridge group length changed");
+  end
+`endif
+endmodule
+
+
+// Deframes checked segmented-mesh packets back into the exact codec group
+// stream.  It accepts the expected context atomically before accepting data.
+module local_reducer_aggregate_stats_once_exact_packet_rx_deframer #(
+  parameter integer DATA_W = 256,
+  parameter integer TAG_W = 8,
+  parameter integer FRAGMENT_W = 3,
+  parameter integer VC_W = 2
+) (
+  input  wire                         clk,
+  input  wire                         rst_n,
+  input  wire                         group_ctx_valid,
+  output wire                         group_ctx_ready,
+  input  wire [15:0]                  group_command_id,
+  input  wire [4:0]                   group_head_base,
+  input  wire [3:0]                   group_source,
+  input  wire [3:0]                   group_destination,
+  input  wire [VC_W-1:0]              group_vc,
+  input  wire [2:0]                   group_epoch,
+  input  wire                         mesh_flit_valid,
+  output wire                         mesh_flit_ready,
+  input  wire [3:0]                   mesh_flit_destination,
+  input  wire [3:0]                   mesh_flit_source,
+  input  wire [TAG_W-1:0]             mesh_flit_tag,
+  input  wire [FRAGMENT_W-1:0]        mesh_flit_fragment,
+  input  wire                         mesh_flit_last,
+  input  wire [VC_W-1:0]              mesh_flit_vc,
+  input  wire [DATA_W-1:0]             mesh_flit_data,
+  output wire                         codec_flit_valid,
+  input  wire                         codec_flit_ready,
+  output wire [DATA_W-1:0]             codec_flit_data,
+  output wire                         codec_flit_group_last,
+  output wire                         protocol_error,
+  output wire                         clean_group_complete
+);
+  localparam integer GROUP_FLITS = 167;
+
+  reg active_q;
+  reg input_done_q;
+  reg [7:0] flit_index_q;
+  reg [15:0] command_q;
+  reg [4:0] head_base_q;
+  reg [3:0] source_q;
+  reg [3:0] destination_q;
+  reg [VC_W-1:0] vc_q;
+  reg [2:0] epoch_q;
+  reg output_valid_q;
+  reg [DATA_W-1:0] output_data_q;
+  reg output_group_last_q;
+  reg group_error_q;
+  reg protocol_error_q;
+  reg clean_group_complete_q;
+
+  wire output_fire = output_valid_q && codec_flit_ready;
+  wire mesh_fire = mesh_flit_valid && mesh_flit_ready;
+  wire expected_group_last = (flit_index_q == 8'd166);
+  wire expected_packet_last = (flit_index_q[2:0] == 3'd7) ||
+    expected_group_last;
+  wire [4:0] expected_packet = flit_index_q[7:3];
+  wire [TAG_W-1:0] expected_tag = {epoch_q, expected_packet};
+  wire valid_head_base = (group_head_base == 5'd0) ||
+    (group_head_base == 5'd8) || (group_head_base == 5'd16) ||
+    (group_head_base == 5'd24);
+  wire metadata_ok =
+    (mesh_flit_destination == destination_q) &&
+    (mesh_flit_source == source_q) &&
+    (mesh_flit_vc == vc_q) &&
+    (mesh_flit_tag == expected_tag) &&
+    (mesh_flit_fragment == flit_index_q[2:0]) &&
+    (mesh_flit_last == expected_packet_last);
+
+  assign group_ctx_ready = !active_q;
+  assign mesh_flit_ready = active_q && !input_done_q &&
+    (!output_valid_q || codec_flit_ready);
+  assign codec_flit_valid = output_valid_q;
+  assign codec_flit_data = output_data_q;
+  assign codec_flit_group_last = output_group_last_q;
+  assign protocol_error = protocol_error_q;
+  assign clean_group_complete = clean_group_complete_q;
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      active_q <= 1'b0;
+      input_done_q <= 1'b0;
+      flit_index_q <= 8'b0;
+      command_q <= 16'b0;
+      head_base_q <= 5'b0;
+      source_q <= 4'b0;
+      destination_q <= 4'b0;
+      vc_q <= {VC_W{1'b0}};
+      epoch_q <= 3'b0;
+      output_valid_q <= 1'b0;
+      output_data_q <= {DATA_W{1'b0}};
+      output_group_last_q <= 1'b0;
+      group_error_q <= 1'b0;
+      protocol_error_q <= 1'b0;
+      clean_group_complete_q <= 1'b0;
+    end else begin
+      clean_group_complete_q <= 1'b0;
+
+      if (group_ctx_valid && group_ctx_ready) begin
+        active_q <= 1'b1;
+        input_done_q <= 1'b0;
+        flit_index_q <= 8'b0;
+        command_q <= group_command_id;
+        head_base_q <= group_head_base;
+        source_q <= group_source;
+        destination_q <= group_destination;
+        vc_q <= group_vc;
+        epoch_q <= group_epoch;
+        output_valid_q <= 1'b0;
+        group_error_q <= !valid_head_base;
+        if (!valid_head_base)
+          protocol_error_q <= 1'b1;
+      end else begin
+        if (mesh_fire) begin
+          output_valid_q <= 1'b1;
+          output_data_q <= mesh_flit_data;
+          output_group_last_q <= expected_group_last;
+
+          if (!metadata_ok) begin
+            group_error_q <= 1'b1;
+            protocol_error_q <= 1'b1;
+          end
+
+          if (expected_group_last)
+            input_done_q <= 1'b1;
+          else
+            flit_index_q <= flit_index_q + 1'b1;
+        end else if (output_fire) begin
+          output_valid_q <= 1'b0;
+        end
+
+        if (output_fire && output_group_last_q) begin
+          active_q <= 1'b0;
+          input_done_q <= 1'b0;
+          output_valid_q <= 1'b0;
+          flit_index_q <= 8'b0;
+          if (!group_error_q)
+            clean_group_complete_q <= 1'b1;
+          group_error_q <= 1'b0;
+        end
+      end
+    end
+  end
+
+`ifndef SYNTHESIS
+  initial begin
+    if (DATA_W != 256 || TAG_W != 8 || FRAGMENT_W != 3 || VC_W != 2) begin
+      $error("packet RX bridge widths must be DATA=256 TAG=8 FRAGMENT=3 VC=2");
+      $finish(1);
+    end
+    if (GROUP_FLITS != 167)
+      $error("packet RX bridge group length changed");
+  end
+`endif
+endmodule

--- a/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_packet_bridge.sv
+++ b/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_packet_bridge.sv
@@ -232,6 +232,8 @@ module local_reducer_aggregate_stats_once_exact_packet_rx_deframer #(
     (mesh_flit_tag == expected_tag) &&
     (mesh_flit_fragment == flit_index_q[2:0]) &&
     (mesh_flit_last == expected_packet_last);
+  wire terminal_padding_ok = !expected_group_last ||
+    (mesh_flit_data[DATA_W-1:8] == {(DATA_W-8){1'b0}});
 
   assign group_ctx_ready = !active_q;
   assign mesh_flit_ready = active_q && !input_done_q &&
@@ -284,7 +286,7 @@ module local_reducer_aggregate_stats_once_exact_packet_rx_deframer #(
           output_data_q <= mesh_flit_data;
           output_group_last_q <= expected_group_last;
 
-          if (!metadata_ok) begin
+          if (!metadata_ok || !terminal_padding_ok) begin
             group_error_q <= 1'b1;
             protocol_error_q <= 1'b1;
           end

--- a/tests/local_reducer_aggregate_stats_once_exact_packet_mesh_tb.sv
+++ b/tests/local_reducer_aggregate_stats_once_exact_packet_mesh_tb.sv
@@ -25,6 +25,8 @@ module local_reducer_aggregate_stats_once_exact_packet_mesh_tb;
         state = state ^ (state << 5);
         payload_for[(lane * 32) +: 32] = state;
       end
+      if (flit_id == 166)
+        payload_for[DATA_W-1:8] = {(DATA_W-8){1'b0}};
     end
   endfunction
 
@@ -422,6 +424,23 @@ module local_reducer_aggregate_stats_once_exact_packet_mesh_tb;
   integer bad_rx_clean_count;
   integer bad_rx_done;
 
+  // Direct malformed RX: terminal bits above the eight valid payload bits
+  // must be zero before the transport can report clean completion.
+  reg bad_padding_ctx_valid;
+  wire bad_padding_ctx_ready;
+  reg bad_padding_mesh_valid;
+  wire bad_padding_mesh_ready;
+  reg [7:0] bad_padding_mesh_tag;
+  reg [2:0] bad_padding_mesh_fragment;
+  reg bad_padding_mesh_last;
+  reg [DATA_W-1:0] bad_padding_mesh_data;
+  wire bad_padding_codec_valid;
+  wire bad_padding_error;
+  wire bad_padding_clean;
+  integer bad_padding_output_count;
+  integer bad_padding_clean_count;
+  integer bad_padding_done;
+
   local_reducer_aggregate_stats_once_exact_packet_rx_deframer u_bad_rx (
     .clk(clk), .rst_n(rst_n), .group_ctx_valid(bad_rx_ctx_valid),
     .group_ctx_ready(bad_rx_ctx_ready), .group_command_id(bad_rx_command),
@@ -435,6 +454,24 @@ module local_reducer_aggregate_stats_once_exact_packet_mesh_tb;
     .codec_flit_valid(bad_rx_codec_valid), .codec_flit_ready(1'b1),
     .codec_flit_data(), .codec_flit_group_last(),
     .protocol_error(bad_rx_error), .clean_group_complete(bad_rx_clean)
+  );
+
+  local_reducer_aggregate_stats_once_exact_packet_rx_deframer u_bad_padding (
+    .clk(clk), .rst_n(rst_n), .group_ctx_valid(bad_padding_ctx_valid),
+    .group_ctx_ready(bad_padding_ctx_ready), .group_command_id(16'h6400),
+    .group_head_base(5'd8), .group_source(4'd1), .group_destination(4'd0),
+    .group_vc(2'd2), .group_epoch(3'd6),
+    .mesh_flit_valid(bad_padding_mesh_valid),
+    .mesh_flit_ready(bad_padding_mesh_ready), .mesh_flit_destination(4'd0),
+    .mesh_flit_source(4'd1), .mesh_flit_tag(bad_padding_mesh_tag),
+    .mesh_flit_fragment(bad_padding_mesh_fragment),
+    .mesh_flit_last(bad_padding_mesh_last), .mesh_flit_vc(2'd2),
+    .mesh_flit_data(bad_padding_mesh_data),
+    .codec_flit_valid(bad_padding_codec_valid), .codec_flit_ready(1'b1),
+    .codec_flit_data(), .codec_flit_group_last(),
+    .codec_group_command_id(), .codec_group_head_base(),
+    .protocol_error(bad_padding_error),
+    .clean_group_complete(bad_padding_clean)
   );
 
   initial begin
@@ -485,10 +522,8 @@ module local_reducer_aggregate_stats_once_exact_packet_mesh_tb;
         mesh_flit_count, output_flit_count, mesh_packet_count, clean_count,
         good_failures, tx_stability_failures, rx_stability_failures,
         mesh_metadata_failures, output_last_failures, good_tx_error, good_rx_error);
-    bad_early_done = 1;
-    bad_late_done = 1;
-    bad_rx_done = 1;
-    while (!(bad_early_done && bad_late_done && bad_rx_done)) @(posedge clk);
+    while (!(bad_early_done && bad_late_done && bad_rx_done &&
+             bad_padding_done)) @(posedge clk);
     $display("PASS local_reducer_aggregate_stats_once_exact_packet_mesh groups=2 flits=334 packets=42 outputs=334 tx_clean=2 rx_clean=2 clean=2");
     $finish;
   end
@@ -606,6 +641,40 @@ module local_reducer_aggregate_stats_once_exact_packet_mesh_tb;
     bad_rx_done = 1;
   end
 
+  initial begin
+    bad_padding_ctx_valid = 0;
+    bad_padding_mesh_valid = 0;
+    bad_padding_mesh_tag = 0;
+    bad_padding_mesh_fragment = 0;
+    bad_padding_mesh_last = 0;
+    bad_padding_mesh_data = 0;
+    bad_padding_output_count = 0;
+    bad_padding_clean_count = 0;
+    bad_padding_done = 0;
+    @(posedge rst_n);
+    @(negedge clk);
+    bad_padding_ctx_valid = 1;
+    while (!bad_padding_ctx_ready) @(posedge clk);
+    @(negedge clk);
+    bad_padding_ctx_valid = 0;
+    for (integer i = 0; i < 167; i = i + 1) begin
+      bad_padding_mesh_tag = 8'hc0 | (i / 8);
+      bad_padding_mesh_fragment = i % 8;
+      bad_padding_mesh_last = ((i % 8) == 7) || (i == 166);
+      bad_padding_mesh_data = payload_for(12, i);
+      if (i == 166)
+        bad_padding_mesh_data[255] = 1'b1;
+      bad_padding_mesh_valid = 1;
+      while (!(bad_padding_mesh_valid && bad_padding_mesh_ready)) @(posedge clk);
+      @(negedge clk);
+    end
+    bad_padding_mesh_valid = 0;
+    while (bad_padding_output_count < 167) @(posedge clk);
+    if (!bad_padding_error || bad_padding_clean_count != 0)
+      $fatal(1, "nonzero terminal padding was not rejected");
+    bad_padding_done = 1;
+  end
+
   always @(posedge clk) begin
     if (rst_n) begin
       if (bad_rx_codec_valid)
@@ -616,6 +685,10 @@ module local_reducer_aggregate_stats_once_exact_packet_mesh_tb;
         bad_early_clean_count <= bad_early_clean_count + 1;
       if (bad_late_clean)
         bad_late_clean_count <= bad_late_clean_count + 1;
+      if (bad_padding_codec_valid)
+        bad_padding_output_count <= bad_padding_output_count + 1;
+      if (bad_padding_clean)
+        bad_padding_clean_count <= bad_padding_clean_count + 1;
     end
   end
 

--- a/tests/local_reducer_aggregate_stats_once_exact_packet_mesh_tb.sv
+++ b/tests/local_reducer_aggregate_stats_once_exact_packet_mesh_tb.sv
@@ -1,0 +1,626 @@
+`timescale 1ns/1ps
+
+module local_reducer_aggregate_stats_once_exact_packet_mesh_tb;
+  localparam integer DATA_W = 256;
+  localparam integer TAG_W = 8;
+  localparam integer FRAGMENT_W = 3;
+  localparam integer VC_W = 2;
+
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  always #5 clk = ~clk;
+
+  function automatic [DATA_W-1:0] payload_for;
+    input integer group_id;
+    input integer flit_id;
+    reg [31:0] state;
+    integer lane;
+    begin
+      payload_for = {DATA_W{1'b0}};
+      for (lane = 0; lane < 8; lane = lane + 1) begin
+        state = 32'h9e3779b9 ^ (group_id * 32'h45d9f3b) ^
+          (flit_id * 32'h27d4eb2d) ^ (lane * 32'h165667b1);
+        state = state ^ (state << 13);
+        state = state ^ (state >> 17);
+        state = state ^ (state << 5);
+        payload_for[(lane * 32) +: 32] = state;
+      end
+    end
+  endfunction
+
+  function automatic [7:0] tag_for;
+    input integer group_id;
+    input integer flit_id;
+    begin
+      tag_for = ((3 + group_id) * 32) + (flit_id / 8);
+    end
+  endfunction
+
+  function automatic [2:0] fragment_for;
+    input integer flit_id;
+    begin
+      fragment_for = flit_id % 8;
+    end
+  endfunction
+
+  // One source at endpoint 1, one sink at endpoint 0, and no traffic at the
+  // other fourteen endpoints.  The actual segmented mesh and all router/FIFO
+  // instances are therefore part of this equivalence test.
+  reg good_ctx_valid;
+  wire good_tx_ctx_ready;
+  wire good_rx_ctx_ready;
+  reg [15:0] good_command;
+  reg [4:0] good_head;
+  reg [3:0] good_source;
+  reg [3:0] good_destination;
+  reg [VC_W-1:0] good_vc;
+  reg [2:0] good_epoch;
+
+  reg good_codec_valid;
+  wire good_codec_ready;
+  reg [DATA_W-1:0] good_codec_data;
+  reg good_codec_group_last;
+  wire good_tx_mesh_valid;
+  wire good_tx_mesh_ready;
+  wire [3:0] good_tx_mesh_destination;
+  wire [3:0] good_tx_mesh_source;
+  wire [TAG_W-1:0] good_tx_mesh_tag;
+  wire [FRAGMENT_W-1:0] good_tx_mesh_fragment;
+  wire good_tx_mesh_last;
+  wire [VC_W-1:0] good_tx_mesh_vc;
+  wire [DATA_W-1:0] good_tx_mesh_data;
+  wire good_tx_clean_complete;
+
+  wire good_rx_mesh_valid;
+  wire good_rx_mesh_ready;
+  wire [3:0] good_rx_mesh_destination;
+  wire [3:0] good_rx_mesh_source;
+  wire [TAG_W-1:0] good_rx_mesh_tag;
+  wire [FRAGMENT_W-1:0] good_rx_mesh_fragment;
+  wire good_rx_mesh_last;
+  wire [VC_W-1:0] good_rx_mesh_vc;
+  wire [DATA_W-1:0] good_rx_mesh_data;
+  wire good_rx_codec_valid;
+  wire good_rx_codec_ready;
+  wire [DATA_W-1:0] good_rx_codec_data;
+  wire good_rx_codec_group_last;
+  wire good_tx_error;
+  wire good_rx_error;
+  wire good_clean_complete;
+
+  reg [15:0] mesh_in_valid;
+  wire [15:0] mesh_in_ready;
+  reg [16*4-1:0] mesh_in_dest;
+  reg [16*4-1:0] mesh_in_source;
+  reg [16*TAG_W-1:0] mesh_in_tag;
+  reg [16*FRAGMENT_W-1:0] mesh_in_fragment;
+  reg [15:0] mesh_in_last;
+  reg [16*VC_W-1:0] mesh_in_vc;
+  reg [16*DATA_W-1:0] mesh_in_data;
+  wire [15:0] mesh_out_valid;
+  reg [15:0] mesh_out_ready;
+  wire [16*4-1:0] mesh_out_dest;
+  wire [16*4-1:0] mesh_out_source;
+  wire [16*TAG_W-1:0] mesh_out_tag;
+  wire [16*FRAGMENT_W-1:0] mesh_out_fragment;
+  wire [15:0] mesh_out_last;
+  wire [16*VC_W-1:0] mesh_out_vc;
+  wire [16*DATA_W-1:0] mesh_out_data;
+
+  integer good_cycle;
+  integer mesh_flit_count;
+  integer output_flit_count;
+  integer mesh_packet_count;
+  integer mesh_group_packet_count;
+  integer clean_count;
+  integer tx_clean_count;
+  integer good_failures;
+  integer tx_stability_failures;
+  integer rx_stability_failures;
+  integer mesh_metadata_failures;
+  integer output_last_failures;
+  reg tx_hold_valid;
+  reg [3:0] tx_hold_destination;
+  reg [3:0] tx_hold_source;
+  reg [TAG_W-1:0] tx_hold_tag;
+  reg [FRAGMENT_W-1:0] tx_hold_fragment;
+  reg tx_hold_last;
+  reg [VC_W-1:0] tx_hold_vc;
+  reg [DATA_W-1:0] tx_hold_data;
+  reg rx_hold_valid;
+  reg [DATA_W-1:0] rx_hold_data;
+  reg rx_hold_group_last;
+
+  assign good_tx_mesh_ready = mesh_in_ready[1];
+  assign good_rx_codec_ready = !((good_cycle % 7) == 3) &&
+    !((good_cycle % 13) == 6);
+  assign good_rx_mesh_valid = mesh_out_valid[0];
+  assign good_rx_mesh_destination = mesh_out_dest[0 +: 4];
+  assign good_rx_mesh_source = mesh_out_source[0 +: 4];
+  assign good_rx_mesh_tag = mesh_out_tag[0 +: TAG_W];
+  assign good_rx_mesh_fragment = mesh_out_fragment[0 +: FRAGMENT_W];
+  assign good_rx_mesh_last = mesh_out_last[0];
+  assign good_rx_mesh_vc = mesh_out_vc[0 +: VC_W];
+  assign good_rx_mesh_data = mesh_out_data[0 +: DATA_W];
+
+  always @* begin
+    mesh_in_valid = 16'b0;
+    mesh_in_dest = {(16*4){1'b0}};
+    mesh_in_source = {(16*4){1'b0}};
+    mesh_in_tag = {(16*TAG_W){1'b0}};
+    mesh_in_fragment = {(16*FRAGMENT_W){1'b0}};
+    mesh_in_last = 16'b0;
+    mesh_in_vc = {(16*VC_W){1'b0}};
+    mesh_in_data = {(16*DATA_W){1'b0}};
+    mesh_in_valid[1] = good_tx_mesh_valid;
+    mesh_in_dest[1*4 +: 4] = good_tx_mesh_destination;
+    mesh_in_source[1*4 +: 4] = good_tx_mesh_source;
+    mesh_in_tag[1*TAG_W +: TAG_W] = good_tx_mesh_tag;
+    mesh_in_fragment[1*FRAGMENT_W +: FRAGMENT_W] = good_tx_mesh_fragment;
+    mesh_in_last[1] = good_tx_mesh_last;
+    mesh_in_vc[1*VC_W +: VC_W] = good_tx_mesh_vc;
+    mesh_in_data[1*DATA_W +: DATA_W] = good_tx_mesh_data;
+
+    mesh_out_ready = 16'b0;
+    mesh_out_ready[0] = good_rx_mesh_ready;
+  end
+
+  noc_segmented_mesh4x4 #(
+    .DATA_W(DATA_W), .TAG_W(TAG_W), .FRAGMENT_W(FRAGMENT_W), .VC_W(VC_W),
+    .VC_COUNT(4), .FIFO_DEPTH(4)
+  ) u_mesh (
+    .clk(clk), .rst_n(rst_n),
+    .endpoint_in_valid(mesh_in_valid), .endpoint_in_ready(mesh_in_ready),
+    .endpoint_in_dest(mesh_in_dest), .endpoint_in_source(mesh_in_source),
+    .endpoint_in_tag(mesh_in_tag), .endpoint_in_fragment(mesh_in_fragment),
+    .endpoint_in_last(mesh_in_last), .endpoint_in_vc(mesh_in_vc),
+    .endpoint_in_data(mesh_in_data),
+    .endpoint_out_valid(mesh_out_valid), .endpoint_out_ready(mesh_out_ready),
+    .endpoint_out_dest(mesh_out_dest), .endpoint_out_source(mesh_out_source),
+    .endpoint_out_tag(mesh_out_tag), .endpoint_out_fragment(mesh_out_fragment),
+    .endpoint_out_last(mesh_out_last), .endpoint_out_vc(mesh_out_vc),
+    .endpoint_out_data(mesh_out_data),
+    .router_accepted_flit_count(), .router_forwarded_flit_count(),
+    .router_input_stall_cycles(), .router_output_stall_cycles(),
+    .router_contention_cycles(), .router_current_input_occupancy(),
+    .router_max_input_occupancy(), .router_route_flit_count()
+  );
+
+  local_reducer_aggregate_stats_once_exact_packet_tx_framer u_good_tx (
+    .clk(clk), .rst_n(rst_n),
+    .group_ctx_valid(good_ctx_valid), .group_ctx_ready(good_tx_ctx_ready),
+    .group_command_id(good_command), .group_head_base(good_head),
+    .group_source(good_source), .group_destination(good_destination),
+    .group_vc(good_vc), .group_epoch(good_epoch),
+    .codec_flit_valid(good_codec_valid), .codec_flit_ready(good_codec_ready),
+    .codec_flit_data(good_codec_data),
+    .codec_flit_group_last(good_codec_group_last),
+    .mesh_flit_valid(good_tx_mesh_valid), .mesh_flit_ready(good_tx_mesh_ready),
+    .mesh_flit_destination(good_tx_mesh_destination),
+    .mesh_flit_source(good_tx_mesh_source), .mesh_flit_tag(good_tx_mesh_tag),
+    .mesh_flit_fragment(good_tx_mesh_fragment),
+    .mesh_flit_last(good_tx_mesh_last), .mesh_flit_vc(good_tx_mesh_vc),
+    .mesh_flit_data(good_tx_mesh_data),
+    .clean_group_complete(good_tx_clean_complete),
+    .protocol_error(good_tx_error)
+  );
+
+  local_reducer_aggregate_stats_once_exact_packet_rx_deframer u_good_rx (
+    .clk(clk), .rst_n(rst_n),
+    .group_ctx_valid(good_ctx_valid), .group_ctx_ready(good_rx_ctx_ready),
+    .group_command_id(good_command), .group_head_base(good_head),
+    .group_source(good_source), .group_destination(good_destination),
+    .group_vc(good_vc), .group_epoch(good_epoch),
+    .mesh_flit_valid(good_rx_mesh_valid), .mesh_flit_ready(good_rx_mesh_ready),
+    .mesh_flit_destination(good_rx_mesh_destination),
+    .mesh_flit_source(good_rx_mesh_source), .mesh_flit_tag(good_rx_mesh_tag),
+    .mesh_flit_fragment(good_rx_mesh_fragment),
+    .mesh_flit_last(good_rx_mesh_last), .mesh_flit_vc(good_rx_mesh_vc),
+    .mesh_flit_data(good_rx_mesh_data),
+    .codec_flit_valid(good_rx_codec_valid),
+    .codec_flit_ready(good_rx_codec_ready), .codec_flit_data(good_rx_codec_data),
+    .codec_flit_group_last(good_rx_codec_group_last),
+    .protocol_error(good_rx_error), .clean_group_complete(good_clean_complete)
+  );
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      good_cycle <= 0;
+      mesh_flit_count <= 0;
+      output_flit_count <= 0;
+      mesh_packet_count <= 0;
+      mesh_group_packet_count <= 0;
+      clean_count <= 0;
+      tx_clean_count <= 0;
+      good_failures <= 0;
+      tx_stability_failures <= 0;
+      rx_stability_failures <= 0;
+      mesh_metadata_failures <= 0;
+      output_last_failures <= 0;
+      tx_hold_valid <= 1'b0;
+      rx_hold_valid <= 1'b0;
+    end else begin
+      good_cycle <= good_cycle + 1;
+      if (good_tx_error || good_rx_error)
+        good_failures <= good_failures + 1;
+      if (good_tx_clean_complete)
+        tx_clean_count <= tx_clean_count + 1;
+
+      if (tx_hold_valid) begin
+        if (!good_tx_mesh_valid ||
+            good_tx_mesh_destination !== tx_hold_destination ||
+            good_tx_mesh_source !== tx_hold_source ||
+            good_tx_mesh_tag !== tx_hold_tag ||
+            good_tx_mesh_fragment !== tx_hold_fragment ||
+            good_tx_mesh_last !== tx_hold_last ||
+            good_tx_mesh_vc !== tx_hold_vc ||
+            good_tx_mesh_data !== tx_hold_data) begin
+          good_failures <= good_failures + 1;
+          tx_stability_failures <= tx_stability_failures + 1;
+        end
+      end
+      tx_hold_valid <= good_tx_mesh_valid && !good_tx_mesh_ready;
+      if (good_tx_mesh_valid && !good_tx_mesh_ready) begin
+        tx_hold_destination <= good_tx_mesh_destination;
+        tx_hold_source <= good_tx_mesh_source;
+        tx_hold_tag <= good_tx_mesh_tag;
+        tx_hold_fragment <= good_tx_mesh_fragment;
+        tx_hold_last <= good_tx_mesh_last;
+        tx_hold_vc <= good_tx_mesh_vc;
+        tx_hold_data <= good_tx_mesh_data;
+      end
+
+      if (rx_hold_valid) begin
+        if (!good_rx_codec_valid || good_rx_codec_data !== rx_hold_data ||
+            good_rx_codec_group_last !== rx_hold_group_last) begin
+          good_failures <= good_failures + 1;
+          rx_stability_failures <= rx_stability_failures + 1;
+        end
+      end
+      rx_hold_valid <= good_rx_codec_valid && !good_rx_codec_ready;
+      if (good_rx_codec_valid && !good_rx_codec_ready) begin
+        rx_hold_data <= good_rx_codec_data;
+        rx_hold_group_last <= good_rx_codec_group_last;
+      end
+
+      if (good_rx_mesh_valid && good_rx_mesh_ready) begin
+        if (good_rx_mesh_destination !== 4'd0 ||
+            good_rx_mesh_source !== 4'd1 || good_rx_mesh_vc !== 2'd2)
+          begin good_failures <= good_failures + 1; mesh_metadata_failures <= mesh_metadata_failures + 1; end
+        if (good_rx_mesh_tag !== tag_for(mesh_flit_count / 167,
+                                         mesh_flit_count % 167))
+          begin good_failures <= good_failures + 1; mesh_metadata_failures <= mesh_metadata_failures + 1; end
+        if (good_rx_mesh_fragment !== fragment_for(mesh_flit_count % 167))
+          begin good_failures <= good_failures + 1; mesh_metadata_failures <= mesh_metadata_failures + 1; end
+        if (good_rx_mesh_last !== (((mesh_flit_count % 167) % 8) == 7 ||
+                                   (mesh_flit_count % 167) == 166))
+          begin good_failures <= good_failures + 1; mesh_metadata_failures <= mesh_metadata_failures + 1; end
+        if (good_rx_mesh_data !== payload_for(mesh_flit_count / 167,
+                                               mesh_flit_count % 167)) begin
+          good_failures <= good_failures + 1;
+          mesh_metadata_failures <= mesh_metadata_failures + 1;
+        end
+        mesh_flit_count <= mesh_flit_count + 1;
+        if (good_rx_mesh_last) begin
+          mesh_packet_count <= mesh_packet_count + 1;
+          mesh_group_packet_count <= mesh_group_packet_count + 1;
+          if ((mesh_flit_count % 167) == 166) begin
+            if (mesh_group_packet_count != 20)
+              good_failures <= good_failures + 1;
+            mesh_group_packet_count <= 0;
+          end
+        end
+      end
+
+      if (good_rx_codec_valid && good_rx_codec_ready) begin
+        if (good_rx_codec_data !== payload_for(output_flit_count / 167,
+                                                output_flit_count % 167)) begin
+          good_failures <= good_failures + 1;
+        end
+        if (good_rx_codec_group_last !==
+            ((output_flit_count % 167) == 166))
+          begin good_failures <= good_failures + 1; output_last_failures <= output_last_failures + 1; end
+        output_flit_count <= output_flit_count + 1;
+      end
+      if (good_clean_complete)
+        clean_count <= clean_count + 1;
+    end
+  end
+
+  // Direct malformed TX: early group-last is rejected, but the fixed-size
+  // group is drained so that context can be reused after recovery.
+  reg bad_early_ctx_valid;
+  wire bad_early_ctx_ready;
+  reg [15:0] bad_early_command;
+  reg [4:0] bad_early_head;
+  reg [3:0] bad_early_source;
+  reg [3:0] bad_early_destination;
+  reg [1:0] bad_early_vc;
+  reg [2:0] bad_early_epoch;
+  reg bad_early_codec_valid;
+  wire bad_early_codec_ready;
+  reg [DATA_W-1:0] bad_early_data;
+  reg bad_early_group_last;
+  wire bad_early_mesh_valid;
+  wire bad_early_clean;
+  wire bad_early_error;
+  integer bad_early_done;
+  integer bad_early_clean_count;
+
+  local_reducer_aggregate_stats_once_exact_packet_tx_framer u_bad_early (
+    .clk(clk), .rst_n(rst_n), .group_ctx_valid(bad_early_ctx_valid),
+    .group_ctx_ready(bad_early_ctx_ready), .group_command_id(bad_early_command),
+    .group_head_base(bad_early_head), .group_source(bad_early_source),
+    .group_destination(bad_early_destination), .group_vc(bad_early_vc),
+    .group_epoch(bad_early_epoch), .codec_flit_valid(bad_early_codec_valid),
+    .codec_flit_ready(bad_early_codec_ready), .codec_flit_data(bad_early_data),
+    .codec_flit_group_last(bad_early_group_last),
+    .mesh_flit_valid(bad_early_mesh_valid), .mesh_flit_ready(1'b1),
+    .mesh_flit_destination(), .mesh_flit_source(), .mesh_flit_tag(),
+    .mesh_flit_fragment(), .mesh_flit_last(), .mesh_flit_vc(),
+    .mesh_flit_data(), .clean_group_complete(bad_early_clean),
+    .protocol_error(bad_early_error)
+  );
+
+  // Direct malformed TX: the final codec beat omits group-last.
+  reg bad_late_ctx_valid;
+  wire bad_late_ctx_ready;
+  reg [15:0] bad_late_command;
+  reg [4:0] bad_late_head;
+  reg [3:0] bad_late_source;
+  reg [3:0] bad_late_destination;
+  reg [1:0] bad_late_vc;
+  reg [2:0] bad_late_epoch;
+  reg bad_late_codec_valid;
+  wire bad_late_codec_ready;
+  reg [DATA_W-1:0] bad_late_data;
+  reg bad_late_group_last;
+  wire bad_late_mesh_valid;
+  wire bad_late_clean;
+  wire bad_late_error;
+  integer bad_late_done;
+  integer bad_late_clean_count;
+
+  local_reducer_aggregate_stats_once_exact_packet_tx_framer u_bad_late (
+    .clk(clk), .rst_n(rst_n), .group_ctx_valid(bad_late_ctx_valid),
+    .group_ctx_ready(bad_late_ctx_ready), .group_command_id(bad_late_command),
+    .group_head_base(bad_late_head), .group_source(bad_late_source),
+    .group_destination(bad_late_destination), .group_vc(bad_late_vc),
+    .group_epoch(bad_late_epoch), .codec_flit_valid(bad_late_codec_valid),
+    .codec_flit_ready(bad_late_codec_ready), .codec_flit_data(bad_late_data),
+    .codec_flit_group_last(bad_late_group_last),
+    .mesh_flit_valid(bad_late_mesh_valid), .mesh_flit_ready(1'b1),
+    .mesh_flit_destination(), .mesh_flit_source(), .mesh_flit_tag(),
+    .mesh_flit_fragment(), .mesh_flit_last(), .mesh_flit_vc(),
+    .mesh_flit_data(), .clean_group_complete(bad_late_clean),
+    .protocol_error(bad_late_error)
+  );
+
+  // Direct malformed RX: one packet fragment is out of order.  All 167
+  // flits are still supplied, so lack of clean completion is tested directly.
+  reg bad_rx_ctx_valid;
+  wire bad_rx_ctx_ready;
+  reg [15:0] bad_rx_command;
+  reg [4:0] bad_rx_head;
+  reg [3:0] bad_rx_source;
+  reg [3:0] bad_rx_destination;
+  reg [1:0] bad_rx_vc;
+  reg [2:0] bad_rx_epoch;
+  reg bad_rx_mesh_valid;
+  wire bad_rx_mesh_ready;
+  reg [3:0] bad_rx_mesh_dest;
+  reg [3:0] bad_rx_mesh_src;
+  reg [7:0] bad_rx_mesh_tag;
+  reg [2:0] bad_rx_mesh_fragment;
+  reg bad_rx_mesh_last;
+  reg [1:0] bad_rx_mesh_vc;
+  reg [DATA_W-1:0] bad_rx_mesh_data;
+  wire bad_rx_codec_valid;
+  wire bad_rx_error;
+  wire bad_rx_clean;
+  integer bad_rx_output_count;
+  integer bad_rx_clean_count;
+  integer bad_rx_done;
+
+  local_reducer_aggregate_stats_once_exact_packet_rx_deframer u_bad_rx (
+    .clk(clk), .rst_n(rst_n), .group_ctx_valid(bad_rx_ctx_valid),
+    .group_ctx_ready(bad_rx_ctx_ready), .group_command_id(bad_rx_command),
+    .group_head_base(bad_rx_head), .group_source(bad_rx_source),
+    .group_destination(bad_rx_destination), .group_vc(bad_rx_vc),
+    .group_epoch(bad_rx_epoch), .mesh_flit_valid(bad_rx_mesh_valid),
+    .mesh_flit_ready(bad_rx_mesh_ready), .mesh_flit_destination(bad_rx_mesh_dest),
+    .mesh_flit_source(bad_rx_mesh_src), .mesh_flit_tag(bad_rx_mesh_tag),
+    .mesh_flit_fragment(bad_rx_mesh_fragment), .mesh_flit_last(bad_rx_mesh_last),
+    .mesh_flit_vc(bad_rx_mesh_vc), .mesh_flit_data(bad_rx_mesh_data),
+    .codec_flit_valid(bad_rx_codec_valid), .codec_flit_ready(1'b1),
+    .codec_flit_data(), .codec_flit_group_last(),
+    .protocol_error(bad_rx_error), .clean_group_complete(bad_rx_clean)
+  );
+
+  initial begin
+    good_ctx_valid = 0;
+    good_command = 0;
+    good_head = 0;
+    good_source = 0;
+    good_destination = 0;
+    good_vc = 0;
+    good_epoch = 0;
+    good_codec_valid = 0;
+    good_codec_data = 0;
+    good_codec_group_last = 0;
+    repeat (3) @(negedge clk);
+    rst_n = 1'b1;
+    for (integer group_i = 0; group_i < 2; group_i = group_i + 1) begin
+      @(negedge clk);
+      good_command = 16'h5200 + group_i;
+      good_head = 5'd8;
+      good_source = 4'd1;
+      good_destination = 4'd0;
+      good_vc = 2'd2;
+      good_epoch = 3'd3 + group_i;
+      good_ctx_valid = 1'b1;
+      while (!(good_tx_ctx_ready && good_rx_ctx_ready)) @(posedge clk);
+      @(negedge clk);
+      good_ctx_valid = 1'b0;
+      for (integer flit_i = 0; flit_i < 167; flit_i = flit_i + 1) begin
+        good_codec_data = payload_for(group_i, flit_i);
+        good_codec_group_last = (flit_i == 166);
+        good_codec_valid = 1'b1;
+        while (!(good_codec_valid && good_codec_ready)) @(posedge clk);
+        @(negedge clk);
+      end
+      good_codec_valid = 1'b0;
+      good_codec_group_last = 1'b0;
+      good_codec_data = 0;
+      while (clean_count <= group_i) @(posedge clk);
+      @(negedge clk);
+    end
+    while (mesh_flit_count < 334 || output_flit_count < 334 || clean_count < 2)
+      @(posedge clk);
+    if (good_failures != 0 || mesh_flit_count != 334 ||
+        output_flit_count != 334 || mesh_packet_count != 42 || clean_count != 2 ||
+        tx_clean_count != 2 ||
+        good_tx_error || good_rx_error)
+      $fatal(1, "mesh equivalence failed mesh=%0d output=%0d packets=%0d clean=%0d failures=%0d txstable=%0d rxstable=%0d meta=%0d outlast=%0d errors=%b/%b",
+        mesh_flit_count, output_flit_count, mesh_packet_count, clean_count,
+        good_failures, tx_stability_failures, rx_stability_failures,
+        mesh_metadata_failures, output_last_failures, good_tx_error, good_rx_error);
+    bad_early_done = 1;
+    bad_late_done = 1;
+    bad_rx_done = 1;
+    while (!(bad_early_done && bad_late_done && bad_rx_done)) @(posedge clk);
+    $display("PASS local_reducer_aggregate_stats_once_exact_packet_mesh groups=2 flits=334 packets=42 outputs=334 tx_clean=2 rx_clean=2 clean=2");
+    $finish;
+  end
+
+  initial begin
+    bad_early_ctx_valid = 0;
+    bad_early_command = 16'h6100;
+    bad_early_head = 5'd8;
+    bad_early_source = 4'd1;
+    bad_early_destination = 4'd0;
+    bad_early_vc = 2'd2;
+    bad_early_epoch = 3'd1;
+    bad_early_codec_valid = 0;
+    bad_early_data = 0;
+    bad_early_group_last = 0;
+    bad_early_done = 0;
+    bad_early_clean_count = 0;
+    @(posedge rst_n);
+    @(negedge clk);
+    bad_early_ctx_valid = 1;
+    while (!bad_early_ctx_ready) @(posedge clk);
+    @(negedge clk);
+    bad_early_ctx_valid = 0;
+    for (integer i = 0; i < 167; i = i + 1) begin
+      bad_early_data = payload_for(9, i);
+      bad_early_group_last = (i == 10) || (i == 166);
+      bad_early_codec_valid = 1;
+      while (!(bad_early_codec_valid && bad_early_codec_ready)) @(posedge clk);
+      @(negedge clk);
+    end
+    bad_early_codec_valid = 0;
+    bad_early_group_last = 0;
+    while (!bad_early_error) @(posedge clk);
+    while (!bad_early_ctx_ready) @(posedge clk);
+    if (bad_early_clean_count != 0)
+      $fatal(1, "early malformed TX completed cleanly");
+    bad_early_done = 1;
+  end
+
+  initial begin
+    bad_late_ctx_valid = 0;
+    bad_late_command = 16'h6200;
+    bad_late_head = 5'd8;
+    bad_late_source = 4'd1;
+    bad_late_destination = 4'd0;
+    bad_late_vc = 2'd2;
+    bad_late_epoch = 3'd2;
+    bad_late_codec_valid = 0;
+    bad_late_data = 0;
+    bad_late_group_last = 0;
+    bad_late_done = 0;
+    bad_late_clean_count = 0;
+    @(posedge rst_n);
+    @(negedge clk);
+    bad_late_ctx_valid = 1;
+    while (!bad_late_ctx_ready) @(posedge clk);
+    @(negedge clk);
+    bad_late_ctx_valid = 0;
+    for (integer i = 0; i < 167; i = i + 1) begin
+      bad_late_data = payload_for(10, i);
+      bad_late_group_last = 1'b0;
+      bad_late_codec_valid = 1;
+      while (!(bad_late_codec_valid && bad_late_codec_ready)) @(posedge clk);
+      @(negedge clk);
+    end
+    bad_late_codec_valid = 0;
+    while (!bad_late_error) @(posedge clk);
+    while (!bad_late_ctx_ready) @(posedge clk);
+    if (bad_late_clean_count != 0)
+      $fatal(1, "late malformed TX completed cleanly");
+    bad_late_done = 1;
+  end
+
+  initial begin
+    bad_rx_ctx_valid = 0;
+    bad_rx_command = 16'h6300;
+    bad_rx_head = 5'd8;
+    bad_rx_source = 4'd1;
+    bad_rx_destination = 4'd0;
+    bad_rx_vc = 2'd2;
+    bad_rx_epoch = 3'd7;
+    bad_rx_mesh_valid = 0;
+    bad_rx_mesh_dest = 0;
+    bad_rx_mesh_src = 0;
+    bad_rx_mesh_tag = 0;
+    bad_rx_mesh_fragment = 0;
+    bad_rx_mesh_last = 0;
+    bad_rx_mesh_vc = 0;
+    bad_rx_mesh_data = 0;
+    bad_rx_output_count = 0;
+    bad_rx_clean_count = 0;
+    bad_rx_done = 0;
+    @(posedge rst_n);
+    @(negedge clk);
+    bad_rx_ctx_valid = 1;
+    while (!bad_rx_ctx_ready) @(posedge clk);
+    @(negedge clk);
+    bad_rx_ctx_valid = 0;
+    for (integer i = 0; i < 167; i = i + 1) begin
+      bad_rx_mesh_dest = 4'd0;
+      bad_rx_mesh_src = 4'd1;
+      bad_rx_mesh_tag = 8'he0 | (i / 8);
+      bad_rx_mesh_fragment = (i == 166) ? 3'd5 : (i % 8);
+      bad_rx_mesh_last = ((i % 8) == 7) || (i == 166);
+      bad_rx_mesh_vc = 2'd2;
+      bad_rx_mesh_data = payload_for(11, i);
+      bad_rx_mesh_valid = 1;
+      while (!(bad_rx_mesh_valid && bad_rx_mesh_ready)) @(posedge clk);
+      @(negedge clk);
+    end
+    bad_rx_mesh_valid = 0;
+    while (bad_rx_output_count < 167) @(posedge clk);
+    if (!bad_rx_error || bad_rx_clean_count != 0)
+      $fatal(1, "malformed RX was not rejected");
+    bad_rx_done = 1;
+  end
+
+  always @(posedge clk) begin
+    if (rst_n) begin
+      if (bad_rx_codec_valid)
+        bad_rx_output_count <= bad_rx_output_count + 1;
+      if (bad_rx_clean)
+        bad_rx_clean_count <= bad_rx_clean_count + 1;
+      if (bad_early_clean)
+        bad_early_clean_count <= bad_early_clean_count + 1;
+      if (bad_late_clean)
+        bad_late_clean_count <= bad_late_clean_count + 1;
+    end
+  end
+
+  initial begin
+    #500000;
+    $fatal(1, "simulation timeout");
+  end
+endmodule

--- a/tests/test_local_reducer_aggregate_stats_once_exact_packet_mesh.py
+++ b/tests/test_local_reducer_aggregate_stats_once_exact_packet_mesh.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BRIDGE = REPO_ROOT / "npu/sim/rtl/local_reducer_aggregate_stats_once_exact_packet_bridge.sv"
+FIFO = REPO_ROOT / "npu/sim/rtl/noc_ready_valid_fifo.sv"
+ROUTER = REPO_ROOT / "npu/sim/rtl/noc_segmented_mesh_router.sv"
+MESH = REPO_ROOT / "npu/sim/rtl/noc_segmented_mesh4x4.sv"
+TB = REPO_ROOT / "tests/local_reducer_aggregate_stats_once_exact_packet_mesh_tb.sv"
+
+
+def _tool(name: str) -> str | None:
+    path = shutil.which(name)
+    if path is not None:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    return str(fallback) if fallback.exists() else None
+
+
+@pytest.mark.skipif(
+    _tool("iverilog") is None or _tool("vvp") is None,
+    reason="iverilog/vvp unavailable",
+)
+def test_stats_once_exact_packet_bridge_real_mesh(tmp_path: Path) -> None:
+    simv = tmp_path / "stats_once_exact_packet_mesh.vvp"
+    subprocess.run(
+        [
+            str(_tool("iverilog")),
+            "-g2012",
+            "-s",
+            "local_reducer_aggregate_stats_once_exact_packet_mesh_tb",
+            "-o",
+            str(simv),
+            str(BRIDGE),
+            str(FIFO),
+            str(ROUTER),
+            str(MESH),
+            str(TB),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    run = subprocess.run(
+        [str(_tool("vvp")), str(simv)],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert (
+        "PASS local_reducer_aggregate_stats_once_exact_packet_mesh" in run.stdout
+    )
+    assert "groups=2" in run.stdout
+    assert "flits=334" in run.stdout
+    assert "packets=42" in run.stdout
+    assert "outputs=334" in run.stdout
+    assert "tx_clean=2" in run.stdout
+    assert "rx_clean=2" in run.stdout
+    assert "clean=2" in run.stdout
+
+
+@pytest.mark.skipif(_tool("yosys") is None, reason="yosys unavailable")
+def test_stats_once_exact_packet_bridge_yosys_import_process_check() -> None:
+    yosys = str(_tool("yosys"))
+    for top in (
+        "local_reducer_aggregate_stats_once_exact_packet_tx_framer",
+        "local_reducer_aggregate_stats_once_exact_packet_rx_deframer",
+    ):
+        subprocess.run(
+            [
+                yosys,
+                "-q",
+                "-p",
+                "read_verilog -DSYNTHESIS -sv "
+                f"{BRIDGE}; hierarchy -check -top {top}; proc; check",
+            ],
+            check=True,
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )


### PR DESCRIPTION
## Summary
- frame each exact 167-flit stats-once group into 21 bounded packets for the existing 256-bit segmented mesh
- preserve command/head/source/destination/VC/epoch context and reject malformed packet order, length, framing, or padding
- prove two exact groups through the real 4x4 mesh under deterministic backpressure
- define the finite SRAM endpoint bridge contract for the next embodiment step

## Exact transport contract
- packets 0..19 contain 8 flits; packet 20 contains 7 flits
- tag is `{epoch[2:0], packet_index[4:0]}`
- RX completion is suppressed on malformed metadata or packet framing
- no whole-group payload register is introduced

## Verification
- `/home/rtlgen/.venvs/rtlgen-control-plane/bin/python -m pytest -q tests/test_local_reducer_aggregate_stats_once_exact_packet_mesh.py tests/test_local_reducer_aggregate_stats_once_exact_codec.py` (`4 passed`)
- `/home/rtlgen/.venvs/rtlgen-control-plane/bin/python scripts/validate_runs.py --skip_eval_queue` (`OK`)

## Follow-on boundary
This PR proves direct packet transport through the actual segmented mesh. The next step is a finite ping-pong SRAM adapter through `noc_sram_packet_endpoint`, followed by 15-source root composition and measured Llama7B recosting.
