### PR TITLE
Add exact stats-once finite SRAM endpoint roundtrip

### DIFF
--- a/npu/docs/attention_score32_exact_stats_once_sram_endpoint_bridge_contract.md
+++ b/npu/docs/attention_score32_exact_stats_once_sram_endpoint_bridge_contract.md
@@ -59,3 +59,9 @@ counts, completion order, stalls, and maximum slot occupancy.
 SRAM is initially an inferred synchronous word array for control and schedule
 closure. Its bitcell area and energy must later be substituted from a cited
 macro model; the inferred array is not itself a physical SRAM PPA claim.
+
+The minimum adapter therefore retains two distinct 16x256 memory boundaries:
+one source packet store and one destination packet store. Synthesis validation
+must prove that each boundary remains a memory cell after process lowering; a
+register-and-multiplexer expansion is not an acceptable SRAM embodiment or a
+valid basis for packet-storage PPA.

--- a/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_sram_packet_adapter.sv
+++ b/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_sram_packet_adapter.sv
@@ -1,5 +1,56 @@
 `timescale 1ns/1ps
 
+// One-read/one-write 16x256 packet SRAM with a registered, backpressured read
+// response.  The array has no reset and is kept in a dedicated module so
+// synthesis retains a memory boundary instead of expanding packet payloads
+// into resettable state registers.
+module local_reducer_aggregate_stats_once_exact_packet_sram #(
+  parameter integer DATA_W = 256,
+  parameter integer ADDR_W = 4
+) (
+  input wire clk,
+  input wire rst_n,
+  input wire write_valid,
+  input wire [ADDR_W-1:0] write_addr,
+  input wire [DATA_W-1:0] write_data,
+  input wire read_req_valid,
+  output wire read_req_ready,
+  input wire [ADDR_W-1:0] read_req_addr,
+  output wire read_rsp_valid,
+  input wire read_rsp_ready,
+  output wire [ADDR_W-1:0] read_rsp_addr,
+  output wire [DATA_W-1:0] read_rsp_data
+);
+  reg [DATA_W-1:0] mem [0:(1 << ADDR_W)-1];
+  reg read_rsp_valid_q;
+  reg [ADDR_W-1:0] read_rsp_addr_q;
+  reg [DATA_W-1:0] read_rsp_data_q;
+
+  assign read_req_ready = !read_rsp_valid_q || read_rsp_ready;
+  assign read_rsp_valid = read_rsp_valid_q;
+  assign read_rsp_addr = read_rsp_addr_q;
+  assign read_rsp_data = read_rsp_data_q;
+
+  always @(posedge clk) begin
+    if (write_valid)
+      mem[write_addr] <= write_data;
+    if (read_req_valid && read_req_ready) begin
+      read_rsp_addr_q <= read_req_addr;
+      read_rsp_data_q <= mem[read_req_addr];
+    end
+  end
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      read_rsp_valid_q <= 1'b0;
+    end else if (read_req_valid && read_req_ready) begin
+      read_rsp_valid_q <= 1'b1;
+    end else if (read_rsp_valid_q && read_rsp_ready) begin
+      read_rsp_valid_q <= 1'b0;
+    end
+  end
+endmodule
+
 // Finite SRAM adapter for one exact stats-once group.  The packet framer and
 // deframer retain the wire contract; this block owns only two source and two
 // destination packet slots and the endpoint memory handshakes around them.
@@ -112,6 +163,10 @@ module local_reducer_aggregate_stats_once_exact_sram_packet_adapter #(
   wire rx_deframer_error;
 
   reg tx_group_active_q;
+  reg [3:0] tx_group_source_q;
+  reg [3:0] tx_group_destination_q;
+  reg [VC_W-1:0] tx_group_vc_q;
+  reg [2:0] tx_group_epoch_q;
   reg tx_fill_active_q;
   reg tx_fill_slot_q;
   reg [3:0] tx_fill_word_q;
@@ -125,13 +180,9 @@ module local_reducer_aggregate_stats_once_exact_sram_packet_adapter #(
   reg tx_wait_fill_q;
   reg tx_wait_slot_q;
   reg [1:0] src_slot_state [0:SLOT_COUNT-1];
-  reg [DATA_W-1:0] src_mem [0:SLOT_COUNT-1][0:SLOT_WORDS-1];
   reg [FLIT_COUNT_W-1:0] src_expected_count [0:SLOT_COUNT-1];
   reg [FLIT_COUNT_W-1:0] src_req_count [0:SLOT_COUNT-1];
   reg [FLIT_COUNT_W-1:0] src_rsp_count [0:SLOT_COUNT-1];
-  reg src_rsp_valid_q;
-  reg src_rsp_slot_q;
-  reg [DATA_W-1:0] src_rsp_data_q;
   reg source_error_q;
 
   reg rx_group_active_q;
@@ -155,7 +206,6 @@ module local_reducer_aggregate_stats_once_exact_sram_packet_adapter #(
   reg [VC_W-1:0] dst_slot_vc [0:SLOT_COUNT-1];
   reg [TAG_W-1:0] dst_slot_tag [0:SLOT_COUNT-1];
   reg [FLIT_COUNT_W-1:0] dst_slot_count [0:SLOT_COUNT-1];
-  reg [DATA_W-1:0] dst_mem [0:SLOT_COUNT-1][0:SLOT_WORDS-1];
   reg [31:0] rx_write_cycle_q;
   reg rx_descriptor_installed_q;
   reg destination_error_q;
@@ -163,6 +213,15 @@ module local_reducer_aggregate_stats_once_exact_sram_packet_adapter #(
   reg replay_slot_q;
   reg [3:0] replay_word_q;
   reg [4:0] replay_next_packet_q;
+
+  wire src_mem_read_req_ready;
+  wire src_mem_read_rsp_valid;
+  wire [3:0] src_mem_read_rsp_addr;
+  wire [DATA_W-1:0] src_mem_read_rsp_data;
+  wire dst_mem_read_req_ready;
+  wire dst_mem_read_rsp_valid;
+  wire [3:0] dst_mem_read_rsp_addr;
+  wire [DATA_W-1:0] dst_mem_read_rsp_data;
 
   wire [1:0] src_occupied_count =
     (src_slot_state[0] != SLOT_FREE) + (src_slot_state[1] != SLOT_FREE);
@@ -183,7 +242,7 @@ module local_reducer_aggregate_stats_once_exact_sram_packet_adapter #(
 
   local_reducer_aggregate_stats_once_exact_packet_tx_framer tx_framer (
     .clk(clk), .rst_n(rst_n),
-    .group_ctx_valid(group_ctx_valid && (TX_ENABLE != 0)),
+    .group_ctx_valid(tx_ctx_fire),
     .group_ctx_ready(tx_framer_ctx_ready),
     .group_command_id(group_command_id), .group_head_base(group_head_base),
     .group_source(group_source), .group_destination(group_destination),
@@ -203,20 +262,21 @@ module local_reducer_aggregate_stats_once_exact_sram_packet_adapter #(
 
   local_reducer_aggregate_stats_once_exact_packet_rx_deframer rx_deframer (
     .clk(clk), .rst_n(rst_n),
-    .group_ctx_valid(group_ctx_valid && (RX_ENABLE != 0)),
+    .group_ctx_valid(rx_ctx_fire),
     .group_ctx_ready(rx_deframer_ctx_ready),
     .group_command_id(group_command_id), .group_head_base(group_head_base),
     .group_source(group_source), .group_destination(group_destination),
     .group_vc(group_vc), .group_epoch(group_epoch),
-    .mesh_flit_valid(replay_active_q && (RX_ENABLE != 0)),
+    .mesh_flit_valid(dst_mem_read_rsp_valid && (RX_ENABLE != 0)),
     .mesh_flit_ready(rx_deframer_flit_ready),
-    .mesh_flit_destination(dst_slot_destination[replay_slot_q]),
-    .mesh_flit_source(dst_slot_source[replay_slot_q]),
-    .mesh_flit_tag(dst_slot_tag[replay_slot_q]),
-    .mesh_flit_fragment(replay_word_q[FRAGMENT_W-1:0]),
-    .mesh_flit_last(replay_word_q + 1'b1 == dst_slot_count[replay_slot_q]),
-    .mesh_flit_vc(dst_slot_vc[replay_slot_q]),
-    .mesh_flit_data(dst_mem[replay_slot_q][replay_word_q[WORD_INDEX_W-1:0]]),
+    .mesh_flit_destination(dst_slot_destination[dst_mem_read_rsp_addr[3]]),
+    .mesh_flit_source(dst_slot_source[dst_mem_read_rsp_addr[3]]),
+    .mesh_flit_tag(dst_slot_tag[dst_mem_read_rsp_addr[3]]),
+    .mesh_flit_fragment(dst_mem_read_rsp_addr[FRAGMENT_W-1:0]),
+    .mesh_flit_last(dst_mem_read_rsp_addr[WORD_INDEX_W-1:0] + 1'b1 ==
+                    dst_slot_count[dst_mem_read_rsp_addr[3]]),
+    .mesh_flit_vc(dst_slot_vc[dst_mem_read_rsp_addr[3]]),
+    .mesh_flit_data(dst_mem_read_rsp_data),
     .codec_flit_valid(codec_out_valid), .codec_flit_ready(codec_out_ready),
     .codec_flit_data(codec_out_data),
     .codec_flit_group_last(codec_out_group_last),
@@ -333,9 +393,9 @@ module local_reducer_aggregate_stats_once_exact_sram_packet_adapter #(
   assign mesh_in_data = ep_tx_flit_data;
   assign mesh_out_ready = ep_rx_flit_ready;
 
-  assign ep_tx_mem_req_ready = (TX_ENABLE != 0) && !src_rsp_valid_q;
-  assign ep_tx_mem_rsp_valid = src_rsp_valid_q && (TX_ENABLE != 0);
-  assign ep_tx_mem_rsp_data = src_rsp_data_q;
+  assign ep_tx_mem_req_ready = (TX_ENABLE != 0) && src_mem_read_req_ready;
+  assign ep_tx_mem_rsp_valid = src_mem_read_rsp_valid && (TX_ENABLE != 0);
+  assign ep_tx_mem_rsp_data = src_mem_read_rsp_data;
   wire ep_tx_mem_req_fire = ep_tx_mem_req_valid && ep_tx_mem_req_ready;
   wire ep_tx_mem_rsp_fire = ep_tx_mem_rsp_valid && ep_tx_mem_rsp_ready;
 
@@ -399,6 +459,50 @@ module local_reducer_aggregate_stats_once_exact_sram_packet_adapter #(
   integer replay_found_i;
   reg replay_found_r;
   reg replay_found_slot_r;
+  wire replay_issue_available = replay_active_q &&
+    (replay_word_q < dst_slot_count[replay_slot_q]);
+  wire [3:0] src_fill_mem_addr =
+    {tx_fill_slot_q, tx_fill_word_q[WORD_INDEX_W-1:0]};
+  wire [3:0] src_read_mem_addr =
+    {tx_addr_slot_i[0], tx_addr_word_i[WORD_INDEX_W-1:0]};
+  wire [3:0] dst_write_mem_addr =
+    {rx_addr_slot_i[0], rx_addr_word_i[WORD_INDEX_W-1:0]};
+  wire [3:0] dst_read_mem_addr =
+    {replay_slot_q, replay_word_q[WORD_INDEX_W-1:0]};
+  wire dst_mem_read_req_valid = replay_issue_available && (RX_ENABLE != 0);
+  wire dst_mem_read_req_fire = dst_mem_read_req_valid &&
+    dst_mem_read_req_ready;
+  wire dst_mem_read_rsp_fire = dst_mem_read_rsp_valid &&
+    rx_deframer_flit_ready;
+
+  local_reducer_aggregate_stats_once_exact_packet_sram #(
+    .DATA_W(DATA_W), .ADDR_W(4)
+  ) source_packet_sram (
+    .clk(clk), .rst_n(rst_n),
+    .write_valid(tx_framer_flit_valid && tx_framer_flit_ready),
+    .write_addr(src_fill_mem_addr), .write_data(tx_framer_flit_data),
+    .read_req_valid(ep_tx_mem_req_valid && (TX_ENABLE != 0)),
+    .read_req_ready(src_mem_read_req_ready),
+    .read_req_addr(src_read_mem_addr),
+    .read_rsp_valid(src_mem_read_rsp_valid),
+    .read_rsp_ready(ep_tx_mem_rsp_ready && (TX_ENABLE != 0)),
+    .read_rsp_addr(src_mem_read_rsp_addr),
+    .read_rsp_data(src_mem_read_rsp_data)
+  );
+
+  local_reducer_aggregate_stats_once_exact_packet_sram #(
+    .DATA_W(DATA_W), .ADDR_W(4)
+  ) destination_packet_sram (
+    .clk(clk), .rst_n(rst_n), .write_valid(ep_rx_mem_write_fire),
+    .write_addr(dst_write_mem_addr), .write_data(ep_rx_mem_write_data),
+    .read_req_valid(dst_mem_read_req_valid),
+    .read_req_ready(dst_mem_read_req_ready),
+    .read_req_addr(dst_read_mem_addr),
+    .read_rsp_valid(dst_mem_read_rsp_valid),
+    .read_rsp_ready(rx_deframer_flit_ready),
+    .read_rsp_addr(dst_mem_read_rsp_addr),
+    .read_rsp_data(dst_mem_read_rsp_data)
+  );
   always @* begin
     replay_found_r = 1'b0;
     replay_found_slot_r = 1'b0;
@@ -415,6 +519,10 @@ module local_reducer_aggregate_stats_once_exact_sram_packet_adapter #(
   always @(posedge clk or negedge rst_n) begin
     if (!rst_n) begin
       tx_group_active_q <= 1'b0;
+      tx_group_source_q <= 0;
+      tx_group_destination_q <= 0;
+      tx_group_vc_q <= 0;
+      tx_group_epoch_q <= 0;
       tx_fill_active_q <= 1'b0;
       tx_fill_slot_q <= 1'b0;
       tx_fill_word_q <= 4'd0;
@@ -427,9 +535,6 @@ module local_reducer_aggregate_stats_once_exact_sram_packet_adapter #(
       tx_packet_index_q <= 0;
       tx_wait_fill_q <= 1'b0;
       tx_wait_slot_q <= 1'b0;
-      src_rsp_valid_q <= 1'b0;
-      src_rsp_slot_q <= 1'b0;
-      src_rsp_data_q <= 0;
       source_error_q <= 1'b0;
       rx_group_active_q <= 1'b0;
       rx_group_source_q <= 0;
@@ -455,8 +560,6 @@ module local_reducer_aggregate_stats_once_exact_sram_packet_adapter #(
       tx_descriptor_count <= 0;
       rx_completion_count <= 0;
       replay_packet_count <= 0;
-      max_source_occupancy <= 0;
-      max_destination_occupancy <= 0;
       for (reset_i = 0; reset_i < SLOT_COUNT; reset_i = reset_i + 1) begin
         src_slot_state[reset_i] <= SLOT_FREE;
         src_expected_count[reset_i] <= 0;
@@ -476,6 +579,10 @@ module local_reducer_aggregate_stats_once_exact_sram_packet_adapter #(
 
       if (tx_ctx_fire) begin
         tx_group_active_q <= 1'b1;
+        tx_group_source_q <= group_source;
+        tx_group_destination_q <= group_destination;
+        tx_group_vc_q <= group_vc;
+        tx_group_epoch_q <= group_epoch;
         tx_fill_active_q <= 1'b1;
         tx_fill_slot_q <= 1'b0;
         tx_fill_word_q <= 0;
@@ -489,13 +596,11 @@ module local_reducer_aggregate_stats_once_exact_sram_packet_adapter #(
 
       if (tx_framer_flit_valid && tx_framer_flit_ready) begin
         if (tx_framer_fragment != tx_fill_word_q[FRAGMENT_W-1:0] ||
-            tx_framer_source != group_source ||
-            tx_framer_destination != group_destination ||
-            tx_framer_vc != group_vc ||
-            tx_framer_tag != {group_epoch, tx_packet_index_q})
+            tx_framer_source != tx_group_source_q ||
+            tx_framer_destination != tx_group_destination_q ||
+            tx_framer_vc != tx_group_vc_q ||
+            tx_framer_tag != {tx_group_epoch_q, tx_packet_index_q})
           source_error_q <= 1'b1;
-        src_mem[tx_fill_slot_q][tx_fill_word_q[WORD_INDEX_W-1:0]] <=
-          tx_framer_flit_data;
         if (tx_framer_last) begin
           if ((tx_packet_index_q < 5'd20 && tx_fill_word_q != 4'd7) ||
               (tx_packet_index_q == 5'd20 && tx_fill_word_q != 4'd6))
@@ -536,30 +641,26 @@ module local_reducer_aggregate_stats_once_exact_sram_packet_adapter #(
       end
 
       if (ep_tx_mem_req_fire) begin
-        src_rsp_valid_q <= 1'b1;
         if (!tx_addr_valid_r || tx_addr_word_i >= SLOT_WORDS ||
             src_slot_state[tx_addr_slot_i] != SLOT_IN_FLIGHT ||
             src_req_count[tx_addr_slot_i] >= src_expected_count[tx_addr_slot_i]) begin
           source_error_q <= 1'b1;
-          src_rsp_slot_q <= tx_addr_slot_i[0:0];
-          src_rsp_data_q <= 0;
         end else begin
-          src_rsp_slot_q <= tx_addr_slot_i[0:0];
-          src_rsp_data_q <= src_mem[tx_addr_slot_i][tx_addr_word_i];
           src_req_count[tx_addr_slot_i] <=
             src_req_count[tx_addr_slot_i] + 1'b1;
         end
       end
       if (ep_tx_mem_rsp_fire) begin
-        src_rsp_valid_q <= 1'b0;
-        if (src_slot_state[src_rsp_slot_q] != SLOT_IN_FLIGHT ||
-            src_rsp_count[src_rsp_slot_q] >= src_expected_count[src_rsp_slot_q]) begin
+        if (src_slot_state[src_mem_read_rsp_addr[3]] != SLOT_IN_FLIGHT ||
+            src_rsp_count[src_mem_read_rsp_addr[3]] >=
+            src_expected_count[src_mem_read_rsp_addr[3]]) begin
           source_error_q <= 1'b1;
         end else begin
-          src_rsp_count[src_rsp_slot_q] <= src_rsp_count[src_rsp_slot_q] + 1'b1;
-          if (src_rsp_count[src_rsp_slot_q] + 1'b1 ==
-              src_expected_count[src_rsp_slot_q])
-            src_slot_state[src_rsp_slot_q] <= SLOT_FREE;
+          src_rsp_count[src_mem_read_rsp_addr[3]] <=
+            src_rsp_count[src_mem_read_rsp_addr[3]] + 1'b1;
+          if (src_rsp_count[src_mem_read_rsp_addr[3]] + 1'b1 ==
+              src_expected_count[src_mem_read_rsp_addr[3]])
+            src_slot_state[src_mem_read_rsp_addr[3]] <= SLOT_FREE;
         end
       end
 
@@ -600,7 +701,6 @@ module local_reducer_aggregate_stats_once_exact_sram_packet_adapter #(
             rx_addr_word_i >= dst_slot_count[rx_active_slot_q]) begin
           destination_error_q <= 1'b1;
         end else begin
-          dst_mem[rx_active_slot_q][rx_addr_word_i] <= ep_rx_mem_write_data;
         end
       end
 
@@ -638,14 +738,20 @@ module local_reducer_aggregate_stats_once_exact_sram_packet_adapter #(
         replay_word_q <= 0;
         dst_slot_state[replay_found_slot_r] <= DST_REPLAY;
       end
-      if (replay_active_q && rx_deframer_flit_ready) begin
-        if (replay_word_q + 1'b1 == dst_slot_count[replay_slot_q]) begin
+
+      if (dst_mem_read_req_fire)
+        replay_word_q <= replay_word_q + 1'b1;
+
+      if (dst_mem_read_rsp_fire) begin
+        if (dst_mem_read_rsp_addr[WORD_INDEX_W-1:0] + 1'b1 ==
+            dst_slot_count[dst_mem_read_rsp_addr[3]]) begin
           replay_active_q <= 1'b0;
-          dst_slot_state[replay_slot_q] <= 3'd0;
+          dst_slot_state[dst_mem_read_rsp_addr[3]] <= 3'd0;
           replay_next_packet_q <= replay_next_packet_q + 1'b1;
           replay_packet_count <= replay_packet_count + 1'b1;
-        end else begin
-          replay_word_q <= replay_word_q + 1'b1;
+        end else if (!replay_active_q ||
+                     dst_mem_read_rsp_addr[3] != replay_slot_q) begin
+          destination_error_q <= 1'b1;
         end
       end
     end

--- a/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_sram_packet_adapter.sv
+++ b/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_sram_packet_adapter.sv
@@ -1,0 +1,676 @@
+`timescale 1ns/1ps
+
+// Finite SRAM adapter for one exact stats-once group.  The packet framer and
+// deframer retain the wire contract; this block owns only two source and two
+// destination packet slots and the endpoint memory handshakes around them.
+module local_reducer_aggregate_stats_once_exact_sram_packet_adapter #(
+  parameter integer DATA_W = 256,
+  parameter integer TAG_W = 8,
+  parameter integer FRAGMENT_W = 3,
+  parameter integer VC_W = 2,
+  parameter integer ENDPOINT_W = 4,
+  parameter integer ADDR_W = 16,
+  parameter integer FLIT_COUNT_W = 4,
+  parameter integer LOCAL_ENDPOINT_ID = 0,
+  parameter integer TX_ENABLE = 1,
+  parameter integer RX_ENABLE = 1,
+  parameter integer SRC_BASE_ADDR = 0,
+  parameter integer DST_BASE_ADDR = 4096,
+  parameter integer RX_WRITE_STALL_PERIOD = 0
+) (
+  input wire clk,
+  input wire rst_n,
+
+  input wire group_ctx_valid,
+  output wire group_ctx_ready,
+  input wire [15:0] group_command_id,
+  input wire [4:0] group_head_base,
+  input wire [3:0] group_source,
+  input wire [3:0] group_destination,
+  input wire [VC_W-1:0] group_vc,
+  input wire [2:0] group_epoch,
+
+  input wire codec_in_valid,
+  output wire codec_in_ready,
+  input wire [DATA_W-1:0] codec_in_data,
+  input wire codec_in_group_last,
+  input wire tx_release_valid,
+  output wire tx_release_ready,
+  output wire codec_out_valid,
+  input wire codec_out_ready,
+  output wire [DATA_W-1:0] codec_out_data,
+  output wire codec_out_group_last,
+
+  output wire tx_group_complete,
+  output wire rx_group_complete,
+  output wire rx_descriptor_installed,
+  output wire protocol_error,
+  output reg [31:0] tx_descriptor_count,
+  output reg [31:0] rx_completion_count,
+  output reg [31:0] replay_packet_count,
+  output reg [2:0] max_source_occupancy,
+  output reg [2:0] max_destination_occupancy,
+
+  output wire mesh_in_valid,
+  input wire mesh_in_ready,
+  output wire [ENDPOINT_W-1:0] mesh_in_destination,
+  output wire [ENDPOINT_W-1:0] mesh_in_source,
+  output wire [TAG_W-1:0] mesh_in_tag,
+  output wire [FRAGMENT_W-1:0] mesh_in_fragment,
+  output wire mesh_in_last,
+  output wire [VC_W-1:0] mesh_in_vc,
+  output wire [DATA_W-1:0] mesh_in_data,
+
+  input wire mesh_out_valid,
+  output wire mesh_out_ready,
+  input wire [ENDPOINT_W-1:0] mesh_out_destination,
+  input wire [ENDPOINT_W-1:0] mesh_out_source,
+  input wire [TAG_W-1:0] mesh_out_tag,
+  input wire [FRAGMENT_W-1:0] mesh_out_fragment,
+  input wire mesh_out_last,
+  input wire [VC_W-1:0] mesh_out_vc,
+  input wire [DATA_W-1:0] mesh_out_data
+);
+  localparam integer SLOT_COUNT = 2;
+  localparam integer SLOT_WORDS = 8;
+  localparam integer DATA_BYTES = DATA_W / 8;
+  localparam integer SLOT_BYTES = SLOT_WORDS * DATA_BYTES;
+  localparam integer WORD_INDEX_W = 3;
+  localparam integer RX_STALL_MOD =
+    (RX_WRITE_STALL_PERIOD < 1) ? 1 : RX_WRITE_STALL_PERIOD;
+  localparam [ADDR_W-1:0] SRC_SLOT0_BASE = SRC_BASE_ADDR;
+  localparam [ADDR_W-1:0] SRC_SLOT1_BASE = SRC_BASE_ADDR + SLOT_BYTES;
+  localparam [ADDR_W-1:0] DST_SLOT0_BASE = DST_BASE_ADDR;
+  localparam [ADDR_W-1:0] DST_SLOT1_BASE = DST_BASE_ADDR + SLOT_BYTES;
+
+  localparam [1:0] SLOT_FREE = 2'd0;
+  localparam [1:0] SLOT_FILL = 2'd1;
+  localparam [1:0] SLOT_READY = 2'd2;
+  localparam [1:0] SLOT_IN_FLIGHT = 2'd3;
+  localparam [2:0] DST_RESERVED = 3'd1;
+  localparam [2:0] DST_ACTIVE = 3'd2;
+  localparam [2:0] DST_COMPLETE = 3'd3;
+  localparam [2:0] DST_REPLAY = 3'd4;
+
+  wire tx_framer_ctx_ready;
+  wire tx_framer_codec_ready;
+  wire tx_framer_flit_valid;
+  wire tx_framer_flit_ready;
+  wire [DATA_W-1:0] tx_framer_flit_data;
+  wire [ENDPOINT_W-1:0] tx_framer_destination;
+  wire [ENDPOINT_W-1:0] tx_framer_source;
+  wire [TAG_W-1:0] tx_framer_tag;
+  wire [FRAGMENT_W-1:0] tx_framer_fragment;
+  wire tx_framer_last;
+  wire [VC_W-1:0] tx_framer_vc;
+  wire tx_framer_clean;
+  wire tx_framer_error;
+
+  wire rx_deframer_ctx_ready;
+  wire rx_deframer_flit_ready;
+  wire rx_deframer_clean;
+  wire rx_deframer_error;
+
+  reg tx_group_active_q;
+  reg tx_fill_active_q;
+  reg tx_fill_slot_q;
+  reg [3:0] tx_fill_word_q;
+  reg tx_desc_pending_q;
+  reg tx_desc_slot_q;
+  reg [ENDPOINT_W-1:0] tx_desc_destination_q;
+  reg [VC_W-1:0] tx_desc_vc_q;
+  reg [TAG_W-1:0] tx_desc_tag_q;
+  reg [FLIT_COUNT_W-1:0] tx_desc_count_q;
+  reg [4:0] tx_packet_index_q;
+  reg tx_wait_fill_q;
+  reg tx_wait_slot_q;
+  reg [1:0] src_slot_state [0:SLOT_COUNT-1];
+  reg [DATA_W-1:0] src_mem [0:SLOT_COUNT-1][0:SLOT_WORDS-1];
+  reg [FLIT_COUNT_W-1:0] src_expected_count [0:SLOT_COUNT-1];
+  reg [FLIT_COUNT_W-1:0] src_req_count [0:SLOT_COUNT-1];
+  reg [FLIT_COUNT_W-1:0] src_rsp_count [0:SLOT_COUNT-1];
+  reg src_rsp_valid_q;
+  reg src_rsp_slot_q;
+  reg [DATA_W-1:0] src_rsp_data_q;
+  reg source_error_q;
+
+  reg rx_group_active_q;
+  reg [3:0] rx_group_source_q;
+  reg [3:0] rx_group_destination_q;
+  reg [VC_W-1:0] rx_group_vc_q;
+  reg [2:0] rx_group_epoch_q;
+  reg rx_desc_pending_q;
+  reg rx_desc_slot_q;
+  reg [4:0] rx_desc_packet_q;
+  reg rx_active_q;
+  reg rx_active_slot_q;
+  reg [4:0] rx_active_packet_q;
+  reg rx_wait_next_desc_q;
+  reg rx_wait_slot_q;
+  reg [4:0] rx_wait_packet_q;
+  reg [2:0] dst_slot_state [0:SLOT_COUNT-1];
+  reg [4:0] dst_slot_packet [0:SLOT_COUNT-1];
+  reg [ENDPOINT_W-1:0] dst_slot_source [0:SLOT_COUNT-1];
+  reg [ENDPOINT_W-1:0] dst_slot_destination [0:SLOT_COUNT-1];
+  reg [VC_W-1:0] dst_slot_vc [0:SLOT_COUNT-1];
+  reg [TAG_W-1:0] dst_slot_tag [0:SLOT_COUNT-1];
+  reg [FLIT_COUNT_W-1:0] dst_slot_count [0:SLOT_COUNT-1];
+  reg [DATA_W-1:0] dst_mem [0:SLOT_COUNT-1][0:SLOT_WORDS-1];
+  reg [31:0] rx_write_cycle_q;
+  reg rx_descriptor_installed_q;
+  reg destination_error_q;
+  reg replay_active_q;
+  reg replay_slot_q;
+  reg [3:0] replay_word_q;
+  reg [4:0] replay_next_packet_q;
+
+  wire [1:0] src_occupied_count =
+    (src_slot_state[0] != SLOT_FREE) + (src_slot_state[1] != SLOT_FREE);
+  wire [1:0] dst_occupied_count =
+    (dst_slot_state[0] != 3'd0) + (dst_slot_state[1] != 3'd0);
+  wire src_all_free = (src_occupied_count == 0);
+  wire dst_all_free = (dst_occupied_count == 0);
+  wire tx_ctx_fire = group_ctx_valid && group_ctx_ready && (TX_ENABLE != 0);
+  wire rx_ctx_fire = group_ctx_valid && group_ctx_ready && (RX_ENABLE != 0);
+
+  assign group_ctx_ready =
+    ((TX_ENABLE == 0) ||
+     (tx_framer_ctx_ready && !tx_group_active_q && src_all_free &&
+      !tx_desc_pending_q)) &&
+    ((RX_ENABLE == 0) ||
+     (rx_deframer_ctx_ready && !rx_group_active_q && dst_all_free &&
+      !rx_desc_pending_q));
+
+  local_reducer_aggregate_stats_once_exact_packet_tx_framer tx_framer (
+    .clk(clk), .rst_n(rst_n),
+    .group_ctx_valid(group_ctx_valid && (TX_ENABLE != 0)),
+    .group_ctx_ready(tx_framer_ctx_ready),
+    .group_command_id(group_command_id), .group_head_base(group_head_base),
+    .group_source(group_source), .group_destination(group_destination),
+    .group_vc(group_vc), .group_epoch(group_epoch),
+    .codec_flit_valid(codec_in_valid && (TX_ENABLE != 0)),
+    .codec_flit_ready(tx_framer_codec_ready), .codec_flit_data(codec_in_data),
+    .codec_flit_group_last(codec_in_group_last),
+    .mesh_flit_valid(tx_framer_flit_valid),
+    .mesh_flit_ready(tx_framer_flit_ready),
+    .mesh_flit_destination(tx_framer_destination),
+    .mesh_flit_source(tx_framer_source), .mesh_flit_tag(tx_framer_tag),
+    .mesh_flit_fragment(tx_framer_fragment), .mesh_flit_last(tx_framer_last),
+    .mesh_flit_vc(tx_framer_vc), .mesh_flit_data(tx_framer_flit_data),
+    .clean_group_complete(tx_framer_clean),
+    .protocol_error(tx_framer_error)
+  );
+
+  local_reducer_aggregate_stats_once_exact_packet_rx_deframer rx_deframer (
+    .clk(clk), .rst_n(rst_n),
+    .group_ctx_valid(group_ctx_valid && (RX_ENABLE != 0)),
+    .group_ctx_ready(rx_deframer_ctx_ready),
+    .group_command_id(group_command_id), .group_head_base(group_head_base),
+    .group_source(group_source), .group_destination(group_destination),
+    .group_vc(group_vc), .group_epoch(group_epoch),
+    .mesh_flit_valid(replay_active_q && (RX_ENABLE != 0)),
+    .mesh_flit_ready(rx_deframer_flit_ready),
+    .mesh_flit_destination(dst_slot_destination[replay_slot_q]),
+    .mesh_flit_source(dst_slot_source[replay_slot_q]),
+    .mesh_flit_tag(dst_slot_tag[replay_slot_q]),
+    .mesh_flit_fragment(replay_word_q[FRAGMENT_W-1:0]),
+    .mesh_flit_last(replay_word_q + 1'b1 == dst_slot_count[replay_slot_q]),
+    .mesh_flit_vc(dst_slot_vc[replay_slot_q]),
+    .mesh_flit_data(dst_mem[replay_slot_q][replay_word_q[WORD_INDEX_W-1:0]]),
+    .codec_flit_valid(codec_out_valid), .codec_flit_ready(codec_out_ready),
+    .codec_flit_data(codec_out_data),
+    .codec_flit_group_last(codec_out_group_last),
+    .codec_group_command_id(), .codec_group_head_base(),
+    .protocol_error(rx_deframer_error),
+    .clean_group_complete(rx_deframer_clean)
+  );
+
+  assign codec_in_ready = (TX_ENABLE != 0) && tx_framer_codec_ready;
+  assign tx_framer_flit_ready =
+    (TX_ENABLE != 0) && tx_fill_active_q && !tx_desc_pending_q &&
+    (src_slot_state[tx_fill_slot_q] == SLOT_FILL) &&
+    (tx_fill_word_q < 4'd8);
+
+  wire ep_tx_desc_valid = tx_desc_pending_q && tx_release_valid &&
+    (TX_ENABLE != 0);
+  wire ep_tx_desc_ready;
+  wire [ENDPOINT_W-1:0] ep_tx_desc_destination = tx_desc_destination_q;
+  wire [VC_W-1:0] ep_tx_desc_vc = tx_desc_vc_q;
+  wire [TAG_W-1:0] ep_tx_desc_tag = tx_desc_tag_q;
+  wire [ADDR_W-1:0] ep_tx_desc_base_addr =
+    tx_desc_slot_q ? SRC_SLOT1_BASE : SRC_SLOT0_BASE;
+  wire [FLIT_COUNT_W-1:0] ep_tx_desc_flit_count = tx_desc_count_q;
+  wire ep_tx_desc_fire = ep_tx_desc_valid && ep_tx_desc_ready;
+  assign tx_release_ready = (TX_ENABLE != 0) && tx_desc_pending_q &&
+    ep_tx_desc_ready;
+
+  wire ep_tx_mem_req_valid;
+  wire ep_tx_mem_req_ready;
+  wire [ADDR_W-1:0] ep_tx_mem_req_addr;
+  wire ep_tx_mem_rsp_valid;
+  wire ep_tx_mem_rsp_ready;
+  wire [DATA_W-1:0] ep_tx_mem_rsp_data;
+  wire ep_tx_flit_valid;
+  wire ep_tx_flit_ready = mesh_in_ready;
+  wire [ENDPOINT_W-1:0] ep_tx_flit_source;
+  wire [ENDPOINT_W-1:0] ep_tx_flit_destination;
+  wire [VC_W-1:0] ep_tx_flit_vc;
+  wire [TAG_W-1:0] ep_tx_flit_tag;
+  wire [FRAGMENT_W-1:0] ep_tx_flit_fragment;
+  wire ep_tx_flit_last;
+  wire [DATA_W-1:0] ep_tx_flit_data;
+
+  wire ep_rx_desc_valid = rx_desc_pending_q && (RX_ENABLE != 0);
+  wire ep_rx_desc_ready;
+  wire [ENDPOINT_W-1:0] ep_rx_desc_source = rx_group_source_q;
+  wire [VC_W-1:0] ep_rx_desc_vc = rx_group_vc_q;
+  wire [TAG_W-1:0] ep_rx_desc_tag =
+    {rx_group_epoch_q, rx_desc_packet_q};
+  wire [ADDR_W-1:0] ep_rx_desc_base_addr =
+    rx_desc_slot_q ? DST_SLOT1_BASE : DST_SLOT0_BASE;
+  wire [FLIT_COUNT_W-1:0] ep_rx_desc_flit_count =
+    (rx_desc_packet_q == 5'd20) ? 4'd7 : 4'd8;
+  wire ep_rx_desc_fire = ep_rx_desc_valid && ep_rx_desc_ready;
+
+  wire ep_rx_mem_write_valid;
+  wire ep_rx_mem_write_ready;
+  wire [ADDR_W-1:0] ep_rx_mem_write_addr;
+  wire [DATA_W-1:0] ep_rx_mem_write_data;
+  wire ep_rx_flit_ready;
+  wire ep_rx_completion_valid;
+  wire ep_rx_completion_ready;
+  wire [ENDPOINT_W-1:0] ep_rx_completion_source;
+  wire [VC_W-1:0] ep_rx_completion_vc;
+  wire [TAG_W-1:0] ep_rx_completion_tag;
+  wire ep_protocol_error;
+
+  noc_sram_packet_endpoint #(
+    .DATA_W(DATA_W), .ENDPOINT_W(ENDPOINT_W), .VC_W(VC_W), .TAG_W(TAG_W),
+    .FRAGMENT_W(FRAGMENT_W), .ADDR_W(ADDR_W), .FLIT_COUNT_W(FLIT_COUNT_W),
+    .TX_DESC_DEPTH(2), .TX_OUTSTANDING(1), .RX_CONTEXTS(1),
+    .LOCAL_ENDPOINT_ID(LOCAL_ENDPOINT_ID)
+  ) endpoint (
+    .clk(clk), .rst_n(rst_n),
+    .tx_desc_valid(ep_tx_desc_valid), .tx_desc_ready(ep_tx_desc_ready),
+    .tx_desc_destination(ep_tx_desc_destination), .tx_desc_vc(ep_tx_desc_vc),
+    .tx_desc_tag(ep_tx_desc_tag), .tx_desc_base_addr(ep_tx_desc_base_addr),
+    .tx_desc_flit_count(ep_tx_desc_flit_count),
+    .tx_mem_req_valid(ep_tx_mem_req_valid),
+    .tx_mem_req_ready(ep_tx_mem_req_ready), .tx_mem_req_addr(ep_tx_mem_req_addr),
+    .tx_mem_rsp_valid(ep_tx_mem_rsp_valid), .tx_mem_rsp_ready(ep_tx_mem_rsp_ready),
+    .tx_mem_rsp_data(ep_tx_mem_rsp_data), .tx_flit_valid(ep_tx_flit_valid),
+    .tx_flit_ready(ep_tx_flit_ready), .tx_flit_source(ep_tx_flit_source),
+    .tx_flit_destination(ep_tx_flit_destination), .tx_flit_vc(ep_tx_flit_vc),
+    .tx_flit_tag(ep_tx_flit_tag), .tx_flit_fragment(ep_tx_flit_fragment),
+    .tx_flit_last(ep_tx_flit_last), .tx_flit_data(ep_tx_flit_data),
+    .rx_desc_valid(ep_rx_desc_valid), .rx_desc_ready(ep_rx_desc_ready),
+    .rx_desc_source(ep_rx_desc_source), .rx_desc_vc(ep_rx_desc_vc),
+    .rx_desc_tag(ep_rx_desc_tag), .rx_desc_base_addr(ep_rx_desc_base_addr),
+    .rx_desc_flit_count(ep_rx_desc_flit_count), .rx_flit_valid(mesh_out_valid),
+    .rx_flit_ready(ep_rx_flit_ready), .rx_flit_source(mesh_out_source),
+    .rx_flit_destination(mesh_out_destination), .rx_flit_vc(mesh_out_vc),
+    .rx_flit_tag(mesh_out_tag), .rx_flit_fragment(mesh_out_fragment),
+    .rx_flit_last(mesh_out_last), .rx_flit_data(mesh_out_data),
+    .rx_mem_write_valid(ep_rx_mem_write_valid),
+    .rx_mem_write_ready(ep_rx_mem_write_ready),
+    .rx_mem_write_addr(ep_rx_mem_write_addr),
+    .rx_mem_write_data(ep_rx_mem_write_data),
+    .rx_completion_valid(ep_rx_completion_valid),
+    .rx_completion_ready(ep_rx_completion_ready),
+    .rx_completion_source(ep_rx_completion_source),
+    .rx_completion_vc(ep_rx_completion_vc),
+    .rx_completion_tag(ep_rx_completion_tag),
+    .protocol_error(ep_protocol_error)
+  );
+
+  assign mesh_in_valid = ep_tx_flit_valid && (TX_ENABLE != 0);
+  assign mesh_in_destination = ep_tx_flit_destination;
+  assign mesh_in_source = ep_tx_flit_source;
+  assign mesh_in_tag = ep_tx_flit_tag;
+  assign mesh_in_fragment = ep_tx_flit_fragment;
+  assign mesh_in_last = ep_tx_flit_last;
+  assign mesh_in_vc = ep_tx_flit_vc;
+  assign mesh_in_data = ep_tx_flit_data;
+  assign mesh_out_ready = ep_rx_flit_ready;
+
+  assign ep_tx_mem_req_ready = (TX_ENABLE != 0) && !src_rsp_valid_q;
+  assign ep_tx_mem_rsp_valid = src_rsp_valid_q && (TX_ENABLE != 0);
+  assign ep_tx_mem_rsp_data = src_rsp_data_q;
+  wire ep_tx_mem_req_fire = ep_tx_mem_req_valid && ep_tx_mem_req_ready;
+  wire ep_tx_mem_rsp_fire = ep_tx_mem_rsp_valid && ep_tx_mem_rsp_ready;
+
+  integer tx_addr_slot_i;
+  integer tx_addr_word_i;
+  reg tx_addr_valid_r;
+  always @* begin
+    tx_addr_valid_r = 1'b0;
+    tx_addr_slot_i = 0;
+    tx_addr_word_i = 0;
+    if ((ep_tx_mem_req_addr >= SRC_SLOT0_BASE) &&
+        (ep_tx_mem_req_addr < SRC_SLOT1_BASE)) begin
+      tx_addr_valid_r = 1'b1;
+      tx_addr_slot_i = 0;
+      tx_addr_word_i = (ep_tx_mem_req_addr - SRC_SLOT0_BASE) / DATA_BYTES;
+    end else if ((ep_tx_mem_req_addr >= SRC_SLOT1_BASE) &&
+                 (ep_tx_mem_req_addr < SRC_SLOT1_BASE + SLOT_BYTES)) begin
+      tx_addr_valid_r = 1'b1;
+      tx_addr_slot_i = 1;
+      tx_addr_word_i =
+        (ep_tx_mem_req_addr - SRC_SLOT1_BASE) / DATA_BYTES;
+    end
+  end
+
+  integer rx_addr_slot_i;
+  integer rx_addr_word_i;
+  reg rx_addr_valid_r;
+  always @* begin
+    rx_addr_valid_r = 1'b0;
+    rx_addr_slot_i = 0;
+    rx_addr_word_i = 0;
+    if ((ep_rx_mem_write_addr >= DST_SLOT0_BASE) &&
+        (ep_rx_mem_write_addr < DST_SLOT1_BASE)) begin
+      rx_addr_valid_r = 1'b1;
+      rx_addr_slot_i = 0;
+      rx_addr_word_i = (ep_rx_mem_write_addr - DST_SLOT0_BASE) / DATA_BYTES;
+    end else if ((ep_rx_mem_write_addr >= DST_SLOT1_BASE) &&
+                 (ep_rx_mem_write_addr < DST_SLOT1_BASE + SLOT_BYTES)) begin
+      rx_addr_valid_r = 1'b1;
+      rx_addr_slot_i = 1;
+      rx_addr_word_i =
+        (ep_rx_mem_write_addr - DST_SLOT1_BASE) / DATA_BYTES;
+    end
+  end
+
+  wire rx_write_stall = (RX_WRITE_STALL_PERIOD != 0) &&
+    ((rx_write_cycle_q % RX_STALL_MOD) == 0);
+  assign ep_rx_mem_write_ready = (RX_ENABLE != 0) && !rx_write_stall;
+  assign ep_rx_completion_ready = (RX_ENABLE != 0) && rx_active_q;
+  wire ep_rx_mem_write_fire =
+    ep_rx_mem_write_valid && ep_rx_mem_write_ready;
+  wire ep_rx_completion_fire =
+    ep_rx_completion_valid && ep_rx_completion_ready;
+  assign rx_descriptor_installed = rx_descriptor_installed_q;
+  assign tx_group_complete = tx_framer_clean;
+  assign rx_group_complete = rx_deframer_clean;
+  assign protocol_error = tx_framer_error || rx_deframer_error ||
+    ep_protocol_error || source_error_q || destination_error_q;
+
+  integer reset_i;
+  integer replay_found_i;
+  reg replay_found_r;
+  reg replay_found_slot_r;
+  always @* begin
+    replay_found_r = 1'b0;
+    replay_found_slot_r = 1'b0;
+    for (replay_found_i = 0; replay_found_i < SLOT_COUNT; replay_found_i = replay_found_i + 1) begin
+      if (!replay_found_r &&
+          (dst_slot_state[replay_found_i] == DST_COMPLETE) &&
+          (dst_slot_packet[replay_found_i] == replay_next_packet_q)) begin
+        replay_found_r = 1'b1;
+        replay_found_slot_r = replay_found_i[0:0];
+      end
+    end
+  end
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      tx_group_active_q <= 1'b0;
+      tx_fill_active_q <= 1'b0;
+      tx_fill_slot_q <= 1'b0;
+      tx_fill_word_q <= 4'd0;
+      tx_desc_pending_q <= 1'b0;
+      tx_desc_slot_q <= 1'b0;
+      tx_desc_destination_q <= 0;
+      tx_desc_vc_q <= 0;
+      tx_desc_tag_q <= 0;
+      tx_desc_count_q <= 0;
+      tx_packet_index_q <= 0;
+      tx_wait_fill_q <= 1'b0;
+      tx_wait_slot_q <= 1'b0;
+      src_rsp_valid_q <= 1'b0;
+      src_rsp_slot_q <= 1'b0;
+      src_rsp_data_q <= 0;
+      source_error_q <= 1'b0;
+      rx_group_active_q <= 1'b0;
+      rx_group_source_q <= 0;
+      rx_group_destination_q <= 0;
+      rx_group_vc_q <= 0;
+      rx_group_epoch_q <= 0;
+      rx_desc_pending_q <= 1'b0;
+      rx_desc_slot_q <= 1'b0;
+      rx_desc_packet_q <= 0;
+      rx_active_q <= 1'b0;
+      rx_active_slot_q <= 1'b0;
+      rx_active_packet_q <= 0;
+      rx_wait_next_desc_q <= 1'b0;
+      rx_wait_slot_q <= 1'b0;
+      rx_wait_packet_q <= 0;
+      rx_write_cycle_q <= 0;
+      rx_descriptor_installed_q <= 1'b0;
+      destination_error_q <= 1'b0;
+      replay_active_q <= 1'b0;
+      replay_slot_q <= 1'b0;
+      replay_word_q <= 0;
+      replay_next_packet_q <= 0;
+      tx_descriptor_count <= 0;
+      rx_completion_count <= 0;
+      replay_packet_count <= 0;
+      max_source_occupancy <= 0;
+      max_destination_occupancy <= 0;
+      for (reset_i = 0; reset_i < SLOT_COUNT; reset_i = reset_i + 1) begin
+        src_slot_state[reset_i] <= SLOT_FREE;
+        src_expected_count[reset_i] <= 0;
+        src_req_count[reset_i] <= 0;
+        src_rsp_count[reset_i] <= 0;
+        dst_slot_state[reset_i] <= 3'd0;
+        dst_slot_packet[reset_i] <= 0;
+        dst_slot_source[reset_i] <= 0;
+        dst_slot_destination[reset_i] <= 0;
+        dst_slot_vc[reset_i] <= 0;
+        dst_slot_tag[reset_i] <= 0;
+        dst_slot_count[reset_i] <= 0;
+      end
+    end else begin
+      rx_write_cycle_q <= rx_write_cycle_q + 1'b1;
+      rx_descriptor_installed_q <= 1'b0;
+
+      if (tx_ctx_fire) begin
+        tx_group_active_q <= 1'b1;
+        tx_fill_active_q <= 1'b1;
+        tx_fill_slot_q <= 1'b0;
+        tx_fill_word_q <= 0;
+        tx_desc_pending_q <= 1'b0;
+        tx_packet_index_q <= 0;
+        tx_wait_fill_q <= 1'b0;
+        src_slot_state[0] <= SLOT_FILL;
+      end
+      if (tx_framer_clean)
+        tx_group_active_q <= 1'b0;
+
+      if (tx_framer_flit_valid && tx_framer_flit_ready) begin
+        if (tx_framer_fragment != tx_fill_word_q[FRAGMENT_W-1:0] ||
+            tx_framer_source != group_source ||
+            tx_framer_destination != group_destination ||
+            tx_framer_vc != group_vc ||
+            tx_framer_tag != {group_epoch, tx_packet_index_q})
+          source_error_q <= 1'b1;
+        src_mem[tx_fill_slot_q][tx_fill_word_q[WORD_INDEX_W-1:0]] <=
+          tx_framer_flit_data;
+        if (tx_framer_last) begin
+          if ((tx_packet_index_q < 5'd20 && tx_fill_word_q != 4'd7) ||
+              (tx_packet_index_q == 5'd20 && tx_fill_word_q != 4'd6))
+            source_error_q <= 1'b1;
+          src_slot_state[tx_fill_slot_q] <= SLOT_READY;
+          src_expected_count[tx_fill_slot_q] <= tx_fill_word_q + 1'b1;
+          tx_desc_pending_q <= 1'b1;
+          tx_desc_slot_q <= tx_fill_slot_q;
+          tx_desc_destination_q <= tx_framer_destination;
+          tx_desc_vc_q <= tx_framer_vc;
+          tx_desc_tag_q <= tx_framer_tag;
+          tx_desc_count_q <= tx_fill_word_q + 1'b1;
+          tx_fill_active_q <= 1'b0;
+          tx_wait_fill_q <= (tx_packet_index_q != 5'd20);
+          tx_wait_slot_q <= !tx_fill_slot_q;
+          if (tx_packet_index_q != 5'd20)
+            tx_packet_index_q <= tx_packet_index_q + 1'b1;
+        end else begin
+          tx_fill_word_q <= tx_fill_word_q + 1'b1;
+        end
+      end
+
+      if (ep_tx_desc_fire) begin
+        tx_desc_pending_q <= 1'b0;
+        src_slot_state[tx_desc_slot_q] <= SLOT_IN_FLIGHT;
+        src_req_count[tx_desc_slot_q] <= 0;
+        src_rsp_count[tx_desc_slot_q] <= 0;
+        tx_descriptor_count <= tx_descriptor_count + 1'b1;
+      end
+
+      if (tx_wait_fill_q && !tx_fill_active_q && !tx_desc_pending_q &&
+          (src_slot_state[tx_wait_slot_q] == SLOT_FREE)) begin
+        tx_fill_active_q <= 1'b1;
+        tx_fill_slot_q <= tx_wait_slot_q;
+        tx_fill_word_q <= 0;
+        src_slot_state[tx_wait_slot_q] <= SLOT_FILL;
+        tx_wait_fill_q <= 1'b0;
+      end
+
+      if (ep_tx_mem_req_fire) begin
+        src_rsp_valid_q <= 1'b1;
+        if (!tx_addr_valid_r || tx_addr_word_i >= SLOT_WORDS ||
+            src_slot_state[tx_addr_slot_i] != SLOT_IN_FLIGHT ||
+            src_req_count[tx_addr_slot_i] >= src_expected_count[tx_addr_slot_i]) begin
+          source_error_q <= 1'b1;
+          src_rsp_slot_q <= tx_addr_slot_i[0:0];
+          src_rsp_data_q <= 0;
+        end else begin
+          src_rsp_slot_q <= tx_addr_slot_i[0:0];
+          src_rsp_data_q <= src_mem[tx_addr_slot_i][tx_addr_word_i];
+          src_req_count[tx_addr_slot_i] <=
+            src_req_count[tx_addr_slot_i] + 1'b1;
+        end
+      end
+      if (ep_tx_mem_rsp_fire) begin
+        src_rsp_valid_q <= 1'b0;
+        if (src_slot_state[src_rsp_slot_q] != SLOT_IN_FLIGHT ||
+            src_rsp_count[src_rsp_slot_q] >= src_expected_count[src_rsp_slot_q]) begin
+          source_error_q <= 1'b1;
+        end else begin
+          src_rsp_count[src_rsp_slot_q] <= src_rsp_count[src_rsp_slot_q] + 1'b1;
+          if (src_rsp_count[src_rsp_slot_q] + 1'b1 ==
+              src_expected_count[src_rsp_slot_q])
+            src_slot_state[src_rsp_slot_q] <= SLOT_FREE;
+        end
+      end
+
+      if (rx_ctx_fire) begin
+        rx_group_active_q <= 1'b1;
+        rx_group_source_q <= group_source;
+        rx_group_destination_q <= group_destination;
+        rx_group_vc_q <= group_vc;
+        rx_group_epoch_q <= group_epoch;
+        rx_desc_pending_q <= 1'b1;
+        rx_desc_slot_q <= 1'b0;
+        rx_desc_packet_q <= 0;
+        dst_slot_state[0] <= DST_RESERVED;
+        rx_wait_next_desc_q <= 1'b0;
+        replay_next_packet_q <= 0;
+      end
+      if (rx_deframer_clean)
+        rx_group_active_q <= 1'b0;
+
+      if (ep_rx_desc_fire) begin
+        dst_slot_state[rx_desc_slot_q] <= DST_ACTIVE;
+        dst_slot_packet[rx_desc_slot_q] <= rx_desc_packet_q;
+        dst_slot_source[rx_desc_slot_q] <= rx_group_source_q;
+        dst_slot_destination[rx_desc_slot_q] <= rx_group_destination_q;
+        dst_slot_vc[rx_desc_slot_q] <= rx_group_vc_q;
+        dst_slot_tag[rx_desc_slot_q] <= {rx_group_epoch_q, rx_desc_packet_q};
+        dst_slot_count[rx_desc_slot_q] <= ep_rx_desc_flit_count;
+        rx_desc_pending_q <= 1'b0;
+        rx_active_q <= 1'b1;
+        rx_active_slot_q <= rx_desc_slot_q;
+        rx_active_packet_q <= rx_desc_packet_q;
+        rx_descriptor_installed_q <= 1'b1;
+      end
+
+      if (ep_rx_mem_write_fire) begin
+        if (!rx_addr_valid_r || rx_addr_word_i >= SLOT_WORDS || !rx_active_q ||
+            rx_addr_slot_i[0:0] != rx_active_slot_q ||
+            rx_addr_word_i >= dst_slot_count[rx_active_slot_q]) begin
+          destination_error_q <= 1'b1;
+        end else begin
+          dst_mem[rx_active_slot_q][rx_addr_word_i] <= ep_rx_mem_write_data;
+        end
+      end
+
+      if (ep_rx_completion_fire) begin
+        if (!rx_active_q ||
+            ep_rx_completion_tag != dst_slot_tag[rx_active_slot_q] ||
+            ep_rx_completion_source != dst_slot_source[rx_active_slot_q] ||
+            ep_rx_completion_vc != dst_slot_vc[rx_active_slot_q]) begin
+          destination_error_q <= 1'b1;
+        end
+        dst_slot_state[rx_active_slot_q] <= DST_COMPLETE;
+        rx_active_q <= 1'b0;
+        rx_completion_count <= rx_completion_count + 1'b1;
+        if (rx_active_packet_q == 5'd20) begin
+          rx_wait_next_desc_q <= 1'b0;
+        end else begin
+          rx_wait_next_desc_q <= 1'b1;
+          rx_wait_slot_q <= !rx_active_slot_q;
+          rx_wait_packet_q <= rx_active_packet_q + 1'b1;
+        end
+      end
+
+      if (rx_wait_next_desc_q && !rx_desc_pending_q && !rx_active_q &&
+          (dst_slot_state[rx_wait_slot_q] == 3'd0)) begin
+        rx_desc_pending_q <= 1'b1;
+        rx_desc_slot_q <= rx_wait_slot_q;
+        rx_desc_packet_q <= rx_wait_packet_q;
+        dst_slot_state[rx_wait_slot_q] <= DST_RESERVED;
+        rx_wait_next_desc_q <= 1'b0;
+      end
+
+      if (!replay_active_q && replay_found_r) begin
+        replay_active_q <= 1'b1;
+        replay_slot_q <= replay_found_slot_r;
+        replay_word_q <= 0;
+        dst_slot_state[replay_found_slot_r] <= DST_REPLAY;
+      end
+      if (replay_active_q && rx_deframer_flit_ready) begin
+        if (replay_word_q + 1'b1 == dst_slot_count[replay_slot_q]) begin
+          replay_active_q <= 1'b0;
+          dst_slot_state[replay_slot_q] <= 3'd0;
+          replay_next_packet_q <= replay_next_packet_q + 1'b1;
+          replay_packet_count <= replay_packet_count + 1'b1;
+        end else begin
+          replay_word_q <= replay_word_q + 1'b1;
+        end
+      end
+    end
+  end
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      max_source_occupancy <= 0;
+      max_destination_occupancy <= 0;
+    end else begin
+      if ({1'b0, src_occupied_count} > max_source_occupancy)
+        max_source_occupancy <= {1'b0, src_occupied_count};
+      if ({1'b0, dst_occupied_count} > max_destination_occupancy)
+        max_destination_occupancy <= {1'b0, dst_occupied_count};
+    end
+  end
+
+`ifndef SYNTHESIS
+  initial begin
+    if (DATA_W != 256 || TAG_W != 8 || FRAGMENT_W != 3 || VC_W != 2) begin
+      $error("stats-once SRAM adapter widths must match the packet bridge");
+      $finish(1);
+    end
+    if (SLOT_COUNT != 2 || SLOT_WORDS != 8)
+      $error("stats-once SRAM adapter must retain the two-by-eight minimum");
+  end
+`endif
+endmodule

--- a/tests/local_reducer_aggregate_stats_once_exact_sram_packet_adapter_tb.sv
+++ b/tests/local_reducer_aggregate_stats_once_exact_sram_packet_adapter_tb.sv
@@ -393,6 +393,12 @@ module local_reducer_aggregate_stats_once_exact_sram_packet_adapter_tb;
       @(posedge clk);
     @(negedge clk);
     source_ctx_valid = 1'b0;
+    // Context is a handshake, not a live sideband.  Change every route field
+    // immediately afterward to prove the adapter retained the accepted values.
+    source_source = 4'd9;
+    source_destination = 4'd14;
+    source_vc = 2'd1;
+    source_epoch = 3'd2;
 
     for (i = 0; i < GROUP_BEATS; i = i + 1) begin
       @(negedge clk);

--- a/tests/local_reducer_aggregate_stats_once_exact_sram_packet_adapter_tb.sv
+++ b/tests/local_reducer_aggregate_stats_once_exact_sram_packet_adapter_tb.sv
@@ -1,0 +1,463 @@
+`timescale 1ns/1ps
+
+module local_reducer_aggregate_stats_once_exact_sram_packet_adapter_tb;
+  localparam integer BEAT_W = 419;
+  localparam integer FLIT_W = 256;
+  localparam integer GROUP_BEATS = 128;
+  localparam integer GROUP_FLITS = 167;
+  localparam integer GROUP_PACKETS = 21;
+
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  integer cycle = 0;
+  always #5 clk = ~clk;
+
+  reg sink_ctx_valid = 1'b0;
+  wire sink_ctx_ready;
+  wire sink_decoder_ctx_ready;
+  reg [15:0] sink_command = 16'h4a20;
+  reg [4:0] sink_head = 5'd8;
+  reg [3:0] sink_source = 4'd5;
+  reg [3:0] sink_destination = 4'd0;
+  reg [1:0] sink_vc = 2'd2;
+  reg [2:0] sink_epoch = 3'd3;
+  wire sink_codec_valid;
+  wire sink_codec_ready;
+  wire [FLIT_W-1:0] sink_codec_data;
+  wire sink_codec_group_last;
+  wire sink_group_complete;
+  wire sink_rx_descriptor_installed;
+  wire sink_protocol_error;
+  wire [31:0] sink_completion_count;
+  wire [31:0] sink_replay_count;
+  wire [2:0] sink_max_slots;
+  wire [2:0] sink_max_destination_slots;
+
+  reg source_ctx_valid = 1'b0;
+  wire source_ctx_ready;
+  wire source_encoder_ctx_ready;
+  reg [15:0] source_command = 16'h4a20;
+  reg [4:0] source_head = 5'd8;
+  reg [3:0] source_source = 4'd5;
+  reg [3:0] source_destination = 4'd0;
+  reg [1:0] source_vc = 2'd2;
+  reg [2:0] source_epoch = 3'd3;
+  reg source_beat_valid = 1'b0;
+  wire source_beat_ready;
+  reg [BEAT_W-1:0] source_beat_data = {BEAT_W{1'b0}};
+  wire source_encoder_flit_valid;
+  wire source_encoder_flit_ready;
+  wire [FLIT_W-1:0] source_encoder_flit_data;
+  wire source_encoder_flit_group_last;
+  wire source_encoder_error;
+  wire source_group_complete;
+  wire source_protocol_error;
+  wire [31:0] source_descriptor_count;
+  wire [2:0] source_max_slots;
+  reg source_release_valid = 1'b0;
+  wire source_release_ready;
+
+  reg [15:0] mesh_in_valid;
+  wire [15:0] mesh_in_ready;
+  reg [16*4-1:0] mesh_in_destination;
+  reg [16*4-1:0] mesh_in_source;
+  reg [16*8-1:0] mesh_in_tag;
+  reg [16*3-1:0] mesh_in_fragment;
+  reg [15:0] mesh_in_last;
+  reg [16*2-1:0] mesh_in_vc;
+  reg [16*FLIT_W-1:0] mesh_in_data;
+  wire [15:0] mesh_out_valid;
+  wire [15:0] mesh_out_ready;
+  wire [16*4-1:0] mesh_out_destination;
+  wire [16*4-1:0] mesh_out_source;
+  wire [16*8-1:0] mesh_out_tag;
+  wire [16*3-1:0] mesh_out_fragment;
+  wire [15:0] mesh_out_last;
+  wire [16*2-1:0] mesh_out_vc;
+  wire [16*FLIT_W-1:0] mesh_out_data;
+
+  wire source_mesh_in_valid;
+  wire source_mesh_in_ready;
+  wire [3:0] source_mesh_in_destination;
+  wire [3:0] source_mesh_in_source;
+  wire [7:0] source_mesh_in_tag;
+  wire [2:0] source_mesh_in_fragment;
+  wire source_mesh_in_last;
+  wire [1:0] source_mesh_in_vc;
+  wire [FLIT_W-1:0] source_mesh_in_data;
+  wire source_mesh_out_ready;
+
+  wire sink_mesh_in_valid;
+  wire sink_mesh_in_ready;
+  wire [3:0] sink_mesh_in_destination;
+  wire [3:0] sink_mesh_in_source;
+  wire [7:0] sink_mesh_in_tag;
+  wire [2:0] sink_mesh_in_fragment;
+  wire sink_mesh_in_last;
+  wire [1:0] sink_mesh_in_vc;
+  wire [FLIT_W-1:0] sink_mesh_in_data;
+  wire sink_mesh_out_valid;
+  wire sink_mesh_out_ready;
+  wire [3:0] sink_mesh_out_destination;
+  wire [3:0] sink_mesh_out_source;
+  wire [7:0] sink_mesh_out_tag;
+  wire [2:0] sink_mesh_out_fragment;
+  wire sink_mesh_out_last;
+  wire [1:0] sink_mesh_out_vc;
+  wire [FLIT_W-1:0] sink_mesh_out_data;
+
+  reg [BEAT_W-1:0] expected_beats [0:GROUP_BEATS-1];
+  integer output_beat_count = 0;
+  integer input_beat_count = 0;
+  integer mesh_flit_count = 0;
+  integer mesh_packet_count = 0;
+  integer failures = 0;
+  integer encoder_clean_count = 0;
+  integer decoder_clean_count = 0;
+  reg bad_rst_n = 1'b0;
+  reg bad_rx_desc_valid = 1'b0;
+  wire bad_rx_desc_ready;
+  reg [3:0] bad_rx_desc_source = 4'd5;
+  reg [1:0] bad_rx_desc_vc = 2'd1;
+  reg [7:0] bad_rx_desc_tag = 8'ha1;
+  reg [15:0] bad_rx_desc_base = 16'h2000;
+  reg [3:0] bad_rx_desc_count = 4'd2;
+  reg bad_rx_flit_valid = 1'b0;
+  wire bad_rx_flit_ready;
+  reg [3:0] bad_rx_flit_source = 4'd5;
+  reg [3:0] bad_rx_flit_destination = 4'd0;
+  reg [1:0] bad_rx_flit_vc = 2'd1;
+  reg [7:0] bad_rx_flit_tag = 8'ha1;
+  reg [2:0] bad_rx_flit_fragment = 3'd0;
+  reg bad_rx_flit_last = 1'b0;
+  reg [FLIT_W-1:0] bad_rx_flit_data = 0;
+  wire bad_rx_mem_write_valid;
+  wire bad_rx_completion_valid;
+  wire bad_protocol_error;
+  reg bad_done = 1'b0;
+
+  wire decoder_beat_valid;
+  wire decoder_protocol_error;
+  wire [BEAT_W-1:0] decoder_beat_data;
+  wire decoder_beat_ready = ((cycle % 11) != 4) && ((cycle % 17) != 3);
+
+  local_reducer_aggregate_stats_once_exact_encoder encoder (
+    .clk(clk), .rst_n(rst_n),
+    .group_ctx_valid(source_ctx_valid), .group_ctx_ready(source_encoder_ctx_ready),
+    .group_command_id(source_command), .group_head_base(source_head),
+    .beat_valid(source_beat_valid), .beat_ready(source_beat_ready),
+    .beat_data(source_beat_data), .flit_valid(source_encoder_flit_valid),
+    .flit_ready(source_encoder_flit_ready), .flit_data(source_encoder_flit_data),
+    .flit_group_last(source_encoder_flit_group_last),
+    .protocol_error(source_encoder_error)
+  );
+
+  local_reducer_aggregate_stats_once_exact_sram_packet_adapter #(
+    .LOCAL_ENDPOINT_ID(5), .TX_ENABLE(1), .RX_ENABLE(0),
+    .RX_WRITE_STALL_PERIOD(0)
+  ) source_adapter (
+    .clk(clk), .rst_n(rst_n),
+    .group_ctx_valid(source_ctx_valid), .group_ctx_ready(source_ctx_ready),
+    .group_command_id(source_command), .group_head_base(source_head),
+    .group_source(source_source), .group_destination(source_destination),
+    .group_vc(source_vc), .group_epoch(source_epoch),
+    .codec_in_valid(source_encoder_flit_valid),
+    .codec_in_ready(source_encoder_flit_ready),
+    .codec_in_data(source_encoder_flit_data),
+    .codec_in_group_last(source_encoder_flit_group_last),
+    .tx_release_valid(source_release_valid),
+    .tx_release_ready(source_release_ready),
+    .codec_out_valid(), .codec_out_ready(1'b0), .codec_out_data(),
+    .codec_out_group_last(), .tx_group_complete(source_group_complete),
+    .rx_group_complete(), .rx_descriptor_installed(),
+    .protocol_error(source_protocol_error),
+    .tx_descriptor_count(source_descriptor_count), .rx_completion_count(),
+    .replay_packet_count(), .max_source_occupancy(source_max_slots),
+    .max_destination_occupancy(),
+    .mesh_in_valid(source_mesh_in_valid), .mesh_in_ready(source_mesh_in_ready),
+    .mesh_in_destination(source_mesh_in_destination),
+    .mesh_in_source(source_mesh_in_source), .mesh_in_tag(source_mesh_in_tag),
+    .mesh_in_fragment(source_mesh_in_fragment), .mesh_in_last(source_mesh_in_last),
+    .mesh_in_vc(source_mesh_in_vc), .mesh_in_data(source_mesh_in_data),
+    .mesh_out_valid(1'b0), .mesh_out_ready(source_mesh_out_ready),
+    .mesh_out_destination(4'b0), .mesh_out_source(4'b0), .mesh_out_tag(8'b0),
+    .mesh_out_fragment(3'b0), .mesh_out_last(1'b0), .mesh_out_vc(2'b0),
+    .mesh_out_data({FLIT_W{1'b0}})
+  );
+
+  local_reducer_aggregate_stats_once_exact_sram_packet_adapter #(
+    .LOCAL_ENDPOINT_ID(0), .TX_ENABLE(0), .RX_ENABLE(1),
+    .RX_WRITE_STALL_PERIOD(5)
+  ) sink_adapter (
+    .clk(clk), .rst_n(rst_n),
+    .group_ctx_valid(sink_ctx_valid), .group_ctx_ready(sink_ctx_ready),
+    .group_command_id(sink_command), .group_head_base(sink_head),
+    .group_source(sink_source), .group_destination(sink_destination),
+    .group_vc(sink_vc), .group_epoch(sink_epoch),
+    .codec_in_valid(1'b0), .codec_in_ready(), .codec_in_data({FLIT_W{1'b0}}),
+    .codec_in_group_last(1'b0), .codec_out_valid(sink_codec_valid),
+    .tx_release_valid(1'b0), .tx_release_ready(),
+    .codec_out_ready(sink_codec_ready), .codec_out_data(sink_codec_data),
+    .codec_out_group_last(sink_codec_group_last),
+    .tx_group_complete(), .rx_group_complete(sink_group_complete),
+    .rx_descriptor_installed(sink_rx_descriptor_installed),
+    .protocol_error(sink_protocol_error), .tx_descriptor_count(),
+    .rx_completion_count(sink_completion_count),
+    .replay_packet_count(sink_replay_count),
+    .max_source_occupancy(sink_max_slots),
+    .max_destination_occupancy(sink_max_destination_slots),
+    .mesh_in_valid(sink_mesh_in_valid), .mesh_in_ready(sink_mesh_in_ready),
+    .mesh_in_destination(sink_mesh_in_destination),
+    .mesh_in_source(sink_mesh_in_source), .mesh_in_tag(sink_mesh_in_tag),
+    .mesh_in_fragment(sink_mesh_in_fragment), .mesh_in_last(sink_mesh_in_last),
+    .mesh_in_vc(sink_mesh_in_vc), .mesh_in_data(sink_mesh_in_data),
+    .mesh_out_valid(sink_mesh_out_valid), .mesh_out_ready(sink_mesh_out_ready),
+    .mesh_out_destination(sink_mesh_out_destination),
+    .mesh_out_source(sink_mesh_out_source), .mesh_out_tag(sink_mesh_out_tag),
+    .mesh_out_fragment(sink_mesh_out_fragment), .mesh_out_last(sink_mesh_out_last),
+    .mesh_out_vc(sink_mesh_out_vc), .mesh_out_data(sink_mesh_out_data)
+  );
+
+  local_reducer_aggregate_stats_once_exact_decoder decoder (
+    .clk(clk), .rst_n(rst_n), .group_ctx_valid(sink_ctx_valid),
+    .group_ctx_ready(sink_decoder_ctx_ready),
+    .group_command_id(sink_command), .group_head_base(sink_head),
+    .flit_valid(sink_codec_valid), .flit_ready(sink_codec_ready),
+    .flit_data(sink_codec_data), .flit_group_last(sink_codec_group_last),
+    .beat_valid(decoder_beat_valid), .beat_ready(decoder_beat_ready),
+    .beat_data(decoder_beat_data), .protocol_error(decoder_protocol_error)
+  );
+
+  noc_sram_packet_endpoint #(
+    .ADDR_W(16), .TX_DESC_DEPTH(1), .TX_OUTSTANDING(1), .RX_CONTEXTS(1),
+    .LOCAL_ENDPOINT_ID(0)
+  ) malformed_endpoint (
+    .clk(clk), .rst_n(bad_rst_n),
+    .tx_desc_valid(1'b0), .tx_desc_ready(), .tx_desc_destination(4'b0),
+    .tx_desc_vc(2'b0), .tx_desc_tag(8'b0), .tx_desc_base_addr(16'b0),
+    .tx_desc_flit_count(4'b0), .tx_mem_req_valid(), .tx_mem_req_ready(1'b0),
+    .tx_mem_req_addr(), .tx_mem_rsp_valid(1'b0), .tx_mem_rsp_ready(),
+    .tx_mem_rsp_data(256'b0), .tx_flit_valid(), .tx_flit_ready(1'b0),
+    .tx_flit_source(), .tx_flit_destination(), .tx_flit_vc(), .tx_flit_tag(),
+    .tx_flit_fragment(), .tx_flit_last(), .tx_flit_data(),
+    .rx_desc_valid(bad_rx_desc_valid), .rx_desc_ready(bad_rx_desc_ready),
+    .rx_desc_source(bad_rx_desc_source), .rx_desc_vc(bad_rx_desc_vc),
+    .rx_desc_tag(bad_rx_desc_tag), .rx_desc_base_addr(bad_rx_desc_base),
+    .rx_desc_flit_count(bad_rx_desc_count), .rx_flit_valid(bad_rx_flit_valid),
+    .rx_flit_ready(bad_rx_flit_ready), .rx_flit_source(bad_rx_flit_source),
+    .rx_flit_destination(bad_rx_flit_destination), .rx_flit_vc(bad_rx_flit_vc),
+    .rx_flit_tag(bad_rx_flit_tag), .rx_flit_fragment(bad_rx_flit_fragment),
+    .rx_flit_last(bad_rx_flit_last), .rx_flit_data(bad_rx_flit_data),
+    .rx_mem_write_valid(bad_rx_mem_write_valid), .rx_mem_write_ready(1'b1),
+    .rx_mem_write_addr(), .rx_mem_write_data(),
+    .rx_completion_valid(bad_rx_completion_valid), .rx_completion_ready(1'b1),
+    .rx_completion_source(), .rx_completion_vc(), .rx_completion_tag(),
+    .protocol_error(bad_protocol_error)
+  );
+
+  noc_segmented_mesh4x4 #(
+    .DATA_W(FLIT_W), .TAG_W(8), .FRAGMENT_W(3), .VC_W(2),
+    .VC_COUNT(4), .FIFO_DEPTH(4)
+  ) mesh (
+    .clk(clk), .rst_n(rst_n),
+    .endpoint_in_valid(mesh_in_valid), .endpoint_in_ready(mesh_in_ready),
+    .endpoint_in_dest(mesh_in_destination), .endpoint_in_source(mesh_in_source),
+    .endpoint_in_tag(mesh_in_tag), .endpoint_in_fragment(mesh_in_fragment),
+    .endpoint_in_last(mesh_in_last), .endpoint_in_vc(mesh_in_vc),
+    .endpoint_in_data(mesh_in_data), .endpoint_out_valid(mesh_out_valid),
+    .endpoint_out_ready(mesh_out_ready), .endpoint_out_dest(mesh_out_destination),
+    .endpoint_out_source(mesh_out_source), .endpoint_out_tag(mesh_out_tag),
+    .endpoint_out_fragment(mesh_out_fragment), .endpoint_out_last(mesh_out_last),
+    .endpoint_out_vc(mesh_out_vc), .endpoint_out_data(mesh_out_data),
+    .router_accepted_flit_count(), .router_forwarded_flit_count(),
+    .router_input_stall_cycles(), .router_output_stall_cycles(),
+    .router_contention_cycles(), .router_current_input_occupancy(),
+    .router_max_input_occupancy(), .router_route_flit_count()
+  );
+
+  always @* begin
+    mesh_in_valid = 16'b0;
+    mesh_in_destination = 64'b0;
+    mesh_in_source = 64'b0;
+    mesh_in_tag = 128'b0;
+    mesh_in_fragment = 48'b0;
+    mesh_in_last = 16'b0;
+    mesh_in_vc = 32'b0;
+    mesh_in_data = {(16*FLIT_W){1'b0}};
+    mesh_in_valid[5] = source_mesh_in_valid;
+    mesh_in_destination[5*4 +: 4] = source_mesh_in_destination;
+    mesh_in_source[5*4 +: 4] = source_mesh_in_source;
+    mesh_in_tag[5*8 +: 8] = source_mesh_in_tag;
+    mesh_in_fragment[5*3 +: 3] = source_mesh_in_fragment;
+    mesh_in_last[5] = source_mesh_in_last;
+    mesh_in_vc[5*2 +: 2] = source_mesh_in_vc;
+    mesh_in_data[5*FLIT_W +: FLIT_W] = source_mesh_in_data;
+    mesh_in_valid[0] = sink_mesh_in_valid;
+    mesh_in_destination[0 +: 4] = sink_mesh_in_destination;
+    mesh_in_source[0 +: 4] = sink_mesh_in_source;
+    mesh_in_tag[0 +: 8] = sink_mesh_in_tag;
+    mesh_in_fragment[0 +: 3] = sink_mesh_in_fragment;
+    mesh_in_last[0] = sink_mesh_in_last;
+    mesh_in_vc[0 +: 2] = sink_mesh_in_vc;
+    mesh_in_data[0 +: FLIT_W] = sink_mesh_in_data;
+  end
+
+  assign source_mesh_in_ready = mesh_in_ready[5];
+  assign sink_mesh_in_ready = mesh_in_ready[0];
+  assign mesh_out_ready = 16'b0 | (16'b1 << 0) & {16{sink_mesh_out_ready}};
+  assign sink_mesh_out_valid = mesh_out_valid[0];
+  assign sink_mesh_out_destination = mesh_out_destination[0 +: 4];
+  assign sink_mesh_out_source = mesh_out_source[0 +: 4];
+  assign sink_mesh_out_tag = mesh_out_tag[0 +: 8];
+  assign sink_mesh_out_fragment = mesh_out_fragment[0 +: 3];
+  assign sink_mesh_out_last = mesh_out_last[0];
+  assign sink_mesh_out_vc = mesh_out_vc[0 +: 2];
+  assign sink_mesh_out_data = mesh_out_data[0 +: FLIT_W];
+
+  function automatic [BEAT_W-1:0] make_beat;
+    input integer index;
+    reg [BEAT_W-1:0] value;
+    integer head;
+    integer slice;
+    integer lane;
+    begin
+      value = {BEAT_W{1'b0}};
+      head = index / 16;
+      slice = index % 16;
+      value[15:0] = 16'h4a20;
+      value[20:16] = 8 + head;
+      value[52:21] = 32'h1200_0000 + head * 32'h31;
+      value[85:53] = 33'h1 + head * 33'h71;
+      value[89:86] = slice[3:0];
+      value[90] = (slice == 15);
+      for (lane = 0; lane < 8; lane = lane + 1)
+        value[91 + lane * 41 +: 41] =
+          41'h10000 + index * 41'h13 + lane * 41'h7;
+      make_beat = value;
+    end
+  endfunction
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      cycle <= 0;
+      mesh_flit_count <= 0;
+      mesh_packet_count <= 0;
+      output_beat_count <= 0;
+    end else begin
+      cycle <= cycle + 1;
+      if (source_release_valid && source_release_ready)
+        source_release_valid <= 1'b0;
+      else if (sink_rx_descriptor_installed)
+        source_release_valid <= 1'b1;
+      if (source_mesh_in_valid && source_mesh_in_ready) begin
+        mesh_flit_count <= mesh_flit_count + 1;
+        if (source_mesh_in_last)
+          mesh_packet_count <= mesh_packet_count + 1;
+      end
+      if (source_beat_valid && source_beat_ready)
+        input_beat_count <= input_beat_count + 1;
+      if (decoder_beat_valid && decoder_beat_ready) begin
+        if (decoder_beat_data !== expected_beats[output_beat_count])
+          failures <= failures + 1;
+        output_beat_count <= output_beat_count + 1;
+      end
+      if (source_group_complete)
+        encoder_clean_count <= encoder_clean_count + 1;
+      if (sink_group_complete)
+        decoder_clean_count <= decoder_clean_count + 1;
+      if (source_protocol_error || sink_protocol_error || source_encoder_error ||
+          decoder_protocol_error)
+        failures <= failures + 1;
+    end
+  end
+
+  integer i;
+  initial begin
+    for (i = 0; i < GROUP_BEATS; i = i + 1)
+      expected_beats[i] = make_beat(i);
+    repeat (4) @(posedge clk);
+    rst_n = 1'b1;
+
+    @(negedge clk);
+    sink_ctx_valid = 1'b1;
+    while (!(sink_ctx_valid && sink_ctx_ready && sink_decoder_ctx_ready))
+      @(posedge clk);
+    @(negedge clk);
+    sink_ctx_valid = 1'b0;
+    while (!sink_rx_descriptor_installed)
+      @(posedge clk);
+
+    @(negedge clk);
+    source_ctx_valid = 1'b1;
+    while (!(source_ctx_valid && source_ctx_ready && source_encoder_ctx_ready))
+      @(posedge clk);
+    @(negedge clk);
+    source_ctx_valid = 1'b0;
+
+    for (i = 0; i < GROUP_BEATS; i = i + 1) begin
+      @(negedge clk);
+      source_beat_data = expected_beats[i];
+      source_beat_valid = 1'b1;
+      while (!(source_beat_valid && source_beat_ready))
+        @(posedge clk);
+      @(negedge clk);
+      source_beat_valid = 1'b0;
+    end
+
+    while (output_beat_count < GROUP_BEATS || decoder_clean_count < 1 ||
+           source_descriptor_count < GROUP_PACKETS ||
+           sink_completion_count < GROUP_PACKETS ||
+           sink_replay_count < GROUP_PACKETS || !bad_done)
+      @(posedge clk);
+
+    if (failures != 0 || input_beat_count != GROUP_BEATS ||
+        output_beat_count != GROUP_BEATS || mesh_flit_count != GROUP_FLITS ||
+        mesh_packet_count != GROUP_PACKETS || source_descriptor_count != GROUP_PACKETS ||
+        sink_completion_count != GROUP_PACKETS || sink_replay_count != GROUP_PACKETS ||
+        source_max_slots != 2 || sink_max_destination_slots != 2 ||
+        source_protocol_error || sink_protocol_error || source_encoder_error ||
+        decoder_protocol_error || !bad_done)
+      $fatal(1, "adapter roundtrip failed beats=%0d/%0d flits=%0d packets=%0d desc=%0d completions=%0d replay=%0d failures=%0d slots=%0d/%0d errors=%b/%b/%b/%b",
+        input_beat_count, output_beat_count, mesh_flit_count, mesh_packet_count,
+        source_descriptor_count, sink_completion_count, sink_replay_count,
+        failures, source_max_slots, sink_max_destination_slots,
+        source_protocol_error, sink_protocol_error, source_encoder_error,
+        decoder_protocol_error);
+    $display("PASS stats_once_exact_sram_packet_adapter beats=128 flits=167 packets=21 source_max_slots=%0d destination_max_slots=%0d", source_max_slots, sink_max_destination_slots);
+    $finish;
+  end
+
+  initial begin
+    // First prove that a flit without an installed context is consumed as a
+    // protocol violation.  Then reset the endpoint and send fragment 1 first
+    // under a live two-fragment context to exercise ordering enforcement.
+    repeat (2) @(posedge clk);
+    bad_rst_n = 1'b1;
+    @(negedge clk);
+    bad_rx_flit_fragment = 3'd0;
+    bad_rx_flit_last = 1'b0;
+    bad_rx_flit_valid = 1'b1;
+    while (!(bad_rx_flit_valid && bad_rx_flit_ready)) @(posedge clk);
+    @(negedge clk);
+    bad_rx_flit_valid = 1'b0;
+    while (!bad_protocol_error) @(posedge clk);
+
+    bad_rst_n = 1'b0;
+    repeat (2) @(posedge clk);
+    bad_rst_n = 1'b1;
+    @(negedge clk);
+    bad_rx_desc_valid = 1'b1;
+    while (!(bad_rx_desc_valid && bad_rx_desc_ready)) @(posedge clk);
+    @(negedge clk);
+    bad_rx_desc_valid = 1'b0;
+    bad_rx_flit_fragment = 3'd1;
+    bad_rx_flit_last = 1'b1;
+    bad_rx_flit_valid = 1'b1;
+    while (!(bad_rx_flit_valid && bad_rx_flit_ready)) @(posedge clk);
+    @(negedge clk);
+    bad_rx_flit_valid = 1'b0;
+    while (!bad_protocol_error) @(posedge clk);
+    bad_done = 1'b1;
+  end
+
+endmodule

--- a/tests/test_local_reducer_aggregate_stats_once_exact_sram_packet_adapter.py
+++ b/tests/test_local_reducer_aggregate_stats_once_exact_sram_packet_adapter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import shutil
 import subprocess
 from pathlib import Path
@@ -71,8 +72,9 @@ def test_finite_sram_adapter_exact_roundtrip_through_real_mesh(tmp_path: Path) -
 
 
 @pytest.mark.skipif(_tool("yosys") is None, reason="yosys unavailable")
-def test_finite_sram_adapter_yosys_import_process_check() -> None:
+def test_finite_sram_adapter_yosys_retains_two_packet_srams(tmp_path: Path) -> None:
     yosys = str(_tool("yosys"))
+    netlist = tmp_path / "stats_once_exact_sram_packet_adapter.json"
     subprocess.run(
         [
             yosys,
@@ -82,7 +84,8 @@ def test_finite_sram_adapter_yosys_import_process_check() -> None:
             + " ".join(str(path) for path in RTL_SOURCES)
             + "; hierarchy -check -top "
             + "local_reducer_aggregate_stats_once_exact_sram_packet_adapter; "
-            + "proc; check",
+            + "proc; memory_dff; memory_collect; check; write_json "
+            + str(netlist),
         ],
         check=True,
         cwd=REPO_ROOT,
@@ -90,3 +93,28 @@ def test_finite_sram_adapter_yosys_import_process_check() -> None:
         text=True,
         timeout=60,
     )
+    design = json.loads(netlist.read_text())
+    adapter = design["modules"][
+        "local_reducer_aggregate_stats_once_exact_sram_packet_adapter"
+    ]
+    packet_sram_instances = [
+        cell
+        for cell in adapter["cells"].values()
+        if "local_reducer_aggregate_stats_once_exact_packet_sram" in cell["type"]
+    ]
+    assert len(packet_sram_instances) == 2
+
+    packet_sram_modules = [
+        module
+        for name, module in design["modules"].items()
+        if "local_reducer_aggregate_stats_once_exact_packet_sram" in name
+    ]
+    assert len(packet_sram_modules) == 1
+    memory_cells = [
+        cell
+        for cell in packet_sram_modules[0]["cells"].values()
+        if cell["type"] == "$mem_v2"
+    ]
+    assert len(memory_cells) == 1
+    assert memory_cells[0]["parameters"]["SIZE"] == "00000000000000000000000000010000"
+    assert memory_cells[0]["parameters"]["WIDTH"] == "00000000000000000000000100000000"

--- a/tests/test_local_reducer_aggregate_stats_once_exact_sram_packet_adapter.py
+++ b/tests/test_local_reducer_aggregate_stats_once_exact_sram_packet_adapter.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RTL = REPO_ROOT / "npu/sim/rtl"
+TB = REPO_ROOT / "tests/local_reducer_aggregate_stats_once_exact_sram_packet_adapter_tb.sv"
+
+
+def _tool(name: str) -> str | None:
+    path = shutil.which(name)
+    if path is not None:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    return str(fallback) if fallback.exists() else None
+
+
+RTL_SOURCES = [
+    RTL / "noc_ready_valid_fifo.sv",
+    RTL / "noc_segmented_mesh_router.sv",
+    RTL / "noc_segmented_mesh4x4.sv",
+    RTL / "noc_sram_packet_endpoint.sv",
+    RTL / "local_reducer_aggregate_stats_once_exact_packet_bridge.sv",
+    RTL / "local_reducer_aggregate_stats_once_exact_codec.sv",
+    RTL / "local_reducer_aggregate_stats_once_exact_sram_packet_adapter.sv",
+]
+
+
+@pytest.mark.skipif(
+    _tool("iverilog") is None or _tool("vvp") is None,
+    reason="iverilog/vvp unavailable",
+)
+def test_finite_sram_adapter_exact_roundtrip_through_real_mesh(tmp_path: Path) -> None:
+    simv = tmp_path / "stats_once_exact_sram_packet_adapter.vvp"
+    subprocess.run(
+        [
+            str(_tool("iverilog")),
+            "-g2012",
+            "-s",
+            "local_reducer_aggregate_stats_once_exact_sram_packet_adapter_tb",
+            "-o",
+            str(simv),
+            *[str(path) for path in RTL_SOURCES],
+            str(TB),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    run = subprocess.run(
+        [str(_tool("vvp")), str(simv)],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert "PASS stats_once_exact_sram_packet_adapter" in run.stdout
+    assert "flits=167" in run.stdout
+    assert "packets=21" in run.stdout
+    assert "beats=128" in run.stdout
+    assert "source_max_slots=2" in run.stdout
+    assert "destination_max_slots=2" in run.stdout
+
+
+@pytest.mark.skipif(_tool("yosys") is None, reason="yosys unavailable")
+def test_finite_sram_adapter_yosys_import_process_check() -> None:
+    yosys = str(_tool("yosys"))
+    subprocess.run(
+        [
+            yosys,
+            "-q",
+            "-p",
+            "read_verilog -DSYNTHESIS -sv "
+            + " ".join(str(path) for path in RTL_SOURCES)
+            + "; hierarchy -check -top "
+            + "local_reducer_aggregate_stats_once_exact_sram_packet_adapter; "
+            + "proc; check",
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )


### PR DESCRIPTION
## Summary
- add a two-slot source and two-slot destination adapter around the existing descriptor-driven SRAM packet endpoint
- prove the exact 128-beat / 167-flit / 21-packet stats-once group through endpoint 5, the real 4x4 segmented mesh, endpoint 0, and the exact decoder
- enforce receive-context installation before TX release, ordered packet replay, completion-based reclamation, and malformed context/fragment rejection
- retain source and destination payload stores as distinct 16x256 synchronous SRAM inference boundaries

## Review corrections included
- gate TX/RX context acceptance atomically
- latch route context at the group handshake rather than reading live inputs
- replace asynchronous destination reads with registered, backpressured synchronous SRAM responses
- remove duplicate occupancy-counter procedural drivers
- structurally assert two packet SRAM instances and one `$mem_v2` per SRAM module

## Verification
- related endpoint, mesh, performance-model, packet, and exact adapter tests: `23 passed in 98.18s`
- run-manifest validation: `OK: runs validation passed`
- exact adapter checks: 128 input/output beats, 167 mesh flits, 21 packets, 21 descriptors/completions/replays, and observed occupancy of both source and destination slots

## Remaining physical boundary
The inferred arrays establish functional SRAM timing and keep payloads out of wide state registers. Their bitcell area and energy still require a cited macro model; inferred-array synthesis is not presented as physical SRAM PPA.
