### PR TITLE
Add finite 15-source exact shared-root transport

### DIFF
--- a/npu/docs/attention_score32_exact_stats_once_shared_root_contract.md
+++ b/npu/docs/attention_score32_exact_stats_once_shared_root_contract.md
@@ -1,0 +1,64 @@
+# Score32 Exact Stats-Once Shared Root Contract
+
+This boundary scales the proven one-source finite SRAM path to the complete
+16-cluster reduction topology. Remote endpoints 0 through 14 send exact local
+partials to root endpoint 15. The root cluster's own partial is the sixteenth
+leaf and does not traverse the mesh.
+
+## Traffic Identity
+
+- one remote source group contains 128 canonical 419-bit beats
+- stats-once encoding produces exactly 167 256-bit flits
+- packet indices 0 through 19 contain eight flits; packet 20 contains seven
+- tag is `{epoch[2:0], packet_index[4:0]}`
+- `(source, VC, tag)` is the shared endpoint's live context key
+- all 15 sources may therefore use the same epoch and packet index concurrently
+
+The root ejection link accepts at most one flit per cycle. A complete remote
+group set consequently has a hard serialization lower bound of 2,505 flits,
+before route bubbles, SRAM stalls, decoder stalls, or global-tree backpressure.
+
+## Shared Endpoint
+
+Endpoint 15 is instantiated once, with at least 15 live RX contexts. It is not
+replicated once per source. The root scheduler installs one context per source
+before releasing that source's matching TX descriptor. Missing context is a
+protocol error and is never used as flow control.
+
+Descriptors are packet-major across sources. Each source may have at most one
+packet context live. A completion retires that context and permits installation
+of the source's next packet when its alternating destination slot is free.
+The baseline static scheduler releases one complete 15-source packet round
+every 120 cycles (`15 sources x 8 flits`). This matches the root ejection
+capacity, produces a continuous root stream after fill, and remains valid for
+the seven-flit terminal round. A dynamic scheduler may release earlier only if
+it proves the same context and slot-reuse invariants.
+
+## Destination Storage And Replay
+
+Each remote source owns two eight-word 256-bit packet slots at the root. The
+minimum root payload storage is therefore 15 independent 16x256 synchronous
+SRAM banks, or 7,680 bytes. An accepted final write precedes registered packet
+completion. Completion makes a slot replayable but does not make it free.
+
+Each source independently replays completed packets in packet-index order into
+one exact packet deframer and exact stats-once decoder. A slot becomes free only
+after its final replay word is accepted. The 15 canonical leaf streams retain
+independent ready/valid backpressure until the exact global tree consumes the
+corresponding beat from every remote source; root-local leaf 15 joins there.
+
+## Equivalence And Performance Gates
+
+The RTL gate must prove:
+
+- 15 x 128 canonical input beats equal 15 x 128 decoded output beats exactly
+- 2,505 flits, 315 packets, descriptors, completions, and replays are conserved
+- every source ID 0 through 14 reaches the single root endpoint
+- contexts are installed before TX release and tags remain ordered per source
+- no source exceeds two destination slots and no slot is reused before replay
+- synthesis retains one shared endpoint and 15 packet SRAM instances
+
+The performance model uses the actual registered-credit mesh and endpoint
+descriptor timing. Its result is an optimistic NoC/control lower bound until
+RTL replay and global-tree backpressure traces are compared cycle by cycle.
+DRAM/HBM controller timing remains outside this contract.

--- a/npu/docs/attention_score32_exact_stats_once_shared_root_contract.md
+++ b/npu/docs/attention_score32_exact_stats_once_shared_root_contract.md
@@ -34,6 +34,12 @@ capacity, produces a continuous root stream after fill, and remains valid for
 the seven-flit terminal round. A dynamic scheduler may release earlier only if
 it proves the same context and slot-reuse invariants.
 
+The RTL latches a group barrier after all 15 remote contexts arrive and opens
+packet index `n` at 120-cycle intervals. The complete real-mesh equivalence
+trace delivers all 2,505 flits over exactly 2,505 cycles from first root
+delivery through last root delivery. Thus the finite endpoint, SRAM replay,
+and source scheduling add no root-ejection bubbles for this group.
+
 ## Destination Storage And Replay
 
 Each remote source owns two eight-word 256-bit packet slots at the root. The

--- a/npu/sim/perf/noc_sram_packet_mesh.py
+++ b/npu/sim/perf/noc_sram_packet_mesh.py
@@ -408,6 +408,7 @@ def simulate_packet_mesh(
     descriptors: Iterable[PacketDescriptor],
     *,
     descriptor_scheduler: str = "endpoint_parallel",
+    rx_context_limits: Mapping[int, int] | None = None,
     destination_sram_ready_schedule: ReadySchedule = None,
     source_sram_request_ready_schedule: ReadySchedule = None,
     completion_ready_schedule: ReadySchedule = None,
@@ -458,7 +459,19 @@ def simulate_packet_mesh(
             protocol_errors=(),
         )
 
-    states = [_EndpointState(endpoint) for endpoint in range(ENDPOINTS)]
+    context_limits = dict(rx_context_limits or {})
+    for endpoint, limit in context_limits.items():
+        if not 0 <= int(endpoint) < ENDPOINTS:
+            raise ValueError("rx_context_limits keys must be endpoints in [0, 15]")
+        if int(limit) < 1:
+            raise ValueError("rx_context_limits values must be positive")
+    states = [
+        _EndpointState(
+            endpoint,
+            rx_context_limit=int(context_limits.get(endpoint, RX_CONTEXTS)),
+        )
+        for endpoint in range(ENDPOINTS)
+    ]
     routers = [
         _RouterState(
             x_coord=coordinates(endpoint)[0],

--- a/npu/sim/perf/stats_once_shared_root.py
+++ b/npu/sim/perf/stats_once_shared_root.py
@@ -1,0 +1,205 @@
+"""Finite shared-root transport model for exact stats-once reduction groups.
+
+Fifteen remote clusters send one 167-flit group each to root endpoint 15.
+The model uses the cycle-accurate registered-credit mesh and descriptor-driven
+endpoint model.  It also schedules the two destination packet slots per source
+through a conservative synchronous-SRAM replay timeline.
+
+The mesh result is a NoC/control lower bound: downstream exact decoders and the
+global reduction tree may add backpressure.  Those consumers must be compared
+against this trace rather than hidden in an aggregate bandwidth assumption.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from npu.sim.perf.noc_sram_packet_mesh import (
+    FLIT_BYTES,
+    PacketDescriptor,
+    PacketMeshResult,
+    simulate_packet_mesh,
+)
+
+REMOTE_SOURCES = 15
+ROOT_ENDPOINT = 15
+PACKETS_PER_GROUP = 21
+GROUP_FLITS = 167
+FULL_PACKET_FLITS = 8
+FINAL_PACKET_FLITS = 7
+PACKET_SLOT_BYTES = FULL_PACKET_FLITS * FLIT_BYTES
+SLOTS_PER_SOURCE = 2
+SOURCE_SLOT_STRIDE_BYTES = SLOTS_PER_SOURCE * PACKET_SLOT_BYTES
+PACKET_ROUND_RELEASE_INTERVAL_CYCLES = REMOTE_SOURCES * FULL_PACKET_FLITS
+
+
+@dataclass(frozen=True)
+class PacketReplay:
+    source: int
+    packet: int
+    slot: int
+    descriptor_cycle: int
+    completion_cycle: int
+    first_output_cycle: int
+    final_output_cycle: int
+
+
+@dataclass(frozen=True)
+class SharedRootResult:
+    mesh: PacketMeshResult
+    replays: tuple[PacketReplay, ...]
+    root_delivery_span_cycles: int
+    serialization_lower_bound_cycles: int
+    max_slots_per_source: int
+    slot_reuse_violations: tuple[tuple[int, int, int], ...]
+    packet_round_release_interval_cycles: int
+
+
+def packet_flit_count(packet: int) -> int:
+    if not 0 <= packet < PACKETS_PER_GROUP:
+        raise ValueError("packet must be in [0, 20]")
+    return FINAL_PACKET_FLITS if packet == PACKETS_PER_GROUP - 1 else FULL_PACKET_FLITS
+
+
+def build_shared_root_descriptors(
+    *,
+    epoch: int = 0,
+    vc: int = 1,
+    release_cycles: Mapping[tuple[int, int], int] | None = None,
+) -> tuple[PacketDescriptor, ...]:
+    if not 0 <= epoch < 8:
+        raise ValueError("epoch must be a 3-bit value")
+    if not 0 <= vc < 4:
+        raise ValueError("vc must be in [0, 3]")
+
+    releases = dict(release_cycles or {})
+    if any(cycle < 0 for cycle in releases.values()):
+        raise ValueError("release cycles must be non-negative")
+    descriptors = []
+    schedule_order = 0
+    # Packet-major order installs at most one live context per source and lets
+    # all sources contend fairly for the single root ejection port.
+    for packet in range(PACKETS_PER_GROUP):
+        slot = packet % SLOTS_PER_SOURCE
+        for source in range(REMOTE_SOURCES):
+            descriptors.append(
+                PacketDescriptor(
+                    source=source,
+                    destination=ROOT_ENDPOINT,
+                    vc=vc,
+                    tag=(epoch << 5) | packet,
+                    flit_count=packet_flit_count(packet),
+                    tx_base_addr=slot * PACKET_SLOT_BYTES,
+                    rx_base_addr=(source * SOURCE_SLOT_STRIDE_BYTES)
+                    + (slot * PACKET_SLOT_BYTES),
+                    release_cycle=int(releases.get((source, packet), 0)),
+                    schedule_order=schedule_order,
+                    data_seed=(source << 8) | packet,
+                    packet_id=f"source-{source}-packet-{packet}",
+                )
+            )
+            schedule_order += 1
+    return tuple(descriptors)
+
+
+def _schedule_replays(
+    mesh: PacketMeshResult,
+    descriptors: tuple[PacketDescriptor, ...],
+) -> tuple[tuple[PacketReplay, ...], int, tuple[tuple[int, int, int], ...]]:
+    descriptor_cycles = {
+        event.packet_index: event.cycle for event in mesh.rx_descriptor_handshakes
+    }
+    completion_cycles = {event.packet_index: event.cycle for event in mesh.completions}
+    replays = []
+    previous_final = [-1] * REMOTE_SOURCES
+    intervals: list[list[list[tuple[int, int, int]]]] = [
+        [[] for _ in range(SLOTS_PER_SOURCE)] for _ in range(REMOTE_SOURCES)
+    ]
+
+    for index, descriptor in enumerate(descriptors):
+        packet = int(descriptor.tag & 0x1F)
+        source = descriptor.source
+        slot = packet % SLOTS_PER_SOURCE
+        completion = completion_cycles[index]
+        # Completion is registered after the final write. The adapter then
+        # selects the ordered packet and performs a synchronous SRAM read.
+        first_output = max(completion + 4, previous_final[source] + 1)
+        final_output = first_output + descriptor.flit_count - 1
+        previous_final[source] = final_output
+        replay = PacketReplay(
+            source=source,
+            packet=packet,
+            slot=slot,
+            descriptor_cycle=descriptor_cycles[index],
+            completion_cycle=completion,
+            first_output_cycle=first_output,
+            final_output_cycle=final_output,
+        )
+        replays.append(replay)
+        intervals[source][slot].append(
+            (replay.descriptor_cycle, replay.final_output_cycle, packet)
+        )
+
+    violations = []
+    max_slots = 0
+    for source in range(REMOTE_SOURCES):
+        events = []
+        for slot in range(SLOTS_PER_SOURCE):
+            ordered = sorted(intervals[source][slot])
+            for previous, current in zip(ordered, ordered[1:]):
+                if current[0] <= previous[1]:
+                    violations.append((source, previous[2], current[2]))
+            for start, end, _packet in ordered:
+                events.append((start, 1))
+                events.append((end + 1, -1))
+        occupancy = 0
+        for _cycle, delta in sorted(events, key=lambda item: (item[0], item[1])):
+            occupancy += delta
+            max_slots = max(max_slots, occupancy)
+    return tuple(replays), max_slots, tuple(violations)
+
+
+def simulate_exact_stats_once_shared_root(*, epoch: int = 0, vc: int = 1) -> SharedRootResult:
+    release_cycles = {
+        (source, packet): packet * PACKET_ROUND_RELEASE_INTERVAL_CYCLES
+        for packet in range(PACKETS_PER_GROUP)
+        for source in range(REMOTE_SOURCES)
+    }
+    descriptors = build_shared_root_descriptors(
+        epoch=epoch,
+        vc=vc,
+        release_cycles=release_cycles,
+    )
+    mesh = simulate_packet_mesh(
+        descriptors,
+        rx_context_limits={ROOT_ENDPOINT: REMOTE_SOURCES},
+        descriptor_scheduler="endpoint_parallel",
+    )
+    replays, max_slots, violations = _schedule_replays(mesh, descriptors)
+
+    root_cycles = [delivery.cycle for delivery in mesh.deliveries]
+    span = max(root_cycles) - min(root_cycles) + 1
+    return SharedRootResult(
+        mesh=mesh,
+        replays=replays,
+        root_delivery_span_cycles=span,
+        serialization_lower_bound_cycles=REMOTE_SOURCES * GROUP_FLITS,
+        max_slots_per_source=max_slots,
+        slot_reuse_violations=violations,
+        packet_round_release_interval_cycles=
+        PACKET_ROUND_RELEASE_INTERVAL_CYCLES,
+    )
+
+
+__all__ = [
+    "GROUP_FLITS",
+    "PACKETS_PER_GROUP",
+    "PACKET_ROUND_RELEASE_INTERVAL_CYCLES",
+    "REMOTE_SOURCES",
+    "ROOT_ENDPOINT",
+    "SharedRootResult",
+    "build_shared_root_descriptors",
+    "packet_flit_count",
+    "simulate_exact_stats_once_shared_root",
+]

--- a/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter.sv
+++ b/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter.sv
@@ -1,0 +1,592 @@
+`timescale 1ns/1ps
+
+// Shared root receive adapter for the exact stats-once transport.
+//
+// The root owns one descriptor endpoint and demultiplexes its single memory
+// write stream into one 16x256 packet SRAM per remote source.  Each source has
+// two logical eight-word destination slots.  A completed slot is replayed in
+// packet order through its own exact packet deframer; no source has a packet-
+// sized register or a private NoC endpoint at the root.
+module local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter #(
+  parameter integer DATA_W = 256,
+  parameter integer TAG_W = 8,
+  parameter integer FRAGMENT_W = 3,
+  parameter integer VC_W = 2,
+  parameter integer ENDPOINT_W = 4,
+  parameter integer ADDR_W = 16,
+  parameter integer FLIT_COUNT_W = 4,
+  parameter integer SOURCE_COUNT = 15,
+  parameter integer ROOT_ENDPOINT_ID = 15
+) (
+  input wire clk,
+  input wire rst_n,
+
+  input wire [SOURCE_COUNT-1:0] group_ctx_valid,
+  output wire [SOURCE_COUNT-1:0] group_ctx_ready,
+  input wire [SOURCE_COUNT*16-1:0] group_command_id,
+  input wire [SOURCE_COUNT*5-1:0] group_head_base,
+  input wire [SOURCE_COUNT*4-1:0] group_source,
+  input wire [SOURCE_COUNT*4-1:0] group_destination,
+  input wire [SOURCE_COUNT*VC_W-1:0] group_vc,
+  input wire [SOURCE_COUNT*3-1:0] group_epoch,
+
+  output wire [SOURCE_COUNT-1:0] tx_release_valid,
+  input wire [SOURCE_COUNT-1:0] tx_release_ready,
+  output wire [SOURCE_COUNT-1:0] codec_out_valid,
+  input wire [SOURCE_COUNT-1:0] codec_out_ready,
+  output wire [SOURCE_COUNT*DATA_W-1:0] codec_out_data,
+  output wire [SOURCE_COUNT-1:0] codec_out_group_last,
+  output wire [SOURCE_COUNT-1:0] group_complete,
+  output wire [SOURCE_COUNT-1:0] descriptor_installed,
+  output wire [SOURCE_COUNT-1:0] source_protocol_error,
+
+  output wire mesh_in_valid,
+  input wire mesh_in_ready,
+  output wire [ENDPOINT_W-1:0] mesh_in_destination,
+  output wire [ENDPOINT_W-1:0] mesh_in_source,
+  output wire [TAG_W-1:0] mesh_in_tag,
+  output wire [FRAGMENT_W-1:0] mesh_in_fragment,
+  output wire mesh_in_last,
+  output wire [VC_W-1:0] mesh_in_vc,
+  output wire [DATA_W-1:0] mesh_in_data,
+
+  input wire mesh_out_valid,
+  output wire mesh_out_ready,
+  input wire [ENDPOINT_W-1:0] mesh_out_destination,
+  input wire [ENDPOINT_W-1:0] mesh_out_source,
+  input wire [TAG_W-1:0] mesh_out_tag,
+  input wire [FRAGMENT_W-1:0] mesh_out_fragment,
+  input wire mesh_out_last,
+  input wire [VC_W-1:0] mesh_out_vc,
+  input wire [DATA_W-1:0] mesh_out_data,
+
+  output reg [31:0] root_accepted_flit_count,
+  output reg [31:0] root_descriptor_install_count,
+  output reg [31:0] root_completion_count,
+  output reg [31:0] root_replay_packet_count,
+  output reg [5:0] max_occupied_slots,
+  output wire protocol_error
+);
+  localparam integer DATA_BYTES = DATA_W / 8;
+  localparam integer SLOT_WORDS = 8;
+  localparam integer SLOT_BYTES = SLOT_WORDS * DATA_BYTES;
+  localparam integer BANK_WORDS = 16;
+  localparam integer BANK_BYTES = BANK_WORDS * DATA_BYTES;
+  localparam integer SLOT_COUNT = 2;
+
+  localparam [1:0] SLOT_FREE = 2'd0;
+  localparam [1:0] SLOT_RESERVED = 2'd1;
+  localparam [1:0] SLOT_ACTIVE = 2'd2;
+  localparam [1:0] SLOT_COMPLETE = 2'd3;
+
+  reg group_active_q [0:SOURCE_COUNT-1];
+  reg [15:0] command_q [0:SOURCE_COUNT-1];
+  reg [4:0] head_q [0:SOURCE_COUNT-1];
+  reg [3:0] source_q [0:SOURCE_COUNT-1];
+  reg [3:0] destination_q [0:SOURCE_COUNT-1];
+  reg [VC_W-1:0] vc_q [0:SOURCE_COUNT-1];
+  reg [2:0] epoch_q [0:SOURCE_COUNT-1];
+
+  reg desc_pending_q [0:SOURCE_COUNT-1];
+  reg desc_slot_q [0:SOURCE_COUNT-1];
+  reg [4:0] desc_packet_q [0:SOURCE_COUNT-1];
+  reg active_packet_q [0:SOURCE_COUNT-1];
+  reg [4:0] active_packet_index_q [0:SOURCE_COUNT-1];
+  reg [4:0] next_packet_q [0:SOURCE_COUNT-1];
+  reg wait_next_q [0:SOURCE_COUNT-1];
+  reg wait_slot_q [0:SOURCE_COUNT-1];
+  reg [4:0] wait_packet_q [0:SOURCE_COUNT-1];
+  reg release_pending_q [0:SOURCE_COUNT-1];
+  reg local_error_q [0:SOURCE_COUNT-1];
+
+  reg [1:0] slot_state [0:SOURCE_COUNT-1][0:SLOT_COUNT-1];
+  reg [4:0] slot_packet [0:SOURCE_COUNT-1][0:SLOT_COUNT-1];
+  reg [3:0] slot_flit_count [0:SOURCE_COUNT-1][0:SLOT_COUNT-1];
+  reg replay_active_q [0:SOURCE_COUNT-1];
+  reg replay_slot_q [0:SOURCE_COUNT-1];
+  reg [3:0] replay_word_q [0:SOURCE_COUNT-1];
+
+  wire [SOURCE_COUNT-1:0] packet_sram_read_rsp_valid_w;
+  wire [SOURCE_COUNT*4-1:0] packet_sram_read_rsp_addr_w;
+  wire [SOURCE_COUNT-1:0] replay_response_fire_w;
+
+  wire [SOURCE_COUNT-1:0] deframer_ctx_ready_w;
+  wire [SOURCE_COUNT-1:0] deframer_flit_valid_w;
+  wire [SOURCE_COUNT-1:0] deframer_flit_ready_w;
+  wire [SOURCE_COUNT-1:0] deframer_clean_w;
+  wire [SOURCE_COUNT-1:0] deframer_error_w;
+  wire [SOURCE_COUNT*DATA_W-1:0] deframer_data_w;
+
+  wire ep_tx_desc_valid = 1'b0;
+  wire ep_tx_mem_req_ready = 1'b0;
+  wire ep_tx_mem_rsp_valid = 1'b0;
+  wire ep_tx_flit_ready = 1'b0;
+  wire ep_rx_desc_ready;
+  wire ep_rx_flit_ready;
+  wire ep_rx_mem_write_valid;
+  wire ep_rx_mem_write_ready;
+  wire [ADDR_W-1:0] ep_rx_mem_write_addr;
+  wire [DATA_W-1:0] ep_rx_mem_write_data;
+  wire ep_rx_completion_valid;
+  wire ep_rx_completion_ready;
+  wire [ENDPOINT_W-1:0] ep_rx_completion_source;
+  wire [VC_W-1:0] ep_rx_completion_vc;
+  wire [TAG_W-1:0] ep_rx_completion_tag;
+  wire ep_protocol_error;
+
+  wire [ENDPOINT_W-1:0] ep_rx_desc_source;
+  wire [VC_W-1:0] ep_rx_desc_vc;
+  wire [TAG_W-1:0] ep_rx_desc_tag;
+  wire [ADDR_W-1:0] ep_rx_desc_base_addr;
+  wire [FLIT_COUNT_W-1:0] ep_rx_desc_flit_count;
+
+  wire ep_rx_desc_valid;
+  wire ep_rx_desc_fire = ep_rx_desc_valid && ep_rx_desc_ready;
+  wire ep_rx_mem_write_fire = ep_rx_mem_write_valid && ep_rx_mem_write_ready;
+  wire ep_rx_completion_fire = ep_rx_completion_valid && ep_rx_completion_ready;
+
+  integer descriptor_select_i;
+  reg descriptor_select_valid;
+  reg [ENDPOINT_W-1:0] descriptor_select_source;
+  always @* begin
+    descriptor_select_valid = 1'b0;
+    descriptor_select_source = {ENDPOINT_W{1'b0}};
+    for (descriptor_select_i = 0;
+         descriptor_select_i < SOURCE_COUNT;
+         descriptor_select_i = descriptor_select_i + 1) begin
+      if (desc_pending_q[descriptor_select_i] && !descriptor_select_valid) begin
+        descriptor_select_valid = 1'b1;
+        descriptor_select_source = descriptor_select_i[ENDPOINT_W-1:0];
+      end
+    end
+  end
+
+  assign ep_rx_desc_valid = descriptor_select_valid;
+  assign ep_rx_desc_source = descriptor_select_source;
+  assign ep_rx_desc_vc = vc_q[descriptor_select_source];
+  assign ep_rx_desc_tag = {
+    epoch_q[descriptor_select_source],
+    desc_packet_q[descriptor_select_source]
+  };
+  assign ep_rx_desc_base_addr =
+    descriptor_select_source * BANK_BYTES +
+    (desc_slot_q[descriptor_select_source] ? SLOT_BYTES : 0);
+  assign ep_rx_desc_flit_count =
+    (desc_packet_q[descriptor_select_source] == 5'd20) ? 4'd7 : 4'd8;
+
+  noc_sram_packet_endpoint #(
+    .DATA_W(DATA_W),
+    .ENDPOINT_W(ENDPOINT_W),
+    .VC_W(VC_W),
+    .TAG_W(TAG_W),
+    .FRAGMENT_W(FRAGMENT_W),
+    .ADDR_W(ADDR_W),
+    .FLIT_COUNT_W(FLIT_COUNT_W),
+    .TX_DESC_DEPTH(1),
+    .TX_OUTSTANDING(1),
+    .RX_CONTEXTS(SOURCE_COUNT),
+    .LOCAL_ENDPOINT_ID(ROOT_ENDPOINT_ID)
+  ) shared_root_endpoint (
+    .clk(clk), .rst_n(rst_n),
+    .tx_desc_valid(ep_tx_desc_valid), .tx_desc_ready(),
+    .tx_desc_destination(4'b0), .tx_desc_vc({VC_W{1'b0}}),
+    .tx_desc_tag({TAG_W{1'b0}}), .tx_desc_base_addr({ADDR_W{1'b0}}),
+    .tx_desc_flit_count({FLIT_COUNT_W{1'b0}}),
+    .tx_mem_req_valid(), .tx_mem_req_ready(ep_tx_mem_req_ready),
+    .tx_mem_req_addr(), .tx_mem_rsp_valid(ep_tx_mem_rsp_valid),
+    .tx_mem_rsp_ready(), .tx_mem_rsp_data({DATA_W{1'b0}}),
+    .tx_flit_valid(), .tx_flit_ready(ep_tx_flit_ready),
+    .tx_flit_source(), .tx_flit_destination(), .tx_flit_vc(),
+    .tx_flit_tag(), .tx_flit_fragment(), .tx_flit_last(), .tx_flit_data(),
+    .rx_desc_valid(ep_rx_desc_valid), .rx_desc_ready(ep_rx_desc_ready),
+    .rx_desc_source(ep_rx_desc_source), .rx_desc_vc(ep_rx_desc_vc),
+    .rx_desc_tag(ep_rx_desc_tag), .rx_desc_base_addr(ep_rx_desc_base_addr),
+    .rx_desc_flit_count(ep_rx_desc_flit_count),
+    .rx_flit_valid(mesh_out_valid), .rx_flit_ready(ep_rx_flit_ready),
+    .rx_flit_source(mesh_out_source), .rx_flit_destination(mesh_out_destination),
+    .rx_flit_vc(mesh_out_vc), .rx_flit_tag(mesh_out_tag),
+    .rx_flit_fragment(mesh_out_fragment), .rx_flit_last(mesh_out_last),
+    .rx_flit_data(mesh_out_data),
+    .rx_mem_write_valid(ep_rx_mem_write_valid),
+    .rx_mem_write_ready(ep_rx_mem_write_ready),
+    .rx_mem_write_addr(ep_rx_mem_write_addr),
+    .rx_mem_write_data(ep_rx_mem_write_data),
+    .rx_completion_valid(ep_rx_completion_valid),
+    .rx_completion_ready(ep_rx_completion_ready),
+    .rx_completion_source(ep_rx_completion_source),
+    .rx_completion_vc(ep_rx_completion_vc),
+    .rx_completion_tag(ep_rx_completion_tag),
+    .protocol_error(ep_protocol_error)
+  );
+
+  assign mesh_in_valid = 1'b0;
+  assign mesh_in_destination = {ENDPOINT_W{1'b0}};
+  assign mesh_in_source = {ENDPOINT_W{1'b0}};
+  assign mesh_in_tag = {TAG_W{1'b0}};
+  assign mesh_in_fragment = {FRAGMENT_W{1'b0}};
+  assign mesh_in_last = 1'b0;
+  assign mesh_in_vc = {VC_W{1'b0}};
+  assign mesh_in_data = {DATA_W{1'b0}};
+  assign mesh_out_ready = ep_rx_flit_ready;
+  assign ep_rx_completion_ready = 1'b1;
+
+  integer write_route_i;
+  reg write_route_valid;
+  reg [ENDPOINT_W-1:0] write_route_source;
+  reg [3:0] write_route_addr;
+  always @* begin
+    write_route_valid = 1'b0;
+    write_route_source = {ENDPOINT_W{1'b0}};
+    write_route_addr = 4'b0;
+    for (write_route_i = 0;
+         write_route_i < SOURCE_COUNT;
+         write_route_i = write_route_i + 1) begin
+      if (!write_route_valid &&
+          ep_rx_mem_write_addr >= write_route_i * BANK_BYTES &&
+          ep_rx_mem_write_addr < (write_route_i + 1) * BANK_BYTES) begin
+        write_route_valid = 1'b1;
+        write_route_source = write_route_i[ENDPOINT_W-1:0];
+        write_route_addr =
+          (ep_rx_mem_write_addr - write_route_i * BANK_BYTES) / DATA_BYTES;
+      end
+    end
+  end
+  // An invalid route is consumed so the endpoint can report it as a protocol
+  // error instead of deadlocking the mesh. Valid writes are never stalled by
+  // the inferred SRAMs themselves.
+  assign ep_rx_mem_write_ready = !ep_rx_mem_write_valid || write_route_valid;
+
+  wire write_route_state_ok = write_route_valid &&
+    (slot_state[write_route_source][write_route_addr[3]] == SLOT_ACTIVE);
+
+  genvar source_g;
+  generate
+    for (source_g = 0; source_g < SOURCE_COUNT; source_g = source_g + 1) begin : gen_source
+      localparam integer SOURCE_ID = source_g;
+
+      wire source_ctx_fire = group_ctx_valid[SOURCE_ID] &&
+        group_ctx_ready[SOURCE_ID];
+      wire descriptor_fire = ep_rx_desc_fire &&
+        (descriptor_select_source == SOURCE_ID);
+      wire completion_fire = ep_rx_completion_fire &&
+        (ep_rx_completion_source == SOURCE_ID);
+      wire release_fire = tx_release_valid[SOURCE_ID] &&
+        tx_release_ready[SOURCE_ID];
+      wire source_write_fire = ep_rx_mem_write_fire &&
+        (write_route_source == SOURCE_ID);
+      wire source_write_slot = write_route_addr[3];
+      wire source_write_state_ok =
+        slot_state[SOURCE_ID][source_write_slot] == SLOT_ACTIVE;
+
+      wire replay_found;
+      wire replay_found_slot;
+      integer replay_scan_i;
+      reg replay_found_r;
+      reg replay_found_slot_r;
+      always @* begin
+        replay_found_r = 1'b0;
+        replay_found_slot_r = 1'b0;
+        for (replay_scan_i = 0;
+             replay_scan_i < SLOT_COUNT;
+             replay_scan_i = replay_scan_i + 1) begin
+          if (!replay_found_r &&
+              slot_state[SOURCE_ID][replay_scan_i] == SLOT_COMPLETE &&
+              slot_packet[SOURCE_ID][replay_scan_i] == next_packet_q[SOURCE_ID]) begin
+            replay_found_r = 1'b1;
+            replay_found_slot_r = replay_scan_i[0:0];
+          end
+        end
+      end
+      assign replay_found = replay_found_r;
+      assign replay_found_slot = replay_found_slot_r;
+
+      wire replay_issue = replay_active_q[SOURCE_ID] &&
+        (replay_word_q[SOURCE_ID] <
+         slot_flit_count[SOURCE_ID][replay_slot_q[SOURCE_ID]]);
+      wire packet_sram_read_req_ready;
+      wire packet_sram_read_rsp_valid;
+      wire [3:0] packet_sram_read_rsp_addr;
+      wire [DATA_W-1:0] packet_sram_read_rsp_data;
+      wire replay_request_fire = replay_issue &&
+        packet_sram_read_req_ready;
+      wire replay_response_fire = packet_sram_read_rsp_valid &&
+        deframer_flit_ready_w[SOURCE_ID];
+      wire replay_response_last = replay_response_fire &&
+        (({1'b0, packet_sram_read_rsp_addr[2:0]} + 1'b1) ==
+         {1'b0, slot_flit_count[SOURCE_ID][packet_sram_read_rsp_addr[3]]});
+
+      wire packet_sram_write_valid = source_write_fire && source_write_state_ok;
+      wire [3:0] packet_sram_write_addr = write_route_addr;
+      wire packet_sram_read_rsp_ready = deframer_flit_ready_w[SOURCE_ID];
+
+      local_reducer_aggregate_stats_once_exact_packet_sram #(
+        .DATA_W(DATA_W), .ADDR_W(4)
+      ) destination_packet_sram (
+        .clk(clk), .rst_n(rst_n),
+        .write_valid(packet_sram_write_valid),
+        .write_addr(packet_sram_write_addr),
+        .write_data(ep_rx_mem_write_data),
+        .read_req_valid(replay_issue),
+        .read_req_ready(packet_sram_read_req_ready),
+        .read_req_addr({replay_slot_q[SOURCE_ID], replay_word_q[SOURCE_ID][2:0]}),
+        .read_rsp_valid(packet_sram_read_rsp_valid),
+        .read_rsp_ready(packet_sram_read_rsp_ready),
+        .read_rsp_addr(packet_sram_read_rsp_addr),
+        .read_rsp_data(packet_sram_read_rsp_data)
+      );
+
+      wire deframer_ctx_valid = source_ctx_fire;
+      wire [DATA_W-1:0] deframer_data = packet_sram_read_rsp_data;
+      wire deframer_flit_last =
+        (({1'b0, packet_sram_read_rsp_addr[2:0]} + 1'b1) ==
+         {1'b0, slot_flit_count[SOURCE_ID][packet_sram_read_rsp_addr[3]]});
+
+      local_reducer_aggregate_stats_once_exact_packet_rx_deframer deframer (
+        .clk(clk), .rst_n(rst_n),
+        .group_ctx_valid(deframer_ctx_valid),
+        .group_ctx_ready(deframer_ctx_ready_w[SOURCE_ID]),
+        .group_command_id(group_command_id[SOURCE_ID*16 +: 16]),
+        .group_head_base(group_head_base[SOURCE_ID*5 +: 5]),
+        .group_source(group_source[SOURCE_ID*4 +: 4]),
+        .group_destination(group_destination[SOURCE_ID*4 +: 4]),
+        .group_vc(group_vc[SOURCE_ID*VC_W +: VC_W]),
+        .group_epoch(group_epoch[SOURCE_ID*3 +: 3]),
+        .mesh_flit_valid(packet_sram_read_rsp_valid),
+        .mesh_flit_ready(deframer_flit_ready_w[SOURCE_ID]),
+        .mesh_flit_destination(ROOT_ENDPOINT_ID[ENDPOINT_W-1:0]),
+        .mesh_flit_source(SOURCE_ID[ENDPOINT_W-1:0]),
+        .mesh_flit_tag({epoch_q[SOURCE_ID], slot_packet[SOURCE_ID][packet_sram_read_rsp_addr[3]]}),
+        .mesh_flit_fragment(packet_sram_read_rsp_addr[FRAGMENT_W-1:0]),
+        .mesh_flit_last(deframer_flit_last),
+        .mesh_flit_vc(vc_q[SOURCE_ID]),
+        .mesh_flit_data(deframer_data),
+        .codec_flit_valid(deframer_flit_valid_w[SOURCE_ID]),
+        .codec_flit_ready(codec_out_ready[SOURCE_ID]),
+        .codec_flit_data(deframer_data_w[SOURCE_ID*DATA_W +: DATA_W]),
+        .codec_flit_group_last(codec_out_group_last[SOURCE_ID]),
+        .codec_group_command_id(), .codec_group_head_base(),
+        .protocol_error(deframer_error_w[SOURCE_ID]),
+        .clean_group_complete(deframer_clean_w[SOURCE_ID])
+      );
+
+      assign packet_sram_read_rsp_valid_w[SOURCE_ID] =
+        packet_sram_read_rsp_valid;
+      assign packet_sram_read_rsp_addr_w[SOURCE_ID*4 +: 4] =
+        packet_sram_read_rsp_addr;
+      assign codec_out_data[SOURCE_ID*DATA_W +: DATA_W] =
+        deframer_data_w[SOURCE_ID*DATA_W +: DATA_W];
+
+      assign group_ctx_ready[SOURCE_ID] =
+        !group_active_q[SOURCE_ID] &&
+        !desc_pending_q[SOURCE_ID] &&
+        !active_packet_q[SOURCE_ID] &&
+        !wait_next_q[SOURCE_ID] &&
+        !replay_active_q[SOURCE_ID] &&
+        (slot_state[SOURCE_ID][0] == SLOT_FREE) &&
+        (slot_state[SOURCE_ID][1] == SLOT_FREE) &&
+        deframer_ctx_ready_w[SOURCE_ID];
+      assign tx_release_valid[SOURCE_ID] = release_pending_q[SOURCE_ID];
+      assign codec_out_valid[SOURCE_ID] = deframer_flit_valid_w[SOURCE_ID];
+      assign group_complete[SOURCE_ID] = deframer_clean_w[SOURCE_ID];
+      assign descriptor_installed[SOURCE_ID] = descriptor_fire;
+      assign source_protocol_error[SOURCE_ID] =
+        local_error_q[SOURCE_ID] || deframer_error_w[SOURCE_ID];
+
+      integer reset_slot_i;
+      always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+          group_active_q[SOURCE_ID] <= 1'b0;
+          command_q[SOURCE_ID] <= 16'b0;
+          head_q[SOURCE_ID] <= 5'b0;
+          source_q[SOURCE_ID] <= SOURCE_ID[3:0];
+          destination_q[SOURCE_ID] <= ROOT_ENDPOINT_ID[3:0];
+          vc_q[SOURCE_ID] <= {VC_W{1'b0}};
+          epoch_q[SOURCE_ID] <= 3'b0;
+          desc_pending_q[SOURCE_ID] <= 1'b0;
+          desc_slot_q[SOURCE_ID] <= 1'b0;
+          desc_packet_q[SOURCE_ID] <= 5'b0;
+          active_packet_q[SOURCE_ID] <= 1'b0;
+          active_packet_index_q[SOURCE_ID] <= 5'b0;
+          next_packet_q[SOURCE_ID] <= 5'b0;
+          wait_next_q[SOURCE_ID] <= 1'b0;
+          wait_slot_q[SOURCE_ID] <= 1'b0;
+          wait_packet_q[SOURCE_ID] <= 5'b0;
+          release_pending_q[SOURCE_ID] <= 1'b0;
+          local_error_q[SOURCE_ID] <= 1'b0;
+          replay_active_q[SOURCE_ID] <= 1'b0;
+          replay_slot_q[SOURCE_ID] <= 1'b0;
+          replay_word_q[SOURCE_ID] <= 4'b0;
+          for (reset_slot_i = 0; reset_slot_i < SLOT_COUNT; reset_slot_i = reset_slot_i + 1) begin
+            slot_state[SOURCE_ID][reset_slot_i] <= SLOT_FREE;
+            slot_packet[SOURCE_ID][reset_slot_i] <= 5'b0;
+            slot_flit_count[SOURCE_ID][reset_slot_i] <= 4'b0;
+          end
+        end else begin
+          if (source_ctx_fire) begin
+            group_active_q[SOURCE_ID] <= 1'b1;
+            command_q[SOURCE_ID] <= group_command_id[SOURCE_ID*16 +: 16];
+            head_q[SOURCE_ID] <= group_head_base[SOURCE_ID*5 +: 5];
+            source_q[SOURCE_ID] <= group_source[SOURCE_ID*4 +: 4];
+            destination_q[SOURCE_ID] <= group_destination[SOURCE_ID*4 +: 4];
+            vc_q[SOURCE_ID] <= group_vc[SOURCE_ID*VC_W +: VC_W];
+            epoch_q[SOURCE_ID] <= group_epoch[SOURCE_ID*3 +: 3];
+            desc_pending_q[SOURCE_ID] <= 1'b1;
+            desc_slot_q[SOURCE_ID] <= 1'b0;
+            desc_packet_q[SOURCE_ID] <= 5'd0;
+            slot_state[SOURCE_ID][0] <= SLOT_RESERVED;
+            next_packet_q[SOURCE_ID] <= 5'd0;
+            wait_next_q[SOURCE_ID] <= 1'b0;
+          end
+
+          if (descriptor_fire) begin
+            desc_pending_q[SOURCE_ID] <= 1'b0;
+            active_packet_q[SOURCE_ID] <= 1'b1;
+            active_packet_index_q[SOURCE_ID] <= desc_packet_q[SOURCE_ID];
+            slot_state[SOURCE_ID][desc_slot_q[SOURCE_ID]] <= SLOT_ACTIVE;
+            slot_packet[SOURCE_ID][desc_slot_q[SOURCE_ID]] <= desc_packet_q[SOURCE_ID];
+            slot_flit_count[SOURCE_ID][desc_slot_q[SOURCE_ID]] <=
+              (desc_packet_q[SOURCE_ID] == 5'd20) ? 4'd7 : 4'd8;
+            release_pending_q[SOURCE_ID] <= 1'b1;
+          end
+
+          if (release_fire)
+            release_pending_q[SOURCE_ID] <= 1'b0;
+
+          if (source_write_fire && !source_write_state_ok)
+            local_error_q[SOURCE_ID] <= 1'b1;
+
+          if (completion_fire) begin
+            if (!active_packet_q[SOURCE_ID] ||
+                ep_rx_completion_vc != vc_q[SOURCE_ID] ||
+                ep_rx_completion_tag !=
+                  {epoch_q[SOURCE_ID], active_packet_index_q[SOURCE_ID]}) begin
+              local_error_q[SOURCE_ID] <= 1'b1;
+            end
+            slot_state[SOURCE_ID][desc_slot_q[SOURCE_ID]] <= SLOT_COMPLETE;
+            active_packet_q[SOURCE_ID] <= 1'b0;
+            if (active_packet_index_q[SOURCE_ID] != 5'd20) begin
+              wait_next_q[SOURCE_ID] <= 1'b1;
+              wait_slot_q[SOURCE_ID] <= !desc_slot_q[SOURCE_ID];
+              wait_packet_q[SOURCE_ID] <= active_packet_index_q[SOURCE_ID] + 1'b1;
+            end
+          end
+
+          if (wait_next_q[SOURCE_ID] && !desc_pending_q[SOURCE_ID] &&
+              !active_packet_q[SOURCE_ID] &&
+              slot_state[SOURCE_ID][wait_slot_q[SOURCE_ID]] == SLOT_FREE) begin
+            desc_pending_q[SOURCE_ID] <= 1'b1;
+            desc_slot_q[SOURCE_ID] <= wait_slot_q[SOURCE_ID];
+            desc_packet_q[SOURCE_ID] <= wait_packet_q[SOURCE_ID];
+            slot_state[SOURCE_ID][wait_slot_q[SOURCE_ID]] <= SLOT_RESERVED;
+            wait_next_q[SOURCE_ID] <= 1'b0;
+          end
+
+          if (!replay_active_q[SOURCE_ID] && replay_found) begin
+            replay_active_q[SOURCE_ID] <= 1'b1;
+            replay_slot_q[SOURCE_ID] <= replay_found_slot;
+            replay_word_q[SOURCE_ID] <= 4'b0;
+            slot_state[SOURCE_ID][replay_found_slot] <= SLOT_ACTIVE;
+          end
+
+          if (replay_request_fire)
+            replay_word_q[SOURCE_ID] <= replay_word_q[SOURCE_ID] + 1'b1;
+
+          if (replay_response_last) begin
+            replay_active_q[SOURCE_ID] <= 1'b0;
+            slot_state[SOURCE_ID][packet_sram_read_rsp_addr[3]] <= SLOT_FREE;
+            next_packet_q[SOURCE_ID] <= next_packet_q[SOURCE_ID] + 1'b1;
+          end
+
+          if (deframer_clean_w[SOURCE_ID])
+            group_active_q[SOURCE_ID] <= 1'b0;
+        end
+      end
+    end
+  endgenerate
+
+  integer occupied_source_i;
+  integer occupied_slot_i;
+  reg [5:0] occupied_now;
+  always @* begin
+    occupied_now = 6'd0;
+    for (occupied_source_i = 0;
+         occupied_source_i < SOURCE_COUNT;
+         occupied_source_i = occupied_source_i + 1) begin
+      for (occupied_slot_i = 0;
+           occupied_slot_i < SLOT_COUNT;
+           occupied_slot_i = occupied_slot_i + 1) begin
+        if (slot_state[occupied_source_i][occupied_slot_i] != SLOT_FREE)
+          occupied_now = occupied_now + 1'b1;
+      end
+    end
+  end
+
+  reg root_error_q;
+
+  reg [5:0] replay_fire_count_now;
+  integer replay_count_i;
+  always @* begin
+    replay_fire_count_now = 6'd0;
+    for (replay_count_i = 0;
+         replay_count_i < SOURCE_COUNT;
+         replay_count_i = replay_count_i + 1)
+      if (replay_response_fire_w[replay_count_i])
+        replay_fire_count_now = replay_fire_count_now + 1'b1;
+  end
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      root_accepted_flit_count <= 32'b0;
+      root_descriptor_install_count <= 32'b0;
+      root_completion_count <= 32'b0;
+      root_replay_packet_count <= 32'b0;
+      max_occupied_slots <= 6'b0;
+      root_error_q <= 1'b0;
+    end else begin
+      if (ep_rx_mem_write_fire)
+        root_accepted_flit_count <= root_accepted_flit_count + 1'b1;
+      if (ep_rx_desc_fire)
+        root_descriptor_install_count <= root_descriptor_install_count + 1'b1;
+      if (ep_rx_completion_fire)
+        root_completion_count <= root_completion_count + 1'b1;
+      if (replay_fire_count_now != 0)
+        root_replay_packet_count <=
+          root_replay_packet_count + replay_fire_count_now;
+      if (occupied_now > max_occupied_slots)
+        max_occupied_slots <= occupied_now;
+      if (ep_rx_mem_write_fire &&
+          (!write_route_valid || mesh_out_source != write_route_source ||
+           !write_route_state_ok))
+        root_error_q <= 1'b1;
+      if (ep_rx_completion_fire && ep_rx_completion_source >= SOURCE_COUNT)
+        root_error_q <= 1'b1;
+    end
+  end
+
+  genvar count_g;
+  generate
+    for (count_g = 0; count_g < SOURCE_COUNT; count_g = count_g + 1) begin : gen_count
+      wire [3:0] count_response_addr =
+        packet_sram_read_rsp_addr_w[count_g*4 +: 4];
+      wire count_response_fire =
+        replay_active_q[count_g] && packet_sram_read_rsp_valid_w[count_g] &&
+        deframer_flit_ready_w[count_g] &&
+        (({1'b0, count_response_addr[2:0]} + 1'b1) ==
+         {1'b0, slot_flit_count[count_g][count_response_addr[3]]});
+      assign replay_response_fire_w[count_g] = count_response_fire;
+    end
+  endgenerate
+
+  assign protocol_error = root_error_q || ep_protocol_error ||
+    (|source_protocol_error);
+
+`ifndef SYNTHESIS
+  initial begin
+    if (DATA_W != 256 || TAG_W != 8 || FRAGMENT_W != 3 || VC_W != 2 ||
+        SOURCE_COUNT != 15 || ROOT_ENDPOINT_ID != 15)
+      $error("shared root exact adapter width/topology contract changed");
+    if (BANK_WORDS != 16 || SLOT_WORDS != 8)
+      $error("shared root packet SRAM geometry changed");
+  end
+`endif
+endmodule

--- a/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter.sv
+++ b/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter.sv
@@ -106,6 +106,25 @@ module local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter #(
   reg replay_slot_q [0:SOURCE_COUNT-1];
   reg [3:0] replay_word_q [0:SOURCE_COUNT-1];
 
+  integer active_group_i;
+  reg all_groups_active;
+  reg any_group_active;
+  reg group_release_open_q;
+  reg [4:0] release_round_q;
+  reg [6:0] release_interval_q;
+  always @* begin
+    all_groups_active = 1'b1;
+    any_group_active = 1'b0;
+    for (active_group_i = 0;
+         active_group_i < SOURCE_COUNT;
+         active_group_i = active_group_i + 1) begin
+      if (!group_active_q[active_group_i])
+        all_groups_active = 1'b0;
+      if (group_active_q[active_group_i])
+        any_group_active = 1'b1;
+    end
+  end
+
   wire [SOURCE_COUNT-1:0] packet_sram_read_rsp_valid_w;
   wire [SOURCE_COUNT*4-1:0] packet_sram_read_rsp_addr_w;
   wire [SOURCE_COUNT-1:0] replay_response_fire_w;
@@ -378,6 +397,7 @@ module local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter #(
 
       assign group_ctx_ready[SOURCE_ID] =
         !group_active_q[SOURCE_ID] &&
+        (!group_release_open_q || !any_group_active) &&
         !desc_pending_q[SOURCE_ID] &&
         !active_packet_q[SOURCE_ID] &&
         !wait_next_q[SOURCE_ID] &&
@@ -385,7 +405,12 @@ module local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter #(
         (slot_state[SOURCE_ID][0] == SLOT_FREE) &&
         (slot_state[SOURCE_ID][1] == SLOT_FREE) &&
         deframer_ctx_ready_w[SOURCE_ID];
-      assign tx_release_valid[SOURCE_ID] = release_pending_q[SOURCE_ID];
+      // A reduction group cannot make forward progress without every leaf.
+      // Hold early sources until all remote contexts are latched so context
+      // arrival skew cannot bias the fixed-priority descriptor scheduler.
+      assign tx_release_valid[SOURCE_ID] =
+        release_pending_q[SOURCE_ID] && group_release_open_q &&
+        (active_packet_index_q[SOURCE_ID] <= release_round_q);
       assign codec_out_valid[SOURCE_ID] = deframer_flit_valid_w[SOURCE_ID];
       assign group_complete[SOURCE_ID] = deframer_clean_w[SOURCE_ID];
       assign descriptor_installed[SOURCE_ID] = descriptor_fire;
@@ -542,7 +567,24 @@ module local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter #(
       root_replay_packet_count <= 32'b0;
       max_occupied_slots <= 6'b0;
       root_error_q <= 1'b0;
+      group_release_open_q <= 1'b0;
+      release_round_q <= 5'b0;
+      release_interval_q <= 7'b0;
     end else begin
+      if (all_groups_active)
+        group_release_open_q <= 1'b1;
+      else if (!any_group_active)
+        group_release_open_q <= 1'b0;
+      if (!group_release_open_q) begin
+        release_round_q <= 5'b0;
+        release_interval_q <= 7'b0;
+      end else if (release_interval_q == 7'd119) begin
+        release_interval_q <= 7'b0;
+        if (release_round_q != 5'd20)
+          release_round_q <= release_round_q + 1'b1;
+      end else begin
+        release_interval_q <= release_interval_q + 1'b1;
+      end
       if (ep_rx_mem_write_fire)
         root_accepted_flit_count <= root_accepted_flit_count + 1'b1;
       if (ep_rx_desc_fire)

--- a/tests/local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter_tb.sv
+++ b/tests/local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter_tb.sv
@@ -306,6 +306,8 @@ module local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter_tb;
   integer failures = 0;
   integer mesh_flit_count = 0;
   integer mesh_packet_count = 0;
+  integer first_root_flit_cycle = -1;
+  integer last_root_flit_cycle = -1;
   reg [SOURCE_COUNT-1:0] mesh_source_mask = {SOURCE_COUNT{1'b0}};
   integer monitor_i;
 
@@ -324,6 +326,8 @@ module local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter_tb;
       cycle <= 0;
       mesh_flit_count <= 0;
       mesh_packet_count <= 0;
+      first_root_flit_cycle <= -1;
+      last_root_flit_cycle <= -1;
       mesh_source_mask <= {SOURCE_COUNT{1'b0}};
       for (monitor_i = 0; monitor_i < SOURCE_COUNT; monitor_i = monitor_i + 1) begin
         beat_index[monitor_i] <= 0;
@@ -358,6 +362,9 @@ module local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter_tb;
       end
 
       if (root_mesh_out_valid && root_mesh_out_ready) begin
+        if (first_root_flit_cycle < 0)
+          first_root_flit_cycle <= cycle;
+        last_root_flit_cycle <= cycle;
         mesh_flit_count <= mesh_flit_count + 1;
         if (root_mesh_out_source < SOURCE_COUNT)
           mesh_source_mask[root_mesh_out_source] <= 1'b1;
@@ -435,6 +442,7 @@ module local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter_tb;
         root_descriptor_install_count != TOTAL_PACKETS ||
         root_completion_count != TOTAL_PACKETS ||
         root_replay_packet_count != TOTAL_PACKETS ||
+        (last_root_flit_cycle - first_root_flit_cycle + 1) < TOTAL_FLITS ||
         mesh_source_mask != {SOURCE_COUNT{1'b1}} || root_protocol_error ||
         (|encoder_error) || (|tx_adapter_error) || (|root_source_error) ||
         (|decoder_error) || root_max_occupied_slots == 0) begin
@@ -445,10 +453,12 @@ module local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter_tb;
         root_max_occupied_slots, failures, mesh_source_mask, root_protocol_error,
         |encoder_error, |tx_adapter_error, |root_source_error, |decoder_error);
     end
-    $display("PASS shared_root_stats_once sources=15 beats=%0d flits=%0d packets=%0d descriptors=%0d completions=%0d replays=%0d max_occupied_slots=%0d source_mask=%h",
+    $display("PASS shared_root_stats_once sources=15 beats=%0d flits=%0d packets=%0d descriptors=%0d completions=%0d replays=%0d root_delivery_span=%0d max_occupied_slots=%0d source_mask=%h",
       TOTAL_BEATS, mesh_flit_count, mesh_packet_count,
       root_descriptor_install_count, root_completion_count,
-      root_replay_packet_count, root_max_occupied_slots, mesh_source_mask);
+      root_replay_packet_count,
+      last_root_flit_cycle - first_root_flit_cycle + 1,
+      root_max_occupied_slots, mesh_source_mask);
     $finish;
   end
 endmodule

--- a/tests/local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter_tb.sv
+++ b/tests/local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter_tb.sv
@@ -1,0 +1,454 @@
+`timescale 1ns/1ps
+
+module local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter_tb;
+  localparam integer SOURCE_COUNT = 15;
+  localparam integer ROOT_ID = 15;
+  localparam integer BEAT_W = 419;
+  localparam integer FLIT_W = 256;
+  localparam integer GROUP_BEATS = 128;
+  localparam integer GROUP_FLITS = 167;
+  localparam integer GROUP_PACKETS = 21;
+  localparam integer TOTAL_BEATS = SOURCE_COUNT * GROUP_BEATS;
+  localparam integer TOTAL_FLITS = SOURCE_COUNT * GROUP_FLITS;
+  localparam integer TOTAL_PACKETS = SOURCE_COUNT * GROUP_PACKETS;
+  localparam integer SIM_TIMEOUT_CYCLES = 4000000;
+
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  integer cycle = 0;
+  always #5 clk = ~clk;
+
+  reg [SOURCE_COUNT-1:0] group_ctx_valid = {SOURCE_COUNT{1'b0}};
+  wire [SOURCE_COUNT-1:0] root_group_ctx_ready;
+  wire [SOURCE_COUNT-1:0] tx_group_ctx_ready;
+  wire [SOURCE_COUNT-1:0] encoder_group_ctx_ready;
+  wire [SOURCE_COUNT-1:0] decoder_group_ctx_ready;
+  reg [SOURCE_COUNT*16-1:0] group_command_id = {SOURCE_COUNT*16{1'b0}};
+  reg [SOURCE_COUNT*5-1:0] group_head_base = {SOURCE_COUNT*5{1'b0}};
+  reg [SOURCE_COUNT*4-1:0] group_source = {SOURCE_COUNT*4{1'b0}};
+  reg [SOURCE_COUNT*4-1:0] group_destination = {SOURCE_COUNT*4{1'b0}};
+  reg [SOURCE_COUNT*2-1:0] group_vc = {SOURCE_COUNT*2{1'b0}};
+  reg [SOURCE_COUNT*3-1:0] group_epoch = {SOURCE_COUNT*3{1'b0}};
+
+  reg [SOURCE_COUNT-1:0] encoder_beat_valid = {SOURCE_COUNT{1'b0}};
+  wire [SOURCE_COUNT-1:0] encoder_beat_ready;
+  reg [SOURCE_COUNT*BEAT_W-1:0] encoder_beat_data;
+  wire [SOURCE_COUNT-1:0] encoder_flit_valid;
+  wire [SOURCE_COUNT-1:0] encoder_flit_ready;
+  wire [SOURCE_COUNT*FLIT_W-1:0] encoder_flit_data;
+  wire [SOURCE_COUNT-1:0] encoder_flit_group_last;
+  wire [SOURCE_COUNT-1:0] encoder_error;
+
+  wire [SOURCE_COUNT-1:0] tx_release_valid;
+  wire [SOURCE_COUNT-1:0] tx_release_ready;
+  wire [SOURCE_COUNT-1:0] tx_adapter_error;
+  wire [SOURCE_COUNT-1:0] tx_group_complete;
+
+  wire [SOURCE_COUNT-1:0] root_codec_valid;
+  wire [SOURCE_COUNT-1:0] root_codec_ready;
+  wire [SOURCE_COUNT*FLIT_W-1:0] root_codec_data;
+  wire [SOURCE_COUNT-1:0] root_codec_group_last;
+  wire [SOURCE_COUNT-1:0] root_group_complete;
+  wire [SOURCE_COUNT-1:0] root_descriptor_installed;
+  wire [SOURCE_COUNT-1:0] root_source_error;
+  wire root_protocol_error;
+  wire [31:0] root_accepted_flit_count;
+  wire [31:0] root_descriptor_install_count;
+  wire [31:0] root_completion_count;
+  wire [31:0] root_replay_packet_count;
+  wire [5:0] root_max_occupied_slots;
+
+  wire [SOURCE_COUNT-1:0] decoder_beat_valid;
+  reg [SOURCE_COUNT-1:0] decoder_beat_ready = {SOURCE_COUNT{1'b0}};
+  wire [SOURCE_COUNT*BEAT_W-1:0] decoder_beat_data;
+  wire [SOURCE_COUNT-1:0] decoder_error;
+
+  wire [SOURCE_COUNT-1:0] source_mesh_in_valid;
+  wire [SOURCE_COUNT-1:0] source_mesh_in_ready;
+  wire [SOURCE_COUNT*4-1:0] source_mesh_in_destination;
+  wire [SOURCE_COUNT*4-1:0] source_mesh_in_source;
+  wire [SOURCE_COUNT*8-1:0] source_mesh_in_tag;
+  wire [SOURCE_COUNT*3-1:0] source_mesh_in_fragment;
+  wire [SOURCE_COUNT-1:0] source_mesh_in_last;
+  wire [SOURCE_COUNT*2-1:0] source_mesh_in_vc;
+  wire [SOURCE_COUNT*FLIT_W-1:0] source_mesh_in_data;
+
+  wire [SOURCE_COUNT-1:0] source_mesh_out_ready;
+  wire [SOURCE_COUNT-1:0] source_mesh_out_valid = {SOURCE_COUNT{1'b0}};
+  wire [SOURCE_COUNT*4-1:0] source_mesh_out_destination = {SOURCE_COUNT*4{1'b0}};
+  wire [SOURCE_COUNT*4-1:0] source_mesh_out_source = {SOURCE_COUNT*4{1'b0}};
+  wire [SOURCE_COUNT*8-1:0] source_mesh_out_tag = {SOURCE_COUNT*8{1'b0}};
+  wire [SOURCE_COUNT*3-1:0] source_mesh_out_fragment = {SOURCE_COUNT*3{1'b0}};
+  wire [SOURCE_COUNT-1:0] source_mesh_out_last = {SOURCE_COUNT{1'b0}};
+  wire [SOURCE_COUNT*2-1:0] source_mesh_out_vc = {SOURCE_COUNT*2{1'b0}};
+  wire [SOURCE_COUNT*FLIT_W-1:0] source_mesh_out_data = {SOURCE_COUNT*FLIT_W{1'b0}};
+
+  wire [15:0] mesh_endpoint_in_valid;
+  wire [15:0] mesh_endpoint_in_ready;
+  wire [16*4-1:0] mesh_endpoint_in_dest;
+  wire [16*4-1:0] mesh_endpoint_in_source;
+  wire [16*8-1:0] mesh_endpoint_in_tag;
+  wire [16*3-1:0] mesh_endpoint_in_fragment;
+  wire [15:0] mesh_endpoint_in_last;
+  wire [16*2-1:0] mesh_endpoint_in_vc;
+  wire [16*FLIT_W-1:0] mesh_endpoint_in_data;
+  wire [15:0] mesh_endpoint_out_valid;
+  wire [15:0] mesh_endpoint_out_ready;
+  wire [16*4-1:0] mesh_endpoint_out_dest;
+  wire [16*4-1:0] mesh_endpoint_out_source;
+  wire [16*8-1:0] mesh_endpoint_out_tag;
+  wire [16*3-1:0] mesh_endpoint_out_fragment;
+  wire [15:0] mesh_endpoint_out_last;
+  wire [16*2-1:0] mesh_endpoint_out_vc;
+  wire [16*FLIT_W-1:0] mesh_endpoint_out_data;
+
+  wire root_mesh_in_ready = 1'b1;
+  wire root_mesh_out_valid = mesh_endpoint_out_valid[ROOT_ID];
+  wire root_mesh_out_ready;
+  wire [3:0] root_mesh_out_destination = mesh_endpoint_out_dest[ROOT_ID*4 +: 4];
+  wire [3:0] root_mesh_out_source = mesh_endpoint_out_source[ROOT_ID*4 +: 4];
+  wire [7:0] root_mesh_out_tag = mesh_endpoint_out_tag[ROOT_ID*8 +: 8];
+  wire [2:0] root_mesh_out_fragment = mesh_endpoint_out_fragment[ROOT_ID*3 +: 3];
+  wire root_mesh_out_last = mesh_endpoint_out_last[ROOT_ID];
+  wire [1:0] root_mesh_out_vc = mesh_endpoint_out_vc[ROOT_ID*2 +: 2];
+  wire [FLIT_W-1:0] root_mesh_out_data = mesh_endpoint_out_data[ROOT_ID*FLIT_W +: FLIT_W];
+
+  assign mesh_endpoint_in_valid[SOURCE_COUNT-1:0] = source_mesh_in_valid;
+  assign mesh_endpoint_in_valid[ROOT_ID] = 1'b0;
+  assign mesh_endpoint_in_dest[SOURCE_COUNT*4-1:0] = source_mesh_in_destination;
+  assign mesh_endpoint_in_dest[ROOT_ID*4 +: 4] = 4'b0;
+  assign mesh_endpoint_in_source[SOURCE_COUNT*4-1:0] = source_mesh_in_source;
+  assign mesh_endpoint_in_source[ROOT_ID*4 +: 4] = 4'b0;
+  assign mesh_endpoint_in_tag[SOURCE_COUNT*8-1:0] = source_mesh_in_tag;
+  assign mesh_endpoint_in_tag[ROOT_ID*8 +: 8] = 8'b0;
+  assign mesh_endpoint_in_fragment[SOURCE_COUNT*3-1:0] = source_mesh_in_fragment;
+  assign mesh_endpoint_in_fragment[ROOT_ID*3 +: 3] = 3'b0;
+  assign mesh_endpoint_in_last[SOURCE_COUNT-1:0] = source_mesh_in_last;
+  assign mesh_endpoint_in_last[ROOT_ID] = 1'b0;
+  assign mesh_endpoint_in_vc[SOURCE_COUNT*2-1:0] = source_mesh_in_vc;
+  assign mesh_endpoint_in_vc[ROOT_ID*2 +: 2] = 2'b0;
+  assign mesh_endpoint_in_data[SOURCE_COUNT*FLIT_W-1:0] = source_mesh_in_data;
+  assign mesh_endpoint_in_data[ROOT_ID*FLIT_W +: FLIT_W] = {FLIT_W{1'b0}};
+  assign source_mesh_in_ready = mesh_endpoint_in_ready[SOURCE_COUNT-1:0];
+
+  assign mesh_endpoint_out_ready[SOURCE_COUNT-1:0] = {SOURCE_COUNT{1'b1}};
+  assign mesh_endpoint_out_ready[ROOT_ID] = root_mesh_out_ready;
+
+  noc_segmented_mesh4x4 #(
+    .DATA_W(FLIT_W), .TAG_W(8), .FRAGMENT_W(3), .VC_W(2),
+    .VC_COUNT(4), .FIFO_DEPTH(4)
+  ) mesh (
+    .clk(clk), .rst_n(rst_n),
+    .endpoint_in_valid(mesh_endpoint_in_valid),
+    .endpoint_in_ready(mesh_endpoint_in_ready),
+    .endpoint_in_dest(mesh_endpoint_in_dest),
+    .endpoint_in_source(mesh_endpoint_in_source),
+    .endpoint_in_tag(mesh_endpoint_in_tag),
+    .endpoint_in_fragment(mesh_endpoint_in_fragment),
+    .endpoint_in_last(mesh_endpoint_in_last),
+    .endpoint_in_vc(mesh_endpoint_in_vc),
+    .endpoint_in_data(mesh_endpoint_in_data),
+    .endpoint_out_valid(mesh_endpoint_out_valid),
+    .endpoint_out_ready(mesh_endpoint_out_ready),
+    .endpoint_out_dest(mesh_endpoint_out_dest),
+    .endpoint_out_source(mesh_endpoint_out_source),
+    .endpoint_out_tag(mesh_endpoint_out_tag),
+    .endpoint_out_fragment(mesh_endpoint_out_fragment),
+    .endpoint_out_last(mesh_endpoint_out_last),
+    .endpoint_out_vc(mesh_endpoint_out_vc),
+    .endpoint_out_data(mesh_endpoint_out_data),
+    .router_accepted_flit_count(), .router_forwarded_flit_count(),
+    .router_input_stall_cycles(), .router_output_stall_cycles(),
+    .router_contention_cycles(), .router_current_input_occupancy(),
+    .router_max_input_occupancy(), .router_route_flit_count()
+  );
+
+  local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter root (
+    .clk(clk), .rst_n(rst_n),
+    .group_ctx_valid(group_ctx_valid), .group_ctx_ready(root_group_ctx_ready),
+    .group_command_id(group_command_id), .group_head_base(group_head_base),
+    .group_source(group_source), .group_destination(group_destination),
+    .group_vc(group_vc), .group_epoch(group_epoch),
+    .tx_release_valid(tx_release_valid), .tx_release_ready(tx_release_ready),
+    .codec_out_valid(root_codec_valid), .codec_out_ready(root_codec_ready),
+    .codec_out_data(root_codec_data), .codec_out_group_last(root_codec_group_last),
+    .group_complete(root_group_complete),
+    .descriptor_installed(root_descriptor_installed),
+    .source_protocol_error(root_source_error),
+    .mesh_in_valid(), .mesh_in_ready(root_mesh_in_ready),
+    .mesh_in_destination(), .mesh_in_source(), .mesh_in_tag(),
+    .mesh_in_fragment(), .mesh_in_last(), .mesh_in_vc(), .mesh_in_data(),
+    .mesh_out_valid(root_mesh_out_valid), .mesh_out_ready(root_mesh_out_ready),
+    .mesh_out_destination(root_mesh_out_destination),
+    .mesh_out_source(root_mesh_out_source), .mesh_out_tag(root_mesh_out_tag),
+    .mesh_out_fragment(root_mesh_out_fragment), .mesh_out_last(root_mesh_out_last),
+    .mesh_out_vc(root_mesh_out_vc), .mesh_out_data(root_mesh_out_data),
+    .root_accepted_flit_count(root_accepted_flit_count),
+    .root_descriptor_install_count(root_descriptor_install_count),
+    .root_completion_count(root_completion_count),
+    .root_replay_packet_count(root_replay_packet_count),
+    .max_occupied_slots(root_max_occupied_slots),
+    .protocol_error(root_protocol_error)
+  );
+
+  genvar source_g;
+  generate
+    for (source_g = 0; source_g < SOURCE_COUNT; source_g = source_g + 1) begin : gen_source
+      localparam integer SOURCE_ID = source_g;
+      local_reducer_aggregate_stats_once_exact_encoder encoder (
+        .clk(clk), .rst_n(rst_n),
+        .group_ctx_valid(group_ctx_valid[SOURCE_ID]),
+        .group_ctx_ready(encoder_group_ctx_ready[SOURCE_ID]),
+        .group_command_id(group_command_id[SOURCE_ID*16 +: 16]),
+        .group_head_base(group_head_base[SOURCE_ID*5 +: 5]),
+        .beat_valid(encoder_beat_valid[SOURCE_ID]),
+        .beat_ready(encoder_beat_ready[SOURCE_ID]),
+        .beat_data(encoder_beat_data[SOURCE_ID*BEAT_W +: BEAT_W]),
+        .flit_valid(encoder_flit_valid[SOURCE_ID]),
+        .flit_ready(encoder_flit_ready[SOURCE_ID]),
+        .flit_data(encoder_flit_data[SOURCE_ID*FLIT_W +: FLIT_W]),
+        .flit_group_last(encoder_flit_group_last[SOURCE_ID]),
+        .protocol_error(encoder_error[SOURCE_ID])
+      );
+
+      local_reducer_aggregate_stats_once_exact_sram_packet_adapter #(
+        .LOCAL_ENDPOINT_ID(SOURCE_ID), .TX_ENABLE(1), .RX_ENABLE(0),
+        .RX_WRITE_STALL_PERIOD(0)
+      ) tx_adapter (
+        .clk(clk), .rst_n(rst_n),
+        .group_ctx_valid(group_ctx_valid[SOURCE_ID]),
+        .group_ctx_ready(tx_group_ctx_ready[SOURCE_ID]),
+        .group_command_id(group_command_id[SOURCE_ID*16 +: 16]),
+        .group_head_base(group_head_base[SOURCE_ID*5 +: 5]),
+        .group_source(group_source[SOURCE_ID*4 +: 4]),
+        .group_destination(group_destination[SOURCE_ID*4 +: 4]),
+        .group_vc(group_vc[SOURCE_ID*2 +: 2]),
+        .group_epoch(group_epoch[SOURCE_ID*3 +: 3]),
+        .codec_in_valid(encoder_flit_valid[SOURCE_ID]),
+        .codec_in_ready(encoder_flit_ready[SOURCE_ID]),
+        .codec_in_data(encoder_flit_data[SOURCE_ID*FLIT_W +: FLIT_W]),
+        .codec_in_group_last(encoder_flit_group_last[SOURCE_ID]),
+        .tx_release_valid(tx_release_valid[SOURCE_ID]),
+        .tx_release_ready(tx_release_ready[SOURCE_ID]),
+        .codec_out_valid(), .codec_out_ready(1'b0), .codec_out_data(),
+        .codec_out_group_last(), .tx_group_complete(tx_group_complete[SOURCE_ID]),
+        .rx_group_complete(), .rx_descriptor_installed(),
+        .protocol_error(tx_adapter_error[SOURCE_ID]),
+        .tx_descriptor_count(), .rx_completion_count(), .replay_packet_count(),
+        .max_source_occupancy(), .max_destination_occupancy(),
+        .mesh_in_valid(source_mesh_in_valid[SOURCE_ID]),
+        .mesh_in_ready(source_mesh_in_ready[SOURCE_ID]),
+        .mesh_in_destination(source_mesh_in_destination[SOURCE_ID*4 +: 4]),
+        .mesh_in_source(source_mesh_in_source[SOURCE_ID*4 +: 4]),
+        .mesh_in_tag(source_mesh_in_tag[SOURCE_ID*8 +: 8]),
+        .mesh_in_fragment(source_mesh_in_fragment[SOURCE_ID*3 +: 3]),
+        .mesh_in_last(source_mesh_in_last[SOURCE_ID]),
+        .mesh_in_vc(source_mesh_in_vc[SOURCE_ID*2 +: 2]),
+        .mesh_in_data(source_mesh_in_data[SOURCE_ID*FLIT_W +: FLIT_W]),
+        .mesh_out_valid(source_mesh_out_valid[SOURCE_ID]),
+        .mesh_out_ready(source_mesh_out_ready[SOURCE_ID]),
+        .mesh_out_destination(source_mesh_out_destination[SOURCE_ID*4 +: 4]),
+        .mesh_out_source(source_mesh_out_source[SOURCE_ID*4 +: 4]),
+        .mesh_out_tag(source_mesh_out_tag[SOURCE_ID*8 +: 8]),
+        .mesh_out_fragment(source_mesh_out_fragment[SOURCE_ID*3 +: 3]),
+        .mesh_out_last(source_mesh_out_last[SOURCE_ID]),
+        .mesh_out_vc(source_mesh_out_vc[SOURCE_ID*2 +: 2]),
+        .mesh_out_data(source_mesh_out_data[SOURCE_ID*FLIT_W +: FLIT_W])
+      );
+
+      local_reducer_aggregate_stats_once_exact_decoder decoder (
+        .clk(clk), .rst_n(rst_n),
+        .group_ctx_valid(group_ctx_valid[SOURCE_ID]),
+        .group_ctx_ready(decoder_group_ctx_ready[SOURCE_ID]),
+        .group_command_id(group_command_id[SOURCE_ID*16 +: 16]),
+        .group_head_base(group_head_base[SOURCE_ID*5 +: 5]),
+        .flit_valid(root_codec_valid[SOURCE_ID]),
+        .flit_ready(root_codec_ready[SOURCE_ID]),
+        .flit_data(root_codec_data[SOURCE_ID*FLIT_W +: FLIT_W]),
+        .flit_group_last(root_codec_group_last[SOURCE_ID]),
+        .beat_valid(decoder_beat_valid[SOURCE_ID]),
+        .beat_ready(decoder_beat_ready[SOURCE_ID]),
+        .beat_data(decoder_beat_data[SOURCE_ID*BEAT_W +: BEAT_W]),
+        .protocol_error(decoder_error[SOURCE_ID])
+      );
+    end
+  endgenerate
+
+  function automatic [BEAT_W-1:0] make_beat;
+    input integer source_id;
+    input integer beat_index;
+    reg [BEAT_W-1:0] value;
+    integer head;
+    integer slice;
+    integer lane;
+    begin
+      value = {BEAT_W{1'b0}};
+      head = beat_index / 16;
+      slice = beat_index % 16;
+      value[15:0] = 16'h7000 + source_id;
+      value[20:16] = 8 + head;
+      value[52:21] = 32'h2200_0000 + source_id * 32'h101 + head * 32'h31;
+      value[85:53] = 33'h1 + source_id * 33'h11 + head * 33'h71;
+      value[89:86] = slice[3:0];
+      value[90] = (slice == 15);
+      for (lane = 0; lane < 8; lane = lane + 1)
+        value[91 + lane * 41 +: 41] =
+          41'h30000 + source_id * 41'h101 + beat_index * 41'h13 + lane * 41'h7;
+      make_beat = value;
+    end
+  endfunction
+
+  integer beat_index [0:SOURCE_COUNT-1];
+  integer input_count [0:SOURCE_COUNT-1];
+  integer output_count [0:SOURCE_COUNT-1];
+  integer tx_clean_count [0:SOURCE_COUNT-1];
+  integer root_clean_count [0:SOURCE_COUNT-1];
+  integer failures = 0;
+  integer mesh_flit_count = 0;
+  integer mesh_packet_count = 0;
+  reg [SOURCE_COUNT-1:0] mesh_source_mask = {SOURCE_COUNT{1'b0}};
+  integer monitor_i;
+
+  always @* begin
+    for (monitor_i = 0; monitor_i < SOURCE_COUNT; monitor_i = monitor_i + 1) begin
+      encoder_beat_data[monitor_i*BEAT_W +: BEAT_W] =
+        make_beat(monitor_i, beat_index[monitor_i]);
+      decoder_beat_ready[monitor_i] =
+        ((cycle + monitor_i * 3) % 13 != 5) &&
+        ((cycle + monitor_i) % 7 != 2);
+    end
+  end
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      cycle <= 0;
+      mesh_flit_count <= 0;
+      mesh_packet_count <= 0;
+      mesh_source_mask <= {SOURCE_COUNT{1'b0}};
+      for (monitor_i = 0; monitor_i < SOURCE_COUNT; monitor_i = monitor_i + 1) begin
+        beat_index[monitor_i] <= 0;
+        input_count[monitor_i] <= 0;
+        output_count[monitor_i] <= 0;
+        tx_clean_count[monitor_i] <= 0;
+        root_clean_count[monitor_i] <= 0;
+      end
+    end else begin
+      cycle <= cycle + 1;
+      if (cycle >= SIM_TIMEOUT_CYCLES)
+        $fatal(1, "shared root simulation timeout at cycle=%0d", cycle);
+      for (monitor_i = 0; monitor_i < SOURCE_COUNT; monitor_i = monitor_i + 1) begin
+        if (encoder_beat_valid[monitor_i] && encoder_beat_ready[monitor_i]) begin
+          beat_index[monitor_i] <= beat_index[monitor_i] + 1;
+          input_count[monitor_i] <= input_count[monitor_i] + 1;
+        end
+        if (decoder_beat_valid[monitor_i] && decoder_beat_ready[monitor_i]) begin
+          if (decoder_beat_data[monitor_i*BEAT_W +: BEAT_W] !==
+              make_beat(monitor_i, output_count[monitor_i])) begin
+            failures <= failures + 1;
+          end
+          output_count[monitor_i] <= output_count[monitor_i] + 1;
+        end
+        if (tx_group_complete[monitor_i])
+          tx_clean_count[monitor_i] <= tx_clean_count[monitor_i] + 1;
+        if (root_group_complete[monitor_i])
+          root_clean_count[monitor_i] <= root_clean_count[monitor_i] + 1;
+        if (encoder_error[monitor_i] || tx_adapter_error[monitor_i] ||
+            root_source_error[monitor_i] || decoder_error[monitor_i])
+          failures <= failures + 1;
+      end
+
+      if (root_mesh_out_valid && root_mesh_out_ready) begin
+        mesh_flit_count <= mesh_flit_count + 1;
+        if (root_mesh_out_source < SOURCE_COUNT)
+          mesh_source_mask[root_mesh_out_source] <= 1'b1;
+        if (root_mesh_out_last)
+          mesh_packet_count <= mesh_packet_count + 1;
+      end
+    end
+  end
+
+  function automatic integer all_sources_complete;
+    integer complete_i;
+    begin
+      all_sources_complete = 1;
+      for (complete_i = 0; complete_i < SOURCE_COUNT; complete_i = complete_i + 1)
+        if (input_count[complete_i] != GROUP_BEATS ||
+            output_count[complete_i] != GROUP_BEATS ||
+            tx_clean_count[complete_i] != 1 ||
+            root_clean_count[complete_i] != 1)
+          all_sources_complete = 0;
+    end
+  endfunction
+
+  integer setup_i;
+  initial begin
+    for (setup_i = 0; setup_i < SOURCE_COUNT; setup_i = setup_i + 1) begin
+      group_command_id[setup_i*16 +: 16] = 16'h7000 + setup_i;
+      group_head_base[setup_i*5 +: 5] = 5'd8;
+      group_source[setup_i*4 +: 4] = setup_i[3:0];
+      group_destination[setup_i*4 +: 4] = ROOT_ID[3:0];
+      group_vc[setup_i*2 +: 2] = 2'd2;
+      group_epoch[setup_i*3 +: 3] = (setup_i + 1) % 8;
+      beat_index[setup_i] = 0;
+    end
+    repeat (5) @(posedge clk);
+    rst_n = 1'b1;
+
+    // Wait for all four consumers to be able to accept a context before
+    // asserting it.  This makes the context handshake atomic across the
+    // source encoder, source TX adapter, shared root, and exact decoder.
+    for (setup_i = 0; setup_i < SOURCE_COUNT; setup_i = setup_i + 1) begin
+      while (!(root_group_ctx_ready[setup_i] &&
+               tx_group_ctx_ready[setup_i] &&
+               encoder_group_ctx_ready[setup_i] &&
+               decoder_group_ctx_ready[setup_i])) @(posedge clk);
+      @(negedge clk);
+      group_ctx_valid[setup_i] = 1'b1;
+      @(posedge clk);
+      while (!(root_group_ctx_ready[setup_i] &&
+               tx_group_ctx_ready[setup_i] &&
+               encoder_group_ctx_ready[setup_i] &&
+               decoder_group_ctx_ready[setup_i])) @(posedge clk);
+      @(negedge clk);
+      group_ctx_valid[setup_i] = 1'b0;
+    end
+
+    @(negedge clk);
+    encoder_beat_valid = {SOURCE_COUNT{1'b1}};
+    while (root_descriptor_install_count < TOTAL_PACKETS ||
+           root_completion_count < TOTAL_PACKETS ||
+           root_replay_packet_count < TOTAL_PACKETS ||
+           mesh_flit_count < TOTAL_FLITS || !all_sources_complete())
+      @(posedge clk);
+    repeat (20) @(posedge clk);
+    encoder_beat_valid = {SOURCE_COUNT{1'b0}};
+
+    for (setup_i = 0; setup_i < SOURCE_COUNT; setup_i = setup_i + 1) begin
+      if (input_count[setup_i] != GROUP_BEATS ||
+          output_count[setup_i] != GROUP_BEATS ||
+          tx_clean_count[setup_i] != 1 || root_clean_count[setup_i] != 1)
+        failures = failures + 1;
+    end
+    if (failures != 0 || mesh_flit_count != TOTAL_FLITS ||
+        mesh_packet_count != TOTAL_PACKETS ||
+        root_accepted_flit_count != TOTAL_FLITS ||
+        root_descriptor_install_count != TOTAL_PACKETS ||
+        root_completion_count != TOTAL_PACKETS ||
+        root_replay_packet_count != TOTAL_PACKETS ||
+        mesh_source_mask != {SOURCE_COUNT{1'b1}} || root_protocol_error ||
+        (|encoder_error) || (|tx_adapter_error) || (|root_source_error) ||
+        (|decoder_error) || root_max_occupied_slots == 0) begin
+      $fatal(1, "shared root failed beats=%0d/%0d flits=%0d/%0d packets=%0d/%0d desc=%0d comp=%0d replay=%0d max_slots=%0d failures=%0d mask=%h errors=%b/%b/%b/%b/%b",
+        input_count[0], TOTAL_BEATS, mesh_flit_count, TOTAL_FLITS,
+        mesh_packet_count, TOTAL_PACKETS, root_descriptor_install_count,
+        root_completion_count, root_replay_packet_count,
+        root_max_occupied_slots, failures, mesh_source_mask, root_protocol_error,
+        |encoder_error, |tx_adapter_error, |root_source_error, |decoder_error);
+    end
+    $display("PASS shared_root_stats_once sources=15 beats=%0d flits=%0d packets=%0d descriptors=%0d completions=%0d replays=%0d max_occupied_slots=%0d source_mask=%h",
+      TOTAL_BEATS, mesh_flit_count, mesh_packet_count,
+      root_descriptor_install_count, root_completion_count,
+      root_replay_packet_count, root_max_occupied_slots, mesh_source_mask);
+    $finish;
+  end
+endmodule

--- a/tests/test_local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter.py
+++ b/tests/test_local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RTL = REPO_ROOT / "npu/sim/rtl"
+TB = REPO_ROOT / "tests/local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter_tb.sv"
+TOP = "local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter"
+
+
+def _tool(name: str) -> str | None:
+    path = shutil.which(name)
+    if path is not None:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    return str(fallback) if fallback.exists() else None
+
+
+RTL_SOURCES = [
+    RTL / "noc_ready_valid_fifo.sv",
+    RTL / "noc_segmented_mesh_router.sv",
+    RTL / "noc_segmented_mesh4x4.sv",
+    RTL / "noc_sram_packet_endpoint.sv",
+    RTL / "local_reducer_aggregate_stats_once_exact_packet_bridge.sv",
+    RTL / "local_reducer_aggregate_stats_once_exact_codec.sv",
+    RTL / "local_reducer_aggregate_stats_once_exact_sram_packet_adapter.sv",
+    RTL / "local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter.sv",
+]
+
+
+@pytest.mark.skipif(
+    _tool("iverilog") is None or _tool("vvp") is None,
+    reason="iverilog/vvp unavailable",
+)
+def test_shared_root_exact_15_source_mesh_equivalence(tmp_path: Path) -> None:
+    simv = tmp_path / "shared_root_stats_once.vvp"
+    subprocess.run(
+        [
+            str(_tool("iverilog")),
+            "-g2012",
+            "-s",
+            f"{TOP}_tb",
+            "-o",
+            str(simv),
+            *[str(path) for path in RTL_SOURCES],
+            str(TB),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    run = subprocess.run(
+        [str(_tool("vvp")), str(simv)],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert "PASS shared_root_stats_once sources=15" in run.stdout
+    assert "beats=1920" in run.stdout
+    assert "flits=2505" in run.stdout
+    assert "packets=315" in run.stdout
+    assert "descriptors=315" in run.stdout
+    assert "completions=315" in run.stdout
+    assert "replays=315" in run.stdout
+    assert "source_mask=7fff" in run.stdout
+
+
+@pytest.mark.skipif(_tool("yosys") is None, reason="yosys unavailable")
+def test_shared_root_yosys_has_one_endpoint_and_fifteen_sram_banks(
+    tmp_path: Path,
+) -> None:
+    netlist = tmp_path / "shared_root_stats_once.json"
+    subprocess.run(
+        [
+            str(_tool("yosys")),
+            "-q",
+            "-p",
+            "read_verilog -DSYNTHESIS -sv "
+            + " ".join(str(path) for path in RTL_SOURCES)
+            + f"; hierarchy -check -top {TOP}; proc; memory_dff; memory_collect; "
+            + "check; write_json "
+            + str(netlist),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    design = json.loads(netlist.read_text())
+    top = design["modules"][TOP]
+    endpoint_cells = [
+        cell
+        for cell in top["cells"].values()
+        if "noc_sram_packet_endpoint" in cell["type"]
+    ]
+    packet_sram_cells = [
+        cell
+        for cell in top["cells"].values()
+        if "local_reducer_aggregate_stats_once_exact_packet_sram" in cell["type"]
+    ]
+    deframer_cells = [
+        cell
+        for cell in top["cells"].values()
+        if "local_reducer_aggregate_stats_once_exact_packet_rx_deframer"
+        in cell["type"]
+    ]
+    assert len(endpoint_cells) == 1
+    assert len(packet_sram_cells) == 15
+    assert len(deframer_cells) == 15
+
+    sram_modules = [
+        module
+        for name, module in design["modules"].items()
+        if name.endswith("local_reducer_aggregate_stats_once_exact_packet_sram")
+        or "local_reducer_aggregate_stats_once_exact_packet_sram" in name
+    ]
+    assert len(sram_modules) == 1
+    mem_cells = [cell for cell in sram_modules[0]["cells"].values() if cell["type"] == "$mem_v2"]
+    assert len(mem_cells) == 1
+    assert mem_cells[0]["parameters"]["SIZE"] == "00000000000000000000000000010000"
+    assert mem_cells[0]["parameters"]["WIDTH"] == "00000000000000000000000100000000"
+    assert len(packet_sram_cells) * len(mem_cells) == 15

--- a/tests/test_local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter.py
+++ b/tests/test_local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter.py
@@ -72,6 +72,7 @@ def test_shared_root_exact_15_source_mesh_equivalence(tmp_path: Path) -> None:
     assert "descriptors=315" in run.stdout
     assert "completions=315" in run.stdout
     assert "replays=315" in run.stdout
+    assert "root_delivery_span=2505" in run.stdout
     assert "source_mask=7fff" in run.stdout
 
 
@@ -126,7 +127,11 @@ def test_shared_root_yosys_has_one_endpoint_and_fifteen_sram_banks(
         or "local_reducer_aggregate_stats_once_exact_packet_sram" in name
     ]
     assert len(sram_modules) == 1
-    mem_cells = [cell for cell in sram_modules[0]["cells"].values() if cell["type"] == "$mem_v2"]
+    mem_cells = [
+        cell
+        for cell in sram_modules[0]["cells"].values()
+        if cell["type"] == "$mem_v2"
+    ]
     assert len(mem_cells) == 1
     assert mem_cells[0]["parameters"]["SIZE"] == "00000000000000000000000000010000"
     assert mem_cells[0]["parameters"]["WIDTH"] == "00000000000000000000000100000000"

--- a/tests/test_noc_sram_packet_mesh_perf.py
+++ b/tests/test_noc_sram_packet_mesh_perf.py
@@ -64,6 +64,43 @@ def test_eight_rx_contexts_throttle_a_ninth_packet() -> None:
     assert not result.protocol_errors
 
 
+def test_per_endpoint_rx_context_override_accepts_fifteen_root_sources() -> None:
+    descriptors = [
+        PacketDescriptor(
+            source=source,
+            destination=15,
+            vc=1,
+            tag=source,
+            flit_count=8,
+            packet_id=f"root-source-{source}",
+        )
+        for source in range(15)
+    ]
+    result = simulate_packet_mesh(
+        descriptors,
+        rx_context_limits={15: 15},
+    )
+
+    assert len(result.rx_descriptor_handshakes) == 15
+    assert result.max_rx_context_occupancy == 15
+    assert len(result.deliveries) == 15 * 8
+    assert not result.protocol_errors
+
+
+def test_rx_context_override_rejects_invalid_endpoint_or_capacity() -> None:
+    descriptor = PacketDescriptor(
+        source=0,
+        destination=15,
+        vc=1,
+        tag=0,
+        flit_count=1,
+    )
+    with pytest.raises(ValueError, match="keys"):
+        simulate_packet_mesh([descriptor], rx_context_limits={16: 15})
+    with pytest.raises(ValueError, match="positive"):
+        simulate_packet_mesh([descriptor], rx_context_limits={15: 0})
+
+
 def test_concrete_tags_are_preserved_across_wrap() -> None:
     descriptors = [
         PacketDescriptor(

--- a/tests/test_stats_once_shared_root_perf.py
+++ b/tests/test_stats_once_shared_root_perf.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+
+from npu.sim.perf.stats_once_shared_root import (
+    GROUP_FLITS,
+    PACKET_ROUND_RELEASE_INTERVAL_CYCLES,
+    PACKETS_PER_GROUP,
+    REMOTE_SOURCES,
+    ROOT_ENDPOINT,
+    build_shared_root_descriptors,
+    packet_flit_count,
+    simulate_exact_stats_once_shared_root,
+)
+
+
+def test_shared_root_descriptor_contract_is_exact_and_packet_major() -> None:
+    descriptors = build_shared_root_descriptors(epoch=5, vc=2)
+
+    assert len(descriptors) == REMOTE_SOURCES * PACKETS_PER_GROUP
+    assert [descriptor.source for descriptor in descriptors[:REMOTE_SOURCES]] == list(
+        range(REMOTE_SOURCES)
+    )
+    assert all(descriptor.destination == ROOT_ENDPOINT for descriptor in descriptors)
+    assert all(descriptor.vc == 2 for descriptor in descriptors)
+    assert descriptors[0].tag == 0xA0
+    assert descriptors[-1].tag == 0xB4
+    assert Counter(descriptor.flit_count for descriptor in descriptors) == {
+        8: REMOTE_SOURCES * 20,
+        7: REMOTE_SOURCES,
+    }
+    for packet in range(PACKETS_PER_GROUP):
+        for source in range(REMOTE_SOURCES):
+            descriptor = descriptors[packet * REMOTE_SOURCES + source]
+            assert descriptor.rx_base_addr == source * 512 + (packet % 2) * 256
+            assert descriptor.tx_base_addr == (packet % 2) * 256
+
+
+def test_shared_root_mesh_conserves_all_exact_group_traffic() -> None:
+    result = simulate_exact_stats_once_shared_root(epoch=3, vc=1)
+
+    assert len(result.mesh.descriptors) == REMOTE_SOURCES * PACKETS_PER_GROUP
+    assert len(result.mesh.rx_descriptor_handshakes) == REMOTE_SOURCES * PACKETS_PER_GROUP
+    assert len(result.mesh.tx_descriptor_handshakes) == REMOTE_SOURCES * PACKETS_PER_GROUP
+    assert len(result.mesh.completions) == REMOTE_SOURCES * PACKETS_PER_GROUP
+    assert len(result.mesh.deliveries) == REMOTE_SOURCES * GROUP_FLITS
+    assert result.mesh.max_rx_context_occupancy == REMOTE_SOURCES
+    assert result.root_delivery_span_cycles >= result.serialization_lower_bound_cycles
+    assert result.root_delivery_span_cycles == result.serialization_lower_bound_cycles
+    assert result.serialization_lower_bound_cycles == 2505
+    assert not result.mesh.protocol_errors
+    assert Counter(delivery.flit.source for delivery in result.mesh.deliveries) == {
+        source: GROUP_FLITS for source in range(REMOTE_SOURCES)
+    }
+
+
+def test_shared_root_two_slot_replay_schedule_is_feasible() -> None:
+    result = simulate_exact_stats_once_shared_root()
+
+    assert len(result.replays) == REMOTE_SOURCES * PACKETS_PER_GROUP
+    assert result.max_slots_per_source <= 2
+    assert result.slot_reuse_violations == ()
+    assert result.packet_round_release_interval_cycles == 120
+    assert result.packet_round_release_interval_cycles == (
+        REMOTE_SOURCES * packet_flit_count(0)
+    )
+    assert PACKET_ROUND_RELEASE_INTERVAL_CYCLES == 120
+    for source in range(REMOTE_SOURCES):
+        source_replays = [replay for replay in result.replays if replay.source == source]
+        assert [replay.packet for replay in source_replays] == list(
+            range(PACKETS_PER_GROUP)
+        )
+        assert all(
+            current.first_output_cycle > previous.final_output_cycle
+            for previous, current in zip(source_replays, source_replays[1:])
+        )
+
+
+@pytest.mark.parametrize("packet", [-1, 21])
+def test_packet_flit_count_rejects_out_of_range_packet(packet: int) -> None:
+    with pytest.raises(ValueError, match="packet"):
+        packet_flit_count(packet)
+
+
+def test_shared_root_descriptor_builder_rejects_bad_context() -> None:
+    with pytest.raises(ValueError, match="epoch"):
+        build_shared_root_descriptors(epoch=8)
+    with pytest.raises(ValueError, match="vc"):
+        build_shared_root_descriptors(vc=4)
+    with pytest.raises(ValueError, match="release"):
+        build_shared_root_descriptors(release_cycles={(0, 2): -1})


### PR DESCRIPTION
## Summary
- embody the 15 remote exact stats-once streams with one shared root packet endpoint, 15 independent 16x256 synchronous SRAM banks, and 15 exact deframers
- add a cycle-accurate 15-source shared-root performance model with finite two-slot lifecycle checks
- schedule packet rounds every 120 cycles and match the 2,505-cycle root serialization lower bound in real-mesh RTL simulation
- prove exact conservation of 1,920 canonical beats, 2,505 flits, and 315 packets/descriptors/completions/replays

## Verification
- `python -m pytest -q tests/test_local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter.py tests/test_local_reducer_aggregate_stats_once_exact_packet_mesh.py tests/test_local_reducer_aggregate_stats_once_exact_sram_packet_adapter.py tests/test_local_reducer_aggregate_stats_once_exact_codec.py tests/test_noc_sram_packet_mesh_perf.py tests/test_stats_once_shared_root_perf.py`
- 26 passed
- Yosys confirms one root endpoint, 15 packet SRAM instances, 15 deframers, and one 16x256 `$mem_v2` in each SRAM module instance
