### PR TITLE
Compose finite exact transport with global reduction tree

### DIFF
--- a/npu/docs/attention_score32_exact_stats_once_shared_root_global_tree_contract.md
+++ b/npu/docs/attention_score32_exact_stats_once_shared_root_global_tree_contract.md
@@ -1,0 +1,58 @@
+# Score32 Exact Shared Root To Global Tree Contract
+
+This boundary connects the finite 15-source packet transport to the existing
+16-leaf exact radix-2 reduction and finalization tree. It removes the aggregate
+global-link abstraction without changing the proven local partial format.
+
+## Leaf Identity
+
+Remote sources 0 through 14 traverse the shared root endpoint, replay from
+their independent packet SRAM banks, pass through one packet deframer per
+source, and then pass through one exact stats-once decoder per source. Root
+cluster 15 supplies the sixteenth canonical beat directly and does not consume
+NoC bandwidth.
+
+Each canonical beat is 419 bits and maps without arithmetic conversion:
+
+- bits 15:0: command ID
+- bits 20:16: head ID
+- bits 52:21: signed global maximum
+- bits 85:53: exponential sum
+- bits 89:86: value slice
+- bit 90: final slice
+- bits 418:91: eight 41-bit partial value lanes
+
+These fields drive the existing exact tree's packed leaf ports. Every leaf
+retains its own ready/valid handshake. No FIFO, mux, or scheduler may consume a
+leaf beat until the downstream tree path accepts that same beat.
+
+## Context And Ordering
+
+A group context is accepted atomically by the shared root endpoint and all 15
+remote decoders. A source cannot begin transport from a context accepted by
+only one side of the boundary. The root-local leaf must carry the same command,
+head, slice, and last sequence as the 15 decoded leaves. Existing tree metadata
+checks remain the authority for cross-leaf mismatch detection.
+
+For every source, the decoder emits exactly 128 canonical beats in head-major,
+slice-minor order. The global tree consumes corresponding beats from all 16
+leaves and emits 128 exact finalized rows. Packet completion is not equivalent
+to tree completion: packet slots may retire after decoder acceptance, while
+leaf and tree backpressure continue independently downstream.
+
+## Equivalence Gate
+
+The composed RTL gate must prove:
+
+- 15 x 128 transported beats and 128 root-local beats are accepted exactly
+- all 16 leaf tuples match the canonical software/reference tuples bit-for-bit
+- the exact tree emits all 128 expected finalized rows in order
+- arbitrary independent leaf and root-output backpressure does not change data
+- transport, decoder, tree, ordering, and finalizer protocol errors remain low
+- synthesis retains one packet endpoint, 15 packet SRAM banks, 15 packet
+  deframers, 15 exact decoders, and one 16-leaf radix-2 tree
+
+The cycle report must separate root-link delivery, decoder drain, tree
+completion, and finalizer completion. The measured 2,505-cycle root delivery
+span is the transport floor; any additional composed latency is attributed to
+decoder/tree/finalizer service or explicit downstream backpressure.

--- a/npu/docs/attention_score32_exact_stats_once_shared_root_global_tree_contract.md
+++ b/npu/docs/attention_score32_exact_stats_once_shared_root_global_tree_contract.md
@@ -56,3 +56,9 @@ The cycle report must separate root-link delivery, decoder drain, tree
 completion, and finalizer completion. The measured 2,505-cycle root delivery
 span is the transport floor; any additional composed latency is attributed to
 decoder/tree/finalizer service or explicit downstream backpressure.
+
+The full finite-SRAM, registered-credit mesh, shared-root, decoder, and factored
+`c16/r2/l8/b59` tree simulation reaches that 2,505-cycle inclusive delivery
+floor. It emits all 128 exact finalized rows by cycle 2,600, 75 cycles after
+the final root flit. Peak aggregate destination occupancy is 30 packet slots,
+which is exactly the two-slot bound at each of the 15 remote sources.

--- a/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition.sv
+++ b/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition.sv
@@ -1,0 +1,228 @@
+`timescale 1ns/1ps
+
+// Fixed full-chain boundary for fifteen remote stats-once sources and one
+// root-local canonical source.  The remote packet TX adapters and the 4x4
+// mesh are outside this wrapper; this block owns the root RX endpoint, the
+// fifteen packet-to-canonical decoders, and the exact sixteen-leaf tree.
+//
+// Context admission is deliberately atomic.  A caller may hold
+// group_ctx_valid high, but neither child sees a context until both children
+// report ready in the same cycle.
+module local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition #(
+  parameter integer DATA_W = 256,
+  parameter integer TAG_W = 8,
+  parameter integer FRAGMENT_W = 3,
+  parameter integer VC_W = 2,
+  parameter integer ENDPOINT_W = 4,
+  parameter integer ADDR_W = 16,
+  parameter integer FLIT_COUNT_W = 4,
+  parameter integer SOURCE_COUNT = 15,
+  parameter integer LEAF_COUNT = 16,
+  parameter integer BEAT_W = 419,
+  parameter integer ROOT_ENDPOINT_ID = 15
+) (
+  input wire clk,
+  input wire rst_n,
+
+  input wire group_ctx_valid,
+  output wire group_ctx_ready,
+  input wire [SOURCE_COUNT*16-1:0] group_command_id,
+  input wire [SOURCE_COUNT*5-1:0] group_head_base,
+  input wire [SOURCE_COUNT*4-1:0] group_source,
+  input wire [SOURCE_COUNT*4-1:0] group_destination,
+  input wire [SOURCE_COUNT*VC_W-1:0] group_vc,
+  input wire [SOURCE_COUNT*3-1:0] group_epoch,
+
+  output wire [SOURCE_COUNT-1:0] tx_release_valid,
+  input wire [SOURCE_COUNT-1:0] tx_release_ready,
+
+  input wire root_local_valid,
+  output wire root_local_ready,
+  input wire [BEAT_W-1:0] root_local_beat_data,
+
+  output wire mesh_in_valid,
+  input wire mesh_in_ready,
+  output wire [ENDPOINT_W-1:0] mesh_in_destination,
+  output wire [ENDPOINT_W-1:0] mesh_in_source,
+  output wire [TAG_W-1:0] mesh_in_tag,
+  output wire [FRAGMENT_W-1:0] mesh_in_fragment,
+  output wire mesh_in_last,
+  output wire [VC_W-1:0] mesh_in_vc,
+  output wire [DATA_W-1:0] mesh_in_data,
+
+  input wire mesh_out_valid,
+  output wire mesh_out_ready,
+  input wire [ENDPOINT_W-1:0] mesh_out_destination,
+  input wire [ENDPOINT_W-1:0] mesh_out_source,
+  input wire [TAG_W-1:0] mesh_out_tag,
+  input wire [FRAGMENT_W-1:0] mesh_out_fragment,
+  input wire mesh_out_last,
+  input wire [VC_W-1:0] mesh_out_vc,
+  input wire [DATA_W-1:0] mesh_out_data,
+
+  output wire root_valid,
+  input wire root_ready,
+  output wire [15:0] root_command_id,
+  output wire [4:0] root_head_id,
+  output wire [3:0] root_slice,
+  output wire root_last,
+  output wire [319:0] root_value,
+
+  output wire [SOURCE_COUNT-1:0] group_complete,
+  output wire [SOURCE_COUNT-1:0] descriptor_installed,
+  output wire [SOURCE_COUNT-1:0] source_protocol_error,
+  output wire tree_protocol_error,
+  output wire protocol_error,
+  output wire [31:0] root_accepted_flit_count,
+  output wire [31:0] root_descriptor_install_count,
+  output wire [31:0] root_completion_count,
+  output wire [31:0] root_replay_packet_count,
+  output wire [5:0] max_occupied_slots
+);
+  wire [SOURCE_COUNT-1:0] rx_ctx_ready_w;
+  wire [SOURCE_COUNT-1:0] leaf_ctx_ready_w;
+  wire [SOURCE_COUNT-1:0] atomic_ctx_valid_w;
+  wire atomic_ctx_ready_w;
+
+  // Valid is gated by both ready vectors so the two child protocols can
+  // never consume different subsets of one group context.
+  assign atomic_ctx_ready_w = (&rx_ctx_ready_w) && (&leaf_ctx_ready_w);
+  assign group_ctx_ready = atomic_ctx_ready_w;
+  assign atomic_ctx_valid_w = {SOURCE_COUNT{group_ctx_valid &&
+    atomic_ctx_ready_w}};
+
+  wire [SOURCE_COUNT-1:0] codec_out_valid_w;
+  wire [SOURCE_COUNT-1:0] codec_out_ready_w;
+  wire [SOURCE_COUNT*DATA_W-1:0] codec_out_data_w;
+  wire [SOURCE_COUNT-1:0] codec_out_group_last_w;
+  wire [SOURCE_COUNT-1:0] rx_group_complete_w;
+  wire [SOURCE_COUNT-1:0] rx_descriptor_installed_w;
+  wire [SOURCE_COUNT-1:0] rx_protocol_error_w;
+  wire rx_protocol_error;
+
+  local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter #(
+    .DATA_W(DATA_W),
+    .TAG_W(TAG_W),
+    .FRAGMENT_W(FRAGMENT_W),
+    .VC_W(VC_W),
+    .ENDPOINT_W(ENDPOINT_W),
+    .ADDR_W(ADDR_W),
+    .FLIT_COUNT_W(FLIT_COUNT_W),
+    .SOURCE_COUNT(SOURCE_COUNT),
+    .ROOT_ENDPOINT_ID(ROOT_ENDPOINT_ID)
+  ) root_rx (
+    .clk(clk), .rst_n(rst_n),
+    .group_ctx_valid(atomic_ctx_valid_w),
+    .group_ctx_ready(rx_ctx_ready_w),
+    .group_command_id(group_command_id),
+    .group_head_base(group_head_base),
+    .group_source(group_source),
+    .group_destination(group_destination),
+    .group_vc(group_vc),
+    .group_epoch(group_epoch),
+    .tx_release_valid(tx_release_valid),
+    .tx_release_ready(tx_release_ready),
+    .codec_out_valid(codec_out_valid_w),
+    .codec_out_ready(codec_out_ready_w),
+    .codec_out_data(codec_out_data_w),
+    .codec_out_group_last(codec_out_group_last_w),
+    .group_complete(rx_group_complete_w),
+    .descriptor_installed(rx_descriptor_installed_w),
+    .source_protocol_error(rx_protocol_error_w),
+    .mesh_in_valid(mesh_in_valid),
+    .mesh_in_ready(mesh_in_ready),
+    .mesh_in_destination(mesh_in_destination),
+    .mesh_in_source(mesh_in_source),
+    .mesh_in_tag(mesh_in_tag),
+    .mesh_in_fragment(mesh_in_fragment),
+    .mesh_in_last(mesh_in_last),
+    .mesh_in_vc(mesh_in_vc),
+    .mesh_in_data(mesh_in_data),
+    .mesh_out_valid(mesh_out_valid),
+    .mesh_out_ready(mesh_out_ready),
+    .mesh_out_destination(mesh_out_destination),
+    .mesh_out_source(mesh_out_source),
+    .mesh_out_tag(mesh_out_tag),
+    .mesh_out_fragment(mesh_out_fragment),
+    .mesh_out_last(mesh_out_last),
+    .mesh_out_vc(mesh_out_vc),
+    .mesh_out_data(mesh_out_data),
+    .root_accepted_flit_count(root_accepted_flit_count),
+    .root_descriptor_install_count(root_descriptor_install_count),
+    .root_completion_count(root_completion_count),
+    .root_replay_packet_count(root_replay_packet_count),
+    .max_occupied_slots(max_occupied_slots),
+    .protocol_error(rx_protocol_error)
+  );
+
+  wire [LEAF_COUNT-1:0] leaf_valid_w;
+  wire [LEAF_COUNT-1:0] leaf_ready_w;
+  wire [LEAF_COUNT*16-1:0] leaf_command_id_w;
+  wire [LEAF_COUNT*5-1:0] leaf_head_id_w;
+  wire [LEAF_COUNT*32-1:0] leaf_global_max_w;
+  wire [LEAF_COUNT*33-1:0] leaf_exp_sum_w;
+  wire [LEAF_COUNT*4-1:0] leaf_slice_w;
+  wire [LEAF_COUNT-1:0] leaf_last_w;
+  wire [LEAF_COUNT*328-1:0] leaf_value_w;
+  wire leaf_protocol_error;
+
+  local_reducer_aggregate_stats_once_exact_shared_root_leaf_adapter #(
+    .SOURCE_COUNT(SOURCE_COUNT),
+    .LEAF_COUNT(LEAF_COUNT),
+    .BEAT_W(BEAT_W),
+    .FLIT_W(DATA_W)
+  ) leaves (
+    .clk(clk), .rst_n(rst_n),
+    .source_group_ctx_valid(atomic_ctx_valid_w),
+    .source_group_ctx_ready(leaf_ctx_ready_w),
+    .source_group_command_id(group_command_id),
+    .source_group_head_base(group_head_base),
+    .source_flit_valid(codec_out_valid_w),
+    .source_flit_ready(codec_out_ready_w),
+    .source_flit_data(codec_out_data_w),
+    .source_flit_group_last(codec_out_group_last_w),
+    .decoder_protocol_error(source_protocol_error),
+    .root_local_valid(root_local_valid),
+    .root_local_ready(root_local_ready),
+    .root_local_beat_data(root_local_beat_data),
+    .leaf_valid(leaf_valid_w),
+    .leaf_ready(leaf_ready_w),
+    .leaf_command_id(leaf_command_id_w),
+    .leaf_head_id(leaf_head_id_w),
+    .leaf_global_max(leaf_global_max_w),
+    .leaf_exp_sum(leaf_exp_sum_w),
+    .leaf_slice(leaf_slice_w),
+    .leaf_last(leaf_last_w),
+    .leaf_value(leaf_value_w),
+    .protocol_error(leaf_protocol_error)
+  );
+
+  attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b59 tree (
+    .clk(clk), .rst_n(rst_n),
+    .leaf_valid(leaf_valid_w), .leaf_ready(leaf_ready_w),
+    .leaf_command_id(leaf_command_id_w), .leaf_head_id(leaf_head_id_w),
+    .leaf_global_max(leaf_global_max_w), .leaf_exp_sum(leaf_exp_sum_w),
+    .leaf_slice(leaf_slice_w), .leaf_last(leaf_last_w),
+    .leaf_value(leaf_value_w),
+    .root_valid(root_valid), .root_ready(root_ready),
+    .root_command_id(root_command_id), .root_head_id(root_head_id),
+    .root_slice(root_slice), .root_last(root_last), .root_value(root_value),
+    .protocol_error(tree_protocol_error)
+  );
+
+  assign group_complete = rx_group_complete_w;
+  assign descriptor_installed = rx_descriptor_installed_w;
+  assign protocol_error = rx_protocol_error || leaf_protocol_error ||
+    tree_protocol_error || (|rx_protocol_error_w);
+
+`ifndef SYNTHESIS
+  initial begin
+    if (DATA_W != 256 || TAG_W != 8 || FRAGMENT_W != 3 || VC_W != 2 ||
+        ENDPOINT_W != 4 || SOURCE_COUNT != 15 || LEAF_COUNT != 16 ||
+        BEAT_W != 419 || ROOT_ENDPOINT_ID != 15) begin
+      $error("shared-root full-chain composition width/count contract changed");
+      $finish(1);
+    end
+  end
+`endif
+endmodule

--- a/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_shared_root_leaf_adapter.sv
+++ b/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_shared_root_leaf_adapter.sv
@@ -1,0 +1,122 @@
+`timescale 1ns/1ps
+
+// Convert the fifteen shared-root deframed codec streams into the sixteen
+// packed leaf streams consumed by the exact global reduction tree.  Leaves
+// zero through fourteen are decoded independently; leaf fifteen is a direct
+// canonical stream from the root-local producer.
+module local_reducer_aggregate_stats_once_exact_shared_root_leaf_adapter #(
+  parameter integer SOURCE_COUNT = 15,
+  parameter integer LEAF_COUNT = 16,
+  parameter integer BEAT_W = 419,
+  parameter integer FLIT_W = 256,
+  parameter integer RESERVOIR_W = 768
+) (
+  input wire clk,
+  input wire rst_n,
+
+  input wire [SOURCE_COUNT-1:0] source_group_ctx_valid,
+  output wire [SOURCE_COUNT-1:0] source_group_ctx_ready,
+  input wire [SOURCE_COUNT*16-1:0] source_group_command_id,
+  input wire [SOURCE_COUNT*5-1:0] source_group_head_base,
+  input wire [SOURCE_COUNT-1:0] source_flit_valid,
+  output wire [SOURCE_COUNT-1:0] source_flit_ready,
+  input wire [SOURCE_COUNT*FLIT_W-1:0] source_flit_data,
+  input wire [SOURCE_COUNT-1:0] source_flit_group_last,
+  output wire [SOURCE_COUNT-1:0] decoder_protocol_error,
+
+  input wire root_local_valid,
+  output wire root_local_ready,
+  input wire [BEAT_W-1:0] root_local_beat_data,
+
+  output wire [LEAF_COUNT-1:0] leaf_valid,
+  input wire [LEAF_COUNT-1:0] leaf_ready,
+  output wire [LEAF_COUNT*16-1:0] leaf_command_id,
+  output wire [LEAF_COUNT*5-1:0] leaf_head_id,
+  output wire [LEAF_COUNT*32-1:0] leaf_global_max,
+  output wire [LEAF_COUNT*33-1:0] leaf_exp_sum,
+  output wire [LEAF_COUNT*4-1:0] leaf_slice,
+  output wire [LEAF_COUNT-1:0] leaf_last,
+  output wire [LEAF_COUNT*328-1:0] leaf_value,
+  output wire protocol_error
+);
+  wire [SOURCE_COUNT-1:0] decoder_ctx_ready_w;
+  wire [SOURCE_COUNT-1:0] decoder_flit_ready_w;
+  wire [SOURCE_COUNT-1:0] decoder_beat_valid_w;
+  wire [SOURCE_COUNT-1:0] decoder_beat_ready_w;
+  wire [SOURCE_COUNT*BEAT_W-1:0] decoder_beat_data_w;
+
+  assign source_group_ctx_ready = decoder_ctx_ready_w;
+  assign source_flit_ready = decoder_flit_ready_w;
+  assign root_local_ready = leaf_ready[SOURCE_COUNT];
+
+  genvar source_g;
+  generate
+    for (source_g = 0; source_g < SOURCE_COUNT; source_g = source_g + 1) begin : gen_decoder
+      local_reducer_aggregate_stats_once_exact_decoder #(
+        .BEAT_W(BEAT_W),
+        .FLIT_W(FLIT_W),
+        .RESERVOIR_W(RESERVOIR_W)
+      ) decoder (
+        .clk(clk),
+        .rst_n(rst_n),
+        .group_ctx_valid(source_group_ctx_valid[source_g]),
+        .group_ctx_ready(decoder_ctx_ready_w[source_g]),
+        .group_command_id(source_group_command_id[source_g*16 +: 16]),
+        .group_head_base(source_group_head_base[source_g*5 +: 5]),
+        .flit_valid(source_flit_valid[source_g]),
+        .flit_ready(decoder_flit_ready_w[source_g]),
+        .flit_data(source_flit_data[source_g*FLIT_W +: FLIT_W]),
+        .flit_group_last(source_flit_group_last[source_g]),
+        .beat_valid(decoder_beat_valid_w[source_g]),
+        .beat_ready(decoder_beat_ready_w[source_g]),
+        .beat_data(decoder_beat_data_w[source_g*BEAT_W +: BEAT_W]),
+        .protocol_error(decoder_protocol_error[source_g])
+      );
+
+      assign decoder_beat_ready_w[source_g] = leaf_ready[source_g];
+      assign leaf_valid[source_g] = decoder_beat_valid_w[source_g];
+      assign leaf_command_id[source_g*16 +: 16] =
+        decoder_beat_data_w[source_g*BEAT_W + 0 +: 16];
+      assign leaf_head_id[source_g*5 +: 5] =
+        decoder_beat_data_w[source_g*BEAT_W + 16 +: 5];
+      assign leaf_global_max[source_g*32 +: 32] =
+        decoder_beat_data_w[source_g*BEAT_W + 21 +: 32];
+      assign leaf_exp_sum[source_g*33 +: 33] =
+        decoder_beat_data_w[source_g*BEAT_W + 53 +: 33];
+      assign leaf_slice[source_g*4 +: 4] =
+        decoder_beat_data_w[source_g*BEAT_W + 86 +: 4];
+      assign leaf_last[source_g] =
+        decoder_beat_data_w[source_g*BEAT_W + 90];
+      assign leaf_value[source_g*328 +: 328] =
+        decoder_beat_data_w[source_g*BEAT_W + 91 +: 328];
+    end
+  endgenerate
+
+  assign leaf_valid[SOURCE_COUNT] = root_local_valid;
+  assign leaf_command_id[SOURCE_COUNT*16 +: 16] = root_local_beat_data[15:0];
+  assign leaf_head_id[SOURCE_COUNT*5 +: 5] = root_local_beat_data[20:16];
+  assign leaf_global_max[SOURCE_COUNT*32 +: 32] = root_local_beat_data[52:21];
+  assign leaf_exp_sum[SOURCE_COUNT*33 +: 33] = root_local_beat_data[85:53];
+  assign leaf_slice[SOURCE_COUNT*4 +: 4] = root_local_beat_data[89:86];
+  assign leaf_last[SOURCE_COUNT] = root_local_beat_data[90];
+  assign leaf_value[SOURCE_COUNT*328 +: 328] = root_local_beat_data[BEAT_W-1:91];
+
+  assign protocol_error = |decoder_protocol_error;
+
+`ifndef SYNTHESIS
+  initial begin
+    if (SOURCE_COUNT != 15 || LEAF_COUNT != 16) begin
+      $error("shared-root leaf adapter requires 15 remote sources and 16 leaves");
+      $finish(1);
+    end
+    if (BEAT_W != 419) begin
+      $error("shared-root leaf adapter BEAT_W must be 419");
+      $finish(1);
+    end
+    if (FLIT_W != 256) begin
+      $error("shared-root leaf adapter FLIT_W must be 256");
+      $finish(1);
+    end
+  end
+`endif
+endmodule

--- a/tests/local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition_tb.sv
+++ b/tests/local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition_tb.sv
@@ -403,16 +403,20 @@ module local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composit
               root_completion_count !== SOURCE_COUNT*GROUP_PACKETS ||
               root_replay_packet_count !== SOURCE_COUNT*GROUP_PACKETS ||
               source_desc_sum !== SOURCE_COUNT*GROUP_PACKETS ||
-              source_mask !== {SOURCE_COUNT{1'b1}})
+              source_mask !== {SOURCE_COUNT{1'b1}} ||
+              (root_last_delivery_cycle - root_first_delivery_cycle + 1) !==
+                SOURCE_COUNT*GROUP_FLITS ||
+              max_occupied_slots > SOURCE_COUNT*2)
             $fatal(1, "transport count mismatch flits=%0d desc=%0d comp=%0d replay=%0d txdesc=%0d",
               root_accepted_flit_count, root_descriptor_install_count,
               root_completion_count, root_replay_packet_count, source_desc_sum);
-          $display("PASS full_chain rows=%0d remote_beats=%0d flits=%0d packets=%0d descriptors=%0d completions=%0d replays=%0d source_mask=%h first_last_span=%0d final_cycle=%0d max_slots=%0d",
+          $display("PASS full_chain rows=%0d remote_beats=%0d flits=%0d packets=%0d descriptors=%0d completions=%0d replays=%0d source_mask=%h root_delivery_span=%0d final_cycle=%0d tree_drain_cycles=%0d max_aggregate_slots=%0d slots_per_source=2",
             root_count, SOURCE_COUNT*GROUP_BEATS, root_accepted_flit_count,
             SOURCE_COUNT*GROUP_PACKETS, root_descriptor_install_count,
             root_completion_count, root_replay_packet_count,
-            source_mask, root_last_delivery_cycle - root_first_delivery_cycle,
-            cycle, max_occupied_slots);
+            source_mask,
+            root_last_delivery_cycle - root_first_delivery_cycle + 1,
+            cycle, cycle - root_last_delivery_cycle, max_occupied_slots);
           $finish;
         end
       end

--- a/tests/local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition_tb.sv
+++ b/tests/local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition_tb.sv
@@ -1,0 +1,439 @@
+`timescale 1ns/1ps
+
+module local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition_tb;
+  localparam integer SOURCE_COUNT = 15;
+  localparam integer LEAF_COUNT = 16;
+  localparam integer BEAT_W = 419;
+  localparam integer FLIT_W = 256;
+  localparam integer GROUP_BEATS = 128;
+  localparam integer GROUP_FLITS = 167;
+  localparam integer GROUP_PACKETS = 21;
+  localparam integer SIM_TIMEOUT_CYCLES = 50000;
+  localparam integer NODES = 16;
+  localparam integer DATA_W = 256;
+  localparam integer TAG_W = 8;
+  localparam integer FRAGMENT_W = 3;
+  localparam integer VC_W = 2;
+
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  integer cycle = 0;
+  always #5 clk = ~clk;
+
+  reg ctx_pending = 1'b1;
+  wire [SOURCE_COUNT-1:0] source_ctx_valid;
+  wire [SOURCE_COUNT-1:0] source_ctx_ready;
+  wire [SOURCE_COUNT-1:0] encoder_ctx_ready;
+  wire composition_ctx_ready;
+  wire context_fire = ctx_pending && composition_ctx_ready &&
+    (&source_ctx_ready) && (&encoder_ctx_ready);
+  assign source_ctx_valid = {SOURCE_COUNT{context_fire}};
+
+  wire [SOURCE_COUNT*16-1:0] group_command_id = {SOURCE_COUNT{16'h5a00}};
+  wire [SOURCE_COUNT*5-1:0] group_head_base = {SOURCE_COUNT{5'd0}};
+  wire [SOURCE_COUNT*4-1:0] group_source = {
+    4'd14, 4'd13, 4'd12, 4'd11, 4'd10, 4'd9, 4'd8, 4'd7,
+    4'd6, 4'd5, 4'd4, 4'd3, 4'd2, 4'd1, 4'd0
+  };
+  wire [SOURCE_COUNT*4-1:0] group_destination = {SOURCE_COUNT{4'd15}};
+  wire [SOURCE_COUNT*VC_W-1:0] group_vc = {SOURCE_COUNT{2'd0}};
+  wire [SOURCE_COUNT*3-1:0] group_epoch = {SOURCE_COUNT{3'd0}};
+
+  reg [31:0] source_beat_index [0:SOURCE_COUNT-1];
+  wire [SOURCE_COUNT-1:0] encoder_beat_valid;
+  wire [SOURCE_COUNT-1:0] encoder_beat_ready;
+  wire [SOURCE_COUNT*BEAT_W-1:0] encoder_beat_data;
+  wire [SOURCE_COUNT-1:0] encoder_flit_valid;
+  wire [SOURCE_COUNT-1:0] encoder_flit_ready;
+  wire [SOURCE_COUNT*FLIT_W-1:0] encoder_flit_data;
+  wire [SOURCE_COUNT-1:0] encoder_flit_group_last;
+  wire [SOURCE_COUNT-1:0] encoder_error;
+  wire [SOURCE_COUNT-1:0] tx_group_complete;
+  wire [SOURCE_COUNT-1:0] tx_protocol_error;
+  wire [SOURCE_COUNT*32-1:0] tx_descriptor_count;
+
+  wire [SOURCE_COUNT-1:0] tx_release_valid;
+  wire [SOURCE_COUNT-1:0] tx_release_ready;
+
+  wire [NODES-1:0] mesh_in_valid;
+  wire [NODES-1:0] mesh_in_ready;
+  wire [NODES*4-1:0] mesh_in_dest;
+  wire [NODES*4-1:0] mesh_in_source;
+  wire [NODES*TAG_W-1:0] mesh_in_tag;
+  wire [NODES*FRAGMENT_W-1:0] mesh_in_fragment;
+  wire [NODES-1:0] mesh_in_last;
+  wire [NODES*VC_W-1:0] mesh_in_vc;
+  wire [NODES*DATA_W-1:0] mesh_in_data;
+  wire [NODES-1:0] mesh_out_valid;
+  wire [NODES-1:0] mesh_out_ready;
+  wire [NODES*4-1:0] mesh_out_dest;
+  wire [NODES*4-1:0] mesh_out_source;
+  wire [NODES*TAG_W-1:0] mesh_out_tag;
+  wire [NODES*FRAGMENT_W-1:0] mesh_out_fragment;
+  wire [NODES-1:0] mesh_out_last;
+  wire [NODES*VC_W-1:0] mesh_out_vc;
+  wire [NODES*DATA_W-1:0] mesh_out_data;
+  wire [NODES*32-1:0] router_accepted;
+  wire [NODES*32-1:0] router_forwarded;
+  wire [NODES*32-1:0] router_input_stall;
+  wire [NODES*32-1:0] router_output_stall;
+  wire [NODES*32-1:0] router_contention;
+  wire [NODES*32-1:0] router_current_occupancy;
+  wire [NODES*32-1:0] router_max_occupancy;
+  wire [NODES*5*32-1:0] router_route_count;
+
+  wire [SOURCE_COUNT-1:0] source_mesh_in_valid;
+  wire [SOURCE_COUNT-1:0] source_mesh_in_ready;
+  wire [SOURCE_COUNT*4-1:0] source_mesh_in_dest;
+  wire [SOURCE_COUNT*4-1:0] source_mesh_in_source;
+  wire [SOURCE_COUNT*TAG_W-1:0] source_mesh_in_tag;
+  wire [SOURCE_COUNT*FRAGMENT_W-1:0] source_mesh_in_fragment;
+  wire [SOURCE_COUNT-1:0] source_mesh_in_last;
+  wire [SOURCE_COUNT*VC_W-1:0] source_mesh_in_vc;
+  wire [SOURCE_COUNT*DATA_W-1:0] source_mesh_in_data;
+  wire [SOURCE_COUNT-1:0] source_mesh_out_valid;
+  wire [SOURCE_COUNT-1:0] source_mesh_out_ready;
+  wire [SOURCE_COUNT*4-1:0] source_mesh_out_dest;
+  wire [SOURCE_COUNT*4-1:0] source_mesh_out_source;
+  wire [SOURCE_COUNT*TAG_W-1:0] source_mesh_out_tag;
+  wire [SOURCE_COUNT*FRAGMENT_W-1:0] source_mesh_out_fragment;
+  wire [SOURCE_COUNT-1:0] source_mesh_out_last;
+  wire [SOURCE_COUNT*VC_W-1:0] source_mesh_out_vc;
+  wire [SOURCE_COUNT*DATA_W-1:0] source_mesh_out_data;
+
+  wire composition_mesh_in_valid;
+  wire composition_mesh_in_ready;
+  wire [3:0] composition_mesh_in_dest;
+  wire [3:0] composition_mesh_in_source;
+  wire [TAG_W-1:0] composition_mesh_in_tag;
+  wire [FRAGMENT_W-1:0] composition_mesh_in_fragment;
+  wire composition_mesh_in_last;
+  wire [VC_W-1:0] composition_mesh_in_vc;
+  wire [DATA_W-1:0] composition_mesh_in_data;
+  wire composition_mesh_out_valid;
+  wire composition_mesh_out_ready;
+  wire [3:0] composition_mesh_out_dest;
+  wire [3:0] composition_mesh_out_source;
+  wire [TAG_W-1:0] composition_mesh_out_tag;
+  wire [FRAGMENT_W-1:0] composition_mesh_out_fragment;
+  wire composition_mesh_out_last;
+  wire [VC_W-1:0] composition_mesh_out_vc;
+  wire [DATA_W-1:0] composition_mesh_out_data;
+
+  wire root_local_valid;
+  wire root_local_ready;
+  wire [BEAT_W-1:0] root_local_beat_data;
+  wire root_valid;
+  wire root_ready = 1'b1;
+  wire [15:0] root_command_id;
+  wire [4:0] root_head_id;
+  wire [3:0] root_slice;
+  wire root_last;
+  wire [319:0] root_value;
+  wire [SOURCE_COUNT-1:0] group_complete;
+  wire [SOURCE_COUNT-1:0] descriptor_installed;
+  wire [SOURCE_COUNT-1:0] source_protocol_error;
+  wire tree_protocol_error;
+  wire composition_protocol_error;
+  wire [31:0] root_accepted_flit_count;
+  wire [31:0] root_descriptor_install_count;
+  wire [31:0] root_completion_count;
+  wire [31:0] root_replay_packet_count;
+  wire [5:0] max_occupied_slots;
+
+  function [BEAT_W-1:0] make_partial_beat(input integer beat_index);
+    integer lane;
+    reg [BEAT_W-1:0] result;
+    begin
+      result = {BEAT_W{1'b0}};
+      result[15:0] = 16'h5a00;
+      result[20:16] = beat_index / 16;
+      result[52:21] = 32'd0;
+      result[85:53] = 33'd1;
+      result[89:86] = beat_index % 16;
+      result[90] = ((beat_index % 16) == 15);
+      for (lane = 0; lane < 8; lane = lane + 1)
+        result[91 + lane*41 +: 41] = 41'd1;
+      make_partial_beat = result;
+    end
+  endfunction
+
+  genvar source_g;
+  generate
+    for (source_g = 0; source_g < SOURCE_COUNT; source_g = source_g + 1) begin : gen_source
+      localparam integer SOURCE_ID = source_g;
+      assign encoder_beat_valid[SOURCE_ID] = !ctx_pending &&
+        (source_beat_index[SOURCE_ID] < GROUP_BEATS);
+      assign encoder_beat_data[SOURCE_ID*BEAT_W +: BEAT_W] =
+        make_partial_beat(source_beat_index[SOURCE_ID]);
+
+      local_reducer_aggregate_stats_once_exact_encoder encoder (
+        .clk(clk), .rst_n(rst_n),
+        .group_ctx_valid(source_ctx_valid[SOURCE_ID]),
+        .group_ctx_ready(encoder_ctx_ready[SOURCE_ID]),
+        .group_command_id(16'h5a00), .group_head_base(5'd0),
+        .beat_valid(encoder_beat_valid[SOURCE_ID]),
+        .beat_ready(encoder_beat_ready[SOURCE_ID]),
+        .beat_data(encoder_beat_data[SOURCE_ID*BEAT_W +: BEAT_W]),
+        .flit_valid(encoder_flit_valid[SOURCE_ID]),
+        .flit_ready(encoder_flit_ready[SOURCE_ID]),
+        .flit_data(encoder_flit_data[SOURCE_ID*FLIT_W +: FLIT_W]),
+        .flit_group_last(encoder_flit_group_last[SOURCE_ID]),
+        .protocol_error(encoder_error[SOURCE_ID])
+      );
+
+      local_reducer_aggregate_stats_once_exact_sram_packet_adapter #(
+        .LOCAL_ENDPOINT_ID(SOURCE_ID),
+        .TX_ENABLE(1), .RX_ENABLE(0),
+        .SRC_BASE_ADDR(0), .DST_BASE_ADDR(4096)
+      ) source_tx (
+        .clk(clk), .rst_n(rst_n),
+        .group_ctx_valid(source_ctx_valid[SOURCE_ID]),
+        .group_ctx_ready(source_ctx_ready[SOURCE_ID]),
+        .group_command_id(16'h5a00), .group_head_base(5'd0),
+        .group_source(SOURCE_ID[3:0]), .group_destination(4'd15),
+        .group_vc(2'd0), .group_epoch(3'd0),
+        .codec_in_valid(encoder_flit_valid[SOURCE_ID]),
+        .codec_in_ready(encoder_flit_ready[SOURCE_ID]),
+        .codec_in_data(encoder_flit_data[SOURCE_ID*FLIT_W +: FLIT_W]),
+        .codec_in_group_last(encoder_flit_group_last[SOURCE_ID]),
+        .tx_release_valid(tx_release_valid[SOURCE_ID]),
+        .tx_release_ready(tx_release_ready[SOURCE_ID]),
+        .codec_out_valid(), .codec_out_ready(1'b0), .codec_out_data(),
+        .codec_out_group_last(), .tx_group_complete(tx_group_complete[SOURCE_ID]),
+        .rx_group_complete(), .rx_descriptor_installed(),
+        .protocol_error(tx_protocol_error[SOURCE_ID]),
+        .tx_descriptor_count(tx_descriptor_count[SOURCE_ID*32 +: 32]),
+        .rx_completion_count(), .replay_packet_count(),
+        .max_source_occupancy(), .max_destination_occupancy(),
+        .mesh_in_valid(source_mesh_in_valid[SOURCE_ID]),
+        .mesh_in_ready(source_mesh_in_ready[SOURCE_ID]),
+        .mesh_in_destination(source_mesh_in_dest[SOURCE_ID*4 +: 4]),
+        .mesh_in_source(source_mesh_in_source[SOURCE_ID*4 +: 4]),
+        .mesh_in_tag(source_mesh_in_tag[SOURCE_ID*TAG_W +: TAG_W]),
+        .mesh_in_fragment(source_mesh_in_fragment[SOURCE_ID*FRAGMENT_W +: FRAGMENT_W]),
+        .mesh_in_last(source_mesh_in_last[SOURCE_ID]),
+        .mesh_in_vc(source_mesh_in_vc[SOURCE_ID*VC_W +: VC_W]),
+        .mesh_in_data(source_mesh_in_data[SOURCE_ID*DATA_W +: DATA_W]),
+        .mesh_out_valid(source_mesh_out_valid[SOURCE_ID]),
+        .mesh_out_ready(source_mesh_out_ready[SOURCE_ID]),
+        .mesh_out_destination(source_mesh_out_dest[SOURCE_ID*4 +: 4]),
+        .mesh_out_source(source_mesh_out_source[SOURCE_ID*4 +: 4]),
+        .mesh_out_tag(source_mesh_out_tag[SOURCE_ID*TAG_W +: TAG_W]),
+        .mesh_out_fragment(source_mesh_out_fragment[SOURCE_ID*FRAGMENT_W +: FRAGMENT_W]),
+        .mesh_out_last(source_mesh_out_last[SOURCE_ID]),
+        .mesh_out_vc(source_mesh_out_vc[SOURCE_ID*VC_W +: VC_W]),
+        .mesh_out_data(source_mesh_out_data[SOURCE_ID*DATA_W +: DATA_W])
+      );
+    end
+  endgenerate
+
+  local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition composition (
+    .clk(clk), .rst_n(rst_n),
+    .group_ctx_valid(context_fire),
+    .group_ctx_ready(composition_ctx_ready),
+    .group_command_id(group_command_id),
+    .group_head_base(group_head_base),
+    .group_source(group_source),
+    .group_destination(group_destination),
+    .group_vc(group_vc),
+    .group_epoch(group_epoch),
+    .tx_release_valid(tx_release_valid),
+    .tx_release_ready(tx_release_ready),
+    .root_local_valid(root_local_valid),
+    .root_local_ready(root_local_ready),
+    .root_local_beat_data(root_local_beat_data),
+    .mesh_in_valid(composition_mesh_in_valid),
+    .mesh_in_ready(composition_mesh_in_ready),
+    .mesh_in_destination(composition_mesh_in_dest),
+    .mesh_in_source(composition_mesh_in_source),
+    .mesh_in_tag(composition_mesh_in_tag),
+    .mesh_in_fragment(composition_mesh_in_fragment),
+    .mesh_in_last(composition_mesh_in_last),
+    .mesh_in_vc(composition_mesh_in_vc),
+    .mesh_in_data(composition_mesh_in_data),
+    .mesh_out_valid(composition_mesh_out_valid),
+    .mesh_out_ready(composition_mesh_out_ready),
+    .mesh_out_destination(composition_mesh_out_dest),
+    .mesh_out_source(composition_mesh_out_source),
+    .mesh_out_tag(composition_mesh_out_tag),
+    .mesh_out_fragment(composition_mesh_out_fragment),
+    .mesh_out_last(composition_mesh_out_last),
+    .mesh_out_vc(composition_mesh_out_vc),
+    .mesh_out_data(composition_mesh_out_data),
+    .root_valid(root_valid), .root_ready(root_ready),
+    .root_command_id(root_command_id), .root_head_id(root_head_id),
+    .root_slice(root_slice), .root_last(root_last), .root_value(root_value),
+    .group_complete(group_complete),
+    .descriptor_installed(descriptor_installed),
+    .source_protocol_error(source_protocol_error),
+    .tree_protocol_error(tree_protocol_error),
+    .protocol_error(composition_protocol_error),
+    .root_accepted_flit_count(root_accepted_flit_count),
+    .root_descriptor_install_count(root_descriptor_install_count),
+    .root_completion_count(root_completion_count),
+    .root_replay_packet_count(root_replay_packet_count),
+    .max_occupied_slots(max_occupied_slots)
+  );
+
+  assign mesh_in_valid[SOURCE_COUNT] = composition_mesh_in_valid;
+  assign mesh_in_dest[SOURCE_COUNT*4 +: 4] = composition_mesh_in_dest;
+  assign mesh_in_source[SOURCE_COUNT*4 +: 4] = composition_mesh_in_source;
+  assign mesh_in_tag[SOURCE_COUNT*TAG_W +: TAG_W] = composition_mesh_in_tag;
+  assign mesh_in_fragment[SOURCE_COUNT*FRAGMENT_W +: FRAGMENT_W] = composition_mesh_in_fragment;
+  assign mesh_in_last[SOURCE_COUNT] = composition_mesh_in_last;
+  assign mesh_in_vc[SOURCE_COUNT*VC_W +: VC_W] = composition_mesh_in_vc;
+  assign mesh_in_data[SOURCE_COUNT*DATA_W +: DATA_W] = composition_mesh_in_data;
+  assign composition_mesh_in_ready = mesh_in_ready[SOURCE_COUNT];
+
+  assign composition_mesh_out_valid = mesh_out_valid[SOURCE_COUNT];
+  assign mesh_out_ready[SOURCE_COUNT] = composition_mesh_out_ready;
+  assign composition_mesh_out_dest = mesh_out_dest[SOURCE_COUNT*4 +: 4];
+  assign composition_mesh_out_source = mesh_out_source[SOURCE_COUNT*4 +: 4];
+  assign composition_mesh_out_tag = mesh_out_tag[SOURCE_COUNT*TAG_W +: TAG_W];
+  assign composition_mesh_out_fragment = mesh_out_fragment[SOURCE_COUNT*FRAGMENT_W +: FRAGMENT_W];
+  assign composition_mesh_out_last = mesh_out_last[SOURCE_COUNT];
+  assign composition_mesh_out_vc = mesh_out_vc[SOURCE_COUNT*VC_W +: VC_W];
+  assign composition_mesh_out_data = mesh_out_data[SOURCE_COUNT*DATA_W +: DATA_W];
+
+  generate
+    for (source_g = 0; source_g < SOURCE_COUNT; source_g = source_g + 1) begin : gen_mesh_map
+      assign mesh_in_valid[source_g] = source_mesh_in_valid[source_g];
+      assign source_mesh_in_ready[source_g] = mesh_in_ready[source_g];
+      assign mesh_in_dest[source_g*4 +: 4] = source_mesh_in_dest[source_g*4 +: 4];
+      assign mesh_in_source[source_g*4 +: 4] = source_mesh_in_source[source_g*4 +: 4];
+      assign mesh_in_tag[source_g*TAG_W +: TAG_W] = source_mesh_in_tag[source_g*TAG_W +: TAG_W];
+      assign mesh_in_fragment[source_g*FRAGMENT_W +: FRAGMENT_W] = source_mesh_in_fragment[source_g*FRAGMENT_W +: FRAGMENT_W];
+      assign mesh_in_last[source_g] = source_mesh_in_last[source_g];
+      assign mesh_in_vc[source_g*VC_W +: VC_W] = source_mesh_in_vc[source_g*VC_W +: VC_W];
+      assign mesh_in_data[source_g*DATA_W +: DATA_W] = source_mesh_in_data[source_g*DATA_W +: DATA_W];
+      assign source_mesh_out_valid[source_g] = mesh_out_valid[source_g];
+      assign mesh_out_ready[source_g] = source_mesh_out_ready[source_g];
+      assign source_mesh_out_dest[source_g*4 +: 4] = mesh_out_dest[source_g*4 +: 4];
+      assign source_mesh_out_source[source_g*4 +: 4] = mesh_out_source[source_g*4 +: 4];
+      assign source_mesh_out_tag[source_g*TAG_W +: TAG_W] = mesh_out_tag[source_g*TAG_W +: TAG_W];
+      assign source_mesh_out_fragment[source_g*FRAGMENT_W +: FRAGMENT_W] = mesh_out_fragment[source_g*FRAGMENT_W +: FRAGMENT_W];
+      assign source_mesh_out_last[source_g] = mesh_out_last[source_g];
+      assign source_mesh_out_vc[source_g*VC_W +: VC_W] = mesh_out_vc[source_g*VC_W +: VC_W];
+      assign source_mesh_out_data[source_g*DATA_W +: DATA_W] = mesh_out_data[source_g*DATA_W +: DATA_W];
+    end
+  endgenerate
+
+  noc_segmented_mesh4x4 mesh (
+    .clk(clk), .rst_n(rst_n),
+    .endpoint_in_valid(mesh_in_valid), .endpoint_in_ready(mesh_in_ready),
+    .endpoint_in_dest(mesh_in_dest), .endpoint_in_source(mesh_in_source),
+    .endpoint_in_tag(mesh_in_tag), .endpoint_in_fragment(mesh_in_fragment),
+    .endpoint_in_last(mesh_in_last), .endpoint_in_vc(mesh_in_vc),
+    .endpoint_in_data(mesh_in_data), .endpoint_out_valid(mesh_out_valid),
+    .endpoint_out_ready(mesh_out_ready), .endpoint_out_dest(mesh_out_dest),
+    .endpoint_out_source(mesh_out_source), .endpoint_out_tag(mesh_out_tag),
+    .endpoint_out_fragment(mesh_out_fragment), .endpoint_out_last(mesh_out_last),
+    .endpoint_out_vc(mesh_out_vc), .endpoint_out_data(mesh_out_data),
+    .router_accepted_flit_count(router_accepted),
+    .router_forwarded_flit_count(router_forwarded),
+    .router_input_stall_cycles(router_input_stall),
+    .router_output_stall_cycles(router_output_stall),
+    .router_contention_cycles(router_contention),
+    .router_current_input_occupancy(router_current_occupancy),
+    .router_max_input_occupancy(router_max_occupancy),
+    .router_route_flit_count(router_route_count)
+  );
+
+  reg [31:0] root_beat_index = 0;
+  wire root_local_active = !ctx_pending;
+  wire root_local_valid_w = root_local_active && (root_beat_index < GROUP_BEATS);
+  wire [BEAT_W-1:0] root_local_beat = make_partial_beat(root_beat_index);
+  assign root_local_valid = root_local_valid_w;
+  assign root_local_beat_data = root_local_beat;
+
+  wire root_local_fire = root_local_valid_w && root_local_ready;
+
+  integer source_i;
+  integer lane_i;
+  integer root_count = 0;
+  integer source_desc_sum;
+  reg root_seen_delivery = 1'b0;
+  reg [SOURCE_COUNT-1:0] source_mask = {SOURCE_COUNT{1'b0}};
+  integer root_first_delivery_cycle = 0;
+  integer root_last_delivery_cycle = 0;
+  reg [39:0] observed_lane;
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      cycle <= 0;
+      ctx_pending <= 1'b1;
+      root_beat_index <= 0;
+      for (source_i = 0; source_i < SOURCE_COUNT; source_i = source_i + 1)
+        source_beat_index[source_i] <= 0;
+    end else begin
+      cycle <= cycle + 1;
+      if (cycle >= SIM_TIMEOUT_CYCLES)
+        $fatal(1, "full-chain shared-root timeout");
+      if (context_fire)
+        ctx_pending <= 1'b0;
+      for (source_i = 0; source_i < SOURCE_COUNT; source_i = source_i + 1)
+        if (encoder_beat_valid[source_i] && encoder_beat_ready[source_i])
+          source_beat_index[source_i] <= source_beat_index[source_i] + 1'b1;
+      if (root_local_fire)
+        root_beat_index <= root_beat_index + 1'b1;
+
+      if (composition_protocol_error || (|encoder_error) ||
+          (|tx_protocol_error))
+        $fatal(1, "full-chain protocol error");
+
+      if (root_valid && root_ready) begin
+        if (root_command_id !== 16'h5a00 ||
+            root_head_id !== (root_count / 16) ||
+            root_slice !== (root_count % 16) ||
+            root_last !== ((root_count % 16) == 15))
+          $fatal(1, "root metadata mismatch row=%0d", root_count);
+        for (lane_i = 0; lane_i < 8; lane_i = lane_i + 1) begin
+          observed_lane = root_value[lane_i*40 +: 40];
+          if (observed_lane !== 40'd65535)
+            $fatal(1, "root lane mismatch row=%0d lane=%0d value=%h",
+              root_count, lane_i, observed_lane);
+        end
+        root_count = root_count + 1;
+        if (root_count == GROUP_BEATS) begin
+          source_desc_sum = 0;
+          for (source_i = 0; source_i < SOURCE_COUNT; source_i = source_i + 1)
+            source_desc_sum = source_desc_sum + tx_descriptor_count[source_i*32 +: 32];
+          if (root_accepted_flit_count !== SOURCE_COUNT*GROUP_FLITS ||
+              root_descriptor_install_count !== SOURCE_COUNT*GROUP_PACKETS ||
+              root_completion_count !== SOURCE_COUNT*GROUP_PACKETS ||
+              root_replay_packet_count !== SOURCE_COUNT*GROUP_PACKETS ||
+              source_desc_sum !== SOURCE_COUNT*GROUP_PACKETS ||
+              source_mask !== {SOURCE_COUNT{1'b1}})
+            $fatal(1, "transport count mismatch flits=%0d desc=%0d comp=%0d replay=%0d txdesc=%0d",
+              root_accepted_flit_count, root_descriptor_install_count,
+              root_completion_count, root_replay_packet_count, source_desc_sum);
+          $display("PASS full_chain rows=%0d remote_beats=%0d flits=%0d packets=%0d descriptors=%0d completions=%0d replays=%0d source_mask=%h first_last_span=%0d final_cycle=%0d max_slots=%0d",
+            root_count, SOURCE_COUNT*GROUP_BEATS, root_accepted_flit_count,
+            SOURCE_COUNT*GROUP_PACKETS, root_descriptor_install_count,
+            root_completion_count, root_replay_packet_count,
+            source_mask, root_last_delivery_cycle - root_first_delivery_cycle,
+            cycle, max_occupied_slots);
+          $finish;
+        end
+      end
+    end
+  end
+
+  always @(posedge clk) begin
+    if (rst_n && mesh_out_valid[15] && mesh_out_ready[15]) begin
+      source_mask[mesh_out_source[15*4 +: 4]] <= 1'b1;
+      if (!root_seen_delivery) begin
+        root_seen_delivery <= 1'b1;
+        root_first_delivery_cycle <= cycle;
+      end
+      root_last_delivery_cycle <= cycle;
+    end
+  end
+
+  initial begin
+    for (source_i = 0; source_i < SOURCE_COUNT; source_i = source_i + 1)
+      source_beat_index[source_i] = 0;
+    repeat (5) @(posedge clk);
+    rst_n = 1'b1;
+  end
+endmodule

--- a/tests/local_reducer_aggregate_stats_once_exact_shared_root_global_tree_tb.sv
+++ b/tests/local_reducer_aggregate_stats_once_exact_shared_root_global_tree_tb.sv
@@ -1,0 +1,203 @@
+`timescale 1ns/1ps
+
+module local_reducer_aggregate_stats_once_exact_shared_root_global_tree_tb;
+  localparam integer SOURCE_COUNT = 15;
+  localparam integer LEAF_COUNT = 16;
+  localparam integer BEAT_W = 419;
+  localparam integer FLIT_W = 256;
+  localparam integer GROUP_BEATS = 128;
+  localparam integer SIM_TIMEOUT_CYCLES = 30000;
+
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  integer cycle = 0;
+  always #5 clk = ~clk;
+
+  reg [SOURCE_COUNT-1:0] bridge_ctx_done;
+  reg [SOURCE_COUNT-1:0] encoder_ctx_done;
+  wire [SOURCE_COUNT-1:0] group_ctx_valid =
+    ~(bridge_ctx_done & encoder_ctx_done);
+  wire [SOURCE_COUNT-1:0] bridge_group_ctx_ready;
+  wire [SOURCE_COUNT-1:0] encoder_group_ctx_ready;
+  wire [SOURCE_COUNT*16-1:0] group_command_id =
+    {SOURCE_COUNT{16'h5a00}};
+  wire [SOURCE_COUNT*5-1:0] group_head_base =
+    {SOURCE_COUNT{5'd0}};
+
+  reg [31:0] source_beat_index [0:SOURCE_COUNT-1];
+  reg [31:0] root_beat_index;
+  wire [SOURCE_COUNT-1:0] encoder_beat_valid;
+  wire [SOURCE_COUNT-1:0] encoder_beat_ready;
+  wire [SOURCE_COUNT*BEAT_W-1:0] encoder_beat_data;
+  wire [SOURCE_COUNT-1:0] encoder_flit_valid;
+  wire [SOURCE_COUNT-1:0] encoder_flit_ready;
+  wire [SOURCE_COUNT*FLIT_W-1:0] encoder_flit_data;
+  wire [SOURCE_COUNT-1:0] encoder_flit_group_last;
+  wire [SOURCE_COUNT-1:0] encoder_protocol_error;
+
+  wire [LEAF_COUNT-1:0] leaf_valid;
+  wire [LEAF_COUNT-1:0] leaf_ready;
+  wire [LEAF_COUNT*16-1:0] leaf_command_id;
+  wire [LEAF_COUNT*5-1:0] leaf_head_id;
+  wire [LEAF_COUNT*32-1:0] leaf_global_max;
+  wire [LEAF_COUNT*33-1:0] leaf_exp_sum;
+  wire [LEAF_COUNT*4-1:0] leaf_slice;
+  wire [LEAF_COUNT-1:0] leaf_last;
+  wire [LEAF_COUNT*328-1:0] leaf_value;
+  wire [SOURCE_COUNT-1:0] decoder_protocol_error;
+  wire bridge_protocol_error;
+
+  wire root_valid;
+  wire root_ready = ((cycle % 17) != 5) && ((cycle % 23) != 11);
+  wire [15:0] root_command_id;
+  wire [4:0] root_head_id;
+  wire [3:0] root_slice;
+  wire root_last;
+  wire [319:0] root_value;
+  wire tree_protocol_error;
+
+  integer source_i;
+  integer lane_i;
+  integer root_count = 0;
+  reg [39:0] observed_lane;
+
+  function [BEAT_W-1:0] make_partial_beat(input integer beat_index);
+    integer lane;
+    reg [BEAT_W-1:0] result;
+    begin
+      result = {BEAT_W{1'b0}};
+      result[15:0] = 16'h5a00;
+      result[20:16] = beat_index / 16;
+      result[52:21] = 32'd0;
+      result[85:53] = 33'd1;
+      result[89:86] = beat_index % 16;
+      result[90] = ((beat_index % 16) == 15);
+      for (lane = 0; lane < 8; lane = lane + 1)
+        result[91 + lane*41 +: 41] = 41'd1;
+      make_partial_beat = result;
+    end
+  endfunction
+
+  genvar source_g;
+  generate
+    for (source_g = 0; source_g < SOURCE_COUNT; source_g = source_g + 1) begin : gen_encoder
+      assign encoder_beat_valid[source_g] = encoder_ctx_done[source_g] &&
+        (source_beat_index[source_g] < GROUP_BEATS);
+      assign encoder_beat_data[source_g*BEAT_W +: BEAT_W] =
+        make_partial_beat(source_beat_index[source_g]);
+
+      local_reducer_aggregate_stats_once_exact_encoder encoder (
+        .clk(clk), .rst_n(rst_n),
+        .group_ctx_valid(group_ctx_valid[source_g]),
+        .group_ctx_ready(encoder_group_ctx_ready[source_g]),
+        .group_command_id(16'h5a00), .group_head_base(5'd0),
+        .beat_valid(encoder_beat_valid[source_g]),
+        .beat_ready(encoder_beat_ready[source_g]),
+        .beat_data(encoder_beat_data[source_g*BEAT_W +: BEAT_W]),
+        .flit_valid(encoder_flit_valid[source_g]),
+        .flit_ready(encoder_flit_ready[source_g]),
+        .flit_data(encoder_flit_data[source_g*FLIT_W +: FLIT_W]),
+        .flit_group_last(encoder_flit_group_last[source_g]),
+        .protocol_error(encoder_protocol_error[source_g])
+      );
+    end
+  endgenerate
+
+  wire root_local_valid = root_beat_index < GROUP_BEATS;
+  wire root_local_ready;
+  wire [BEAT_W-1:0] root_local_beat_data =
+    make_partial_beat(root_beat_index);
+
+  local_reducer_aggregate_stats_once_exact_shared_root_leaf_adapter bridge (
+    .clk(clk), .rst_n(rst_n),
+    .source_group_ctx_valid(group_ctx_valid),
+    .source_group_ctx_ready(bridge_group_ctx_ready),
+    .source_group_command_id(group_command_id),
+    .source_group_head_base(group_head_base),
+    .source_flit_valid(encoder_flit_valid),
+    .source_flit_ready(encoder_flit_ready),
+    .source_flit_data(encoder_flit_data),
+    .source_flit_group_last(encoder_flit_group_last),
+    .decoder_protocol_error(decoder_protocol_error),
+    .root_local_valid(root_local_valid),
+    .root_local_ready(root_local_ready),
+    .root_local_beat_data(root_local_beat_data),
+    .leaf_valid(leaf_valid), .leaf_ready(leaf_ready),
+    .leaf_command_id(leaf_command_id), .leaf_head_id(leaf_head_id),
+    .leaf_global_max(leaf_global_max), .leaf_exp_sum(leaf_exp_sum),
+    .leaf_slice(leaf_slice), .leaf_last(leaf_last),
+    .leaf_value(leaf_value), .protocol_error(bridge_protocol_error)
+  );
+
+  attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b59 tree (
+    .clk(clk), .rst_n(rst_n),
+    .leaf_valid(leaf_valid), .leaf_ready(leaf_ready),
+    .leaf_command_id(leaf_command_id), .leaf_head_id(leaf_head_id),
+    .leaf_global_max(leaf_global_max), .leaf_exp_sum(leaf_exp_sum),
+    .leaf_slice(leaf_slice), .leaf_last(leaf_last),
+    .leaf_value(leaf_value),
+    .root_valid(root_valid), .root_ready(root_ready),
+    .root_command_id(root_command_id), .root_head_id(root_head_id),
+    .root_slice(root_slice), .root_last(root_last), .root_value(root_value),
+    .protocol_error(tree_protocol_error)
+  );
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      cycle <= 0;
+      bridge_ctx_done <= {SOURCE_COUNT{1'b0}};
+      encoder_ctx_done <= {SOURCE_COUNT{1'b0}};
+      root_beat_index <= 0;
+      for (source_i = 0; source_i < SOURCE_COUNT; source_i = source_i + 1)
+        source_beat_index[source_i] <= 0;
+    end else begin
+      cycle <= cycle + 1;
+      if (cycle >= SIM_TIMEOUT_CYCLES)
+        $fatal(1, "shared-root global-tree timeout");
+      for (source_i = 0; source_i < SOURCE_COUNT; source_i = source_i + 1) begin
+        if (group_ctx_valid[source_i] && bridge_group_ctx_ready[source_i])
+          bridge_ctx_done[source_i] <= 1'b1;
+        if (group_ctx_valid[source_i] && encoder_group_ctx_ready[source_i])
+          encoder_ctx_done[source_i] <= 1'b1;
+        if (encoder_beat_valid[source_i] && encoder_beat_ready[source_i])
+          source_beat_index[source_i] <= source_beat_index[source_i] + 1'b1;
+      end
+      if (root_local_valid && root_local_ready)
+        root_beat_index <= root_beat_index + 1'b1;
+
+      if (bridge_protocol_error || tree_protocol_error ||
+          (|encoder_protocol_error) || (|decoder_protocol_error))
+        $fatal(1, "unexpected composed protocol error");
+
+      if (root_valid && root_ready) begin
+        if (root_command_id !== 16'h5a00 ||
+            root_head_id !== (root_count / 16) ||
+            root_slice !== (root_count % 16) ||
+            root_last !== ((root_count % 16) == 15))
+          $fatal(1, "root metadata mismatch at row %0d", root_count);
+        for (lane_i = 0; lane_i < 8; lane_i = lane_i + 1) begin
+          observed_lane = root_value[lane_i*40 +: 40];
+          if (observed_lane !== 40'd65535)
+            $fatal(1, "root lane mismatch row=%0d lane=%0d value=%h",
+              root_count, lane_i, observed_lane);
+        end
+        root_count = root_count + 1;
+        if (root_count == GROUP_BEATS) begin
+          $display("PASS shared_root_global_tree rows=128 lane_value=65535 cycles=%0d",
+            cycle);
+          $finish;
+        end
+      end
+    end
+  end
+
+  initial begin
+    bridge_ctx_done = {SOURCE_COUNT{1'b0}};
+    encoder_ctx_done = {SOURCE_COUNT{1'b0}};
+    root_beat_index = 0;
+    for (source_i = 0; source_i < SOURCE_COUNT; source_i = source_i + 1)
+      source_beat_index[source_i] = 0;
+    repeat (5) @(posedge clk);
+    rst_n = 1'b1;
+  end
+endmodule

--- a/tests/local_reducer_aggregate_stats_once_exact_shared_root_leaf_adapter_tb.sv
+++ b/tests/local_reducer_aggregate_stats_once_exact_shared_root_leaf_adapter_tb.sv
@@ -1,0 +1,273 @@
+`timescale 1ns/1ps
+
+module local_reducer_aggregate_stats_once_exact_shared_root_leaf_adapter_tb;
+  localparam integer SOURCE_COUNT = 15;
+  localparam integer LEAF_COUNT = 16;
+  localparam integer BEAT_W = 419;
+  localparam integer FLIT_W = 256;
+  localparam integer GROUP_BEATS = 128;
+  localparam integer SIM_TIMEOUT_CYCLES = 2000000;
+
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  integer cycle = 0;
+  always #5 clk = ~clk;
+
+  reg [SOURCE_COUNT-1:0] group_ctx_valid;
+  wire [SOURCE_COUNT-1:0] bridge_group_ctx_ready;
+  wire [SOURCE_COUNT-1:0] encoder_group_ctx_ready;
+  reg [SOURCE_COUNT-1:0] bridge_ctx_done;
+  reg [SOURCE_COUNT-1:0] encoder_ctx_done;
+  reg [SOURCE_COUNT*16-1:0] group_command_id;
+  reg [SOURCE_COUNT*5-1:0] group_head_base;
+
+  reg [SOURCE_COUNT-1:0] encoder_beat_valid;
+  wire [SOURCE_COUNT-1:0] encoder_beat_ready;
+  reg [SOURCE_COUNT*BEAT_W-1:0] encoder_beat_data;
+  wire [SOURCE_COUNT-1:0] encoder_flit_valid;
+  wire [SOURCE_COUNT-1:0] encoder_flit_ready;
+  wire [SOURCE_COUNT*FLIT_W-1:0] encoder_flit_data;
+  wire [SOURCE_COUNT-1:0] encoder_flit_group_last;
+  wire [SOURCE_COUNT-1:0] encoder_protocol_error;
+
+  reg [SOURCE_COUNT-1:0] source_flit_valid;
+  wire [SOURCE_COUNT-1:0] source_flit_ready;
+  reg [SOURCE_COUNT*FLIT_W-1:0] source_flit_data;
+  reg [SOURCE_COUNT-1:0] source_flit_group_last;
+
+  wire [LEAF_COUNT-1:0] leaf_valid;
+  reg [LEAF_COUNT-1:0] leaf_ready;
+  wire [LEAF_COUNT*16-1:0] leaf_command_id;
+  wire [LEAF_COUNT*5-1:0] leaf_head_id;
+  wire [LEAF_COUNT*32-1:0] leaf_global_max;
+  wire [LEAF_COUNT*33-1:0] leaf_exp_sum;
+  wire [LEAF_COUNT*4-1:0] leaf_slice;
+  wire [LEAF_COUNT-1:0] leaf_last;
+  wire [LEAF_COUNT*328-1:0] leaf_value;
+  wire [SOURCE_COUNT-1:0] decoder_protocol_error;
+  wire protocol_error;
+
+  reg [31:0] source_beat_index [0:SOURCE_COUNT-1];
+  reg [31:0] root_beat_index;
+  integer leaf_beat_count [0:LEAF_COUNT-1];
+  integer source_i;
+  integer leaf_i;
+  integer word_i;
+  reg [BEAT_W-1:0] expected_beat;
+  reg held_valid [0:LEAF_COUNT-1];
+  reg [15:0] held_command [0:LEAF_COUNT-1];
+  reg [4:0] held_head [0:LEAF_COUNT-1];
+  reg [31:0] held_max [0:LEAF_COUNT-1];
+  reg [32:0] held_sum [0:LEAF_COUNT-1];
+  reg [3:0] held_slice [0:LEAF_COUNT-1];
+  reg held_last [0:LEAF_COUNT-1];
+  reg [327:0] held_value [0:LEAF_COUNT-1];
+
+  function [BEAT_W-1:0] make_beat(input integer source, input integer beat_index);
+    integer head_index;
+    integer slice_index;
+    reg [BEAT_W-1:0] result;
+    begin
+      head_index = beat_index / 16;
+      slice_index = beat_index % 16;
+      result = {BEAT_W{1'b0}};
+      result[15:0] = 16'h4000 + source;
+      result[20:16] = ((source % 4) * 8) + head_index;
+      result[52:21] = 32'ha0000000 |
+        (source * 32'h00010000) | (head_index * 32'h00000100);
+      result[85:53] = 33'h100000000 |
+        (source * 33'h00010000) | (head_index * 33'h00000100);
+      result[89:86] = slice_index;
+      result[90] = (slice_index == 15);
+      for (word_i = 0; word_i < 10; word_i = word_i + 1)
+        result[91 + word_i*32 +: 32] =
+          32'h51000000 | (source * 32'h00100000) |
+          (beat_index * 32'h00000100) | word_i;
+      result[411 +: 8] = (source * 8) + slice_index;
+      make_beat = result;
+    end
+  endfunction
+
+  always @* begin
+    group_ctx_valid = {SOURCE_COUNT{1'b0}};
+    group_command_id = {SOURCE_COUNT*16{1'b0}};
+    group_head_base = {SOURCE_COUNT*5{1'b0}};
+    encoder_beat_valid = {SOURCE_COUNT{1'b0}};
+    encoder_beat_data = {SOURCE_COUNT*BEAT_W{1'b0}};
+    source_flit_valid = encoder_flit_valid;
+    source_flit_data = encoder_flit_data;
+    source_flit_group_last = encoder_flit_group_last;
+    for (source_i = 0; source_i < SOURCE_COUNT; source_i = source_i + 1) begin
+      group_ctx_valid[source_i] =
+        !(bridge_ctx_done[source_i] && encoder_ctx_done[source_i]);
+      group_command_id[source_i*16 +: 16] = 16'h4000 + source_i;
+      group_head_base[source_i*5 +: 5] = (source_i % 4) * 8;
+      encoder_beat_valid[source_i] = encoder_ctx_done[source_i] &&
+        (source_beat_index[source_i] < GROUP_BEATS);
+      encoder_beat_data[source_i*BEAT_W +: BEAT_W] =
+        make_beat(source_i, source_beat_index[source_i]);
+    end
+  end
+
+  always @* begin
+    for (leaf_i = 0; leaf_i < LEAF_COUNT; leaf_i = leaf_i + 1)
+      // Each leaf has a distinct deterministic stall pattern.
+      leaf_ready[leaf_i] = ((cycle + leaf_i * 3) % 11 != 0) &&
+        ((cycle + leaf_i * 5) % 17 != 3);
+  end
+
+  assign encoder_flit_ready = source_flit_ready;
+
+  wire root_local_valid = (root_beat_index < GROUP_BEATS);
+  wire root_local_ready;
+  wire [BEAT_W-1:0] root_local_beat_data =
+    make_beat(SOURCE_COUNT, root_beat_index);
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      bridge_ctx_done <= {SOURCE_COUNT{1'b0}};
+      encoder_ctx_done <= {SOURCE_COUNT{1'b0}};
+      root_beat_index <= 0;
+      cycle <= 0;
+      for (source_i = 0; source_i < SOURCE_COUNT; source_i = source_i + 1)
+        source_beat_index[source_i] <= 0;
+    end else begin
+      cycle <= cycle + 1;
+      for (source_i = 0; source_i < SOURCE_COUNT; source_i = source_i + 1) begin
+        if (group_ctx_valid[source_i] && bridge_group_ctx_ready[source_i])
+          bridge_ctx_done[source_i] <= 1'b1;
+        if (group_ctx_valid[source_i] && encoder_group_ctx_ready[source_i])
+          encoder_ctx_done[source_i] <= 1'b1;
+        if (encoder_beat_valid[source_i] && encoder_beat_ready[source_i])
+          source_beat_index[source_i] <= source_beat_index[source_i] + 1;
+      end
+      if (root_local_valid && root_local_ready)
+        root_beat_index <= root_beat_index + 1;
+    end
+  end
+
+  genvar source_g;
+  generate
+    for (source_g = 0; source_g < SOURCE_COUNT; source_g = source_g + 1) begin : gen_encoder
+      local_reducer_aggregate_stats_once_exact_encoder encoder (
+        .clk(clk), .rst_n(rst_n),
+        .group_ctx_valid(group_ctx_valid[source_g]),
+        .group_ctx_ready(encoder_group_ctx_ready[source_g]),
+        .group_command_id(group_command_id[source_g*16 +: 16]),
+        .group_head_base(group_head_base[source_g*5 +: 5]),
+        .beat_valid(encoder_beat_valid[source_g]),
+        .beat_ready(encoder_beat_ready[source_g]),
+        .beat_data(encoder_beat_data[source_g*BEAT_W +: BEAT_W]),
+        .flit_valid(encoder_flit_valid[source_g]),
+        .flit_ready(encoder_flit_ready[source_g]),
+        .flit_data(encoder_flit_data[source_g*FLIT_W +: FLIT_W]),
+        .flit_group_last(encoder_flit_group_last[source_g]),
+        .protocol_error(encoder_protocol_error[source_g])
+      );
+    end
+  endgenerate
+
+  local_reducer_aggregate_stats_once_exact_shared_root_leaf_adapter bridge (
+    .clk(clk), .rst_n(rst_n),
+    .source_group_ctx_valid(group_ctx_valid),
+    .source_group_ctx_ready(bridge_group_ctx_ready),
+    .source_group_command_id(group_command_id),
+    .source_group_head_base(group_head_base),
+    .source_flit_valid(source_flit_valid),
+    .source_flit_ready(source_flit_ready),
+    .source_flit_data(source_flit_data),
+    .source_flit_group_last(source_flit_group_last),
+    .decoder_protocol_error(decoder_protocol_error),
+    .root_local_valid(root_local_valid),
+    .root_local_ready(root_local_ready),
+    .root_local_beat_data(root_local_beat_data),
+    .leaf_valid(leaf_valid), .leaf_ready(leaf_ready),
+    .leaf_command_id(leaf_command_id), .leaf_head_id(leaf_head_id),
+    .leaf_global_max(leaf_global_max), .leaf_exp_sum(leaf_exp_sum),
+    .leaf_slice(leaf_slice), .leaf_last(leaf_last), .leaf_value(leaf_value),
+    .protocol_error(protocol_error)
+  );
+
+  initial begin
+    for (source_i = 0; source_i < SOURCE_COUNT; source_i = source_i + 1)
+      source_beat_index[source_i] = 0;
+    for (leaf_i = 0; leaf_i < LEAF_COUNT; leaf_i = leaf_i + 1) begin
+      leaf_beat_count[leaf_i] = 0;
+      held_valid[leaf_i] = 1'b0;
+    end
+    root_beat_index = 0;
+    bridge_ctx_done = {SOURCE_COUNT{1'b0}};
+    encoder_ctx_done = {SOURCE_COUNT{1'b0}};
+    repeat (5) @(posedge clk);
+    rst_n = 1'b1;
+  end
+
+  always @(posedge clk) begin
+    if (rst_n) begin
+      if (cycle > SIM_TIMEOUT_CYCLES)
+        $fatal(1, "TIMEOUT shared-root leaf adapter");
+
+      for (leaf_i = 0; leaf_i < LEAF_COUNT; leaf_i = leaf_i + 1) begin
+        if (held_valid[leaf_i]) begin
+          if (!leaf_valid[leaf_i] ||
+              leaf_command_id[leaf_i*16 +: 16] !== held_command[leaf_i] ||
+              leaf_head_id[leaf_i*5 +: 5] !== held_head[leaf_i] ||
+              leaf_global_max[leaf_i*32 +: 32] !== held_max[leaf_i] ||
+              leaf_exp_sum[leaf_i*33 +: 33] !== held_sum[leaf_i] ||
+              leaf_slice[leaf_i*4 +: 4] !== held_slice[leaf_i] ||
+              leaf_last[leaf_i] !== held_last[leaf_i] ||
+              leaf_value[leaf_i*328 +: 328] !== held_value[leaf_i])
+            $fatal(1, "leaf %0d changed while stalled", leaf_i);
+        end
+
+        if (leaf_valid[leaf_i] && leaf_ready[leaf_i]) begin
+          expected_beat = make_beat(leaf_i, leaf_beat_count[leaf_i]);
+          if (leaf_command_id[leaf_i*16 +: 16] !== expected_beat[15:0] ||
+              leaf_head_id[leaf_i*5 +: 5] !== expected_beat[20:16] ||
+              leaf_global_max[leaf_i*32 +: 32] !== expected_beat[52:21] ||
+              leaf_exp_sum[leaf_i*33 +: 33] !== expected_beat[85:53] ||
+              leaf_slice[leaf_i*4 +: 4] !== expected_beat[89:86] ||
+              leaf_last[leaf_i] !== expected_beat[90] ||
+              leaf_value[leaf_i*328 +: 328] !== expected_beat[BEAT_W-1:91])
+            $fatal(1, "leaf %0d mapping mismatch at beat %0d", leaf_i,
+              leaf_beat_count[leaf_i]);
+          leaf_beat_count[leaf_i] = leaf_beat_count[leaf_i] + 1;
+          held_valid[leaf_i] = 1'b0;
+        end else if (leaf_valid[leaf_i]) begin
+          held_valid[leaf_i] = 1'b1;
+          held_command[leaf_i] = leaf_command_id[leaf_i*16 +: 16];
+          held_head[leaf_i] = leaf_head_id[leaf_i*5 +: 5];
+          held_max[leaf_i] = leaf_global_max[leaf_i*32 +: 32];
+          held_sum[leaf_i] = leaf_exp_sum[leaf_i*33 +: 33];
+          held_slice[leaf_i] = leaf_slice[leaf_i*4 +: 4];
+          held_last[leaf_i] = leaf_last[leaf_i];
+          held_value[leaf_i] = leaf_value[leaf_i*328 +: 328];
+        end
+      end
+
+      if (protocol_error !== 1'b0 || |encoder_protocol_error)
+        $fatal(1, "unexpected protocol error");
+
+      if (leaf_beat_count[0] == GROUP_BEATS &&
+          leaf_beat_count[1] == GROUP_BEATS &&
+          leaf_beat_count[2] == GROUP_BEATS &&
+          leaf_beat_count[3] == GROUP_BEATS &&
+          leaf_beat_count[4] == GROUP_BEATS &&
+          leaf_beat_count[5] == GROUP_BEATS &&
+          leaf_beat_count[6] == GROUP_BEATS &&
+          leaf_beat_count[7] == GROUP_BEATS &&
+          leaf_beat_count[8] == GROUP_BEATS &&
+          leaf_beat_count[9] == GROUP_BEATS &&
+          leaf_beat_count[10] == GROUP_BEATS &&
+          leaf_beat_count[11] == GROUP_BEATS &&
+          leaf_beat_count[12] == GROUP_BEATS &&
+          leaf_beat_count[13] == GROUP_BEATS &&
+          leaf_beat_count[14] == GROUP_BEATS &&
+          leaf_beat_count[15] == GROUP_BEATS) begin
+        $display("PASS shared_root_leaf_adapter leaves=%0d beats_per_leaf=%0d",
+          LEAF_COUNT, GROUP_BEATS);
+        $finish;
+      end
+    end
+  end
+endmodule

--- a/tests/test_local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition.py
+++ b/tests/test_local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition.py
@@ -102,9 +102,10 @@ def test_full_chain_exact_finite_sram_mesh_and_tree(tmp_path: Path) -> None:
     assert "completions=315" in run.stdout
     assert "replays=315" in run.stdout
     assert "source_mask=7fff" in run.stdout
-    assert "first_last_span=2504" in run.stdout
+    assert "root_delivery_span=2505" in run.stdout
     assert "final_cycle=2600" in run.stdout
-    assert "max_slots=30" in run.stdout
+    assert "max_aggregate_slots=30" in run.stdout
+    assert "slots_per_source=2" in run.stdout
 
 
 @pytest.mark.skipif(_tool("yosys") is None, reason="yosys unavailable")

--- a/tests/test_local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition.py
+++ b/tests/test_local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from npu.rtlgen.gen_attention_score32_exact_banked_finalized_tree import generate
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RTL = REPO_ROOT / "npu/sim/rtl"
+TB = REPO_ROOT / (
+    "tests/local_reducer_aggregate_stats_once_exact_shared_root_"
+    "global_tree_composition_tb.sv"
+)
+TOP = "local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition_tb"
+COMPOSITION = "local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition"
+
+
+def _tool(name: str) -> str | None:
+    path = shutil.which(name)
+    if path is not None:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    return str(fallback) if fallback.exists() else None
+
+
+RTL_SOURCES = [
+    RTL / "noc_ready_valid_fifo.sv",
+    RTL / "noc_segmented_mesh_router.sv",
+    RTL / "noc_segmented_mesh4x4.sv",
+    RTL / "noc_sram_packet_endpoint.sv",
+    RTL / "local_reducer_aggregate_stats_once_exact_packet_bridge.sv",
+    RTL / "local_reducer_aggregate_stats_once_exact_codec.sv",
+    RTL / "local_reducer_aggregate_stats_once_exact_sram_packet_adapter.sv",
+    RTL / "local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter.sv",
+    RTL / "local_reducer_aggregate_stats_once_exact_shared_root_leaf_adapter.sv",
+    RTL / "local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition.sv",
+]
+
+
+def _generate_tree(tmp_path: Path) -> Path:
+    config = {
+        "top_name": "attention_score32_exact_banked_finalized_tree_factored_c16_r2_l8_b59",
+        "attention_score32_exact_banked_finalized_tree": {
+            "clusters": 16,
+            "radix": 2,
+            "value_slices": 16,
+            "head_id_bits": 5,
+            "divider_lanes": 8,
+            "finalizer_banks": 59,
+            "exp_scale_impl": "factored_h33_l64_mul_exact",
+        },
+    }
+    tree_dir = tmp_path / "generated_tree"
+    generate(config, tree_dir)
+    return tree_dir
+
+
+@pytest.mark.skipif(
+    _tool("iverilog") is None or _tool("vvp") is None,
+    reason="iverilog/vvp unavailable",
+)
+def test_full_chain_exact_finite_sram_mesh_and_tree(tmp_path: Path) -> None:
+    tree_dir = _generate_tree(tmp_path)
+    simv = tmp_path / "full_chain.vvp"
+    subprocess.run(
+        [
+            str(_tool("iverilog")),
+            "-g2012",
+            "-s",
+            TOP,
+            "-o",
+            str(simv),
+            str(tree_dir / "top.v"),
+            *[str(path) for path in RTL_SOURCES],
+            str(TB),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    run = subprocess.run(
+        [str(_tool("vvp")), str(simv)],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert "PASS full_chain" in run.stdout
+    assert "rows=128" in run.stdout
+    assert "remote_beats=1920" in run.stdout
+    assert "flits=2505" in run.stdout
+    assert "packets=315" in run.stdout
+    assert "descriptors=315" in run.stdout
+    assert "completions=315" in run.stdout
+    assert "replays=315" in run.stdout
+    assert "source_mask=7fff" in run.stdout
+    assert "first_last_span=2504" in run.stdout
+    assert "final_cycle=2600" in run.stdout
+    assert "max_slots=30" in run.stdout
+
+
+@pytest.mark.skipif(_tool("yosys") is None, reason="yosys unavailable")
+def test_full_chain_structural_composition_has_one_root_and_fifteen_leaves(
+    tmp_path: Path,
+) -> None:
+    tree_dir = _generate_tree(tmp_path)
+    netlist = tmp_path / "full_chain.json"
+    subprocess.run(
+        [
+            str(_tool("yosys")),
+            "-q",
+            "-p",
+            "read_verilog -DSYNTHESIS -sv "
+            + " ".join(str(path) for path in RTL_SOURCES)
+            + " "
+            + str(tree_dir / "top.v")
+            + f"; hierarchy -check -top {COMPOSITION}; proc; check; write_json "
+            + str(netlist),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    design = json.loads(netlist.read_text())
+    cells = design["modules"][COMPOSITION]["cells"].values()
+    assert sum("shared_root_rx_adapter" in cell["type"] for cell in cells) == 1
+    assert sum("shared_root_leaf_adapter" in cell["type"] for cell in cells) == 1
+    assert sum("factored_c16_r2_l8_b59" in cell["type"] for cell in cells) == 1

--- a/tests/test_local_reducer_aggregate_stats_once_exact_shared_root_leaf_adapter.py
+++ b/tests/test_local_reducer_aggregate_stats_once_exact_shared_root_leaf_adapter.py
@@ -7,12 +7,18 @@ from pathlib import Path
 
 import pytest
 
+from npu.rtlgen.gen_attention_score32_exact_banked_finalized_tree import generate
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 RTL = REPO_ROOT / "npu/sim/rtl"
 TB = REPO_ROOT / "tests/local_reducer_aggregate_stats_once_exact_shared_root_leaf_adapter_tb.sv"
 TOP = "local_reducer_aggregate_stats_once_exact_shared_root_leaf_adapter_tb"
 BRIDGE_TOP = "local_reducer_aggregate_stats_once_exact_shared_root_leaf_adapter"
+GLOBAL_TREE_TB = (
+    REPO_ROOT
+    / "tests/local_reducer_aggregate_stats_once_exact_shared_root_global_tree_tb.sv"
+)
 
 
 def _tool(name: str) -> str | None:
@@ -102,3 +108,57 @@ def test_shared_root_leaf_adapter_has_exactly_fifteen_decoders(
     assert len(top["ports"]["leaf_slice"]["bits"]) == 16 * 4
     assert len(top["ports"]["leaf_last"]["bits"]) == 16
     assert len(top["ports"]["leaf_value"]["bits"]) == 16 * 328
+
+
+@pytest.mark.skipif(
+    _tool("iverilog") is None or _tool("vvp") is None,
+    reason="iverilog/vvp unavailable",
+)
+def test_shared_root_leaf_adapter_composes_with_exact_global_tree(
+    tmp_path: Path,
+) -> None:
+    config = {
+        "top_name": (
+            "attention_score32_exact_banked_finalized_tree_"
+            "factored_c16_r2_l8_b59"
+        ),
+        "attention_score32_exact_banked_finalized_tree": {
+            "clusters": 16,
+            "radix": 2,
+            "value_slices": 16,
+            "head_id_bits": 5,
+            "divider_lanes": 8,
+            "finalizer_banks": 59,
+            "exp_scale_impl": "factored_h33_l64_mul_exact",
+        },
+    }
+    tree_dir = tmp_path / "tree"
+    generate(config, tree_dir)
+    simv = tmp_path / "shared_root_global_tree.vvp"
+    subprocess.run(
+        [
+            str(_tool("iverilog")),
+            "-g2012",
+            "-s",
+            "local_reducer_aggregate_stats_once_exact_shared_root_global_tree_tb",
+            "-o",
+            str(simv),
+            str(tree_dir / "top.v"),
+            *[str(path) for path in RTL_SOURCES],
+            str(GLOBAL_TREE_TB),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    run = subprocess.run(
+        [str(_tool("vvp")), str(simv)],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert "PASS shared_root_global_tree rows=128 lane_value=65535" in run.stdout

--- a/tests/test_local_reducer_aggregate_stats_once_exact_shared_root_leaf_adapter.py
+++ b/tests/test_local_reducer_aggregate_stats_once_exact_shared_root_leaf_adapter.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RTL = REPO_ROOT / "npu/sim/rtl"
+TB = REPO_ROOT / "tests/local_reducer_aggregate_stats_once_exact_shared_root_leaf_adapter_tb.sv"
+TOP = "local_reducer_aggregate_stats_once_exact_shared_root_leaf_adapter_tb"
+BRIDGE_TOP = "local_reducer_aggregate_stats_once_exact_shared_root_leaf_adapter"
+
+
+def _tool(name: str) -> str | None:
+    path = shutil.which(name)
+    if path is not None:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    return str(fallback) if fallback.exists() else None
+
+
+RTL_SOURCES = [
+    RTL / "local_reducer_aggregate_stats_once_exact_codec.sv",
+    RTL / "local_reducer_aggregate_stats_once_exact_shared_root_leaf_adapter.sv",
+]
+
+
+@pytest.mark.skipif(
+    _tool("iverilog") is None or _tool("vvp") is None,
+    reason="iverilog/vvp unavailable",
+)
+def test_shared_root_leaf_adapter_mapping_and_independent_backpressure(
+    tmp_path: Path,
+) -> None:
+    simv = tmp_path / "shared_root_leaf_adapter.vvp"
+    subprocess.run(
+        [
+            str(_tool("iverilog")),
+            "-g2012",
+            "-s",
+            TOP,
+            "-o",
+            str(simv),
+            *[str(path) for path in RTL_SOURCES],
+            str(TB),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    run = subprocess.run(
+        [str(_tool("vvp")), str(simv)],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert "PASS shared_root_leaf_adapter leaves=16 beats_per_leaf=128" in run.stdout
+
+
+@pytest.mark.skipif(_tool("yosys") is None, reason="yosys unavailable")
+def test_shared_root_leaf_adapter_has_exactly_fifteen_decoders(
+    tmp_path: Path,
+) -> None:
+    netlist = tmp_path / "shared_root_leaf_adapter.json"
+    subprocess.run(
+        [
+            str(_tool("yosys")),
+            "-q",
+            "-p",
+            "read_verilog -DSYNTHESIS -sv "
+            + " ".join(str(path) for path in RTL_SOURCES)
+            + f"; hierarchy -check -top {BRIDGE_TOP}; proc; check; write_json "
+            + str(netlist),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    design = json.loads(netlist.read_text())
+    top = design["modules"][BRIDGE_TOP]
+    decoder_cells = [
+        cell
+        for cell in top["cells"].values()
+        if "local_reducer_aggregate_stats_once_exact_decoder" in cell["type"]
+    ]
+    assert len(decoder_cells) == 15
+    assert len(top["ports"]["leaf_valid"]["bits"]) == 16
+    assert len(top["ports"]["leaf_command_id"]["bits"]) == 16 * 16
+    assert len(top["ports"]["leaf_head_id"]["bits"]) == 16 * 5
+    assert len(top["ports"]["leaf_global_max"]["bits"]) == 16 * 32
+    assert len(top["ports"]["leaf_exp_sum"]["bits"]) == 16 * 33
+    assert len(top["ports"]["leaf_slice"]["bits"]) == 16 * 4
+    assert len(top["ports"]["leaf_last"]["bits"]) == 16
+    assert len(top["ports"]["leaf_value"]["bits"]) == 16 * 328


### PR DESCRIPTION
## Summary
- decode 15 shared-root stats-once streams into canonical 419-bit leaves and join the direct root-local sixteenth leaf
- atomically admit group contexts into the finite root endpoint and all remote decoders
- compose finite source/destination packet SRAMs, the real registered-credit 4x4 mesh, one shared root endpoint, 15 decoders, and the existing factored `c16/r2/l8/b59` exact reduction/finalization tree
- verify nonzero arithmetic end to end: 16 partial numerators/sums reduce and divide to eight exact 40-bit lane values of 65535 for every row

## Measured full-chain result
- 1,920 remote canonical beats
- 2,505 flits and 315 packets/descriptors/completions/replays
- 128 exact finalized rows
- 2,505-cycle inclusive root delivery span, matching the physical serialization floor
- final output at cycle 2,600, 75 cycles after the final root flit
- 30 peak aggregate destination slots, exactly two per remote source

## Verification
- 15 focused functional, structural, codec, transport, and performance tests pass
- Yosys confirms the expected root RX, leaf bridge, and factored exact-tree composition
