### PR TITLE
Prepare registered SRAM root bank frontier

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -1724,6 +1724,74 @@ def _read_config_target(
                 },
             ],
         )
+    elif (
+        "top_name" in cfg
+        and "attention_score32_exact_shared_root_storage_physical_harness" in cfg
+    ):
+        top_name = str(cfg["top_name"]).strip()
+        if not top_name:
+            raise Layer1TaskGenerationError(f"top_name must not be empty in {config_path}")
+        try:
+            design_dir = str(config_path.parent.resolve().relative_to(repo_root.resolve()))
+        except ValueError as exc:
+            raise Layer1TaskGenerationError(
+                "exact shared-root storage physical config must live under "
+                f"repo_root/runs/designs/...: {config_path}"
+            ) from exc
+        design_name = config_path.parent.name
+        command_slug = "attention_score32_exact_shared_root_storage_physical_harness"
+        return Layer1ConfigTarget(
+            design_kind="block",
+            design_name=design_name,
+            expected_metrics_path=block_metrics_path(design_name),
+            expected_report_paths=[f"{design_dir}/timing_debug_report.md"],
+            commands=[
+                {
+                    "name": f"generate_{command_slug}_rtl",
+                    "run": _with_oss_cad_path(
+                        (
+                            "python3 npu/rtlgen/"
+                            "gen_attention_score32_exact_shared_root_storage_physical_harness.py "
+                            f"--config {config_rel} "
+                            f"--out {design_dir}/verilog"
+                        )
+                    ),
+                },
+                {
+                    "name": "check_attention_score32_exact_shared_root_storage_physical_guard",
+                    "run": (
+                        "python3 npu/eval/"
+                        "check_attention_score32_exact_shared_root_storage_physical_guard.py "
+                        f"--design-dir {design_dir}"
+                    ),
+                },
+                {
+                    "name": "run_block_sweep",
+                    "run": _with_oss_cad_path(
+                        (
+                            "python3 npu/synth/run_block_sweep.py "
+                            f"--design_dir {design_dir} "
+                            "--platform {platform} "
+                            f"--top {top_name} "
+                            f"--sweep {{sweep_path}} "
+                            f"--out_root {out_root} "
+                            f"--macro_manifest {design_dir}/verilog/macro_manifest.json "
+                            + (f"--make_target {make_target} " if make_target else "")
+                            + "--skip_existing"
+                        )
+                    ),
+                },
+                {
+                    "name": f"extract_{command_slug}_timing_paths",
+                    "run": (
+                        "python3 npu/eval/extract_openroad_timing_summary.py "
+                        f"--design-dir {design_dir} "
+                        f"--out {design_dir}/timing_debug_report.md "
+                        "--max-paths 8"
+                    ),
+                },
+            ],
+        )
     elif "top_name" in cfg and (
         "attention_score32_exact_partial_temporal_finalizer_physical_harness" in cfg
         or "attention_exact_partial_async_fifo_physical_harness" in cfg

--- a/docs/proposals/prop_l1_attention_score32_exact_shared_root_storage_macro_ppa_v1/README.md
+++ b/docs/proposals/prop_l1_attention_score32_exact_shared_root_storage_macro_ppa_v1/README.md
@@ -1,0 +1,20 @@
+# Exact shared-root storage macro PPA
+
+This package prepares four remote Nangate45 physical-calibration items for the
+registered shared-root packet SRAM frontier. It does not dispatch development
+branch code.
+
+Full-chain RTL with the available `fakeram45_64x32` behavioral model changes
+the frontier materially. B2/B4/B8/B15 complete in 4120/3077/2855/2620 cycles
+while preserving all 1920 canonical remote beats and all 128 exact final rows.
+B2 is dominated by B4 at the same 32-macro inventory. B4, B8, and B15 remain
+candidates until physical control area and power are measured.
+
+The floorplans scale with raw macro inventory to keep macro utilization near a
+common range: 400 um square cores for B2/B4, 550 um for B8, and 750 um for B15.
+This avoids interpreting congestion from a fixed undersized core as a bank
+architecture penalty.
+
+At queue time, use merged `origin/master` as the source commit. Each normal L1
+task-generation request must place that SHA in
+`source_requirement.required_sha`.

--- a/docs/proposals/prop_l1_attention_score32_exact_shared_root_storage_macro_ppa_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_attention_score32_exact_shared_root_storage_macro_ppa_v1/evaluation_requests.json
@@ -1,0 +1,83 @@
+{
+  "proposal_id": "prop_l1_attention_score32_exact_shared_root_storage_macro_ppa_v1",
+  "source_commit": "TBD",
+  "source_commit_note": "Queue only after merge from merged origin/master and pin source_requirement.required_sha to the merge commit containing the macro backend, harness, guard, configs, sweeps, proposal linkage, and task-generator support.",
+  "requested_items": [
+    {
+      "item_id": "l1_attention_score32_exact_shared_root_storage_macro_b2_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the exact two-bank registered-SRAM storage point.",
+      "evaluation_mode": "physical_calibration",
+      "abstraction_layer": "decoder_attention_exact_shared_root_packet_storage",
+      "comparison_role": "same_macro_count_low_bank_diagnostic",
+      "config_paths": ["runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b2/config.json"],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_shared_root_storage_macro_ppa_v1/sweeps/nangate45_b2.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b2/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b2/timing_debug_report.md"
+      ],
+      "status": "pending_after_proposal_merge",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "acceptance_notes": "Require exactly 32 fakeram45_64x32 macros and retain this point as a diagnostic unless PPA offsets its measured 4120-cycle full-chain latency."
+    },
+    {
+      "item_id": "l1_attention_score32_exact_shared_root_storage_macro_b4_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the exact four-bank registered-SRAM storage point.",
+      "evaluation_mode": "physical_calibration",
+      "abstraction_layer": "decoder_attention_exact_shared_root_packet_storage",
+      "comparison_role": "minimum_macro_area_floor",
+      "config_paths": ["runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b4/config.json"],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_shared_root_storage_macro_ppa_v1/sweeps/nangate45_b4.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b4/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b4/timing_debug_report.md"
+      ],
+      "status": "pending_after_proposal_merge",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "acceptance_notes": "Require exactly 32 fakeram45_64x32 macros and preserve the measured exact full-chain result of 2939 root-span and 3077 final cycles."
+    },
+    {
+      "item_id": "l1_attention_score32_exact_shared_root_storage_macro_b8_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the exact eight-bank registered-SRAM storage point.",
+      "evaluation_mode": "physical_calibration",
+      "abstraction_layer": "decoder_attention_exact_shared_root_packet_storage",
+      "comparison_role": "balanced_macro_throughput_candidate",
+      "config_paths": ["runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b8/config.json"],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_shared_root_storage_macro_ppa_v1/sweeps/nangate45_b8.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b8/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b8/timing_debug_report.md"
+      ],
+      "status": "pending_after_proposal_merge",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "acceptance_notes": "Require exactly 64 fakeram45_64x32 macros and preserve the measured exact full-chain result of 2733 root-span and 2855 final cycles."
+    },
+    {
+      "item_id": "l1_attention_score32_exact_shared_root_storage_macro_b15_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the exact fifteen-bank registered-SRAM throughput anchor.",
+      "evaluation_mode": "physical_calibration",
+      "abstraction_layer": "decoder_attention_exact_shared_root_packet_storage",
+      "comparison_role": "maximum_bank_throughput_anchor",
+      "config_paths": ["runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b15/config.json"],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_shared_root_storage_macro_ppa_v1/sweeps/nangate45_b15.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b15/metrics.csv",
+        "runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b15/timing_debug_report.md"
+      ],
+      "status": "pending_after_proposal_merge",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "acceptance_notes": "Require exactly 120 fakeram45_64x32 macros and preserve the measured exact full-chain result of 2505 root-span and 2620 final cycles."
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_attention_score32_exact_shared_root_storage_macro_ppa_v1/proposal.json
+++ b/docs/proposals/prop_l1_attention_score32_exact_shared_root_storage_macro_ppa_v1/proposal.json
@@ -1,0 +1,99 @@
+{
+  "proposal_id": "prop_l1_attention_score32_exact_shared_root_storage_macro_ppa_v1",
+  "created_utc": "2026-08-19T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "title": "Exact shared-root registered-SRAM bank frontier physical calibration",
+  "abstraction_layer": "decoder_attention_exact_shared_root_packet_storage",
+  "hypothesis": "Registered fakeram timing changes the bank-count frontier; physically measuring B2/B4/B8/B15 with equal macro-utilization floorplans will identify the SRAM/control area, frequency, and power tradeoff needed for hierarchical Llama7B recosting.",
+  "direct_comparison": {
+    "primary_question": "Which exact shared-root bank count gives the best throughput, area, and energy tradeoff after registered SRAM timing and physical macro cost are included?",
+    "baselines": [
+      "attention_score32_exact_stats_once_banked_root_frontier",
+      "local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition"
+    ],
+    "candidate": [
+      "attention_score32_exact_shared_root_storage_macro_b2",
+      "attention_score32_exact_shared_root_storage_macro_b4",
+      "attention_score32_exact_shared_root_storage_macro_b8",
+      "attention_score32_exact_shared_root_storage_macro_b15"
+    ],
+    "include": [
+      "the production shared-root storage arbiter and response skids",
+      "registered fakeram45_64x32 read behavior",
+      "32, 32, 64, and 120 physical SRAM macro inventories",
+      "narrow-I/O self traffic covering all 240 logical words",
+      "per-point floorplans targeting similar raw SRAM macro utilization"
+    ],
+    "exclude": [
+      "the already measured transport codec, endpoint, mesh, decoder, and global tree PPA",
+      "external HBM/DRAM",
+      "a final energy claim before workload activity power is measured"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "stdcell_area_um2",
+      "macro_area_um2",
+      "total_power_mw",
+      "macro_count",
+      "flow_status"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l1_attention_score32_exact_shared_root_storage_macro_b2_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the two-bank 32-macro registered-SRAM storage point.",
+      "status": "pending",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": ["runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b2/config.json"],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_shared_root_storage_macro_ppa_v1/sweeps/nangate45_b2.json",
+      "out_root": "runs/designs/npu_blocks"
+    },
+    {
+      "item_id": "l1_attention_score32_exact_shared_root_storage_macro_b4_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the four-bank 32-macro area-floor storage point.",
+      "status": "pending",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": ["runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b4/config.json"],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_shared_root_storage_macro_ppa_v1/sweeps/nangate45_b4.json",
+      "out_root": "runs/designs/npu_blocks"
+    },
+    {
+      "item_id": "l1_attention_score32_exact_shared_root_storage_macro_b8_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the eight-bank 64-macro balanced storage point.",
+      "status": "pending",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": ["runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b8/config.json"],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_shared_root_storage_macro_ppa_v1/sweeps/nangate45_b8.json",
+      "out_root": "runs/designs/npu_blocks"
+    },
+    {
+      "item_id": "l1_attention_score32_exact_shared_root_storage_macro_b15_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the fifteen-bank 120-macro throughput-anchor storage point.",
+      "status": "pending",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": ["runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b15/config.json"],
+      "sweep_path": "runs/campaigns/npu/attention_score32_exact_shared_root_storage_macro_ppa_v1/sweeps/nangate45_b15.json",
+      "out_root": "runs/designs/npu_blocks"
+    }
+  ],
+  "remaining_abstractions": [
+    "OpenROAD vectorless power is a physical screening metric; workload activity power remains a follow-up.",
+    "Macro placement is selected by OpenROAD inside the fixed per-point die/core bounds.",
+    "The global architecture remains hierarchically accounted because the flat exact tree exceeds the synthesis memory envelope."
+  ],
+  "source_refs": [
+    "npu/rtlgen/gen_attention_score32_exact_shared_root_storage_physical_harness.py",
+    "npu/eval/check_attention_score32_exact_shared_root_storage_physical_guard.py",
+    "npu/docs/generated/attention_score32_exact_stats_once_banked_root_frontier.json"
+  ]
+}

--- a/npu/docs/generated/attention_score32_exact_stats_once_banked_root_frontier.json
+++ b/npu/docs/generated/attention_score32_exact_stats_once_banked_root_frontier.json
@@ -1,26 +1,26 @@
 {
+  "area_floor_point": {
+    "bit_exact": true,
+    "fakeram45_64x32_macros": 32,
+    "full_chain_final_cycle": 3077,
+    "latency_increase_vs_15_banks_pct": 17.442748,
+    "normalized_component_throughput_vs_15_banks": 0.851479,
+    "physical_banks": 4,
+    "root_delivery_span_cycles": 2939
+  },
   "dominated_points": [
     {
       "fakeram45_64x32_macros": 32,
       "physical_banks": 1,
       "reason": "same 32 macros as four banks, but every root write and replay read contends for one single port"
+    },
+    {
+      "fakeram45_64x32_macros": 32,
+      "physical_banks": 2,
+      "reason": "same 32 macros as four banks, but registered-SRAM full-chain completion is 4120 cycles instead of 3077"
     }
   ],
-  "limitations": [
-    "Macro count uses available 64x32 granularity; macro PPA awaits evaluator measurement.",
-    "The model excludes decoder/tree backpressure; the selected B4 point has separate full-chain RTL timing evidence.",
-    "Precision is unchanged because packet storage and replay are bit-exact."
-  ],
-  "memory_contract": {
-    "available_macro": "fakeram45_64x32",
-    "logical_payload_bytes": 7680,
-    "logical_sources": 15,
-    "single_port_write_priority": true,
-    "slot_words": 8,
-    "slots_per_source": 2,
-    "word_bits": 256
-  },
-  "points": [
+  "inferred_memory_model_points": [
     {
       "exact_transport": true,
       "fakeram45_64x32_macros": 32,
@@ -62,41 +62,88 @@
       "schedule_iterations": 1
     }
   ],
+  "limitations": [
+    "Macro PPA and placed control timing await evaluator measurement.",
+    "Cycle results use the available registered fakeram45 behavioral model; post-route clock frequency is not yet applied.",
+    "The inferred-memory model remains diagnostic only and does not select the physical bank point.",
+    "Precision is unchanged because packet storage and replay are bit-exact."
+  ],
+  "memory_contract": {
+    "available_macro": "fakeram45_64x32",
+    "logical_payload_bytes": 7680,
+    "logical_sources": 15,
+    "single_port_write_priority": true,
+    "slot_words": 8,
+    "slots_per_source": 2,
+    "word_bits": 256
+  },
+  "pareto_candidate_banks": [
+    4,
+    8,
+    15
+  ],
+  "rtl_macro_points": [
+    {
+      "bit_exact": true,
+      "fakeram45_64x32_macros": 32,
+      "full_chain_final_cycle": 4120,
+      "latency_increase_vs_15_banks_pct": 57.251908,
+      "normalized_component_throughput_vs_15_banks": 0.635922,
+      "physical_banks": 2,
+      "root_delivery_span_cycles": 3901
+    },
+    {
+      "bit_exact": true,
+      "fakeram45_64x32_macros": 32,
+      "full_chain_final_cycle": 3077,
+      "latency_increase_vs_15_banks_pct": 17.442748,
+      "normalized_component_throughput_vs_15_banks": 0.851479,
+      "physical_banks": 4,
+      "root_delivery_span_cycles": 2939
+    },
+    {
+      "bit_exact": true,
+      "fakeram45_64x32_macros": 64,
+      "full_chain_final_cycle": 2855,
+      "latency_increase_vs_15_banks_pct": 8.969466,
+      "normalized_component_throughput_vs_15_banks": 0.917688,
+      "physical_banks": 8,
+      "root_delivery_span_cycles": 2733
+    },
+    {
+      "bit_exact": true,
+      "fakeram45_64x32_macros": 120,
+      "full_chain_final_cycle": 2620,
+      "latency_increase_vs_15_banks_pct": 0.0,
+      "normalized_component_throughput_vs_15_banks": 1.0,
+      "physical_banks": 15,
+      "root_delivery_span_cycles": 2505
+    }
+  ],
   "rtl_validation": {
-    "bank_depth_words": 64,
-    "bank_word_bits": 256,
-    "baseline_15_bank_final_cycle": 2600,
     "bit_exact": true,
     "canonical_remote_beats": 1920,
     "exact_final_rows": 128,
     "exact_lane_value": 65535,
-    "full_chain_final_cycle": 2613,
-    "full_chain_latency_increase_cycles": 13,
-    "full_chain_latency_increase_pct": 0.5,
-    "physical_banks": 4,
-    "retained_bank_memories": 4,
-    "root_delivery_span_cycles": 2505,
+    "macro_backend": "fakeram45_64x32",
     "test": "tests/test_local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition.py",
     "transport_flits": 2505,
-    "transport_packets": 315
+    "transport_packets": 315,
+    "validated_physical_banks": [
+      2,
+      4,
+      8,
+      15
+    ]
   },
-  "selected_point": {
-    "exact_transport": true,
-    "fakeram45_64x32_macros": 32,
-    "final_replay_cycle": 2533,
-    "max_slots_per_source": 2,
-    "physical_banks": 4,
-    "replay_drain_cycles": 13,
-    "root_delivery_span_cycles": 2505,
-    "schedule_iterations": 1
-  },
-  "selection": {
+  "selection_status": {
+    "b4_latency_increase_vs_15_banks_pct": 17.442748,
+    "b8_latency_increase_vs_15_banks_pct": 8.969466,
+    "b8_macro_reduction_vs_15_banks_pct": 46.666667,
     "macro_reduction_vs_15_banks_pct": 73.333333,
-    "physical_banks": 4,
-    "reason": "minimum 32-macro count while retaining the exact 2505-cycle root serialization floor",
-    "replay_drain_increase_vs_15_banks_cycles": 5,
-    "two_bank_transport_span_penalty_pct": 4.91018
+    "reason": "B4 minimizes SRAM count, B15 maximizes measured throughput, and B8 is intermediate; energy and placed control area are not yet measured",
+    "status": "awaiting_macro_ppa"
   },
-  "semantic_profile": "score32_exact_stats_once_banked_root_v1",
-  "version": 1
+  "semantic_profile": "score32_exact_stats_once_banked_root_macro_v2",
+  "version": 2
 }

--- a/npu/docs/generated/attention_score32_exact_stats_once_banked_root_frontier.md
+++ b/npu/docs/generated/attention_score32_exact_stats_once_banked_root_frontier.md
@@ -1,5 +1,16 @@
 # Exact Stats-Once Shared-Root SRAM Bank Frontier
 
+## Registered-SRAM Full-Chain RTL
+
+| banks | 64x32 macros | root span cycles | final cycle | latency vs B15 | component throughput vs B15 |
+|---:|---:|---:|---:|---:|---:|
+| 2 | 32 | 3901 | 4120 | +57.251908% | 0.635922 |
+| 4 | 32 | 2939 | 3077 | +17.442748% | 0.851479 |
+| 8 | 64 | 2733 | 2855 | +8.969466% | 0.917688 |
+| 15 | 120 | 2505 | 2620 | +0.0% | 1.0 |
+
+## Inferred-Memory Diagnostic Model
+
 | banks | 64x32 macros | root span cycles | replay drain cycles | iterations |
 |---:|---:|---:|---:|---:|
 | 2 | 32 | 2628 | 64 | 24 |
@@ -7,28 +18,27 @@
 | 8 | 64 | 2505 | 8 | 1 |
 | 15 | 120 | 2505 | 8 | 1 |
 
-## Selection
+## Current Candidates
 
-Four banks are selected: minimum 32-macro count while retaining the exact 2505-cycle root serialization floor.
+B4 minimizes SRAM count, B15 maximizes measured throughput, and B8 is intermediate; energy and placed control area are not yet measured.
 
-- macro reduction versus 15 banks: `73.333333%`
-- replay-drain increase versus 15 banks: `5` cycles
-- two-bank transport-span penalty: `4.91018%`
-- one bank is excluded because it uses the same 32 macros as four banks with fewer ports
+- B4: `73.333333%` fewer macros than B15, `+17.442748%` latency
+- B8: `46.666667%` fewer macros than B15, `+8.969466%` latency
+- B15: measured full-chain throughput anchor
+- B2 is dominated by B4 at the same 32-macro count
 - arithmetic and precision are unchanged; storage and replay remain bit-exact
 
 ## Full-Chain RTL Validation
 
-The selected B4 point passes the finite transport, decoder, and exact global-tree composition:
+B2, B4, B8, and B15 pass the finite transport, registered SRAM, decoder, and exact global-tree composition:
 
-- four retained `64x256` physical memories (`32` available `64x32` macros)
 - `1920` canonical remote beats, `2505` flits, and `315` packets
 - `128` exact final rows with every output lane equal to `65535`
-- unchanged `2505`-cycle root delivery span
-- final cycle `2613`, versus `2600` for fifteen banks (`+13`, `+0.5%`)
+- structural tests retain the expected `32`, `32`, `64`, and `120` SRAM macros
 
 ## Limits
 
-- Macro count uses available 64x32 granularity; macro PPA awaits evaluator measurement.
-- The model excludes decoder/tree backpressure; the selected B4 point has separate full-chain RTL timing evidence.
+- Macro PPA and placed control timing await evaluator measurement.
+- Cycle results use the available registered fakeram45 behavioral model; post-route clock frequency is not yet applied.
+- The inferred-memory model remains diagnostic only and does not select the physical bank point.
 - Precision is unchanged because packet storage and replay are bit-exact.

--- a/npu/eval/analyze_attention_score32_exact_stats_once_banked_root.py
+++ b/npu/eval/analyze_attention_score32_exact_stats_once_banked_root.py
@@ -15,10 +15,10 @@ from npu.sim.perf.stats_once_banked_root import (
 
 
 def build_report() -> dict[str, Any]:
-    points = []
+    inferred_points = []
     for banks in (2, 4, 8, 15):
         result = simulate_banked_stats_once_shared_root(physical_banks=banks)
-        points.append(
+        inferred_points.append(
             {
                 "physical_banks": banks,
                 "fakeram45_64x32_macros": result.macro_count,
@@ -30,12 +30,37 @@ def build_report() -> dict[str, Any]:
                 "exact_transport": True,
             }
         )
-    selected = next(point for point in points if point["physical_banks"] == 4)
-    baseline = next(point for point in points if point["physical_banks"] == 15)
-    two_bank = next(point for point in points if point["physical_banks"] == 2)
+    macro_timings = {
+        2: (3901, 4120),
+        4: (2939, 3077),
+        8: (2733, 2855),
+        15: (2505, 2620),
+    }
+    baseline_final = macro_timings[15][1]
+    macro_points = [
+        {
+            "physical_banks": banks,
+            "fakeram45_64x32_macros": packet_sram_macro_count(banks),
+            "root_delivery_span_cycles": timing[0],
+            "full_chain_final_cycle": timing[1],
+            "latency_increase_vs_15_banks_pct": round(
+                100.0 * (timing[1] - baseline_final) / baseline_final,
+                6,
+            ),
+            "normalized_component_throughput_vs_15_banks": round(
+                baseline_final / timing[1],
+                6,
+            ),
+            "bit_exact": True,
+        }
+        for banks, timing in macro_timings.items()
+    ]
+    area_floor = next(point for point in macro_points if point["physical_banks"] == 4)
+    baseline = next(point for point in macro_points if point["physical_banks"] == 15)
+    balance = next(point for point in macro_points if point["physical_banks"] == 8)
     return {
-        "version": 1,
-        "semantic_profile": "score32_exact_stats_once_banked_root_v1",
+        "version": 2,
+        "semantic_profile": "score32_exact_stats_once_banked_root_macro_v2",
         "memory_contract": {
             "logical_sources": 15,
             "slots_per_source": 2,
@@ -53,59 +78,63 @@ def build_report() -> dict[str, Any]:
                     "same 32 macros as four banks, but every root write and "
                     "replay read contends for one single port"
                 ),
-            }
+            },
+            {
+                "physical_banks": 2,
+                "fakeram45_64x32_macros": packet_sram_macro_count(2),
+                "reason": (
+                    "same 32 macros as four banks, but registered-SRAM full-chain "
+                    "completion is 4120 cycles instead of 3077"
+                ),
+            },
         ],
-        "points": points,
-        "selected_point": selected,
-        "selection": {
-            "physical_banks": 4,
+        "inferred_memory_model_points": inferred_points,
+        "rtl_macro_points": macro_points,
+        "area_floor_point": area_floor,
+        "pareto_candidate_banks": [4, 8, 15],
+        "selection_status": {
+            "status": "awaiting_macro_ppa",
             "reason": (
-                "minimum 32-macro count while retaining the exact 2505-cycle "
-                "root serialization floor"
+                "B4 minimizes SRAM count, B15 maximizes measured throughput, and "
+                "B8 is intermediate; energy and placed control area are not yet measured"
             ),
             "macro_reduction_vs_15_banks_pct": round(
                 100.0
-                * (baseline["fakeram45_64x32_macros"] - selected["fakeram45_64x32_macros"])
+                * (baseline["fakeram45_64x32_macros"] - area_floor["fakeram45_64x32_macros"])
                 / baseline["fakeram45_64x32_macros"],
                 6,
             ),
-            "replay_drain_increase_vs_15_banks_cycles": (
-                selected["replay_drain_cycles"] - baseline["replay_drain_cycles"]
-            ),
-            "two_bank_transport_span_penalty_pct": round(
+            "b4_latency_increase_vs_15_banks_pct": area_floor[
+                "latency_increase_vs_15_banks_pct"
+            ],
+            "b8_macro_reduction_vs_15_banks_pct": round(
                 100.0
-                * (
-                    two_bank["root_delivery_span_cycles"]
-                    - selected["root_delivery_span_cycles"]
-                )
-                / selected["root_delivery_span_cycles"],
+                * (baseline["fakeram45_64x32_macros"] - balance["fakeram45_64x32_macros"])
+                / baseline["fakeram45_64x32_macros"],
                 6,
             ),
+            "b8_latency_increase_vs_15_banks_pct": balance[
+                "latency_increase_vs_15_banks_pct"
+            ],
         },
         "rtl_validation": {
             "test": (
                 "tests/test_local_reducer_aggregate_stats_once_exact_"
                 "shared_root_global_tree_composition.py"
             ),
-            "physical_banks": 4,
-            "retained_bank_memories": 4,
-            "bank_depth_words": 64,
-            "bank_word_bits": 256,
+            "validated_physical_banks": [2, 4, 8, 15],
+            "macro_backend": "fakeram45_64x32",
             "canonical_remote_beats": 1920,
             "transport_flits": 2505,
             "transport_packets": 315,
             "exact_final_rows": 128,
             "exact_lane_value": 65535,
-            "root_delivery_span_cycles": 2505,
-            "full_chain_final_cycle": 2613,
-            "baseline_15_bank_final_cycle": 2600,
-            "full_chain_latency_increase_cycles": 13,
-            "full_chain_latency_increase_pct": 0.5,
             "bit_exact": True,
         },
         "limitations": [
-            "Macro count uses available 64x32 granularity; macro PPA awaits evaluator measurement.",
-            "The model excludes decoder/tree backpressure; the selected B4 point has separate full-chain RTL timing evidence.",
+            "Macro PPA and placed control timing await evaluator measurement.",
+            "Cycle results use the available registered fakeram45 behavioral model; post-route clock frequency is not yet applied.",
+            "The inferred-memory model remains diagnostic only and does not select the physical bank point.",
             "Precision is unchanged because packet storage and replay are bit-exact.",
         ],
     }
@@ -115,39 +144,56 @@ def render_markdown(report: dict[str, Any]) -> str:
     lines = [
         "# Exact Stats-Once Shared-Root SRAM Bank Frontier",
         "",
+        "## Registered-SRAM Full-Chain RTL",
+        "",
+        "| banks | 64x32 macros | root span cycles | final cycle | latency vs B15 | component throughput vs B15 |",
+        "|---:|---:|---:|---:|---:|---:|",
+    ]
+    for point in report["rtl_macro_points"]:
+        lines.append(
+            "| {physical_banks} | {fakeram45_64x32_macros} | "
+            "{root_delivery_span_cycles} | {full_chain_final_cycle} | "
+            "+{latency_increase_vs_15_banks_pct}% | "
+            "{normalized_component_throughput_vs_15_banks} |".format(**point)
+        )
+    lines.extend(
+        [
+            "",
+            "## Inferred-Memory Diagnostic Model",
+            "",
         "| banks | 64x32 macros | root span cycles | replay drain cycles | iterations |",
         "|---:|---:|---:|---:|---:|",
-    ]
-    for point in report["points"]:
+        ]
+    )
+    for point in report["inferred_memory_model_points"]:
         lines.append(
             "| {physical_banks} | {fakeram45_64x32_macros} | "
             "{root_delivery_span_cycles} | {replay_drain_cycles} | "
             "{schedule_iterations} |".format(**point)
         )
-    selection = report["selection"]
+    selection = report["selection_status"]
     lines.extend(
         [
             "",
-            "## Selection",
+            "## Current Candidates",
             "",
-            f"Four banks are selected: {selection['reason']}.",
+            selection["reason"] + ".",
             "",
-            f"- macro reduction versus 15 banks: `{selection['macro_reduction_vs_15_banks_pct']}%`",
-            "- replay-drain increase versus 15 banks: "
-            f"`{selection['replay_drain_increase_vs_15_banks_cycles']}` cycles",
-            f"- two-bank transport-span penalty: `{selection['two_bank_transport_span_penalty_pct']}%`",
-            "- one bank is excluded because it uses the same 32 macros as four banks with fewer ports",
+            f"- B4: `{selection['macro_reduction_vs_15_banks_pct']}%` fewer macros than B15, "
+            f"`+{selection['b4_latency_increase_vs_15_banks_pct']}%` latency",
+            f"- B8: `{selection['b8_macro_reduction_vs_15_banks_pct']}%` fewer macros than B15, "
+            f"`+{selection['b8_latency_increase_vs_15_banks_pct']}%` latency",
+            "- B15: measured full-chain throughput anchor",
+            "- B2 is dominated by B4 at the same 32-macro count",
             "- arithmetic and precision are unchanged; storage and replay remain bit-exact",
             "",
             "## Full-Chain RTL Validation",
             "",
-            "The selected B4 point passes the finite transport, decoder, and exact global-tree composition:",
+            "B2, B4, B8, and B15 pass the finite transport, registered SRAM, decoder, and exact global-tree composition:",
             "",
-            "- four retained `64x256` physical memories (`32` available `64x32` macros)",
             "- `1920` canonical remote beats, `2505` flits, and `315` packets",
             "- `128` exact final rows with every output lane equal to `65535`",
-            "- unchanged `2505`-cycle root delivery span",
-            "- final cycle `2613`, versus `2600` for fifteen banks (`+13`, `+0.5%`)",
+            "- structural tests retain the expected `32`, `32`, `64`, and `120` SRAM macros",
             "",
             "## Limits",
             "",

--- a/npu/eval/check_attention_score32_exact_shared_root_storage_physical_guard.py
+++ b/npu/eval/check_attention_score32_exact_shared_root_storage_physical_guard.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Guard exact shared-root storage macro physical-harness artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Sequence
+
+
+_CONFIG_KEY = "attention_score32_exact_shared_root_storage_physical_harness"
+_MANIFEST = "attention_score32_exact_shared_root_storage_physical_harness_manifest.json"
+_PROPOSAL_ID = "prop_l1_attention_score32_exact_shared_root_storage_macro_ppa_v1"
+_EXPECTED_MACROS = {2: 32, 4: 32, 8: 64, 15: 120}
+
+
+def _load(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit(f"expected JSON object: {path}")
+    return payload
+
+
+def check(design_dir: Path) -> None:
+    config = _load(design_dir / "config.json")
+    body = config.get(_CONFIG_KEY)
+    if not isinstance(body, dict):
+        raise SystemExit(f"config missing {_CONFIG_KEY}")
+    banks = int(body.get("physical_banks", 0))
+    if banks not in _EXPECTED_MACROS:
+        raise SystemExit(f"unsupported physical_banks={banks}")
+    top_name = str(config.get("top_name") or "").strip()
+    if not top_name or top_name != design_dir.name:
+        raise SystemExit("top_name must match the design directory")
+    report_links = config.get("report_links")
+    if not isinstance(report_links, dict) or report_links.get("proposal_id") != _PROPOSAL_ID:
+        raise SystemExit("config proposal linkage is missing or incorrect")
+
+    verilog_dir = design_dir / "verilog"
+    rtl = (verilog_dir / "top.v").read_text(encoding="utf-8")
+    manifest = _load(verilog_dir / _MANIFEST)
+    macro = _load(verilog_dir / "macro_manifest.json")
+    expected = _EXPECTED_MACROS[banks]
+    if manifest.get("top_name") != top_name or manifest.get("physical_banks") != banks:
+        raise SystemExit("generated harness manifest identity mismatch")
+    if manifest.get("macro_count") != expected:
+        raise SystemExit("generated harness macro count mismatch")
+    if manifest.get("linked_proposal_id") != _PROPOSAL_ID:
+        raise SystemExit("generated harness proposal linkage mismatch")
+    if manifest.get("top_pin_bits") != 228:
+        raise SystemExit("physical harness top-pin contract changed")
+    if macro.get("module") != top_name or macro.get("blackboxes") != ["fakeram45_64x32"]:
+        raise SystemExit("macro manifest module or blackbox mismatch")
+    params = macro.get("manifest_params")
+    if not isinstance(params, dict) or params.get("macro_count") != expected:
+        raise SystemExit("macro manifest inventory mismatch")
+    required_fragments = (
+        ".USE_FAKERAM(1)",
+        "local_reducer_aggregate_stats_once_exact_shared_root_storage_fabric",
+        "fakeram45_64x32 u_packet_mem",
+        "read_pending_q",
+        "folded_result_q",
+    )
+    missing = [fragment for fragment in required_fragments if fragment not in rtl]
+    if missing:
+        raise SystemExit(f"generated physical harness is incomplete: {missing}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--design-dir", type=Path, required=True)
+    args = parser.parse_args(argv)
+    check(args.design_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/tests/test_analyze_attention_score32_exact_stats_once_banked_root.py
+++ b/npu/eval/tests/test_analyze_attention_score32_exact_stats_once_banked_root.py
@@ -6,33 +6,33 @@ from npu.eval.analyze_attention_score32_exact_stats_once_banked_root import (
 )
 
 
-def test_report_selects_four_bank_minimum_macro_floor_point() -> None:
+def test_report_keeps_b4_b8_b15_until_macro_ppa() -> None:
     report = build_report()
 
-    assert report["selected_point"] == {
+    assert report["area_floor_point"] == {
         "physical_banks": 4,
         "fakeram45_64x32_macros": 32,
-        "root_delivery_span_cycles": 2505,
-        "replay_drain_cycles": 13,
-        "final_replay_cycle": 2533,
-        "max_slots_per_source": 2,
-        "schedule_iterations": 1,
-        "exact_transport": True,
+        "root_delivery_span_cycles": 2939,
+        "full_chain_final_cycle": 3077,
+        "latency_increase_vs_15_banks_pct": 17.442748,
+        "normalized_component_throughput_vs_15_banks": 0.851479,
+        "bit_exact": True,
     }
-    assert report["selection"]["macro_reduction_vs_15_banks_pct"] == 73.333333
-    assert report["selection"]["two_bank_transport_span_penalty_pct"] == 4.91018
-    assert report["rtl_validation"]["retained_bank_memories"] == 4
-    assert report["rtl_validation"]["full_chain_final_cycle"] == 2613
-    assert report["rtl_validation"]["full_chain_latency_increase_pct"] == 0.5
+    assert report["pareto_candidate_banks"] == [4, 8, 15]
+    assert report["selection_status"]["status"] == "awaiting_macro_ppa"
+    assert report["selection_status"]["macro_reduction_vs_15_banks_pct"] == 73.333333
+    assert report["selection_status"]["b8_latency_increase_vs_15_banks_pct"] == 8.969466
+    assert report["rtl_validation"]["validated_physical_banks"] == [2, 4, 8, 15]
     assert report["rtl_validation"]["bit_exact"] is True
-    assert "Precision is unchanged" in report["limitations"][2]
+    assert "Precision is unchanged" in report["limitations"][3]
 
 
 def test_markdown_keeps_noncomparable_metrics_in_separate_columns() -> None:
     markdown = render_markdown(build_report())
 
-    assert "| banks | 64x32 macros | root span cycles | replay drain cycles |" in markdown
-    assert "| 4 | 32 | 2505 | 13 | 1 |" in markdown
-    assert "Four banks are selected" in markdown
+    assert "## Registered-SRAM Full-Chain RTL" in markdown
+    assert "| 4 | 32 | 2939 | 3077 | +17.442748% | 0.851479 |" in markdown
+    assert "| 8 | 64 | 2733 | 2855 | +8.969466% | 0.917688 |" in markdown
+    assert "B4 minimizes SRAM count" in markdown
     assert "## Full-Chain RTL Validation" in markdown
-    assert "final cycle `2613`" in markdown
+    assert "B2 is dominated by B4" in markdown

--- a/npu/rtlgen/gen_attention_score32_exact_shared_root_storage_physical_harness.py
+++ b/npu/rtlgen/gen_attention_score32_exact_shared_root_storage_physical_harness.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Generate a narrow-I/O physical harness for exact shared-root packet SRAM."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_CONFIG_KEY = "attention_score32_exact_shared_root_storage_physical_harness"
+_GENERATOR = (
+    "npu/rtlgen/"
+    "gen_attention_score32_exact_shared_root_storage_physical_harness.py"
+)
+_SOURCE = (
+    REPO_ROOT
+    / "npu/sim/rtl/"
+    "local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter.sv"
+)
+_MANIFEST = "attention_score32_exact_shared_root_storage_physical_harness_manifest.json"
+_PROPOSAL_ID = "prop_l1_attention_score32_exact_shared_root_storage_macro_ppa_v1"
+_PROPOSAL_PATH = f"docs/proposals/{_PROPOSAL_ID}/proposal.json"
+_VALID_BANKS = (2, 4, 8, 15)
+
+
+def _load(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit(f"config must decode to an object: {path}")
+    return payload
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _validate(config: dict[str, Any]) -> tuple[str, int]:
+    top_name = str(config.get("top_name") or "").strip()
+    body = config.get(_CONFIG_KEY)
+    if not top_name or not isinstance(body, dict):
+        raise SystemExit(f"config requires top_name and {_CONFIG_KEY}")
+    physical_banks = int(body.get("physical_banks", 0))
+    if physical_banks not in _VALID_BANKS:
+        raise SystemExit(f"physical_banks must be one of {_VALID_BANKS}")
+    return top_name, physical_banks
+
+
+def _storage_modules() -> str:
+    source = _SOURCE.read_text(encoding="utf-8")
+    marker = "// Shared root receive adapter for the exact stats-once transport."
+    prefix, separator, _remainder = source.partition(marker)
+    if not separator or "shared_root_storage_fabric" not in prefix:
+        raise RuntimeError(f"unable to isolate shared-root storage modules from {_SOURCE}")
+    return prefix.rstrip()
+
+
+def _top(*, top_name: str, physical_banks: int) -> str:
+    return f"""// Generated narrow-I/O shared-root packet-storage physical harness.
+(* keep_hierarchy = 1 *)
+module {top_name} (
+  input wire clk,
+  input wire rst_n,
+  input wire start,
+  input wire [31:0] seed,
+  output wire done,
+  output wire [31:0] folded_result,
+  output wire [31:0] cycle_count,
+  output wire [31:0] write_count,
+  output wire [31:0] read_request_count,
+  output wire [31:0] read_response_count,
+  output wire [31:0] protocol_error_count
+);
+  localparam integer SOURCE_COUNT = 15;
+  localparam integer PHYSICAL_BANKS = {physical_banks};
+  localparam integer DATA_W = 256;
+  localparam integer ADDR_W = 4;
+  localparam [1:0] S_IDLE = 2'd0;
+  localparam [1:0] S_WRITE = 2'd1;
+  localparam [1:0] S_READ = 2'd2;
+  localparam [SOURCE_COUNT-1:0] ALL_SOURCES = {{SOURCE_COUNT{{1'b1}}}};
+
+  reg [1:0] state_q;
+  reg done_q;
+  reg [31:0] seed_q;
+  reg [3:0] source_q;
+  reg [3:0] logical_addr_q;
+  reg [SOURCE_COUNT-1:0] read_pending_q;
+  reg [SOURCE_COUNT-1:0] response_seen_q;
+  reg [31:0] folded_result_q;
+  reg [31:0] cycle_count_q;
+  reg [31:0] write_count_q;
+  reg [31:0] read_request_count_q;
+  reg [31:0] read_response_count_q;
+  reg [31:0] protocol_error_count_q;
+
+  reg [SOURCE_COUNT-1:0] write_valid_r;
+  wire [SOURCE_COUNT-1:0] write_ready_w;
+  reg [SOURCE_COUNT*ADDR_W-1:0] write_addr_r;
+  reg [SOURCE_COUNT*DATA_W-1:0] write_data_r;
+  reg [SOURCE_COUNT-1:0] read_req_valid_r;
+  wire [SOURCE_COUNT-1:0] read_req_ready_w;
+  reg [SOURCE_COUNT*ADDR_W-1:0] read_req_addr_r;
+  wire [SOURCE_COUNT-1:0] read_rsp_valid_w;
+  reg [SOURCE_COUNT-1:0] read_rsp_ready_r;
+  wire [SOURCE_COUNT*ADDR_W-1:0] read_rsp_addr_w;
+  wire [SOURCE_COUNT*DATA_W-1:0] read_rsp_data_w;
+  wire storage_protocol_error_w;
+  wire [SOURCE_COUNT-1:0] write_fire_w = write_valid_r & write_ready_w;
+  wire [SOURCE_COUNT-1:0] read_request_fire_w =
+    read_req_valid_r & read_req_ready_w;
+  wire [SOURCE_COUNT-1:0] read_response_fire_w =
+    read_rsp_valid_w & read_rsp_ready_r;
+
+  integer source_i;
+  integer lane_i;
+  integer request_count_now;
+  integer response_count_now;
+  reg [31:0] response_fold_now;
+  reg [31:0] lane_word_r;
+  always @* begin
+    write_valid_r = {{SOURCE_COUNT{{1'b0}}}};
+    write_addr_r = {{SOURCE_COUNT*ADDR_W{{1'b0}}}};
+    write_data_r = {{SOURCE_COUNT*DATA_W{{1'b0}}}};
+    read_req_valid_r = {{SOURCE_COUNT{{1'b0}}}};
+    read_req_addr_r = {{SOURCE_COUNT*ADDR_W{{1'b0}}}};
+    read_rsp_ready_r = {{SOURCE_COUNT{{1'b0}}}};
+    if (state_q == S_WRITE) begin
+      write_valid_r[source_q] = 1'b1;
+      write_addr_r[source_q*ADDR_W +: ADDR_W] = logical_addr_q;
+      for (lane_i = 0; lane_i < 8; lane_i = lane_i + 1) begin
+        lane_word_r = seed_q ^ {{24'd0, source_q, logical_addr_q}} ^
+          (32'h9e3779b9 * (lane_i + 1));
+        write_data_r[source_q*DATA_W + lane_i*32 +: 32] = lane_word_r;
+      end
+    end
+    if (state_q == S_READ) begin
+      read_req_valid_r = read_pending_q;
+      read_rsp_ready_r = ALL_SOURCES;
+      for (source_i = 0; source_i < SOURCE_COUNT; source_i = source_i + 1)
+        read_req_addr_r[source_i*ADDR_W +: ADDR_W] = logical_addr_q;
+    end
+
+    request_count_now = 0;
+    response_count_now = 0;
+    response_fold_now = 32'd0;
+    for (source_i = 0; source_i < SOURCE_COUNT; source_i = source_i + 1) begin
+      if (read_request_fire_w[source_i])
+        request_count_now = request_count_now + 1;
+      if (read_response_fire_w[source_i]) begin
+        response_count_now = response_count_now + 1;
+        for (lane_i = 0; lane_i < 8; lane_i = lane_i + 1)
+          response_fold_now = response_fold_now ^
+            read_rsp_data_w[source_i*DATA_W + lane_i*32 +: 32];
+      end
+    end
+  end
+
+  local_reducer_aggregate_stats_once_exact_shared_root_storage_fabric #(
+    .DATA_W(DATA_W),
+    .SOURCE_COUNT(SOURCE_COUNT),
+    .PHYSICAL_BANKS(PHYSICAL_BANKS),
+    .ADDR_W(ADDR_W),
+    .USE_FAKERAM(1)
+  ) storage (
+    .clk(clk), .rst_n(rst_n),
+    .write_valid(write_valid_r), .write_ready(write_ready_w),
+    .write_addr(write_addr_r), .write_data(write_data_r),
+    .read_req_valid(read_req_valid_r), .read_req_ready(read_req_ready_w),
+    .read_req_addr(read_req_addr_r), .read_rsp_valid(read_rsp_valid_w),
+    .read_rsp_ready(read_rsp_ready_r), .read_rsp_addr(read_rsp_addr_w),
+    .read_rsp_data(read_rsp_data_w), .protocol_error(storage_protocol_error_w)
+  );
+
+  assign done = done_q;
+  assign folded_result = folded_result_q;
+  assign cycle_count = cycle_count_q;
+  assign write_count = write_count_q;
+  assign read_request_count = read_request_count_q;
+  assign read_response_count = read_response_count_q;
+  assign protocol_error_count = protocol_error_count_q;
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      state_q <= S_IDLE;
+      done_q <= 1'b0;
+      seed_q <= 32'd0;
+      source_q <= 4'd0;
+      logical_addr_q <= 4'd0;
+      read_pending_q <= {{SOURCE_COUNT{{1'b0}}}};
+      response_seen_q <= {{SOURCE_COUNT{{1'b0}}}};
+      folded_result_q <= 32'd0;
+      cycle_count_q <= 32'd0;
+      write_count_q <= 32'd0;
+      read_request_count_q <= 32'd0;
+      read_response_count_q <= 32'd0;
+      protocol_error_count_q <= 32'd0;
+    end else begin
+      if (state_q != S_IDLE)
+        cycle_count_q <= cycle_count_q + 1'b1;
+      if (storage_protocol_error_w)
+        protocol_error_count_q <= protocol_error_count_q + 1'b1;
+      if (request_count_now != 0)
+        read_request_count_q <= read_request_count_q + request_count_now;
+      if (response_count_now != 0) begin
+        read_response_count_q <= read_response_count_q + response_count_now;
+        folded_result_q <= folded_result_q ^ response_fold_now;
+      end
+
+      case (state_q)
+        S_IDLE: begin
+          if (start && !done_q) begin
+            state_q <= S_WRITE;
+            seed_q <= seed == 0 ? 32'h1 : seed;
+            source_q <= 4'd0;
+            logical_addr_q <= 4'd0;
+          end
+        end
+        S_WRITE: begin
+          if (write_fire_w[source_q]) begin
+            write_count_q <= write_count_q + 1'b1;
+            if (logical_addr_q == 4'd15) begin
+              logical_addr_q <= 4'd0;
+              if (source_q == 4'd14) begin
+                state_q <= S_READ;
+                read_pending_q <= ALL_SOURCES;
+                response_seen_q <= {{SOURCE_COUNT{{1'b0}}}};
+              end else begin
+                source_q <= source_q + 1'b1;
+              end
+            end else begin
+              logical_addr_q <= logical_addr_q + 1'b1;
+            end
+          end
+        end
+        S_READ: begin
+          read_pending_q <= read_pending_q & ~read_request_fire_w;
+          response_seen_q <= response_seen_q | read_response_fire_w;
+          if (((read_pending_q & ~read_request_fire_w) == 0) &&
+              ((response_seen_q | read_response_fire_w) == ALL_SOURCES)) begin
+            if (logical_addr_q == 4'd15) begin
+              state_q <= S_IDLE;
+              done_q <= 1'b1;
+            end else begin
+              logical_addr_q <= logical_addr_q + 1'b1;
+              read_pending_q <= ALL_SOURCES;
+              response_seen_q <= {{SOURCE_COUNT{{1'b0}}}};
+            end
+          end
+        end
+        default: state_q <= S_IDLE;
+      endcase
+    end
+  end
+endmodule
+"""
+
+
+def generate(config: dict[str, Any], out_dir: Path) -> None:
+    top_name, physical_banks = _validate(json.loads(json.dumps(config)))
+    storage_rtl = _storage_modules()
+    top_rtl = _top(top_name=top_name, physical_banks=physical_banks)
+    rtl = storage_rtl + "\n\n" + top_rtl
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "top.v").write_text(rtl + "\n", encoding="utf-8")
+    (out_dir / "config.json").write_text(
+        json.dumps(config, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    macro_count = {
+        2: 32,
+        4: 32,
+        8: 64,
+        15: 120,
+    }[physical_banks]
+    manifest = {
+        "version": 1,
+        "generator": _GENERATOR,
+        "top_name": top_name,
+        "semantic_profile": "score32_exact_shared_root_storage_macro_physical_v1",
+        "physical_banks": physical_banks,
+        "logical_sources": 15,
+        "logical_words": 240,
+        "word_bits": 256,
+        "macro_type": "fakeram45_64x32",
+        "macro_count": macro_count,
+        "macro_area_um2": macro_count * 20.14 * 61.6,
+        "top_pin_bits": 228,
+        "traffic": {
+            "writes": 240,
+            "read_requests": 240,
+            "read_responses": 240,
+            "parallel_read_sources": 15,
+            "observable_fold": True,
+        },
+        "linked_proposal_id": _PROPOSAL_ID,
+        "linked_proposal_path": _PROPOSAL_PATH,
+        "source_rtl": str(_SOURCE.relative_to(REPO_ROOT)),
+        "generated_top_sha256": _sha256_text(rtl),
+    }
+    (out_dir / _MANIFEST).write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    macro_manifest = {
+        "version": "0.1",
+        "design_id": top_name,
+        "module": top_name,
+        "platform": "nangate45",
+        "flow_variant": "score32_exact_shared_root_storage_macro_v1",
+        "blackboxes": ["fakeram45_64x32"],
+        "additional_lefs": [
+            "/orfs/flow/platforms/nangate45/lef/fakeram45_64x32.lef"
+        ],
+        "additional_libs": [
+            "/orfs/flow/platforms/nangate45/lib/fakeram45_64x32.lib"
+        ],
+        "additional_gds": [],
+        "blackbox_verilog": ["npu/rtl/fakeram45_64x32_blackbox.v"],
+        "source": {"mode": "generated_physical_harness", "generator": _GENERATOR},
+        "manifest_params": {
+            "physical_banks": physical_banks,
+            "logical_sources": 15,
+            "macro_count": macro_count,
+            "macros_per_256_bit_row": 8,
+        },
+    }
+    (out_dir / "macro_manifest.json").write_text(
+        json.dumps(macro_manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    generate(_load(args.config), args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition.sv
+++ b/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition.sv
@@ -20,7 +20,8 @@ module local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composit
   parameter integer LEAF_COUNT = 16,
   parameter integer BEAT_W = 419,
   parameter integer ROOT_ENDPOINT_ID = 15,
-  parameter integer PHYSICAL_BANKS = 15
+  parameter integer PHYSICAL_BANKS = 15,
+  parameter integer USE_FAKERAM = 0
 ) (
   input wire clk,
   input wire rst_n,
@@ -111,7 +112,8 @@ module local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composit
     .FLIT_COUNT_W(FLIT_COUNT_W),
     .SOURCE_COUNT(SOURCE_COUNT),
     .ROOT_ENDPOINT_ID(ROOT_ENDPOINT_ID),
-    .PHYSICAL_BANKS(PHYSICAL_BANKS)
+    .PHYSICAL_BANKS(PHYSICAL_BANKS),
+    .USE_FAKERAM(USE_FAKERAM)
   ) root_rx (
     .clk(clk), .rst_n(rst_n),
     .group_ctx_valid(atomic_ctx_valid_w),

--- a/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter.sv
+++ b/npu/sim/rtl/local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter.sv
@@ -6,11 +6,13 @@
 module local_reducer_aggregate_stats_once_exact_shared_root_bank_memory #(
   parameter integer DATA_W = 256,
   parameter integer ADDR_W = 6,
-  parameter integer DEPTH = 64
+  parameter integer DEPTH = 64,
+  parameter integer USE_FAKERAM = 0
 ) (
   input wire clk,
   input wire rst_n,
   input wire write_valid,
+  output wire write_ready,
   input wire [ADDR_W-1:0] write_addr,
   input wire [DATA_W-1:0] write_data,
   input wire read_req_valid,
@@ -21,42 +23,126 @@ module local_reducer_aggregate_stats_once_exact_shared_root_bank_memory #(
   output wire [ADDR_W-1:0] read_rsp_addr,
   output wire [DATA_W-1:0] read_rsp_data
 );
-  reg [DATA_W-1:0] mem [0:DEPTH-1];
-  reg read_rsp_valid_q;
-  reg [ADDR_W-1:0] read_rsp_addr_q;
-  reg [DATA_W-1:0] read_rsp_data_q;
+  generate
+    if (USE_FAKERAM == 0) begin : gen_inferred_memory
+      reg [DATA_W-1:0] mem [0:DEPTH-1];
+      reg read_rsp_valid_q;
+      reg [ADDR_W-1:0] read_rsp_addr_q;
+      reg [DATA_W-1:0] read_rsp_data_q;
 
-  // The fabric never presents a read while write_valid is asserted.  Keep
-  // the priority here as well so the bank remains safe as a standalone unit.
-  assign read_req_ready = !write_valid &&
-    (!read_rsp_valid_q || read_rsp_ready);
-  assign read_rsp_valid = read_rsp_valid_q;
-  assign read_rsp_addr = read_rsp_addr_q;
-  assign read_rsp_data = read_rsp_data_q;
+      assign write_ready = 1'b1;
+      assign read_req_ready = !write_valid &&
+        (!read_rsp_valid_q || read_rsp_ready);
+      assign read_rsp_valid = read_rsp_valid_q;
+      assign read_rsp_addr = read_rsp_addr_q;
+      assign read_rsp_data = read_rsp_data_q;
 
-  always @(posedge clk) begin
-    if (write_valid)
-      mem[write_addr] <= write_data;
-    if (read_req_valid && read_req_ready) begin
-      read_rsp_addr_q <= read_req_addr;
-      read_rsp_data_q <= mem[read_req_addr];
+      always @(posedge clk) begin
+        if (write_valid)
+          mem[write_addr] <= write_data;
+        if (read_req_valid && read_req_ready) begin
+          read_rsp_addr_q <= read_req_addr;
+          read_rsp_data_q <= mem[read_req_addr];
+        end
+      end
+
+      always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+          read_rsp_valid_q <= 1'b0;
+        end else if (read_req_valid && read_req_ready) begin
+          read_rsp_valid_q <= 1'b1;
+        end else if (read_rsp_valid_q && read_rsp_ready) begin
+          read_rsp_valid_q <= 1'b0;
+        end
+      end
+    end else begin : gen_fakeram_memory
+      localparam integer MACRO_DEPTH = 64;
+      localparam integer MACRO_WIDTH = 32;
+      localparam integer DEPTH_MACROS =
+        (DEPTH + MACRO_DEPTH - 1) / MACRO_DEPTH;
+      localparam integer WIDTH_MACROS = DATA_W / MACRO_WIDTH;
+      localparam integer PHYSICAL_BITS = WIDTH_MACROS * MACRO_WIDTH;
+      localparam [1:0] S_IDLE = 2'd0;
+      localparam [1:0] S_READ_WAIT = 2'd1;
+      localparam [1:0] S_RESPONSE = 2'd2;
+
+      reg [1:0] state_q;
+      reg [ADDR_W-1:0] read_rsp_addr_q;
+      wire response_replaced_w = state_q == S_RESPONSE && read_rsp_ready;
+      wire operation_ready_w = state_q == S_IDLE || response_replaced_w;
+      wire write_fire_w = write_valid && operation_ready_w;
+      wire read_fire_w = read_req_valid && read_req_ready;
+      wire [ADDR_W-1:0] operation_addr_w =
+        write_fire_w ? write_addr : read_req_addr;
+      wire [ADDR_W+5:0] extended_operation_addr_w =
+        {{6{1'b0}}, operation_addr_w};
+      wire [DEPTH_MACROS*PHYSICAL_BITS-1:0] macro_read_words_w;
+      wire [PHYSICAL_BITS-1:0] selected_read_word_w =
+        macro_read_words_w[
+          (read_rsp_addr_q / MACRO_DEPTH) * PHYSICAL_BITS +: PHYSICAL_BITS];
+
+      assign write_ready = operation_ready_w;
+      assign read_req_ready = operation_ready_w && !write_valid;
+      assign read_rsp_valid = state_q == S_RESPONSE;
+      assign read_rsp_addr = read_rsp_addr_q;
+      assign read_rsp_data = selected_read_word_w[DATA_W-1:0];
+
+      genvar depth_g;
+      genvar width_g;
+      for (depth_g = 0; depth_g < DEPTH_MACROS; depth_g = depth_g + 1) begin : gen_depth
+        for (width_g = 0; width_g < WIDTH_MACROS; width_g = width_g + 1) begin : gen_width
+          fakeram45_64x32 u_packet_mem (
+            .rd_out(macro_read_words_w[
+              (depth_g * PHYSICAL_BITS) + (width_g * MACRO_WIDTH) +: MACRO_WIDTH]),
+            .addr_in(extended_operation_addr_w[5:0]),
+            .we_in(write_fire_w),
+            .wd_in(write_data[width_g*MACRO_WIDTH +: MACRO_WIDTH]),
+            .w_mask_in({MACRO_WIDTH{1'b1}}),
+            .clk(clk),
+            .ce_in((write_fire_w || read_fire_w) &&
+              ((operation_addr_w / MACRO_DEPTH) == depth_g))
+          );
+        end
+      end
+
+      always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+          state_q <= S_IDLE;
+          read_rsp_addr_q <= {ADDR_W{1'b0}};
+        end else begin
+          case (state_q)
+            S_IDLE: begin
+              if (read_fire_w) begin
+                read_rsp_addr_q <= read_req_addr;
+                state_q <= S_READ_WAIT;
+              end
+            end
+            S_READ_WAIT: state_q <= S_RESPONSE;
+            S_RESPONSE: begin
+              if (read_rsp_ready) begin
+                if (read_fire_w) begin
+                  read_rsp_addr_q <= read_req_addr;
+                  state_q <= S_READ_WAIT;
+                end else begin
+                  state_q <= S_IDLE;
+                end
+              end
+            end
+            default: state_q <= S_IDLE;
+          endcase
+        end
+      end
     end
-  end
-
-  always @(posedge clk or negedge rst_n) begin
-    if (!rst_n) begin
-      read_rsp_valid_q <= 1'b0;
-    end else if (read_req_valid && read_req_ready) begin
-      read_rsp_valid_q <= 1'b1;
-    end else if (read_rsp_valid_q && read_rsp_ready) begin
-      read_rsp_valid_q <= 1'b0;
-    end
-  end
+  endgenerate
 
 `ifndef SYNTHESIS
   initial begin
     if (DEPTH != (1 << ADDR_W)) begin
       $error("shared-root bank depth must match its address width");
+      $finish(1);
+    end
+    if (USE_FAKERAM != 0 && (DATA_W % 32) != 0) begin
+      $error("fakeram shared-root banks require 32-bit width granularity");
       $finish(1);
     end
   end
@@ -71,7 +157,8 @@ module local_reducer_aggregate_stats_once_exact_shared_root_storage_fabric #(
   parameter integer DATA_W = 256,
   parameter integer SOURCE_COUNT = 15,
   parameter integer PHYSICAL_BANKS = 15,
-  parameter integer ADDR_W = 4
+  parameter integer ADDR_W = 4,
+  parameter integer USE_FAKERAM = 0
 ) (
   input wire clk,
   input wire rst_n,
@@ -99,6 +186,7 @@ module local_reducer_aggregate_stats_once_exact_shared_root_storage_fabric #(
     (SOURCE_COUNT <= 1) ? 1 : $clog2(SOURCE_COUNT);
 
   wire [PHYSICAL_BANKS-1:0] bank_write_valid_w;
+  wire [PHYSICAL_BANKS-1:0] bank_write_ready_w;
   wire [PHYSICAL_BANKS-1:0] bank_read_req_valid_w;
   wire [PHYSICAL_BANKS-1:0] bank_read_req_ready_w;
   wire [PHYSICAL_BANKS-1:0] bank_read_rsp_valid_w;
@@ -230,8 +318,8 @@ module local_reducer_aggregate_stats_once_exact_shared_root_storage_fabric #(
       for (source_route_g = 0; source_route_g < SOURCE_COUNT;
            source_route_g = source_route_g + 1) begin : gen_source_route
         if ((source_route_g % PHYSICAL_BANKS) == BANK_ID) begin : gen_mapped_source
-          assign write_ready[source_route_g] = !selected_write_r ||
-            (selected_write_i == source_route_g);
+          assign write_ready[source_route_g] = bank_write_ready_w[BANK_ID] &&
+            (!selected_write_r || (selected_write_i == source_route_g));
           assign read_req_ready[source_route_g] = bank_read_req_ready_w[BANK_ID] &&
             !selected_write_r && selected_read_r &&
             (selected_source_i == source_route_g);
@@ -239,10 +327,12 @@ module local_reducer_aggregate_stats_once_exact_shared_root_storage_fabric #(
       end
 
       local_reducer_aggregate_stats_once_exact_shared_root_bank_memory #(
-        .DATA_W(DATA_W), .ADDR_W(BANK_ADDR_W), .DEPTH(BANK_DEPTH)
+        .DATA_W(DATA_W), .ADDR_W(BANK_ADDR_W), .DEPTH(BANK_DEPTH),
+        .USE_FAKERAM(USE_FAKERAM)
       ) bank_memory (
         .clk(clk), .rst_n(rst_n),
         .write_valid(bank_write_valid_w[BANK_ID]),
+        .write_ready(bank_write_ready_w[BANK_ID]),
         .write_addr(bank_write_addr_w[BANK_ID*BANK_ADDR_W +: BANK_ADDR_W]),
         .write_data(bank_write_data_w[BANK_ID*DATA_W +: DATA_W]),
         .read_req_valid(bank_read_req_valid_w[BANK_ID]),
@@ -317,7 +407,8 @@ module local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter #(
   parameter integer FLIT_COUNT_W = 4,
   parameter integer SOURCE_COUNT = 15,
   parameter integer ROOT_ENDPOINT_ID = 15,
-  parameter integer PHYSICAL_BANKS = 15
+  parameter integer PHYSICAL_BANKS = 15,
+  parameter integer USE_FAKERAM = 0
 ) (
   input wire clk,
   input wire rst_n,
@@ -600,7 +691,7 @@ module local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter #(
   // genuinely shared-bank configuration such as PHYSICAL_BANKS=4.
   genvar physical_bank_g;
   generate
-    if (PHYSICAL_BANKS == SOURCE_COUNT) begin : gen_compat_source_banks
+    if (PHYSICAL_BANKS == SOURCE_COUNT && USE_FAKERAM == 0) begin : gen_compat_source_banks
       for (physical_bank_g = 0; physical_bank_g < SOURCE_COUNT;
            physical_bank_g = physical_bank_g + 1) begin : gen_source_bank
         localparam integer BANK_SOURCE_ID = physical_bank_g;
@@ -625,7 +716,8 @@ module local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter #(
     end else begin : gen_shared_physical_banks
       local_reducer_aggregate_stats_once_exact_shared_root_storage_fabric #(
         .DATA_W(DATA_W), .SOURCE_COUNT(SOURCE_COUNT),
-        .PHYSICAL_BANKS(PHYSICAL_BANKS), .ADDR_W(4)
+        .PHYSICAL_BANKS(PHYSICAL_BANKS), .ADDR_W(4),
+        .USE_FAKERAM(USE_FAKERAM)
       ) storage_fabric (
         .clk(clk), .rst_n(rst_n),
         .write_valid(storage_write_valid_w),

--- a/runs/campaigns/npu/attention_score32_exact_shared_root_storage_macro_ppa_v1/sweeps/nangate45_b15.json
+++ b/runs/campaigns/npu/attention_score32_exact_shared_root_storage_macro_ppa_v1/sweeps/nangate45_b15.json
@@ -1,0 +1,10 @@
+{
+  "tag_prefix": "attention_score32_exact_shared_root_storage_macro_b15_v1",
+  "flow_params": {
+    "CLOCK_PERIOD": [4.0, 6.0, 8.0, 10.0, 12.0],
+    "DIE_AREA": ["0 0 850 850"],
+    "CORE_AREA": ["50 50 800 800"],
+    "PLACE_DENSITY": [0.4],
+    "SYNTH_HIERARCHICAL": [1]
+  }
+}

--- a/runs/campaigns/npu/attention_score32_exact_shared_root_storage_macro_ppa_v1/sweeps/nangate45_b2.json
+++ b/runs/campaigns/npu/attention_score32_exact_shared_root_storage_macro_ppa_v1/sweeps/nangate45_b2.json
@@ -1,0 +1,10 @@
+{
+  "tag_prefix": "attention_score32_exact_shared_root_storage_macro_b2_v1",
+  "flow_params": {
+    "CLOCK_PERIOD": [4.0, 6.0, 8.0, 10.0, 12.0],
+    "DIE_AREA": ["0 0 500 500"],
+    "CORE_AREA": ["50 50 450 450"],
+    "PLACE_DENSITY": [0.4],
+    "SYNTH_HIERARCHICAL": [1]
+  }
+}

--- a/runs/campaigns/npu/attention_score32_exact_shared_root_storage_macro_ppa_v1/sweeps/nangate45_b4.json
+++ b/runs/campaigns/npu/attention_score32_exact_shared_root_storage_macro_ppa_v1/sweeps/nangate45_b4.json
@@ -1,0 +1,10 @@
+{
+  "tag_prefix": "attention_score32_exact_shared_root_storage_macro_b4_v1",
+  "flow_params": {
+    "CLOCK_PERIOD": [4.0, 6.0, 8.0, 10.0, 12.0],
+    "DIE_AREA": ["0 0 500 500"],
+    "CORE_AREA": ["50 50 450 450"],
+    "PLACE_DENSITY": [0.4],
+    "SYNTH_HIERARCHICAL": [1]
+  }
+}

--- a/runs/campaigns/npu/attention_score32_exact_shared_root_storage_macro_ppa_v1/sweeps/nangate45_b8.json
+++ b/runs/campaigns/npu/attention_score32_exact_shared_root_storage_macro_ppa_v1/sweeps/nangate45_b8.json
@@ -1,0 +1,10 @@
+{
+  "tag_prefix": "attention_score32_exact_shared_root_storage_macro_b8_v1",
+  "flow_params": {
+    "CLOCK_PERIOD": [4.0, 6.0, 8.0, 10.0, 12.0],
+    "DIE_AREA": ["0 0 650 650"],
+    "CORE_AREA": ["50 50 600 600"],
+    "PLACE_DENSITY": [0.4],
+    "SYNTH_HIERARCHICAL": [1]
+  }
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b15/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b15/config.json
@@ -1,0 +1,10 @@
+{
+  "top_name": "attention_score32_exact_shared_root_storage_macro_b15",
+  "attention_score32_exact_shared_root_storage_physical_harness": {
+    "physical_banks": 15
+  },
+  "report_links": {
+    "proposal_id": "prop_l1_attention_score32_exact_shared_root_storage_macro_ppa_v1",
+    "proposal_path": "docs/proposals/prop_l1_attention_score32_exact_shared_root_storage_macro_ppa_v1/proposal.json"
+  }
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b2/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b2/config.json
@@ -1,0 +1,10 @@
+{
+  "top_name": "attention_score32_exact_shared_root_storage_macro_b2",
+  "attention_score32_exact_shared_root_storage_physical_harness": {
+    "physical_banks": 2
+  },
+  "report_links": {
+    "proposal_id": "prop_l1_attention_score32_exact_shared_root_storage_macro_ppa_v1",
+    "proposal_path": "docs/proposals/prop_l1_attention_score32_exact_shared_root_storage_macro_ppa_v1/proposal.json"
+  }
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b4/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b4/config.json
@@ -1,0 +1,10 @@
+{
+  "top_name": "attention_score32_exact_shared_root_storage_macro_b4",
+  "attention_score32_exact_shared_root_storage_physical_harness": {
+    "physical_banks": 4
+  },
+  "report_links": {
+    "proposal_id": "prop_l1_attention_score32_exact_shared_root_storage_macro_ppa_v1",
+    "proposal_path": "docs/proposals/prop_l1_attention_score32_exact_shared_root_storage_macro_ppa_v1/proposal.json"
+  }
+}

--- a/runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b8/config.json
+++ b/runs/designs/npu_blocks/attention_score32_exact_shared_root_storage_macro_b8/config.json
@@ -1,0 +1,10 @@
+{
+  "top_name": "attention_score32_exact_shared_root_storage_macro_b8",
+  "attention_score32_exact_shared_root_storage_physical_harness": {
+    "physical_banks": 8
+  },
+  "report_links": {
+    "proposal_id": "prop_l1_attention_score32_exact_shared_root_storage_macro_ppa_v1",
+    "proposal_path": "docs/proposals/prop_l1_attention_score32_exact_shared_root_storage_macro_ppa_v1/proposal.json"
+  }
+}

--- a/tests/local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition_tb.sv
+++ b/tests/local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition_tb.sv
@@ -19,6 +19,11 @@ module local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composit
 `else
   localparam integer ROOT_PHYSICAL_BANKS = SOURCE_COUNT;
 `endif
+`ifdef SHARED_ROOT_USE_FAKERAM
+  localparam integer ROOT_USE_FAKERAM = `SHARED_ROOT_USE_FAKERAM;
+`else
+  localparam integer ROOT_USE_FAKERAM = 0;
+`endif
 
   reg clk = 1'b0;
   reg rst_n = 1'b0;
@@ -234,7 +239,8 @@ module local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composit
   endgenerate
 
   local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition #(
-    .PHYSICAL_BANKS(ROOT_PHYSICAL_BANKS)
+    .PHYSICAL_BANKS(ROOT_PHYSICAL_BANKS),
+    .USE_FAKERAM(ROOT_USE_FAKERAM)
   ) composition (
     .clk(clk), .rst_n(rst_n),
     .group_ctx_valid(context_fire),
@@ -375,8 +381,8 @@ module local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composit
     end else begin
       cycle <= cycle + 1;
       if (cycle >= SIM_TIMEOUT_CYCLES) begin
-        $display("TIMEOUT banks=%0d root_rows=%0d root_local=%0d flits=%0d desc=%0d comp=%0d replay=%0d slots=%0d source0=%0d source14=%0d",
-          ROOT_PHYSICAL_BANKS, root_count, root_beat_index,
+        $display("TIMEOUT banks=%0d use_fakeram=%0d root_rows=%0d root_local=%0d flits=%0d desc=%0d comp=%0d replay=%0d slots=%0d source0=%0d source14=%0d",
+          ROOT_PHYSICAL_BANKS, ROOT_USE_FAKERAM, root_count, root_beat_index,
           root_accepted_flit_count, root_descriptor_install_count,
           root_completion_count, root_replay_packet_count,
           max_occupied_slots, source_beat_index[0], source_beat_index[14]);
@@ -430,13 +436,18 @@ module local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composit
               root_replay_packet_count !== SOURCE_COUNT*GROUP_PACKETS ||
               source_desc_sum !== SOURCE_COUNT*GROUP_PACKETS ||
               source_mask !== {SOURCE_COUNT{1'b1}} ||
-              (root_last_delivery_cycle - root_first_delivery_cycle + 1) !==
-                SOURCE_COUNT*GROUP_FLITS ||
+              (!ROOT_USE_FAKERAM &&
+               (root_last_delivery_cycle - root_first_delivery_cycle + 1) !==
+                 SOURCE_COUNT*GROUP_FLITS) ||
               max_occupied_slots > SOURCE_COUNT*2)
-            $fatal(1, "transport count mismatch flits=%0d desc=%0d comp=%0d replay=%0d txdesc=%0d",
+            $fatal(1, "transport count mismatch flits=%0d desc=%0d comp=%0d replay=%0d txdesc=%0d source_mask=%h root_span=%0d slots=%0d",
               root_accepted_flit_count, root_descriptor_install_count,
-              root_completion_count, root_replay_packet_count, source_desc_sum);
-          $display("PASS full_chain rows=%0d remote_beats=%0d flits=%0d packets=%0d descriptors=%0d completions=%0d replays=%0d source_mask=%h root_delivery_span=%0d final_cycle=%0d tree_drain_cycles=%0d max_aggregate_slots=%0d slots_per_source=2",
+              root_completion_count, root_replay_packet_count, source_desc_sum,
+              source_mask,
+              root_last_delivery_cycle - root_first_delivery_cycle + 1,
+              max_occupied_slots);
+          $display("PASS full_chain banks=%0d use_fakeram=%0d rows=%0d remote_beats=%0d flits=%0d packets=%0d descriptors=%0d completions=%0d replays=%0d source_mask=%h root_delivery_span=%0d final_cycle=%0d tree_drain_cycles=%0d max_aggregate_slots=%0d slots_per_source=2",
+            ROOT_PHYSICAL_BANKS, ROOT_USE_FAKERAM,
             root_count, SOURCE_COUNT*GROUP_BEATS, root_accepted_flit_count,
             SOURCE_COUNT*GROUP_PACKETS, root_descriptor_install_count,
             root_completion_count, root_replay_packet_count,

--- a/tests/local_reducer_aggregate_stats_once_exact_shared_root_storage_fabric_b4_tb.sv
+++ b/tests/local_reducer_aggregate_stats_once_exact_shared_root_storage_fabric_b4_tb.sv
@@ -9,6 +9,11 @@ module local_reducer_aggregate_stats_once_exact_shared_root_storage_fabric_b4_tb
   localparam integer PHYSICAL_BANKS = 4;
   localparam integer DATA_W = 256;
   localparam integer ADDR_W = 4;
+`ifdef SHARED_ROOT_USE_FAKERAM
+  localparam integer USE_FAKERAM = `SHARED_ROOT_USE_FAKERAM;
+`else
+  localparam integer USE_FAKERAM = 0;
+`endif
   localparam integer PACKET_COUNT = 21;
   localparam integer FLITS_PER_SOURCE = 167;
   localparam integer CANONICAL_BEATS_PER_SOURCE = 128;
@@ -37,7 +42,8 @@ module local_reducer_aggregate_stats_once_exact_shared_root_storage_fabric_b4_tb
 
   local_reducer_aggregate_stats_once_exact_shared_root_storage_fabric #(
     .DATA_W(DATA_W), .SOURCE_COUNT(SOURCE_COUNT),
-    .PHYSICAL_BANKS(PHYSICAL_BANKS), .ADDR_W(ADDR_W)
+    .PHYSICAL_BANKS(PHYSICAL_BANKS), .ADDR_W(ADDR_W),
+    .USE_FAKERAM(USE_FAKERAM)
   ) fabric (
     .clk(clk), .rst_n(rst_n),
     .write_valid(write_valid), .write_ready(write_ready),
@@ -288,8 +294,8 @@ module local_reducer_aggregate_stats_once_exact_shared_root_storage_fabric_b4_tb
         write_packet_count, TOTAL_PACKETS, read_request_count, TOTAL_FLITS,
         exact_errors, overwrite_errors, protocol_error);
     end
-    $display("PASS shared_root_storage_b4 canonical_beats=%0d flits=%0d packets=%0d exact_outputs=%0d overwrite_errors=%0d independent_backpressure=1",
-      TOTAL_CANONICAL_BEATS, read_flit_count, read_packet_count,
+    $display("PASS shared_root_storage_b4 use_fakeram=%0d canonical_beats=%0d flits=%0d packets=%0d exact_outputs=%0d overwrite_errors=%0d independent_backpressure=1",
+      USE_FAKERAM, TOTAL_CANONICAL_BEATS, read_flit_count, read_packet_count,
       read_flit_count, overwrite_errors);
     $finish;
   end

--- a/tests/test_attention_score32_exact_shared_root_storage_physical_harness.py
+++ b/tests/test_attention_score32_exact_shared_root_storage_physical_harness.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+from control_plane.services.l1_task_generator import _read_config_target
+from npu.eval.check_attention_score32_exact_shared_root_storage_physical_guard import (
+    main as guard_main,
+)
+from npu.rtlgen.gen_attention_score32_exact_shared_root_storage_physical_harness import (
+    generate,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FAKERAM_MODEL = REPO_ROOT / "npu/sim/rtl/fakeram45_64x32_model.sv"
+FAKERAM_BLACKBOX = REPO_ROOT / "npu/rtl/fakeram45_64x32_blackbox.v"
+EXPECTED_MACROS = {2: 32, 4: 32, 8: 64, 15: 120}
+PROPOSAL_ID = "prop_l1_attention_score32_exact_shared_root_storage_macro_ppa_v1"
+
+
+def _tool(name: str) -> str:
+    path = shutil.which(name)
+    if path:
+        return path
+    fallback = Path("/oss-cad-suite/bin") / name
+    if fallback.exists():
+        return str(fallback)
+    pytest.skip(f"{name} unavailable")
+
+
+def _config(top: str, banks: int) -> dict:
+    return {
+        "top_name": top,
+        "attention_score32_exact_shared_root_storage_physical_harness": {
+            "physical_banks": banks,
+        },
+    }
+
+
+@pytest.mark.parametrize("banks", [2, 4, 8, 15])
+def test_generator_retains_expected_macro_inventory(tmp_path: Path, banks: int) -> None:
+    top = f"shared_root_storage_macro_b{banks}"
+    generate(_config(top, banks), tmp_path)
+    manifest = json.loads(
+        (
+            tmp_path
+            / "attention_score32_exact_shared_root_storage_physical_harness_manifest.json"
+        ).read_text(encoding="utf-8")
+    )
+    macro_manifest = json.loads(
+        (tmp_path / "macro_manifest.json").read_text(encoding="utf-8")
+    )
+
+    assert manifest["physical_banks"] == banks
+    assert manifest["macro_count"] == EXPECTED_MACROS[banks]
+    assert manifest["macro_area_um2"] == pytest.approx(
+        EXPECTED_MACROS[banks] * 20.14 * 61.6
+    )
+    assert manifest["top_pin_bits"] == 228
+    assert manifest["traffic"]["writes"] == 240
+    assert macro_manifest["blackboxes"] == ["fakeram45_64x32"]
+    assert macro_manifest["manifest_params"]["macro_count"] == EXPECTED_MACROS[banks]
+
+    lint = subprocess.run(
+        [
+            _tool("verilator"),
+            "--lint-only",
+            "-Wno-WIDTHEXPAND",
+            "-Wno-WIDTHTRUNC",
+            "-Wno-UNUSEDSIGNAL",
+            "-Wno-UNDRIVEN",
+            "-Wno-TIMESCALEMOD",
+            "-Wno-SIDEEFFECT",
+            "-Wno-LATCH",
+            "-Wno-UNOPTFLAT",
+            "-Wno-MULTIDRIVEN",
+            "--top-module",
+            top,
+            str(tmp_path / "top.v"),
+            str(FAKERAM_BLACKBOX),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert lint.returncode == 0, lint.stderr
+
+
+@pytest.mark.parametrize("banks", [2, 4, 8, 15])
+def test_harness_completes_all_macro_reads_and_writes(
+    tmp_path: Path,
+    banks: int,
+) -> None:
+    top = f"shared_root_storage_macro_b{banks}"
+    generate(_config(top, banks), tmp_path)
+    tb = tmp_path / "tb.sv"
+    tb.write_text(
+        f"""`timescale 1ns/1ps
+module tb;
+  reg clk = 0; always #5 clk = ~clk;
+  reg rst_n = 0;
+  reg start = 0;
+  reg [31:0] seed = 32'h12345678;
+  wire done;
+  wire [31:0] folded_result;
+  wire [31:0] cycle_count;
+  wire [31:0] write_count;
+  wire [31:0] read_request_count;
+  wire [31:0] read_response_count;
+  wire [31:0] protocol_error_count;
+  {top} dut (.*);
+  initial begin
+    repeat (4) @(posedge clk); rst_n <= 1;
+    repeat (2) @(posedge clk); start <= 1;
+    @(posedge clk); start <= 0;
+    wait (done); @(posedge clk);
+    if (write_count != 240 || read_request_count != 240 ||
+        read_response_count != 240 || protocol_error_count != 0)
+      $fatal(1, "invalid harness counts w=%0d rq=%0d rs=%0d err=%0d",
+        write_count, read_request_count, read_response_count,
+        protocol_error_count);
+    $display("PASS harness banks={banks} cycles=%0d fold=%h", cycle_count,
+      folded_result);
+    $finish;
+  end
+  initial begin #1000000; $fatal(1, "timeout"); end
+endmodule
+""",
+        encoding="utf-8",
+    )
+    simv = tmp_path / "simv"
+    compile_result = subprocess.run(
+        [
+            _tool("iverilog"),
+            "-g2012",
+            "-s",
+            "tb",
+            "-o",
+            str(simv),
+            str(tmp_path / "top.v"),
+            str(FAKERAM_MODEL),
+            str(tb),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert compile_result.returncode == 0, compile_result.stderr
+    run_result = subprocess.run(
+        [_tool("vvp"), str(simv)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert run_result.returncode == 0, run_result.stdout + run_result.stderr
+    assert f"PASS harness banks={banks}" in run_result.stdout
+
+
+@pytest.mark.parametrize("banks", [2, 4, 8, 15])
+def test_checked_configs_guards_sweeps_and_task_commands(
+    tmp_path: Path,
+    banks: int,
+) -> None:
+    design_name = f"attention_score32_exact_shared_root_storage_macro_b{banks}"
+    source_dir = REPO_ROOT / "runs/designs/npu_blocks" / design_name
+    config = json.loads((source_dir / "config.json").read_text(encoding="utf-8"))
+    assert config["report_links"]["proposal_id"] == PROPOSAL_ID
+
+    copied = tmp_path / "runs/designs/npu_blocks" / design_name
+    copied.mkdir(parents=True)
+    (copied / "config.json").write_text(
+        json.dumps(config, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    generate(config, copied / "verilog")
+    assert guard_main(["--design-dir", str(copied)]) == 0
+
+    target = _read_config_target(
+        source_dir / "config.json",
+        repo_root=REPO_ROOT,
+        config_rel=str((source_dir / "config.json").relative_to(REPO_ROOT)),
+        out_root="runs/designs/npu_blocks",
+        make_target=None,
+    )
+    assert [command["name"] for command in target.commands] == [
+        "generate_attention_score32_exact_shared_root_storage_physical_harness_rtl",
+        "check_attention_score32_exact_shared_root_storage_physical_guard",
+        "run_block_sweep",
+        "extract_attention_score32_exact_shared_root_storage_physical_harness_timing_paths",
+    ]
+    assert "--macro_manifest" in target.commands[2]["run"]
+    assert "/verilog/macro_manifest.json" in target.commands[2]["run"]
+
+    sweep = json.loads(
+        (
+            REPO_ROOT
+            / "runs/campaigns/npu/attention_score32_exact_shared_root_storage_macro_ppa_v1"
+            / f"sweeps/nangate45_b{banks}.json"
+        ).read_text(encoding="utf-8")
+    )["flow_params"]
+    assert sweep["CLOCK_PERIOD"] == [4.0, 6.0, 8.0, 10.0, 12.0]
+    assert sweep["PLACE_DENSITY"] == [0.4]
+    assert sweep["SYNTH_HIERARCHICAL"] == [1]
+
+
+def test_proposal_requests_all_four_bank_points() -> None:
+    request = json.loads(
+        (
+            REPO_ROOT / f"docs/proposals/{PROPOSAL_ID}/evaluation_requests.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert request["source_commit"] == "TBD"
+    assert "source_requirement.required_sha" in request["source_commit_note"]
+    assert [
+        item["item_id"] for item in request["requested_items"]
+    ] == [
+        "l1_attention_score32_exact_shared_root_storage_macro_b2_ppa_v1",
+        "l1_attention_score32_exact_shared_root_storage_macro_b4_ppa_v1",
+        "l1_attention_score32_exact_shared_root_storage_macro_b8_ppa_v1",
+        "l1_attention_score32_exact_shared_root_storage_macro_b15_ppa_v1",
+    ]

--- a/tests/test_local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition.py
+++ b/tests/test_local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition.py
@@ -40,6 +40,7 @@ RTL_SOURCES = [
     RTL / "local_reducer_aggregate_stats_once_exact_shared_root_leaf_adapter.sv",
     RTL / "local_reducer_aggregate_stats_once_exact_shared_root_global_tree_composition.sv",
 ]
+FAKERAM_MODEL = RTL / "fakeram45_64x32_model.sv"
 
 
 def _generate_tree(tmp_path: Path) -> Path:
@@ -64,10 +65,23 @@ def _generate_tree(tmp_path: Path) -> Path:
     _tool("iverilog") is None or _tool("vvp") is None,
     reason="iverilog/vvp unavailable",
 )
-@pytest.mark.parametrize("physical_banks", [15, 4])
+@pytest.mark.parametrize(
+    ("physical_banks", "use_fakeram", "expected_root_span", "expected_final_cycle"),
+    [
+        (15, 0, 2505, 2600),
+        (4, 0, 2505, 2613),
+        (2, 1, 3901, 4120),
+        (4, 1, 2939, 3077),
+        (8, 1, 2733, 2855),
+        (15, 1, 2505, 2620),
+    ],
+)
 def test_full_chain_exact_finite_sram_mesh_and_tree(
     tmp_path: Path,
     physical_banks: int,
+    use_fakeram: int,
+    expected_root_span: int,
+    expected_final_cycle: int,
 ) -> None:
     tree_dir = _generate_tree(tmp_path)
     simv = tmp_path / "full_chain.vvp"
@@ -76,12 +90,14 @@ def test_full_chain_exact_finite_sram_mesh_and_tree(
             str(_tool("iverilog")),
             "-g2012",
             f"-DSHARED_ROOT_PHYSICAL_BANKS={physical_banks}",
+            f"-DSHARED_ROOT_USE_FAKERAM={use_fakeram}",
             "-s",
             TOP,
             "-o",
             str(simv),
             str(tree_dir / "top.v"),
             *[str(path) for path in RTL_SOURCES],
+            str(FAKERAM_MODEL),
             str(TB),
         ],
         check=True,
@@ -107,8 +123,9 @@ def test_full_chain_exact_finite_sram_mesh_and_tree(
     assert "completions=315" in run.stdout
     assert "replays=315" in run.stdout
     assert "source_mask=7fff" in run.stdout
-    assert "root_delivery_span=2505" in run.stdout
-    expected_final_cycle = 2600 if physical_banks == 15 else 2613
+    assert f"banks={physical_banks}" in run.stdout
+    assert f"use_fakeram={use_fakeram}" in run.stdout
+    assert f"root_delivery_span={expected_root_span}" in run.stdout
     assert f"final_cycle={expected_final_cycle}" in run.stdout
     assert "max_aggregate_slots=30" in run.stdout
     assert "slots_per_source=2" in run.stdout

--- a/tests/test_local_reducer_aggregate_stats_once_exact_shared_root_storage_fabric_b4.py
+++ b/tests/test_local_reducer_aggregate_stats_once_exact_shared_root_storage_fabric_b4.py
@@ -29,6 +29,8 @@ RTL_SOURCES = [
     RTL / "local_reducer_aggregate_stats_once_exact_sram_packet_adapter.sv",
     RTL / "local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter.sv",
 ]
+FAKERAM_MODEL = RTL / "fakeram45_64x32_model.sv"
+FAKERAM_BLACKBOX = REPO_ROOT / "npu/rtl/fakeram45_64x32_blackbox.v"
 FULL_ROOT_TB = REPO_ROOT / (
     "tests/local_reducer_aggregate_stats_once_exact_shared_root_rx_adapter_tb.sv"
 )
@@ -47,17 +49,23 @@ FULL_ROOT_SOURCES = [
     _tool("iverilog") is None or _tool("vvp") is None,
     reason="iverilog/vvp unavailable",
 )
-def test_b4_shared_storage_exact_roundtrip(tmp_path: Path) -> None:
+@pytest.mark.parametrize("use_fakeram", [0, 1])
+def test_b4_shared_storage_exact_roundtrip(
+    tmp_path: Path,
+    use_fakeram: int,
+) -> None:
     simv = tmp_path / "shared_root_storage_b4.vvp"
     subprocess.run(
         [
             str(_tool("iverilog")),
             "-g2012",
+            f"-DSHARED_ROOT_USE_FAKERAM={use_fakeram}",
             "-s",
             TB_TOP,
             "-o",
             str(simv),
             *[str(path) for path in RTL_SOURCES],
+            str(FAKERAM_MODEL),
             str(TB),
         ],
         check=True,
@@ -75,6 +83,7 @@ def test_b4_shared_storage_exact_roundtrip(tmp_path: Path) -> None:
         timeout=60,
     )
     assert "PASS shared_root_storage_b4" in run.stdout
+    assert f"use_fakeram={use_fakeram}" in run.stdout
     assert "canonical_beats=1920" in run.stdout
     assert "flits=2505" in run.stdout
     assert "packets=315" in run.stdout
@@ -168,3 +177,58 @@ def test_b4_shared_storage_has_four_64x256_banks(tmp_path: Path) -> None:
     assert len(mem_cells) == 1
     assert int(mem_cells[0]["parameters"]["SIZE"], 2) == 64
     assert int(mem_cells[0]["parameters"]["WIDTH"], 2) == 256
+
+
+@pytest.mark.skipif(_tool("yosys") is None, reason="yosys unavailable")
+@pytest.mark.parametrize(
+    ("physical_banks", "expected_macros_per_bank", "expected_macro_count"),
+    [(2, 16, 32), (4, 8, 32), (8, 8, 64), (15, 8, 120)],
+)
+def test_shared_storage_has_expected_fakeram_macros(
+    tmp_path: Path,
+    physical_banks: int,
+    expected_macros_per_bank: int,
+    expected_macro_count: int,
+) -> None:
+    netlist = tmp_path / f"shared_root_storage_b{physical_banks}_fakeram.json"
+    subprocess.run(
+        [
+            str(_tool("yosys")),
+            "-q",
+            "-p",
+            "read_verilog -DSYNTHESIS -sv "
+            + str(FAKERAM_BLACKBOX)
+            + " "
+            + " ".join(str(path) for path in RTL_SOURCES)
+            + f"; chparam -set PHYSICAL_BANKS {physical_banks} "
+            + f"-set USE_FAKERAM 1 {TOP}; "
+            + f"hierarchy -check -top {TOP}; proc; check; write_json "
+            + str(netlist),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    design = json.loads(netlist.read_text())
+    top = design["modules"][TOP]
+    bank_cells = [
+        cell
+        for cell in top["cells"].values()
+        if "shared_root_bank_memory" in cell["type"]
+    ]
+    bank_modules = [
+        module
+        for name, module in design["modules"].items()
+        if "shared_root_bank_memory" in name
+    ]
+    assert len(bank_cells) == physical_banks
+    assert len(bank_modules) == 1
+    macros_per_bank = sum(
+        1
+        for cell in bank_modules[0]["cells"].values()
+        if cell["type"] == "fakeram45_64x32"
+    )
+    assert macros_per_bank == expected_macros_per_bank
+    assert len(bank_cells) * macros_per_bank == expected_macro_count


### PR DESCRIPTION
## Summary
- add a selectable `fakeram45_64x32` backend to the production exact shared-root storage fabric
- propagate registered SRAM latency and write backpressure through the root adapter and global-tree composition
- measure bit-exact full-chain B2/B4/B8/B15 timing and revise the frontier
- add a narrow-I/O macro-backed physical harness, guards, configs, utilization-scaled sweeps, and evaluator task generation
- propose four remote Nangate45 PPA items with merged-source pinning

## Exact full-chain result
| banks | macros | root span | final cycle | component throughput vs B15 |
|---:|---:|---:|---:|---:|
| 2 | 32 | 3901 | 4120 | 0.635922 |
| 4 | 32 | 2939 | 3077 | 0.851479 |
| 8 | 64 | 2733 | 2855 | 0.917688 |
| 15 | 120 | 2505 | 2620 | 1.0 |

All points preserve 1920 canonical remote beats, 2505 flits, 315 packets, 128 final rows, and exact lane value 65535. B2 is dominated by B4. B4/B8/B15 remain candidates pending PPA.

## Verification
- macro/full-chain gate: 17 passed
- harness/config/guard/report gate: 15 passed
- production default-memory root gate: 5 passed
- L1 task-generator suite: 99 passed; 5 unrelated stale historical proposal-state failures also reproduce from current master data
- Verilator lint, Yosys macro inventory, JSON syntax, Python compile, and `git diff --check` pass
