### PR TITLE
control-plane: block evaluator leases on stale image runtime

### DIFF
--- a/control_plane/control_plane/cli/run_worker_daemon.py
+++ b/control_plane/control_plane/cli/run_worker_daemon.py
@@ -91,6 +91,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--auto-update-source", action="store_true")
     parser.add_argument("--source-update-ref", default="origin/master")
     parser.add_argument("--no-restart-on-source-update", action="store_true")
+    parser.add_argument("--skip-runtime-contract-check", action="store_true")
     args = parser.parse_args(argv)
     capability_filter = _parse_json_flag(args.capability_filter_json)
     capabilities = _worker_capabilities(
@@ -146,6 +147,9 @@ def main(argv: list[str] | None = None) -> int:
             auto_update_source=args.auto_update_source,
             source_update_ref=args.source_update_ref,
             restart_on_source_update=not args.no_restart_on_source_update,
+            enforce_runtime_contract=(
+                args.machine_role == "evaluator" and not args.skip_runtime_contract_check
+            ),
         ),
     )
     print(

--- a/control_plane/control_plane/services/operator_status.py
+++ b/control_plane/control_plane/services/operator_status.py
@@ -230,6 +230,12 @@ def load_operator_status(session: Session, request: OperatorStatusRequest) -> Op
                 source_blocked_items.append(row)
         worker_attention = None
         if (
+            last_progress is not None
+            and str(last_progress.get("phase") or "") == "runtime_contract"
+            and str(last_progress.get("status") or "") == "blocked"
+        ):
+            worker_attention = "evaluator_runtime_contract_blocked"
+        elif (
             active_slots == 0
             and source_blocked_items
             and _last_progress_is_legacy_tracked_modification_block(last_progress)

--- a/control_plane/control_plane/services/worker_daemon.py
+++ b/control_plane/control_plane/services/worker_daemon.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+import os
+from pathlib import Path
 import time
 from typing import Callable
 
@@ -35,6 +37,16 @@ class WorkerDaemonConfig:
     auto_update_source: bool = False
     source_update_ref: str = "origin/master"
     restart_on_source_update: bool = True
+    enforce_runtime_contract: bool = False
+    installed_init_helper: str = "/usr/local/sbin/rtlgen-container-init"
+    runtime_roots: tuple[str, ...] = (
+        "/orfs/flow/designs/src",
+        "/orfs/flow/designs/nangate45",
+        "/orfs/flow/logs",
+        "/orfs/flow/objects",
+        "/orfs/flow/reports",
+        "/orfs/flow/results",
+    )
 
 
 @dataclass(frozen=True)
@@ -61,6 +73,37 @@ def _dispose_session_engine(session_factory: sessionmaker, logger: Callable[[str
 
 def _is_retryable_db_error(exc: Exception) -> bool:
     return isinstance(exc, (OperationalError, DBAPIError))
+
+
+def _runtime_contract_error(config: WorkerDaemonConfig) -> str | None:
+    """Return why an evaluator image cannot safely execute the current checkout."""
+
+    if not config.enforce_runtime_contract:
+        return None
+
+    repo_helper = Path(config.worker.repo_root).resolve() / ".devcontainer" / "rtlgen-container-init"
+    image_helper = Path(config.installed_init_helper)
+    if not repo_helper.is_file():
+        return f"repository container initializer is missing: {repo_helper}"
+    if not image_helper.is_file():
+        return f"installed container initializer is missing: {image_helper}"
+    try:
+        helpers_match = repo_helper.read_bytes() == image_helper.read_bytes()
+    except OSError as exc:
+        return f"could not compare container initializers: {exc}"
+    if not helpers_match:
+        return (
+            f"installed container initializer does not match {repo_helper}; "
+            "rebuild the evaluator container image"
+        )
+
+    for raw_path in config.runtime_roots:
+        path = Path(raw_path)
+        if not path.is_dir():
+            return f"OpenROAD runtime path is missing: {path}"
+        if not os.access(path, os.W_OK | os.X_OK):
+            return f"OpenROAD runtime path is not writable by uid={os.getuid()}: {path}"
+    return None
 
 
 def _record_daemon_progress(
@@ -304,29 +347,49 @@ def run_worker_daemon(
                     continue
                 raise
 
-        try:
-            reconcile_result = _reconcile_next_item_source(
+        runtime_contract_error = _runtime_contract_error(config)
+        if runtime_contract_error is not None:
+            logger(f"worker-daemon runtime_contract_blocked error={runtime_contract_error}")
+            _record_daemon_progress(
                 session_factory,
                 config=config,
                 logger=logger,
+                progress={
+                    "phase": "runtime_contract",
+                    "status": "blocked",
+                    "error": runtime_contract_error,
+                },
             )
-            if reconcile_result is not None:
-                batch = [reconcile_result]
-            else:
-                batch = _run_parallel_batch(session_factory, config=config)
-        except SystemExit:
-            raise
-        except Exception as exc:
-            if _is_retryable_db_error(exc):
-                logger(f"worker-daemon db_unavailable stage=batch error={exc}")
-                _dispose_session_engine(session_factory, logger)
-                if config.max_polls is not None and poll_count >= config.max_polls:
-                    logger("worker-daemon stop reason=max_polls")
-                    break
-                time.sleep(config.poll_seconds)
-                continue
-            logger(f"worker-daemon batch_error error={exc}")
-            batch = [WorkerLoopResult(status="worker_error", summary=str(exc))]
+            batch = [
+                WorkerLoopResult(
+                    status="runtime_contract_blocked",
+                    summary=runtime_contract_error,
+                )
+            ]
+        else:
+            try:
+                reconcile_result = _reconcile_next_item_source(
+                    session_factory,
+                    config=config,
+                    logger=logger,
+                )
+                if reconcile_result is not None:
+                    batch = [reconcile_result]
+                else:
+                    batch = _run_parallel_batch(session_factory, config=config)
+            except SystemExit:
+                raise
+            except Exception as exc:
+                if _is_retryable_db_error(exc):
+                    logger(f"worker-daemon db_unavailable stage=batch error={exc}")
+                    _dispose_session_engine(session_factory, logger)
+                    if config.max_polls is not None and poll_count >= config.max_polls:
+                        logger("worker-daemon stop reason=max_polls")
+                        break
+                    time.sleep(config.poll_seconds)
+                    continue
+                logger(f"worker-daemon batch_error error={exc}")
+                batch = [WorkerLoopResult(status="worker_error", summary=str(exc))]
 
         results.extend(batch)
 

--- a/control_plane/control_plane/tests/test_operator_status.py
+++ b/control_plane/control_plane/tests/test_operator_status.py
@@ -574,6 +574,43 @@ def test_operator_status_does_not_flag_assigned_ready_worker_with_progress() -> 
         assert "stalled_workers=" not in status.health_summary["message"]
 
 
+def test_operator_status_flags_runtime_contract_blocked_evaluator() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    create_all(engine)
+    now = utcnow()
+    with Session(engine) as session:
+        machine = WorkerMachine(
+            machine_key="worker-stale-image",
+            hostname="eval-host",
+            executor_kind="local_process",
+            capabilities={
+                "flow": "openroad",
+                "platform": "nangate45",
+                "last_progress": {
+                    "phase": "runtime_contract",
+                    "status": "blocked",
+                    "error": "installed container initializer does not match repository helper",
+                },
+            },
+            role="evaluator",
+            slot_capacity=4,
+            last_seen_at=now,
+        )
+        session.add(machine)
+        session.flush()
+        ready_item = _seed_item(session, item_id="stale_image_item", state=WorkItemState.READY)
+        ready_item.assigned_machine_key = machine.machine_key
+        session.commit()
+
+        status = load_operator_status(session, OperatorStatusRequest(recent_limit=5))
+
+    row = next(r for r in status.evaluator_machines if r["machine_key"] == "worker-stale-image")
+    assert row["active_slots"] == 0
+    assert row["assigned_ready"] == 1
+    assert row["worker_attention"] == "evaluator_runtime_contract_blocked"
+    assert "stalled_workers=1" in status.health_summary["message"]
+
+
 def test_operator_status_reports_blocked_dependency_reason() -> None:
     engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
     create_all(engine)

--- a/control_plane/control_plane/tests/test_worker_daemon.py
+++ b/control_plane/control_plane/tests/test_worker_daemon.py
@@ -541,6 +541,64 @@ def test_worker_daemon_records_source_reconcile_error_progress() -> None:
             assert progress["error"] == "fetch failed"
 
 
+def test_worker_daemon_blocks_before_lease_when_evaluator_image_is_stale() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_git_repo(repo_root)
+        repo_helper = repo_root / ".devcontainer" / "rtlgen-container-init"
+        repo_helper.parent.mkdir()
+        repo_helper.write_text("current image contract\n", encoding="utf-8")
+        installed_helper = Path(td) / "installed-rtlgen-container-init"
+        installed_helper.write_text("stale image contract\n", encoding="utf-8")
+
+        db_path = Path(td) / "cp.db"
+        engine = create_engine(f"sqlite+pysqlite:///{db_path}", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            _seed_ready_work_item(
+                session,
+                item_id="daemon_item_stale_image",
+                repo_root=repo_root,
+                assigned_machine_key="daemon-worker-stale-image",
+            )
+
+        session_factory = build_session_factory(engine)
+        result = run_worker_daemon(
+            session_factory,
+            config=WorkerDaemonConfig(
+                worker=WorkerConfig(
+                    repo_root=str(repo_root),
+                    machine_key="daemon-worker-stale-image",
+                    capabilities={"platform": "nangate45", "flow": "openroad"},
+                    capability_filter={"platform": "nangate45", "flow": "openroad"},
+                    heartbeat_seconds=1,
+                ),
+                poll_seconds=0,
+                max_polls=1,
+                enforce_runtime_contract=True,
+                installed_init_helper=str(installed_helper),
+                runtime_roots=(),
+            ),
+        )
+
+        assert [row.status for row in result.results] == ["runtime_contract_blocked"]
+        assert "rebuild the evaluator container image" in result.results[0].summary
+        with Session(engine) as session:
+            item = session.query(WorkItem).filter_by(item_id="daemon_item_stale_image").one()
+            assert item.state == WorkItemState.READY
+            assert session.query(Run).count() == 0
+            machine = session.query(WorkerMachine).filter_by(machine_key="daemon-worker-stale-image").one()
+            assert machine.capabilities["last_progress"] == {
+                "phase": "runtime_contract",
+                "status": "blocked",
+                "error": (
+                    f"installed container initializer does not match {repo_helper}; "
+                    "rebuild the evaluator container image"
+                ),
+            }
+
+
 def test_worker_daemon_executes_two_items_with_concurrency() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_worker_daemon_cli.py
+++ b/control_plane/control_plane/tests/test_worker_daemon_cli.py
@@ -44,4 +44,5 @@ def test_run_worker_daemon_cli_persists_filter_and_source_capabilities(monkeypat
         "repo_root": str(tmp_path.resolve()),
         "head": "abc123",
     }
+    assert config.enforce_runtime_contract is True
     assert '"poll_count": 0' in capsys.readouterr().out

--- a/docs/operations/devcontainer_uid_ownership.md
+++ b/docs/operations/devcontainer_uid_ownership.md
@@ -50,6 +50,16 @@ worker, completion, Git, Codex, RTL generation, and OpenROAD processes remain
 unprivileged. Ownership changes are non-recursive; OpenROAD tools, platform
 files, and scripts remain root-owned image content.
 
+Automatic evaluator source reconciliation updates the service checkout and
+re-executes the worker, but it cannot update files installed into the container
+image. In particular, a change to `.devcontainer/rtlgen-container-init`
+requires rebuilding the evaluator image. Before leasing work, the evaluator
+worker compares that repository file with
+`/usr/local/sbin/rtlgen-container-init` and checks that every OpenROAD runtime
+root is writable. A mismatch leaves the item in `READY` and reports
+`evaluator_runtime_contract_blocked` in operator status; it must not be
+recorded as a design or OpenROAD failure.
+
 ## One-time host repair
 
 Stop Codex and the old container before repairing ownership. On each developer
@@ -77,4 +87,5 @@ ps -eo user,pid,cmd | grep -E 'codex|control_plane'
 The host must be able to edit and remove `permission-test`. Control-plane
 processes must run as `rtlgen`; PostgreSQL retains its normal system accounts.
 For the evaluator, also confirm its stable machine key, remote DB connection,
-heartbeat, and exact-source reconciliation before dispatching more work.
+heartbeat, exact-source reconciliation, and absence of
+`evaluator_runtime_contract_blocked` before dispatching more work.


### PR DESCRIPTION
## Summary
- validate the evaluator image-installed initializer and writable OpenROAD runtime roots before leasing work
- keep incompatible-image jobs READY and expose `evaluator_runtime_contract_blocked` in operator status
- document that source hot-refresh cannot replace image-installed files

## Failure addressed
Issue #1696 was not a design failure. The current repository helper prepares `/orfs/flow` for UID 1000, but the evaluator image still contains the older helper; `run_block_sweep.py` failed before OpenROAD with `PermissionError` under `/orfs/flow/designs/src`.

## Verification
`PYTHONPATH=control_plane /home/rtlgen/.venvs/rtlgen-control-plane/bin/python -m pytest -q control_plane/control_plane/tests/test_worker_daemon.py control_plane/control_plane/tests/test_worker_daemon_cli.py control_plane/control_plane/tests/test_operator_status.py tests/test_devcontainer_user_contract.py`

Result: 52 passed.