### PR TITLE
control-plane: enforce loaded worker source at lease time

### DIFF
--- a/control_plane/control_plane/cli/run_worker.py
+++ b/control_plane/control_plane/cli/run_worker.py
@@ -8,6 +8,7 @@ import socket
 
 from control_plane.db import build_engine, build_session_factory, create_all
 from control_plane.services.worker_service import render_worker_results, run_worker
+from control_plane.services.worker_source import capabilities_with_worker_source
 from control_plane.workers.executor import WorkerConfig
 
 
@@ -56,6 +57,12 @@ def main(argv: list[str] | None = None) -> int:
     engine = build_engine(args.database_url)
     create_all(engine)
     session_factory = build_session_factory(engine)
+    capability_filter = _parse_json_flag(args.capability_filter_json)
+    capabilities = capabilities_with_worker_source(
+        repo_root=args.repo_root,
+        capabilities=_parse_json_flag(args.capabilities_json),
+        capability_filter=capability_filter,
+    )
     config = WorkerConfig(
         repo_root=args.repo_root,
         machine_key=args.machine_key,
@@ -63,8 +70,8 @@ def main(argv: list[str] | None = None) -> int:
         executor_kind=args.executor_kind,
         machine_role=args.machine_role,
         slot_capacity=args.slot_capacity if args.slot_capacity is not None else max(1, args.max_items),
-        capabilities=_parse_json_flag(args.capabilities_json),
-        capability_filter=_parse_json_flag(args.capability_filter_json),
+        capabilities=capabilities,
+        capability_filter=capability_filter,
         lease_seconds=args.lease_seconds,
         heartbeat_seconds=args.heartbeat_seconds,
         command_timeout_seconds=args.command_timeout_seconds,

--- a/control_plane/control_plane/cli/run_worker_daemon.py
+++ b/control_plane/control_plane/cli/run_worker_daemon.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 import argparse
 import json
-from pathlib import Path
 import socket
-import subprocess
 
 from control_plane.db import build_engine, build_session_factory, create_all
 from control_plane.services.worker_daemon import WorkerDaemonConfig, run_worker_daemon
+from control_plane.services.worker_source import capabilities_with_worker_source
 from control_plane.workers.executor import WorkerConfig
 
 
@@ -17,36 +16,6 @@ def _parse_json_flag(raw: str | None):
     if raw is None:
         return None
     return json.loads(raw)
-
-
-def _service_repo_head(repo_root: str) -> str | None:
-    repo = Path(repo_root).resolve()
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(repo), "rev-parse", "HEAD"],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            text=True,
-        )
-    except (OSError, subprocess.CalledProcessError):
-        return None
-    head = result.stdout.strip()
-    return head or None
-
-
-def _worker_capabilities(*, repo_root: str, capabilities_json: str | None, capability_filter_json: str | None) -> dict:
-    capabilities = dict(_parse_json_flag(capabilities_json) or {})
-    capability_filter = dict(_parse_json_flag(capability_filter_json) or {})
-    for key, value in capability_filter.items():
-        capabilities.setdefault(key, value)
-    worker_source = dict(capabilities.get("worker_source") or {})
-    worker_source.setdefault("repo_root", str(Path(repo_root).resolve()))
-    head = _service_repo_head(repo_root)
-    if head:
-        worker_source["head"] = head
-    capabilities["worker_source"] = worker_source
-    return capabilities
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -94,10 +63,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--skip-runtime-contract-check", action="store_true")
     args = parser.parse_args(argv)
     capability_filter = _parse_json_flag(args.capability_filter_json)
-    capabilities = _worker_capabilities(
+    capabilities = capabilities_with_worker_source(
         repo_root=args.repo_root,
-        capabilities_json=args.capabilities_json,
-        capability_filter_json=args.capability_filter_json,
+        capabilities=_parse_json_flag(args.capabilities_json),
+        capability_filter=capability_filter,
     )
 
     engine = build_engine(args.database_url)

--- a/control_plane/control_plane/services/operator_status.py
+++ b/control_plane/control_plane/services/operator_status.py
@@ -25,6 +25,7 @@ from control_plane.services.dependency_gate import dependency_gate_config_from_p
 from control_plane.services.operator_submission import assess_submission_eligibility
 from control_plane.services.run_index_query import comparative_run_index
 from control_plane.services.trial_variance import load_seed_trial_variance
+from control_plane.services.worker_source import source_head_satisfies_requirement
 
 
 _SOURCE_RECONCILER_TRACKED_SNAPSHOT_COMMIT = "989f3b00"
@@ -65,27 +66,6 @@ def _submission_finalization_fields(link: GitHubLink) -> dict[str, Any]:
 
 def _default_repo_root() -> str:
     return os.environ.get("RTLGEN_SERVICE_REPO") or os.environ.get("REPO_ROOT") or "/workspaces/rtlgen-eval-clean"
-
-
-def _source_head_satisfies_requirement(*, repo_root: str, worker_head: str, required_sha: str) -> bool:
-    worker = str(worker_head or "").strip()
-    required = str(required_sha or "").strip()
-    if not required:
-        return True
-    if not worker:
-        return False
-    if worker == required:
-        return True
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(Path(repo_root).resolve()), "merge-base", "--is-ancestor", required, worker],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-    except (OSError, RuntimeError):
-        return False
-    return result.returncode == 0
 
 
 def _source_reconciler_has_tracked_snapshot_support(*, repo_root: str, worker_head: str) -> bool:
@@ -214,7 +194,7 @@ def load_operator_status(session: Session, request: OperatorStatusRequest) -> Op
             required_sha = str(item.source_commit or "").strip()
             if not required_sha:
                 continue
-            satisfied = _source_head_satisfies_requirement(
+            satisfied = source_head_satisfies_requirement(
                 repo_root=request.repo_root,
                 worker_head=worker_head,
                 required_sha=required_sha,

--- a/control_plane/control_plane/services/scheduler.py
+++ b/control_plane/control_plane/services/scheduler.py
@@ -12,6 +12,7 @@ from control_plane.models.enums import FlowName, LeaseStatus, WorkItemState
 from control_plane.models.work_items import WorkItem
 from control_plane.models.worker_machines import WorkerMachine
 from control_plane.models.worker_leases import WorkerLease
+from control_plane.services.worker_source import source_head_satisfies_requirement
 
 
 class NoEligibleWorkItem(RuntimeError):
@@ -109,6 +110,20 @@ def machine_active_lease_count(session: Session, machine_id: str) -> int:
     )
 
 
+def worker_source_satisfies_item(
+    work_item: WorkItem, machine_capabilities: dict[str, Any] | None
+) -> bool:
+    required_sha = str(work_item.source_commit or "").strip()
+    if not required_sha:
+        return True
+    worker_source = dict((machine_capabilities or {}).get("worker_source") or {})
+    return source_head_satisfies_requirement(
+        repo_root=str(worker_source.get("repo_root") or ""),
+        worker_head=str(worker_source.get("head") or ""),
+        required_sha=required_sha,
+    )
+
+
 def select_next_work_item(
     session: Session,
     *,
@@ -152,6 +167,8 @@ def select_next_work_item(
     query = query.order_by(*order_cols, WorkItem.priority.desc(), WorkItem.created_at.asc(), WorkItem.item_id.asc())
     active_count = machine_active_lease_count(session, machine.id) if machine is not None else 0
     for item in query.all():
+        if not worker_source_satisfies_item(item, effective):
+            continue
         if work_item_requires_exclusive_worker(item) and active_count > 0:
             continue
         return item

--- a/control_plane/control_plane/services/worker_daemon.py
+++ b/control_plane/control_plane/services/worker_daemon.py
@@ -275,6 +275,40 @@ def _reconcile_next_item_source(
         )
 
     if result.status in {"satisfied", "no_requirement"}:
+        worker_source = dict((config.worker.capabilities or {}).get("worker_source") or {})
+        loaded_head = str(worker_source.get("head") or "").strip()
+        if (
+            result.status == "satisfied"
+            and loaded_head
+            and result.current_sha
+            and loaded_head != result.current_sha
+        ):
+            message = (
+                "service checkout changed after worker process start: "
+                f"loaded={loaded_head} current={result.current_sha}"
+            )
+            logger(f"worker-daemon source_reconcile restart_required message={message}")
+            _record_daemon_progress(
+                session_factory,
+                config=config,
+                logger=logger,
+                progress={
+                    "phase": "source_reconcile",
+                    "status": "restart_required",
+                    "item_id": item.item_id,
+                    "required_sha": required_sha,
+                    "loaded_head": loaded_head,
+                    "current_sha": result.current_sha,
+                    "message": message,
+                },
+            )
+            if config.restart_on_source_update:
+                reexec_current_process()
+            return WorkerLoopResult(
+                status="source_restart_required",
+                item_id=item.item_id,
+                summary=message,
+            )
         return None
 
     logger(

--- a/control_plane/control_plane/services/worker_source.py
+++ b/control_plane/control_plane/services/worker_source.py
@@ -1,0 +1,74 @@
+"""Worker-process source identity helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+from typing import Any
+
+
+def service_repo_head(repo_root: str) -> str | None:
+    repo = Path(repo_root).resolve()
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    head = result.stdout.strip()
+    return head or None
+
+
+def capabilities_with_worker_source(
+    *,
+    repo_root: str,
+    capabilities: dict[str, Any] | None,
+    capability_filter: dict[str, Any] | None,
+) -> dict[str, Any]:
+    merged = dict(capabilities or {})
+    for key, value in dict(capability_filter or {}).items():
+        merged.setdefault(key, value)
+    worker_source = dict(merged.get("worker_source") or {})
+    worker_source["repo_root"] = str(Path(repo_root).resolve())
+    head = service_repo_head(repo_root)
+    if head:
+        worker_source["head"] = head
+    merged["worker_source"] = worker_source
+    return merged
+
+
+def source_head_satisfies_requirement(
+    *, repo_root: str, worker_head: str, required_sha: str
+) -> bool:
+    """Check the code loaded by a worker, not the mutable checkout's current HEAD."""
+
+    worker = str(worker_head or "").strip()
+    required = str(required_sha or "").strip()
+    if not required:
+        return True
+    if not worker:
+        return False
+    if worker == required:
+        return True
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(Path(repo_root).resolve()),
+                "merge-base",
+                "--is-ancestor",
+                required,
+                worker,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, RuntimeError):
+        return False
+    return result.returncode == 0

--- a/control_plane/control_plane/tests/test_leases.py
+++ b/control_plane/control_plane/tests/test_leases.py
@@ -229,6 +229,63 @@ def test_acquire_next_lease_persists_capability_filter() -> None:
         assert machine.capabilities["flow"] == "openroad"
 
 
+def test_acquire_next_lease_accepts_exact_loaded_worker_source() -> None:
+    with make_session() as session:
+        _, item_b = seed_ready_items(session)
+        from control_plane.services.lease_service import upsert_worker_machine
+
+        item_b.source_commit = "required-source"
+        session.commit()
+        upsert_worker_machine(session, machine_key="machine-1")
+        assign_work_item(session, item_id=item_b.item_id, machine_key="machine-1")
+
+        result = acquire_next_lease(
+            session,
+            machine_key="machine-1",
+            capabilities={
+                "platform": "nangate45",
+                "flow": "openroad",
+                "worker_source": {
+                    "head": "required-source",
+                    "repo_root": "/unused-for-exact-match",
+                },
+            },
+            lease_seconds=900,
+        )
+
+        assert result.item_id == item_b.item_id
+
+
+def test_acquire_next_lease_rejects_older_loaded_worker_source() -> None:
+    with make_session() as session:
+        _, item_b = seed_ready_items(session)
+        from control_plane.services.lease_service import upsert_worker_machine
+
+        item_b.source_commit = "required-source"
+        session.commit()
+        upsert_worker_machine(session, machine_key="machine-1")
+        assign_work_item(session, item_id=item_b.item_id, machine_key="machine-1")
+
+        with pytest.raises(NoEligibleWorkItem, match="no eligible work item"):
+            acquire_next_lease(
+                session,
+                machine_key="machine-1",
+                capabilities={
+                    "platform": "nangate45",
+                    "flow": "openroad",
+                    "worker_source": {
+                        "head": "older-loaded-source",
+                        "repo_root": "/not/a/git/repository",
+                    },
+                },
+                lease_seconds=900,
+            )
+
+        session.refresh(item_b)
+        assert item_b.state == WorkItemState.READY
+        assert session.query(WorkerLease).filter_by(work_item_id=item_b.id).count() == 0
+
+
 def test_heartbeat_updates_expiry_and_machine_progress() -> None:
     with make_session() as session:
         _, item_b = seed_ready_items(session)

--- a/control_plane/control_plane/tests/test_worker_daemon.py
+++ b/control_plane/control_plane/tests/test_worker_daemon.py
@@ -541,6 +541,69 @@ def test_worker_daemon_records_source_reconcile_error_progress() -> None:
             assert progress["error"] == "fetch failed"
 
 
+def test_worker_daemon_requires_reexec_when_checkout_changed_under_process() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        repo_root = Path(td) / "repo"
+        repo_root.mkdir()
+        _init_git_repo(repo_root)
+        db_path = Path(td) / "cp.db"
+        engine = create_engine(f"sqlite+pysqlite:///{db_path}", future=True)
+        create_all(engine)
+        with Session(engine) as session:
+            _seed_ready_work_item(
+                session,
+                item_id="daemon_item_checkout_changed",
+                repo_root=repo_root,
+                assigned_machine_key="daemon-worker-checkout-changed",
+                source_commit="required-source",
+            )
+
+        session_factory = build_session_factory(engine)
+        with patch(
+            "control_plane.services.worker_daemon.reconcile_service_repo_source",
+            return_value=SourceReconciliationResult(
+                status="satisfied",
+                required_sha="required-source",
+                current_sha="current-checkout-source",
+                source_commit_relation="exact",
+            ),
+        ):
+            result = run_worker_daemon(
+                session_factory,
+                config=WorkerDaemonConfig(
+                    worker=WorkerConfig(
+                        repo_root=str(repo_root),
+                        machine_key="daemon-worker-checkout-changed",
+                        capabilities={
+                            "platform": "nangate45",
+                            "flow": "openroad",
+                            "worker_source": {
+                                "head": "loaded-process-source",
+                                "repo_root": str(repo_root),
+                            },
+                        },
+                        capability_filter={"platform": "nangate45", "flow": "openroad"},
+                        heartbeat_seconds=1,
+                    ),
+                    poll_seconds=0,
+                    max_polls=1,
+                    auto_update_source=True,
+                    restart_on_source_update=False,
+                ),
+            )
+
+        assert [row.status for row in result.results] == ["source_restart_required"]
+        with Session(engine) as session:
+            item = session.query(WorkItem).filter_by(item_id="daemon_item_checkout_changed").one()
+            assert item.state == WorkItemState.READY
+            machine = session.query(WorkerMachine).filter_by(machine_key="daemon-worker-checkout-changed").one()
+            progress = machine.capabilities["last_progress"]
+            assert progress["phase"] == "source_reconcile"
+            assert progress["status"] == "restart_required"
+            assert progress["loaded_head"] == "loaded-process-source"
+            assert progress["current_sha"] == "current-checkout-source"
+
+
 def test_worker_daemon_blocks_before_lease_when_evaluator_image_is_stale() -> None:
     with tempfile.TemporaryDirectory() as td:
         repo_root = Path(td) / "repo"

--- a/control_plane/control_plane/tests/test_worker_daemon_cli.py
+++ b/control_plane/control_plane/tests/test_worker_daemon_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from control_plane.cli import run_worker_daemon as cli
 from control_plane.services.worker_daemon import WorkerDaemonResult
+from control_plane.services import worker_source
 
 
 def test_run_worker_daemon_cli_persists_filter_and_source_capabilities(monkeypatch, tmp_path, capsys) -> None:
@@ -10,7 +11,7 @@ def test_run_worker_daemon_cli_persists_filter_and_source_capabilities(monkeypat
     monkeypatch.setattr(cli, "build_engine", lambda _url: object())
     monkeypatch.setattr(cli, "create_all", lambda _engine: None)
     monkeypatch.setattr(cli, "build_session_factory", lambda _engine: object())
-    monkeypatch.setattr(cli, "_service_repo_head", lambda _repo_root: "abc123")
+    monkeypatch.setattr(worker_source, "service_repo_head", lambda _repo_root: "abc123")
 
     def fake_run_worker_daemon(session_factory, *, config, log_fn=None):
         captured["session_factory"] = session_factory

--- a/docs/operations/devcontainer_uid_ownership.md
+++ b/docs/operations/devcontainer_uid_ownership.md
@@ -60,6 +60,13 @@ root is writable. A mismatch leaves the item in `READY` and reports
 `evaluator_runtime_contract_blocked` in operator status; it must not be
 recorded as a design or OpenROAD failure.
 
+The scheduler also compares each item's required source SHA with the source SHA
+loaded by the worker process at startup. This check occurs when the lease is
+acquired, so an item arriving between a daemon poll and a parallel worker batch
+cannot bypass source reconciliation. A changed service checkout requires worker
+re-execution before the item becomes lease-eligible; the checkout's current
+`HEAD` alone is not evidence that the running Python process loaded that code.
+
 ## One-time host repair
 
 Stop Codex and the old container before repairing ownership. On each developer


### PR DESCRIPTION
## Summary
- reject a lease unless the worker process loaded the item-required source SHA or a descendant
- re-exec when the mutable service checkout no longer matches the source loaded by the running daemon
- share source identity helpers across daemon, one-shot worker, scheduler, and operator status

## Incident
The B4 retry required and checked out `978e5a5`, but the 16-thread evaluator process still had `b729e78` loaded. The item arrived after the daemon source precheck and was leased by an already-started batch. It then repeated the stale-image failure. Checkout identity is therefore insufficient; lease eligibility must use process-loaded identity.

## Verification
Focused control-plane and devcontainer contract suite: 67 passed.

Closes the source-precheck race observed in #1696.