### PR TITLE
npu: retain physical macro evidence in sweep metrics

### DIFF
--- a/docs/proposals/prop_l1_attention_score32_exact_shared_root_storage_macro_ppa_v1/README.md
+++ b/docs/proposals/prop_l1_attention_score32_exact_shared_root_storage_macro_ppa_v1/README.md
@@ -15,6 +15,12 @@ common range: 400 um square cores for B2/B4, 550 um for B8, and 750 um for B15.
 This avoids interpreting congestion from a fixed undersized core as a bank
 architecture penalty.
 
+Each accepted metrics row must retain `macro_count`, `macro_area_um2`,
+`blackbox_instance_counts`, `missing_blackboxes`, and `macro_manifest_path`.
+The bank comparison is invalid if the CSV cannot prove the expected 32, 32,
+64, and 120 physical SRAM instances; a passing pre-synthesis guard alone is
+not sufficient evidence for the placed result.
+
 At queue time, use merged `origin/master` as the source commit. Each normal L1
 task-generation request must place that SHA in
 `source_requirement.required_sha`.

--- a/npu/synth/run_block_sweep.py
+++ b/npu/synth/run_block_sweep.py
@@ -1158,6 +1158,8 @@ def add_utilization_metrics(
     )
     if stdcell_area is not None:
         metrics["stdcell_area_um2"] = stdcell_area
+    if instance_area is not None and stdcell_area is not None:
+        metrics["macro_area_um2"] = max(0.0, instance_area - stdcell_area)
 
     stdcell_count = first_openroad_metric(
         metrics_json,
@@ -1908,6 +1910,8 @@ def append_metrics(metrics_path: Path, row: Dict[str, object]):
         "total_power_mw",
         "instance_area_um2",
         "stdcell_area_um2",
+        "macro_area_um2",
+        "macro_count",
         "stdcell_count",
         "core_area_um2",
         "utilization_pct",
@@ -1926,6 +1930,10 @@ def append_metrics(metrics_path: Path, row: Dict[str, object]):
         "fsm_encfile_sha1",
         "fsm_encfile_sha256",
         "fsm_encoding_json",
+        "blackbox_instance_counts",
+        "missing_blackboxes",
+        "macro_manifest_path",
+        "macro_selection",
     ]
 
     existing_rows: List[Dict[str, object]] = []
@@ -1945,6 +1953,15 @@ def append_metrics(metrics_path: Path, row: Dict[str, object]):
                 existing_rows = list(reader)
             else:
                 needs_rewrite = True
+
+    for key in row:
+        if key not in header:
+            header.append(key)
+
+    def csv_value(value: object) -> object:
+        if isinstance(value, (dict, list, tuple)):
+            return json.dumps(value, sort_keys=True)
+        return value
 
     def identity_key(record: Dict[str, object]) -> tuple[str, str, str, str]:
         return (
@@ -1967,7 +1984,7 @@ def append_metrics(metrics_path: Path, row: Dict[str, object]):
             writer.writeheader()
             for old_row in existing_rows:
                 writer.writerow({h: old_row.get(h, "") for h in header})
-            writer.writerow({h: row.get(h, "") for h in header})
+            writer.writerow({h: csv_value(row.get(h, "")) for h in header})
         return
 
     needs_header = not metrics_path.exists()
@@ -1975,7 +1992,7 @@ def append_metrics(metrics_path: Path, row: Dict[str, object]):
         writer = csv.DictWriter(f, fieldnames=header)
         if needs_header:
             writer.writeheader()
-        writer.writerow({h: row.get(h, "") for h in header})
+        writer.writerow({h: csv_value(row.get(h, "")) for h in header})
 
 
 def command_to_text(command: List[object]) -> str:
@@ -2694,6 +2711,8 @@ def run_single(design_dir: Path, design_name: str, platform: str, top: str, veri
         "total_power_mw": metrics.get("total_power_mw"),
         "instance_area_um2": metrics.get("instance_area_um2"),
         "stdcell_area_um2": metrics.get("stdcell_area_um2"),
+        "macro_area_um2": metrics.get("macro_area_um2"),
+        "macro_count": sum(blackbox_counts.values()),
         "stdcell_count": metrics.get("stdcell_count"),
         "core_area_um2": metrics.get("core_area_um2"),
         "utilization_pct": metrics.get("utilization_pct"),

--- a/tests/test_run_block_sweep_mode_compare.py
+++ b/tests/test_run_block_sweep_mode_compare.py
@@ -869,6 +869,50 @@ class ModeCompareRegressionTest(unittest.TestCase):
             self.assertEqual("flow_failed", rows[0]["status"])
             self.assertEqual("/orfs/flow/logs/new", rows[0]["result_path"])
 
+    def test_append_metrics_preserves_structured_macro_evidence(self):
+        with tempfile.TemporaryDirectory() as td:
+            metrics_path = Path(td) / "metrics.csv"
+            row = {
+                "design": "macro_design",
+                "platform": "nangate45",
+                "config_hash": "cfg",
+                "param_hash": "params",
+                "tag": "macro_tag",
+                "status": "ok",
+                "critical_path_ns": 4.0,
+                "die_area": 250000.0,
+                "total_power_mw": 2.0,
+                "instance_area_um2": 41000.0,
+                "stdcell_area_um2": 1300.0,
+                "macro_area_um2": 39700.0,
+                "macro_count": 32,
+                "blackbox_instance_counts": {"fakeram45_64x32": 32},
+                "missing_blackboxes": [],
+                "macro_manifest_path": "verilog/macro_manifest.json",
+                "macro_selection": {"entry": "fakeram45_64x32"},
+                "custom_physical_field": {"retained": True},
+            }
+
+            self.run_block_sweep.append_metrics(metrics_path, row)
+
+            with metrics_path.open(newline="", encoding="utf-8") as f:
+                rows = list(csv.DictReader(f))
+            self.assertEqual(1, len(rows))
+            self.assertEqual("32", rows[0]["macro_count"])
+            self.assertEqual(
+                {"fakeram45_64x32": 32},
+                json.loads(rows[0]["blackbox_instance_counts"]),
+            )
+            self.assertEqual([], json.loads(rows[0]["missing_blackboxes"]))
+            self.assertEqual(
+                {"entry": "fakeram45_64x32"},
+                json.loads(rows[0]["macro_selection"]),
+            )
+            self.assertEqual(
+                {"retained": True},
+                json.loads(rows[0]["custom_physical_field"]),
+            )
+
     def test_run_single_assigns_distinct_fsm_capture_base_per_synth_invocation(self):
         with tempfile.TemporaryDirectory() as td:
             tmp = Path(td)
@@ -1585,6 +1629,7 @@ class SynthTargetMappingRegressionTest(unittest.TestCase):
         )
         self.assertEqual(490000.0, metrics["instance_area_um2"])
         self.assertEqual(470000.0, metrics["stdcell_area_um2"])
+        self.assertEqual(20000.0, metrics["macro_area_um2"])
         self.assertEqual(12345.0, metrics["stdcell_count"])
         self.assertEqual(1960000.0, metrics["core_area_um2"])
         self.assertAlmostEqual(25.0, metrics["utilization_pct"])
@@ -1602,6 +1647,7 @@ class SynthTargetMappingRegressionTest(unittest.TestCase):
         )
         self.assertEqual(510000.0, metrics["instance_area_um2"])
         self.assertEqual(501000.0, metrics["stdcell_area_um2"])
+        self.assertEqual(9000.0, metrics["macro_area_um2"])
         self.assertEqual(23456.0, metrics["stdcell_count"])
         self.assertAlmostEqual(510000.0 * 100.0 / 1960000.0, metrics["utilization_pct"])
 
@@ -1618,6 +1664,7 @@ class SynthTargetMappingRegressionTest(unittest.TestCase):
         )
         self.assertEqual(410000.0, metrics["instance_area_um2"])
         self.assertEqual(409000.0, metrics["stdcell_area_um2"])
+        self.assertEqual(1000.0, metrics["macro_area_um2"])
         self.assertEqual(19876.0, metrics["stdcell_count"])
         self.assertAlmostEqual(41.0, metrics["utilization_pct"])
 


### PR DESCRIPTION
## Summary
- retain all row-specific fields when creating or extending `metrics.csv`
- serialize structured blackbox and macro-selection evidence as JSON
- report physical macro count and macro instance area alongside stdcell area
- require placed-result macro evidence for the shared-root bank frontier

## Why
The B4/B8/B15 decision requires proof of 32/64/120 retained SRAM macros. The previous default CSV header silently dropped that evidence on a new metrics file.

## Verification
`/home/rtlgen/.venvs/rtlgen-control-plane/bin/python -m pytest -q tests/test_run_block_sweep_mode_compare.py`

Result: 40 passed.