### PR TITLE
[codex] Fix full-head GQA8 equivalence

### DIFF
--- a/control_plane/control_plane/services/l2_task_generator.py
+++ b/control_plane/control_plane/services/l2_task_generator.py
@@ -7473,11 +7473,11 @@ def _decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank_evid
     )
     one_group_equivalence_json = (
         f"{base}/decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence__"
-        "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r7.json"
+        "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r8.json"
     )
     four_group_equivalence_json = (
         f"{base}/decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence__"
-        "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1.json"
+        "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1_r2.json"
     )
     out = f"{base}/decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank__{item_id}.json"
     report = f"{base}/decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank__{item_id}.md"
@@ -11948,6 +11948,7 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equiv
         "acceptance": [
             "Write exactly the bounded JSON and Markdown probe reports declared in expected_outputs",
             "Require report passed=true, classification=passed, and counts_passed=true",
+            "Require report head_dimension=128 and score_accumulation_beats_per_block=128",
             "Require compositional_components.strict_generated_top_guard=passed",
             "Require compositional_components.producer_replay_parallelism=1",
             (
@@ -11955,7 +11956,7 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equiv
                 "value_packing=canonical_pack_numerators"
             ),
             (
-                "Require exact totals in report.summary: producer_handshake_count=8192, "
+                "Require exact totals in report.summary: producer_handshake_count=1048576, "
                 "fill_target_accept_count=128, fill_row_accept_count=262144, "
                 "sram_request_accept_count=262144, sram_response_accept_count=262144, "
                 "cluster_row_count=2048, root_row_count=128, command_accept_count=8, "
@@ -12061,6 +12062,7 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotat
         "acceptance": [
             "Write exactly the bounded JSON and Markdown probe reports declared in expected_outputs",
             "Require report passed=true, classification=passed, and counts_passed=true",
+            "Require report head_dimension=128 and score_accumulation_beats_per_block=128",
             "Require compositional_components.strict_generated_top_guard=passed",
             "Require compositional_components.producer_replay_parallelism=1",
             (
@@ -12068,7 +12070,7 @@ def _decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotat
                 "value_packing=canonical_pack_numerators"
             ),
             (
-                "Require exact totals in report.summary: producer_handshake_count=32768, "
+                "Require exact totals in report.summary: producer_handshake_count=4194304, "
                 "fill_target_accept_count=512, fill_row_accept_count=1048576, "
                 "sram_request_accept_count=1048576, sram_response_accept_count=1048576, "
                 "cluster_row_count=8192, root_row_count=512, command_accept_count=32, "

--- a/control_plane/control_plane/tests/test_l2_task_generator.py
+++ b/control_plane/control_plane/tests/test_l2_task_generator.py
@@ -8033,15 +8033,15 @@ def test_generate_l2_campaign_task_adds_score32_exact_reduction_full_gqa8_rerank
                 _make_l2_request(
                     repo_root=str(repo_root),
                     campaign_path=campaign_path,
-                    item_id="l2_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank_llama7b_v1",
+                    item_id="l2_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank_llama7b_v1_r2",
                     requested_by="@tester",
                     source_commit=source_commit,
                     proposal_id=(
-                        "prop_l2_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank_llama7b_v1"
+                        "prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1"
                     ),
                     proposal_path=(
                         "docs/proposals/"
-                        "prop_l2_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank_llama7b_v1/"
+                        "prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1/"
                         "proposal.json"
                     ),
                     abstraction_layer="decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank",
@@ -8053,8 +8053,8 @@ def test_generate_l2_campaign_task_adds_score32_exact_reduction_full_gqa8_rerank
                     depends_on_item_ids=[
                         "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
                         "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1",
-                        "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r7",
-                        "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1",
+                        "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r8",
+                        "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1_r2",
                     ],
                     requires_merged_inputs=True,
                     requires_materialized_refs=True,
@@ -8086,16 +8086,16 @@ def test_generate_l2_campaign_task_adds_score32_exact_reduction_full_gqa8_rerank
             )
             assert decoder_inputs["attention_score32_one_group_gqa8_equivalence_json"].endswith(
                 "decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence__"
-                "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r7.json"
+                "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r8.json"
             )
             assert decoder_inputs["attention_score32_four_group_gqa8_equivalence_json"].endswith(
                 "decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence__"
-                "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1.json"
+                "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1_r2.json"
             )
             assert decoder_inputs["attention_score32_exact_reduction_gqa8_full_equivalence_rerank_out"] == (
                 "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
                 "decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank__"
-                "l2_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank_llama7b_v1.json"
+                "l2_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank_llama7b_v1_r2.json"
             )
             assert decoder_inputs["attention_score32_exact_reduction_gqa8_full_equivalence_rerank_scope"].startswith(
                 "Rerank the quality-aware score32 HBM-controller-PPA frontier"
@@ -8104,8 +8104,8 @@ def test_generate_l2_campaign_task_adds_score32_exact_reduction_full_gqa8_rerank
                 "item_ids": [
                     "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
                     "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1",
-                    "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r7",
-                    "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1",
+                    "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r8",
+                    "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1_r2",
                 ],
                 "requires_merged_inputs": True,
                 "requires_materialized_refs": True,
@@ -15798,7 +15798,8 @@ def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_equivalence_evidence()
             assert work_item.expected_outputs == expected_outputs
             assert acceptance == work_item.acceptance_rules
             assert any("passed=true" in rule and "classification=passed" in rule for rule in acceptance)
-            assert any("producer_handshake_count=8192" in rule for rule in acceptance)
+            assert any("head_dimension=128" in rule for rule in acceptance)
+            assert any("producer_handshake_count=1048576" in rule for rule in acceptance)
             assert any("cluster_summaries" in rule and "errors=0" in rule for rule in acceptance)
             assert any("full_row_audit.passed=true" in rule for rule in acceptance)
             assert work_item.task_request.request_payload["task"]["inputs"]["decoder_contract"] == decoder_inputs
@@ -15894,7 +15895,8 @@ def test_generate_l2_campaign_task_adds_cluster_sram_gqa8_rotation_equivalence_e
                     "attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_report"
                 ],
             ]
-            assert any("producer_handshake_count=32768" in rule for rule in acceptance)
+            assert any("head_dimension=128" in rule for rule in acceptance)
+            assert any("producer_handshake_count=4194304" in rule for rule in acceptance)
             assert any("completed_command_count=4" in rule for rule in acceptance)
             assert any("strict_generated_top_guard=passed" in rule for rule in acceptance)
             assert any("producer_replay_parallelism=1" in rule for rule in acceptance)

--- a/docs/proposals/prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1/README.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1/README.md
@@ -1,0 +1,10 @@
+# GQA8 Full-Head Dimension Revision
+
+The prior one- and four-group score32 GQA8 equivalence runs drove one
+query/key product per token block. Llama7B requires a 128-term dot product.
+This revision retracts that evidence and reruns the same composed hierarchy
+with 128 accepted producer beats per block and an explicit report contract.
+
+Run the one-group replacement first. Run the four-group rotation only after
+the one-group result passes, because its stimulus and runtime are four times
+larger. Neither timeout nor resource termination is functional evidence.

--- a/docs/proposals/prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1/design_brief.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1/design_brief.md
@@ -1,0 +1,19 @@
+# Design Brief
+
+The prior composed GQA8 probes asserted `input_last` on every accepted
+query/key beat.  They exercised the structural hierarchy but reduced each
+token score to one INT8 product.  Llama7B requires a 128-term dot product, so
+the producer accumulation dependency and its release timing were unproven.
+
+The corrected driver emits 128 deterministic dimension beats for every token
+block, asserts `input_last` only on dimension 127, and computes reference scores
+from the same complete sequence.  Large query, key, last, and value stimuli are
+written as sidecar memory files instead of embedded Verilog assignments.  The
+one-group run is the bounded first gate; the four-group rotation follows only
+after it passes.
+
+The remote tasks use the fine-compositional Icarus backend.  It serially
+replays every exact producer stimulus through real producer RTL, then verifies
+the concrete p54/p53 SRAM/reducer paths and global tree with complete sidecars.
+This avoids an unbounded monolithic 856-producer simulation without replacing
+any arithmetic stage by a heuristic result.

--- a/docs/proposals/prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1/evaluation_gate.md
@@ -1,0 +1,21 @@
+# Evaluation Gate
+
+Reject any report that omits `head_dimension=128` or
+`score_accumulation_beats_per_block=128`.
+
+The one-group report must record `1,048,576` producer handshakes. The
+four-group report must record `4,194,304`. SRAM fill, SRAM response, cluster
+row, and root row counts remain those of the existing GQA8 schedule because
+head dimension changes score accumulation depth, not value residency shape.
+
+Require exact structured row equality, zero protocol/sticky errors, serial
+producer replay, and the checked canonical global numerator packing. Treat
+timeout, OOM, or resource termination as inconclusive. Preserve the old
+artifacts as retracted audit evidence; do not overwrite or delete them.
+
+Both replacement runs require an exclusive evaluator worker.  The one-group
+task is bounded at 8 GiB memory, 300% CPU, 2,400 seconds outer runtime, and a
+1,500-second stall timeout.  The four-group task uses the same memory, CPU, and
+stall limits with a 7,200-second outer runtime.  Exceeding a bound must produce
+an explicit inconclusive failure artifact rather than automatic promotion or
+an unbounded retry.

--- a/docs/proposals/prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1/evaluation_requests.json
@@ -1,0 +1,93 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1",
+  "proposal_path": "docs/proposals/prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1/proposal.json",
+  "source_commit": "TBD",
+  "source_commit_note": "Replace TBD with the merge commit containing the 128D probe, tightened task acceptance, and this revision package before dispatch.",
+  "requested_items": [
+    {
+      "item_id": "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r8",
+      "task_type": "l2_campaign",
+      "objective": "Replace the retracted one-dimensional one-group equivalence artifact with a bounded full-128D Llama7B RTL/perf proof.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence",
+      "comparison_role": "corrective_equivalence_check",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "status": "pending_after_proposal_merge",
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence__l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r8.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence__l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r8.md"
+      ],
+      "revision": {
+        "reason": "wrong_head_dimension_stimulus",
+        "invalidates_item_ids": [
+          "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r7",
+          "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1",
+          "l2_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank_llama7b_v1"
+        ],
+        "invalidates": {
+          "prior_contract": "head_dimension=1 implicit stimulus",
+          "replacement_contract": "head_dimension=128 explicit report contract"
+        }
+      },
+      "expected_result": {
+        "direction": "retract_one_dimension_evidence_and_prove_full_head",
+        "reason": "The current Llama7B frontier cannot cite full GQA8 equivalence until all 128 score dimensions traverse the RTL producer accumulation path."
+      },
+      "acceptance_notes": "Require head_dimension=128, score_accumulation_beats_per_block=128, producer_handshake_count=1048576, exact row equality, and zero protocol errors."
+    },
+    {
+      "item_id": "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1_r2",
+      "task_type": "l2_campaign",
+      "objective": "Prove the corrected full-128D score accumulation across GQA8 head bases 0, 8, 16, and 24.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence",
+      "comparison_role": "corrective_equivalence_check",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r8"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "status": "pending_after_one_group_pass",
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence__l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1_r2.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence__l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1_r2.md"
+      ],
+      "expected_result": {
+        "direction": "prove_full_head_gqa8_rotation_or_diagnose",
+        "reason": "One group does not prove rotated ownership for all four Llama7B GQA8 groups."
+      },
+      "acceptance_notes": "Require head_dimension=128, score_accumulation_beats_per_block=128, producer_handshake_count=4194304, head_bases=[0,8,16,24], exact row equality, and zero protocol errors."
+    },
+    {
+      "item_id": "l2_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank_llama7b_v1_r2",
+      "task_type": "l2_campaign",
+      "objective": "Replace the retracted frontier rerank using only explicit full-128D one- and four-group GQA8 equivalence evidence.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank",
+      "comparison_role": "corrective_frontier_rerank",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+        "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1",
+        "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r8",
+        "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "status": "pending_after_equivalence_passes",
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank__l2_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank_llama7b_v1_r2.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank__l2_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank_llama7b_v1_r2.md"
+      ],
+      "expected_result": {
+        "direction": "replace_retracted_full_gqa8_rerank",
+        "reason": "The score32 throughput, energy, area, and precision row must cite only corrected 128D equivalence evidence."
+      },
+      "acceptance_notes": "Reject legacy reports without explicit 128D contracts or with 8192/32768 producer handshakes. Preserve the prior rerank as retracted history."
+    }
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1/implementation_summary.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1/implementation_summary.md
@@ -1,0 +1,12 @@
+# Implementation Summary
+
+- Expanded deterministic query/key generation from one product to all 128
+  Llama7B head dimensions per token block.
+- Added explicit final-dimension sidecars and full-dot-product software
+  references across direct, compositional, and fine-compositional probes.
+- Moved large generated stimuli to `readmemh` sidecars to keep testbench source
+  bounded while preserving exact values.
+- Tightened reports and task acceptance to require explicit 128D contracts and
+  corrected producer handshake counts.
+- Added revision and rerank tasks that reject the legacy one-dimensional
+  evidence rather than silently overwriting it.

--- a/docs/proposals/prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1/promotion_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1/promotion_gate.md
@@ -1,0 +1,8 @@
+# Promotion Gate
+
+Run and merge the one-group full-128D equivalence result first.  Dispatch the
+four-group rotation only after that result passes without protocol errors or
+resource ambiguity.  Replace the active score32 GQA8 frontier rerank only after
+both corrected reports pass and are materialized.  Any timeout or resource
+failure leaves the equivalence claim unresolved and must not restore the
+retracted ranking.

--- a/docs/proposals/prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1/proposal.json
+++ b/docs/proposals/prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1/proposal.json
@@ -1,0 +1,103 @@
+{
+  "proposal_id": "prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1",
+  "created_utc": "2026-08-21T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer2",
+  "kind": "revision",
+  "abstraction_layer": "decoder_attention_score32_gqa8_full_head_dimension_revision",
+  "title": "Replace one-dimensional GQA8 evidence with full 128D Llama7B score accumulation",
+  "hypothesis": "The composed score32 producer, cluster-SRAM, local reducer, and finalized global tree preserve RTL/perf equivalence when every token score is accumulated across all 128 Llama7B head dimensions.",
+  "direct_comparison": {
+    "primary_question": "Does the previously selected score32 GQA8 hierarchy remain exact when the producer sequential dependency spans the full 128-dimensional Llama7B query/key dot product?",
+    "include": [
+      "856 real dual-stream score32 producers",
+      "128 accepted signed INT8 query/key beats per token block",
+      "input_last only on dimension 127",
+      "sixteen cluster SRAM services and local temporal reducers",
+      "the c16/r2/l8/b59 finalized global tree",
+      "one-group and four-group GQA8 ownership",
+      "full structured cluster and root row audits"
+    ],
+    "exclude": [
+      "OpenROAD full-array PPA",
+      "measured SRAM macro energy",
+      "mesh NoC routing and arbitration",
+      "HBM/DRAM controller signoff"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r8",
+      "task_type": "l2_campaign",
+      "objective": "Replace the retracted one-dimensional one-group equivalence artifact with a bounded full-128D Llama7B RTL/perf proof.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence",
+      "comparison_role": "corrective_equivalence_check",
+      "depends_on_item_ids": [],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence__l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r8.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence__l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r8.md"
+      ],
+      "revision": {
+        "reason": "wrong_head_dimension_stimulus",
+        "invalidates_item_ids": [
+          "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r7",
+          "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1",
+          "l2_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank_llama7b_v1"
+        ],
+        "invalidates": {
+          "prior_contract": "one query/key product per token block with input_last asserted on every beat",
+          "replacement_contract": "128 query/key products per token block with input_last asserted only on dimension 127"
+        }
+      }
+    },
+    {
+      "item_id": "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1_r2",
+      "task_type": "l2_campaign",
+      "objective": "Prove the corrected full-128D score accumulation across GQA8 head bases 0, 8, 16, and 24.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence",
+      "comparison_role": "corrective_equivalence_check",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r8"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence__l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1_r2.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence__l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1_r2.md"
+      ]
+    },
+    {
+      "item_id": "l2_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank_llama7b_v1_r2",
+      "task_type": "l2_campaign",
+      "objective": "Replace the retracted frontier rerank using only explicit full-128D one- and four-group GQA8 equivalence evidence.",
+      "evaluation_mode": "frontier_detail",
+      "abstraction_layer": "decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank",
+      "comparison_role": "corrective_frontier_rerank",
+      "depends_on_item_ids": [
+        "l2_decoder_attention_score32_exact_reduction_recost_llama7b_v1",
+        "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1",
+        "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r8",
+        "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1_r2"
+      ],
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "run_physical": false,
+      "expected_outputs": [
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank__l2_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank_llama7b_v1_r2.json",
+        "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank__l2_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank_llama7b_v1_r2.md"
+      ]
+    }
+  ],
+  "baseline_refs": [
+    "npu/docs/attention_score32_exact_local16_global_tree_cluster_sram_gqa8_contract.md",
+    "npu/docs/attention_score32_exact_local16_global_tree_gqa8_contract.md",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence__l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r7.json",
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence__l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1.json"
+  ]
+}

--- a/docs/proposals/prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1/quality_gate.md
+++ b/docs/proposals/prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1/quality_gate.md
@@ -1,0 +1,11 @@
+# Quality Gate
+
+- Accept exactly 128 signed query/key beats per token block and assert
+  `input_last` only on the final dimension.
+- Compute every reference score as the sum of all 128 signed products.
+- Require 1,048,576 producer handshakes for one group and 4,194,304 for all
+  four GQA8 groups.
+- Compare every structured cluster and root row, not only hashes or totals.
+- Require zero protocol and sticky errors and canonical numerator packing.
+- Classify timeout, OOM, and external termination as inconclusive, never pass.
+- Preserve the one-dimensional artifacts as retracted audit history.

--- a/npu/docs/attention_score32_exact_local16_global_tree_cluster_sram_gqa8_contract.md
+++ b/npu/docs/attention_score32_exact_local16_global_tree_cluster_sram_gqa8_contract.md
@@ -14,6 +14,17 @@ This block composes:
 - direct local exact aggregation into the existing finalized global tree root
 - packed cluster compute counters plus packed cluster SRAM counters and errors
 
+## Llama7B Score Accumulation
+
+- every query/key score block has `128` signed INT8 dimensions
+- a producer must accept exactly `128` query/key beats for each token block
+- `input_last` is asserted only on dimension `127`
+- the score entering exp/reduction is the signed sum of all `128` products
+- a report is valid Llama7B evidence only when it records both
+  `head_dimension=128` and `score_accumulation_beats_per_block=128`
+- one logical head group therefore accepts `1,048,576` producer beats; all four
+  GQA8 head groups accept `4,194,304`
+
 ## Fixed Schedule
 
 - internal group-major command cadence is fixed to head bases `0, 8, 16, 24`

--- a/npu/docs/attention_score32_exact_local16_global_tree_gqa8_contract.md
+++ b/npu/docs/attention_score32_exact_local16_global_tree_gqa8_contract.md
@@ -15,6 +15,10 @@ This block is the full structural exact wrapper that composes:
 - direct global exact merge/finalization through the existing ordered banked `c16/r2/l8/b59` tree
 - finalized `320`-bit value output plus component/global counters and protocol signals
 
+The producer-side score contract is Llama7B `head_dim=128`: each token block is
+the dot product of `128` accepted signed INT8 query/key beats, with `input_last`
+asserted only on the final dimension.
+
 ## Cluster Partition
 
 - clusters `0..7` use `54` local producer leaves each
@@ -37,13 +41,13 @@ This block is the full structural exact wrapper that composes:
   the existing finalized-tree contract itself, which consumes `global_max` and
   `exp_sum` internally and emits finalized values only.
 
-## Recorded Bounded Full-Wrapper Evidence
+## Retracted One-Dimensional Evidence
 
-Recorded on July 28, 2026 with:
+The July 28, 2026 bounded run used this command:
 
 - `python npu/eval/probe_attention_score32_exact_local16_global_tree_gqa8.py --config runs/designs/npu_blocks/attention_score32_exact_local16_global_tree_gqa8_p54x8_p53x8_c16_r2_l8_b59/config.json --timeout-sec 240 --json`
 
-Checked-in bounded point:
+It recorded the following historical point:
 
 - command groups: `1`
 - head bases: `[0]`
@@ -61,10 +65,20 @@ Checked-in bounded point:
 - per-cluster emitted aggregate beats: `128`
 - protocol errors: `0`
 
-This bounded point is a full structural wrapper simulation over the real
-`856`-leaf boundary. It is not a reduced proxy.
+That result is not valid Llama7B full-head equivalence evidence. Its stimulus
+asserted `input_last` on every producer beat, so every score covered one product
+instead of the required `128`-term dot product. The structural wrapper and
+reduction rows were exercised, but the sequential producer accumulation path was
+not. The result and dependent full-GQA8 rerank must remain as retracted audit
+history until replaced by reports that record:
 
-## Heavier Run Status
+- `head_dimension=128`
+- `score_accumulation_beats_per_block=128`
+- `producer_handshake_count=1,048,576` for one head group
+- `producer_handshake_count=4,194,304` for four head groups
+- exact structured cluster/root row equality and zero protocol errors
+
+## Historical Heavier Run Status
 
 The same full wrapper was also attempted as a heavier two-group run on July 28,
 2026 with:

--- a/npu/eval/audit_llm_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank.py
+++ b/npu/eval/audit_llm_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank.py
@@ -22,28 +22,23 @@ _EXPECTED_FRONTIER_ITEM_ID = (
     "l2_decoder_attention_score32_quality_aware_hbm_controller_replay_rtl_ppa_recost_frontier_llama7b_v1"
 )
 _EXPECTED_ONE_GROUP_ITEM_ID = (
-    "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r7"
+    "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r8"
 )
 _EXPECTED_FOUR_GROUP_ITEM_ID = (
-    "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1"
+    "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1_r2"
 )
-_EXPECTED_ONE_GROUP_PROPOSAL_ID = (
-    "prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1"
-)
+_EXPECTED_ONE_GROUP_PROPOSAL_ID = "prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1"
 _EXPECTED_ONE_GROUP_PROPOSAL_PATH = (
-    "docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/proposal.json"
+    "docs/proposals/prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1/proposal.json"
 )
-_EXPECTED_FOUR_GROUP_PROPOSAL_ID = (
-    "prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1"
-)
-_EXPECTED_FOUR_GROUP_PROPOSAL_PATH = (
-    "docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/proposal.json"
-)
+_EXPECTED_FOUR_GROUP_PROPOSAL_ID = _EXPECTED_ONE_GROUP_PROPOSAL_ID
+_EXPECTED_FOUR_GROUP_PROPOSAL_PATH = _EXPECTED_ONE_GROUP_PROPOSAL_PATH
 _EXPECTED_SCORE32_FAMILY = "score32_exp_lut_div"
 _EXPECTED_SCORE32_CANDIDATE = "score32_exp_lut_schedule_wrapper_hbm_controller_replay_best"
+_EXPECTED_HEAD_DIMENSION = 128
 _EXPECTED_EQUIVALENCE_COUNTS = {
     1: {
-        "producer_handshake_count": 8192,
+        "producer_handshake_count": 1_048_576,
         "fill_target_accept_count": 128,
         "fill_row_accept_count": 262144,
         "sram_request_accept_count": 262144,
@@ -52,7 +47,7 @@ _EXPECTED_EQUIVALENCE_COUNTS = {
         "root_row_count": 128,
     },
     4: {
-        "producer_handshake_count": 32768,
+        "producer_handshake_count": 4_194_304,
         "fill_target_accept_count": 512,
         "fill_row_accept_count": 1048576,
         "sram_request_accept_count": 1048576,
@@ -285,6 +280,21 @@ def _validate_equivalence(payload: JsonDict, *, label: str, expected_groups: int
         int(_as_float(payload.get("logical_head_groups"), label=f"{label} logical_head_groups")) == expected_groups,
         f"{label} equivalence logical_head_groups must be {expected_groups}",
     )
+    head_dimension = int(_as_float(payload.get("head_dimension"), label=f"{label} head_dimension"))
+    _require(
+        head_dimension == _EXPECTED_HEAD_DIMENSION,
+        f"{label} head_dimension must be {_EXPECTED_HEAD_DIMENSION}, got {head_dimension}",
+    )
+    accumulation_beats = int(
+        _as_float(
+            payload.get("score_accumulation_beats_per_block"),
+            label=f"{label} score_accumulation_beats_per_block",
+        )
+    )
+    _require(
+        accumulation_beats == _EXPECTED_HEAD_DIMENSION,
+        f"{label} score_accumulation_beats_per_block must be {_EXPECTED_HEAD_DIMENSION}, got {accumulation_beats}",
+    )
     head_bases = [int(value) for value in _as_list(payload.get("head_bases"))]
     _require(head_bases == _EXPECTED_HEAD_BASES[expected_groups], f"{label} head_bases are mismatched")
     command_ids = [int(value) for value in _as_list(payload.get("command_ids"))]
@@ -363,6 +373,8 @@ def _validate_equivalence(payload: JsonDict, *, label: str, expected_groups: int
                 )
     return {
         "logical_head_groups": expected_groups,
+        "head_dimension": head_dimension,
+        "score_accumulation_beats_per_block": accumulation_beats,
         "head_bases": head_bases,
         "command_ids": command_ids,
         "summary": {key: expected_counts[key] for key in expected_counts},

--- a/npu/eval/gqa8_compositional_exact.py
+++ b/npu/eval/gqa8_compositional_exact.py
@@ -48,6 +48,7 @@ def _cluster_driver_data(*, cluster: int, logical_head_groups: int) -> JsonDict:
     wave_commands = probe._wave_commands(logical_head_groups=logical_head_groups)
     query_streams: list[list[int]] = [[] for _ in range(producers)]
     key_streams: list[list[int]] = [[] for _ in range(producers)]
+    last_streams: list[list[int]] = [[] for _ in range(producers)]
     beat_limits = [[0 for _ in range(producers)] for _ in wave_commands]
     max_beats = 0
     for producer in range(producers):
@@ -70,30 +71,35 @@ def _cluster_driver_data(*, cluster: int, logical_head_groups: int) -> JsonDict:
                 for stream in range(probe.STREAMS)
             ]
             for block in range(block_count):
-                queries0, keys0 = blocks[0][block][0]
-                queries1, keys1 = blocks[1][block][0]
-                query_streams[producer].append(
-                    probe.full_probe._pack(list(queries0), 8)
-                    | (probe.full_probe._pack(list(queries1), 8) << 64)
-                )
-                key_streams[producer].append(
-                    probe.full_probe._pack(list(keys0), 8)
-                    | (probe.full_probe._pack(list(keys1), 8) << 64)
-                )
-                cursor += 1
+                for dimension in range(probe.HEAD_DIM):
+                    queries0, keys0 = blocks[0][block][dimension]
+                    queries1, keys1 = blocks[1][block][dimension]
+                    query_streams[producer].append(
+                        probe.full_probe._pack(list(queries0), 8)
+                        | (probe.full_probe._pack(list(queries1), 8) << 64)
+                    )
+                    key_streams[producer].append(
+                        probe.full_probe._pack(list(keys0), 8)
+                        | (probe.full_probe._pack(list(keys1), 8) << 64)
+                    )
+                    last_streams[producer].append(int(dimension + 1 == probe.HEAD_DIM))
+                    cursor += 1
             beat_limits[command_index][producer] = cursor
         max_beats = max(max_beats, cursor)
     query_words = [0] * (producers * max_beats)
     key_words = [0] * (producers * max_beats)
+    last_words = [0] * (producers * max_beats)
     for producer in range(producers):
         for beat_index, query in enumerate(query_streams[producer]):
             flat = producer * max_beats + beat_index
             query_words[flat] = query
             key_words[flat] = key_streams[producer][beat_index]
+            last_words[flat] = last_streams[producer][beat_index]
     return {
         "wave_commands": wave_commands,
         "query_words": query_words,
         "key_words": key_words,
+        "last_words": last_words,
         "beat_limits": beat_limits,
         "max_beats_per_producer": max_beats,
     }
@@ -105,6 +111,7 @@ def _write_cluster_sidecars(directory: Path, *, cluster: int, logical_head_group
     data = _cluster_driver_data(cluster=cluster, logical_head_groups=logical_head_groups)
     probe._write_memh(directory / "query.memh", data["query_words"], width_bits=128)
     probe._write_memh(directory / "key.memh", data["key_words"], width_bits=128)
+    probe._write_memh(directory / "last.memh", data["last_words"], width_bits=1)
     fill_words = [
         value
         for command in data["wave_commands"]
@@ -118,6 +125,7 @@ def _write_cluster_sidecars(directory: Path, *, cluster: int, logical_head_group
     return {
         "query_words": len(data["query_words"]),
         "key_words": len(data["key_words"]),
+        "last_words": len(data["last_words"]),
         "fill_words": len(fill_words),
         "max_beats_per_producer": int(data["max_beats_per_producer"]),
     }
@@ -190,6 +198,7 @@ module tb;
   reg [31:0] beat_limit_mem [0:COMMANDS-1][0:PRODUCERS-1];
   reg [127:0] query_mem [0:(PRODUCERS*MAX_BEATS)-1];
   reg [127:0] key_mem [0:(PRODUCERS*MAX_BEATS)-1];
+  reg last_mem [0:(PRODUCERS*MAX_BEATS)-1];
   reg [511:0] fill_mem [0:(COMMANDS*ROWS_PER_TARGET)-1];
   reg out_ready_mem [0:OUT_READY_LEN-1];
   wire preload_complete = fill_command >= ((COMMANDS < 2) ? COMMANDS : 2);
@@ -260,7 +269,7 @@ module tb;
     for (producer = 0; producer < PRODUCERS; producer = producer + 1) begin
       if (rst_n && active >= 0 && beat_issue[producer] < beat_limit_mem[active][producer]) begin
         flat_index = producer * MAX_BEATS + beat_issue[producer];
-        input_valid[producer] = 1'b1; input_last[producer] = 1'b1;
+        input_valid[producer] = 1'b1; input_last[producer] = last_mem[flat_index];
         input_query[producer*128 +: 128] = query_mem[flat_index];
         input_key[producer*128 +: 128] = key_mem[flat_index];
       end
@@ -304,7 +313,8 @@ module tb;
   end
   initial begin
     if (!$value$plusargs("CLUSTER=%d", cluster_id)) cluster_id = 0;
-    $readmemh("query.memh", query_mem); $readmemh("key.memh", key_mem); $readmemh("fill.memh", fill_mem);
+    $readmemh("query.memh", query_mem); $readmemh("key.memh", key_mem);
+    $readmemh("last.memh", last_mem); $readmemh("fill.memh", fill_mem);
 {command_init}
 {beat_limit_init}
 {ready_init}

--- a/npu/eval/gqa8_fine_compositional_exact.py
+++ b/npu/eval/gqa8_fine_compositional_exact.py
@@ -69,6 +69,7 @@ def _producer_case(*, cluster: int, producer: int, logical_head_groups: int) -> 
     commands = probe._wave_commands(logical_head_groups=logical_head_groups)
     query_words: list[int] = []
     key_words: list[int] = []
+    last_words: list[int] = []
     value_words = [[], []]
     beat_limits: list[int] = []
     block_offsets: list[int] = []
@@ -95,16 +96,18 @@ def _producer_case(*, cluster: int, producer: int, logical_head_groups: int) -> 
             for stream in range(probe.STREAMS)
         ]
         for block in range(block_count):
-            queries0, keys0 = stream_blocks[0][block][0]
-            queries1, keys1 = stream_blocks[1][block][0]
-            query_words.append(
-                probe.full_probe._pack(list(queries0), 8)
-                | (probe.full_probe._pack(list(queries1), 8) << 64)
-            )
-            key_words.append(
-                probe.full_probe._pack(list(keys0), 8)
-                | (probe.full_probe._pack(list(keys1), 8) << 64)
-            )
+            for dimension in range(probe.HEAD_DIM):
+                queries0, keys0 = stream_blocks[0][block][dimension]
+                queries1, keys1 = stream_blocks[1][block][dimension]
+                query_words.append(
+                    probe.full_probe._pack(list(queries0), 8)
+                    | (probe.full_probe._pack(list(queries1), 8) << 64)
+                )
+                key_words.append(
+                    probe.full_probe._pack(list(keys0), 8)
+                    | (probe.full_probe._pack(list(keys1), 8) << 64)
+                )
+                last_words.append(int(dimension + 1 == probe.HEAD_DIM))
         beat_limits.append(len(query_words))
         for stream in range(probe.STREAMS):
             blocks = probe.full_probe._value_blocks(
@@ -148,6 +151,7 @@ def _producer_case(*, cluster: int, producer: int, logical_head_groups: int) -> 
         "commands": commands,
         "query_words": query_words,
         "key_words": key_words,
+        "last_words": last_words,
         "value_words": value_words[0] + value_words[1],
         "total_blocks": block_cursor,
         "beat_limits": beat_limits,
@@ -167,6 +171,7 @@ def _write_producer_sidecars(
 
     probe._write_memh(directory / "query.memh", case["query_words"], width_bits=128)
     probe._write_memh(directory / "key.memh", case["key_words"], width_bits=128)
+    probe._write_memh(directory / "last.memh", case["last_words"], width_bits=1)
     total_blocks = int(case["total_blocks"])
     values = list(case["value_words"])
     stream_words = total_blocks * 16
@@ -203,6 +208,7 @@ module tb;
   reg finish_pending=0;
   reg [140:0] command_mem [0:COMMANDS-1];
   reg [127:0] query_mem [0:TOTAL_BEATS-1], key_mem [0:TOTAL_BEATS-1];
+  reg last_mem [0:TOTAL_BEATS-1];
   reg [511:0] value_mem [0:(2*TOTAL_BLOCKS*16)-1];
   wire command_valid=(issued<COMMANDS); wire command_ready;
   wire input_valid=(input_index < ((issued==0)?0:command_mem[issued-1][140:109])); wire input_ready;
@@ -224,7 +230,7 @@ module tb;
     .command_block_count(command_mem[command_drive][76:62]),
     .command_score_multiplier(command_mem[command_drive][55:24]),
     .command_score_shift(command_mem[command_drive][61:56]),
-    .input_valid(input_valid),.input_ready(input_ready),.input_last(1'b1),
+    .input_valid(input_valid),.input_ready(input_ready),.input_last(last_mem[input_drive]),
     .input_query(query_mem[input_drive]),.input_key(key_mem[input_drive]),
     .value_read_req_valid(req_valid),.value_read_req_ready(req_ready),
     .value_read_req_address(req_address),.value_read_req_slice(req_slice),
@@ -295,6 +301,7 @@ module tb;
   end
   initial begin
     $readmemh("query.memh",query_mem); $readmemh("key.memh",key_mem);
+    $readmemh("last.memh",last_mem);
     $readmemh("value.memh",value_mem);
     $readmemh("producer_commands.memh",command_mem);
     resp_valid=0; resp_address=0; resp_slice=0; resp_matrix=0;

--- a/npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
+++ b/npu/eval/probe_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
@@ -50,6 +50,7 @@ HEAD_BASES = (0, 8, 16, 24)
 DEFAULT_LOGICAL_HEAD_GROUPS = 1
 MAX_LOGICAL_HEAD_GROUPS = len(HEAD_BASES)
 SEED = 29
+HEAD_DIM = full_probe.HEAD_DIM
 WAVES = LOCAL_TEMPORAL_WAVES
 TB_TIMEOUT_CYCLES = 50_000
 DEFAULT_SUBPROCESS_TIMEOUT_SEC = 900
@@ -75,7 +76,7 @@ ROWS_PER_STREAM = ROWS_PER_BUFFER // STREAMS
 EXPECTED_TOTALS = {
     "fill_target_accept_count": 128,
     "fill_row_accept_count": 262_144,
-    "producer_handshake_count": 8_192,
+    "producer_handshake_count": 8_192 * HEAD_DIM,
     "sram_request_accept_count": 262_144,
     "sram_response_accept_count": 262_144,
     "cluster_row_count": 2_048,
@@ -331,6 +332,7 @@ def _driver_data(*, logical_head_groups: int = DEFAULT_LOGICAL_HEAD_GROUPS) -> d
     cluster_bases = _cluster_bases()
     query_streams: list[list[int]] = [[] for _ in range(TOTAL_PRODUCERS)]
     key_streams: list[list[int]] = [[] for _ in range(TOTAL_PRODUCERS)]
+    last_streams: list[list[int]] = [[] for _ in range(TOTAL_PRODUCERS)]
     beat_limits = [[0 for _ in range(TOTAL_PRODUCERS)] for _ in range(len(wave_commands))]
     max_beats_per_producer = 0
     for cluster, producers in enumerate(CLUSTER_PRODUCERS):
@@ -356,32 +358,37 @@ def _driver_data(*, logical_head_groups: int = DEFAULT_LOGICAL_HEAD_GROUPS) -> d
                 )
                 blocks = list(stream_blocks)
                 for block in range(block_count):
-                    queries0, keys0 = blocks[0][block][0]
-                    queries1, keys1 = blocks[1][block][0]
-                    query_streams[global_producer].append(
-                        full_probe._pack(list(queries0), 8) | (
-                        full_probe._pack(list(queries1), 8) << 64
-                    )
-                    )
-                    key_streams[global_producer].append(
-                        full_probe._pack(list(keys0), 8) | (
-                        full_probe._pack(list(keys1), 8) << 64
-                    )
-                    )
-                    beat_cursor += 1
+                    for dimension in range(HEAD_DIM):
+                        queries0, keys0 = blocks[0][block][dimension]
+                        queries1, keys1 = blocks[1][block][dimension]
+                        query_streams[global_producer].append(
+                            full_probe._pack(list(queries0), 8) | (
+                            full_probe._pack(list(queries1), 8) << 64
+                        )
+                        )
+                        key_streams[global_producer].append(
+                            full_probe._pack(list(keys0), 8) | (
+                            full_probe._pack(list(keys1), 8) << 64
+                        )
+                        )
+                        last_streams[global_producer].append(int(dimension + 1 == HEAD_DIM))
+                        beat_cursor += 1
                 beat_limits[command_index][global_producer] = beat_cursor
             max_beats_per_producer = max(max_beats_per_producer, beat_cursor)
     query_words = [0] * (TOTAL_PRODUCERS * max_beats_per_producer)
     key_words = [0] * (TOTAL_PRODUCERS * max_beats_per_producer)
+    last_words = [0] * (TOTAL_PRODUCERS * max_beats_per_producer)
     for producer in range(TOTAL_PRODUCERS):
         for beat_index, packed_query in enumerate(query_streams[producer]):
             flat = (producer * max_beats_per_producer) + beat_index
             query_words[flat] = packed_query
             key_words[flat] = key_streams[producer][beat_index]
+            last_words[flat] = last_streams[producer][beat_index]
     return {
         "wave_commands": wave_commands,
         "query_words": query_words,
         "key_words": key_words,
+        "last_words": last_words,
         "max_beats_per_producer": max_beats_per_producer,
         "beat_limits": beat_limits,
     }
@@ -437,11 +444,14 @@ def _write_memh_sidecars(
     driver_data = _driver_data(logical_head_groups=logical_head_groups)
     query_words = list(driver_data["query_words"])
     key_words = list(driver_data["key_words"])
+    last_words = list(driver_data["last_words"])
     query_path = directory / "query.memh"
     key_path = directory / "key.memh"
+    last_path = directory / "last.memh"
     fill_path = directory / "fill.memh"
     _write_memh(query_path, query_words, width_bits=128)
     _write_memh(key_path, key_words, width_bits=128)
+    _write_memh(last_path, last_words, width_bits=1)
     with fill_path.open("w", encoding="ascii") as handle:
         for cluster in range(CLUSTERS):
             for wave_command in _wave_commands(logical_head_groups=logical_head_groups):
@@ -454,9 +464,11 @@ def _write_memh_sidecars(
     return {
         "query": query_path.name,
         "key": key_path.name,
+        "last": last_path.name,
         "fill": fill_path.name,
         "query_words": len(query_words),
         "key_words": len(key_words),
+        "last_words": len(last_words),
         "fill_words": CLUSTERS * logical_head_groups * WAVES * ROWS_PER_BUFFER,
         "max_beats_per_producer": int(driver_data["max_beats_per_producer"]),
         "logical_head_groups": int(logical_head_groups),
@@ -728,6 +740,7 @@ module tb;
   reg [31:0] cmd_beat_limit_mem [0:WAVE_COMMANDS-1][0:TOTAL_PRODUCERS-1];
   reg [127:0] query_mem [0:(TOTAL_PRODUCERS*MAX_BEATS_PER_PRODUCER)-1];
   reg [127:0] key_mem [0:(TOTAL_PRODUCERS*MAX_BEATS_PER_PRODUCER)-1];
+  reg last_mem [0:(TOTAL_PRODUCERS*MAX_BEATS_PER_PRODUCER)-1];
   reg [511:0] fill_mem [0:(CLUSTERS*WAVE_COMMANDS*ROWS_PER_TARGET)-1];
   reg root_ready_mem [0:ROOT_READY_PATTERN_LEN-1];
 
@@ -928,7 +941,7 @@ module tb;
           (beat_issue[producer_index] < cmd_beat_limit_mem[active_command_index][producer_index])) begin
         flat_index = (producer_index * MAX_BEATS_PER_PRODUCER) + beat_issue[producer_index];
         input_valid[producer_index] = 1'b1;
-        input_last[producer_index] = 1'b1;
+        input_last[producer_index] = last_mem[flat_index];
         input_query[(producer_index * 128) +: 128] = query_mem[flat_index];
         input_key[(producer_index * 128) +: 128] = key_mem[flat_index];
       end
@@ -1012,6 +1025,7 @@ module tb;
   initial begin
     $readmemh("query.memh", query_mem);
     $readmemh("key.memh", key_mem);
+    $readmemh("last.memh", last_mem);
     $readmemh("fill.memh", fill_mem);
 {command_init}
 {beat_limit_init}
@@ -1454,6 +1468,8 @@ def build_report(
     )
     report.update(
         {
+            "head_dimension": HEAD_DIM,
+            "score_accumulation_beats_per_block": HEAD_DIM,
             "clusters": CLUSTERS,
             "cluster_producers": list(CLUSTER_PRODUCERS),
             "total_local_producers": TOTAL_PRODUCERS,
@@ -1506,6 +1522,8 @@ def _render_text(report: JsonDict) -> str:
         f"- classification: `{report['classification']}`",
         f"- simulation_status: `{report['simulation_status']}`",
         f"- sim_backend: `{report['sim_backend']}`",
+        f"- head_dimension: `{report['head_dimension']}`",
+        f"- score_accumulation_beats_per_block: `{report['score_accumulation_beats_per_block']}`",
         f"- compile_timeout_sec: `{report['compile_timeout_sec']}`",
         f"- simulation_timeout_sec: `{report['simulation_timeout_sec']}`",
         f"- producer_handshakes: `{summary.get('producer_handshake_count', 0)}`",

--- a/npu/eval/probe_attention_score32_exact_local16_global_tree_gqa8.py
+++ b/npu/eval/probe_attention_score32_exact_local16_global_tree_gqa8.py
@@ -33,6 +33,7 @@ from npu.sim.perf.attention_exact_partial import (
 from npu.sim.perf.attention_online import requantize_score_row
 
 JsonDict = dict[str, Any]
+HEAD_DIM = 128
 _CONFIG_KEY = "attention_score32_exact_local16_global_tree_gqa8"
 _CLUSTER_RESULT_RE = re.compile(
     r"CLUSTER_RESULT cluster=(\d+) cmd=(\d+) head=(\d+) slice=(\d+) last=(\d+) max=(-?\d+) sum=(\d+) value=([0-9a-fA-F]+) cycle=(\d+)"
@@ -257,41 +258,46 @@ def _stream_block_beats(
 ) -> tuple[tuple[tuple[tuple[int, ...], tuple[int, ...]], ...], ...]:
     blocks = []
     for block_index in range(block_count):
-        queries = tuple(
-            (
+        beats = []
+        for dimension in range(HEAD_DIM):
+            queries = tuple(
                 (
-                    seed * 17
-                    + cluster * 19
-                    + producer * 23
-                    + group_index * 29
-                    + wave_index * 31
-                    + stream * 37
-                    + block_index * 41
-                    + head_lane * 43
+                    (
+                        seed * 17
+                        + cluster * 19
+                        + producer * 23
+                        + group_index * 29
+                        + wave_index * 31
+                        + stream * 37
+                        + block_index * 41
+                        + head_lane * 43
+                        + dimension * 47
+                    )
+                    % 127
                 )
-                % 127
+                - 63
+                for head_lane in range(8)
             )
-            - 63
-            for head_lane in range(8)
-        )
-        keys = tuple(
-            (
+            keys = tuple(
                 (
-                    seed * 47
-                    + cluster * 53
-                    + producer * 59
-                    + group_index * 61
-                    + wave_index * 67
-                    + stream * 71
-                    + block_index * 73
-                    + token_lane * 79
+                    (
+                        seed * 47
+                        + cluster * 53
+                        + producer * 59
+                        + group_index * 61
+                        + wave_index * 67
+                        + stream * 71
+                        + block_index * 73
+                        + token_lane * 79
+                        + dimension * 83
+                    )
+                    % 127
                 )
-                % 127
+                - 63
+                for token_lane in range(8)
             )
-            - 63
-            for token_lane in range(8)
-        )
-        blocks.append((((tuple(queries), tuple(keys))),))
+            beats.append((queries, keys))
+        blocks.append(tuple(beats))
     return tuple(blocks)
 
 
@@ -335,9 +341,19 @@ def _value_blocks(
     )
 
 
-def _raw_scores(block: tuple[tuple[int, ...], tuple[int, ...]], head_lane: int) -> list[int]:
-    queries, keys = block
-    return [int(queries[head_lane]) * int(keys[token_lane]) for token_lane in range(8)]
+def _raw_scores(
+    block: tuple[tuple[tuple[int, ...], tuple[int, ...]], ...],
+    head_lane: int,
+) -> list[int]:
+    if len(block) != HEAD_DIM:
+        raise ValueError(f"score block must contain {HEAD_DIM} head-dimension beats")
+    return [
+        sum(
+            int(queries[head_lane]) * int(keys[token_lane])
+            for queries, keys in block
+        )
+        for token_lane in range(8)
+    ]
 
 
 def _producer_wave_stream(
@@ -365,7 +381,7 @@ def _producer_wave_stream(
             score_rows = [
                 list(
                     requantize_score_row(
-                        _raw_scores(blocks[block_index][0], head_lane),
+                        _raw_scores(blocks[block_index], head_lane),
                         multiplier=int(logical_command["multiplier"]),
                         shift=int(logical_command["shift"]),
                     )
@@ -468,15 +484,20 @@ def _hierarchy_driver_data(cluster_producers: tuple[int, ...], workload: dict[st
                     seed=int(workload["seed"]),
                 )
                 for block_index in range(block_count):
-                    queries0, keys0 = blocks0[block_index][0]
-                    queries1, keys1 = blocks1[block_index][0]
-                    query_mem[global_index].append(_pack(list(queries0), 8) | (_pack(list(queries1), 8) << 64))
-                    key_mem[global_index].append(_pack(list(keys0), 8) | (_pack(list(keys1), 8) << 64))
-                    last_mem[global_index].append(1)
+                    for dimension in range(HEAD_DIM):
+                        queries0, keys0 = blocks0[block_index][dimension]
+                        queries1, keys1 = blocks1[block_index][dimension]
+                        query_mem[global_index].append(
+                            _pack(list(queries0), 8) | (_pack(list(queries1), 8) << 64)
+                        )
+                        key_mem[global_index].append(
+                            _pack(list(keys0), 8) | (_pack(list(keys1), 8) << 64)
+                        )
+                        last_mem[global_index].append(int(dimension + 1 == HEAD_DIM))
                     for value_slice in range(16):
                         stream_values[0].append(_pack([lane for row in values0[block_index][value_slice] for lane in row], 8))
                         stream_values[1].append(_pack([lane for row in values1[block_index][value_slice] for lane in row], 8))
-                cumulative_beats += block_count
+                cumulative_beats += block_count * HEAD_DIM
                 cumulative_blocks += block_count
                 beat_limits[command_index][global_index] = cumulative_beats
             value_mem[global_index * 2] = stream_values[0]
@@ -569,6 +590,44 @@ def _ready_init(pattern: tuple[bool, ...]) -> str:
     return "\n".join(f"    root_ready_mem[{index}] = 1'b{1 if value else 0};" for index, value in enumerate(pattern))
 
 
+def _write_memh(path: Path, values: list[int], *, width_bits: int) -> None:
+    width_hex = (width_bits + 3) // 4
+    with path.open("w", encoding="ascii") as handle:
+        for value in values:
+            handle.write(f"{int(value) & ((1 << width_bits) - 1):0{width_hex}x}\n")
+
+
+def _write_driver_sidecars(directory: Path, command_data: dict[str, object]) -> dict[str, int]:
+    query_mem = command_data["query_mem"]
+    key_mem = command_data["key_mem"]
+    last_mem = command_data["last_mem"]
+    value_mem = command_data["value_mem"]
+    max_beats = int(command_data["max_beats_per_producer"])
+    max_blocks = int(command_data["max_blocks_per_producer"])
+    query_words: list[int] = []
+    key_words: list[int] = []
+    last_words: list[int] = []
+    for producer in range(len(query_mem)):
+        count = len(query_mem[producer])
+        query_words.extend([*query_mem[producer], *([0] * (max_beats - count))])
+        key_words.extend([*key_mem[producer], *([0] * (max_beats - count))])
+        last_words.extend([*last_mem[producer], *([0] * (max_beats - count))])
+    value_words: list[int] = []
+    words_per_lane = max_blocks * 16
+    for lane in value_mem:
+        value_words.extend([*lane, *([0] * (words_per_lane - len(lane)))])
+    _write_memh(directory / "query.memh", query_words, width_bits=128)
+    _write_memh(directory / "key.memh", key_words, width_bits=128)
+    _write_memh(directory / "last.memh", last_words, width_bits=1)
+    _write_memh(directory / "value.memh", value_words, width_bits=512)
+    return {
+        "query_words": len(query_words),
+        "key_words": len(key_words),
+        "last_words": len(last_words),
+        "value_words": len(value_words),
+    }
+
+
 def _score_params(head_base: int) -> tuple[int, int]:
     group_index = int(head_base) >> 3
     if group_index == 0:
@@ -644,15 +703,18 @@ def _cluster_summary_logging() -> str:
     return "\n".join(lines)
 
 
-def _testbench(*, top_name: str, cluster_producers: tuple[int, ...], workload: dict[str, object], output_ready_pattern: tuple[bool, ...]) -> str:
+def _testbench(
+    *,
+    top_name: str,
+    cluster_producers: tuple[int, ...],
+    workload: dict[str, object],
+    output_ready_pattern: tuple[bool, ...],
+    command_data: dict[str, object] | None = None,
+) -> str:
     total_producers = sum(cluster_producers)
     value_lanes = total_producers * 2
-    command_data = _hierarchy_driver_data(cluster_producers, workload)
+    command_data = command_data or _hierarchy_driver_data(cluster_producers, workload)
     wave_commands = tuple(command_data["wave_commands"])
-    query_mem = command_data["query_mem"]
-    key_mem = command_data["key_mem"]
-    last_mem = command_data["last_mem"]
-    value_mem = command_data["value_mem"]
     beat_limits = command_data["beat_limits"]
     block_offsets = command_data["block_offsets"]
     max_beats_per_producer = int(command_data["max_beats_per_producer"])
@@ -665,21 +727,6 @@ def _testbench(*, top_name: str, cluster_producers: tuple[int, ...], workload: d
                 f"    cmd_beat_limit_mem[{command_index}][{producer}] = 32'd{int(beat_limits[command_index][producer])}; "
                 f"cmd_block_offset_mem[{command_index}][{producer}] = 32'd{int(block_offsets[command_index][producer])};"
             )
-    beat_init = []
-    for producer in range(total_producers):
-        for beat_index, packed_query in enumerate(query_mem[producer]):
-            flat_index = (producer * max_beats_per_producer) + beat_index
-            beat_init.append(
-                f"    query_mem[{flat_index}] = 128'h{int(packed_query):032x}; "
-                f"key_mem[{flat_index}] = 128'h{int(key_mem[producer][beat_index]):032x}; "
-                f"last_mem[{flat_index}] = 1'b{int(last_mem[producer][beat_index])};"
-            )
-    value_init = []
-    for lane_index in range(value_lanes):
-        for slice_index, packed_matrix in enumerate(value_mem[lane_index]):
-            flat_index = (lane_index * max_blocks_per_producer * 16) + slice_index
-            value_init.append(f"    value_mem[{flat_index}] = 512'h{int(packed_matrix):0128x};")
-
     return f"""`timescale 1ns/1ps
 module tb;
   localparam integer COMMANDS = {int(workload["command_count"])};
@@ -972,10 +1019,12 @@ module tb;
   end
 
   initial begin
+    $readmemh("query.memh", query_mem);
+    $readmemh("key.memh", key_mem);
+    $readmemh("last.memh", last_mem);
+    $readmemh("value.memh", value_mem);
 {_command_init(command_data)}
 {chr(10).join(beat_limit_init)}
-{chr(10).join(beat_init)}
-{chr(10).join(value_init)}
 {_ready_init(output_ready_pattern)}
     clk = 1'b0;
     rst_n = 1'b0;
@@ -1100,6 +1149,8 @@ def build_report(
         temp_dir = Path(temp_dir_name)
         rtl_dir = temp_dir / "rtl"
         generate(resolved_config, rtl_dir)
+        command_data = _hierarchy_driver_data(cluster_producers, workload)
+        _write_driver_sidecars(temp_dir, command_data)
         testbench_path = temp_dir / "tb.v"
         fakeram_path = temp_dir / "fakeram45_2048x39.v"
         testbench_path.write_text(
@@ -1108,6 +1159,7 @@ def build_report(
                 cluster_producers=cluster_producers,
                 workload=workload,
                 output_ready_pattern=tuple(bool(value) for value in output_ready_pattern),
+                command_data=command_data,
             ),
             encoding="utf-8",
         )
@@ -1196,6 +1248,8 @@ def build_report(
 
     report: JsonDict = {
         "passed": passed,
+        "head_dimension": HEAD_DIM,
+        "score_accumulation_beats_per_block": HEAD_DIM,
         "simulation_status": "testbench_timeout" if tb_timeout_cycle is not None else simulation_status,
         "timed_out": timed_out,
         "timeout_classification": "failed_inconclusive" if timed_out else None,
@@ -1247,6 +1301,8 @@ def _render_text(report: JsonDict) -> str:
         "",
         f"- passed: `{report['passed']}`",
         f"- simulation_status: `{report['simulation_status']}`",
+        f"- head_dimension: `{report['head_dimension']}`",
+        f"- score_accumulation_beats_per_block: `{report['score_accumulation_beats_per_block']}`",
         f"- interface_mode: `{report['interface_mode']}`",
         f"- total_local_producers: `{report['total_local_producers']}`",
         f"- outputs: `{report['outputs']}`",

--- a/tests/test_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
+++ b/tests/test_attention_score32_exact_local16_global_tree_cluster_sram_gqa8.py
@@ -169,7 +169,7 @@ def test_expected_counts_scale_to_four_head_groups() -> None:
     assert scaled["totals"] == {
         "fill_target_accept_count": 512,
         "fill_row_accept_count": 1048576,
-        "producer_handshake_count": 32768,
+        "producer_handshake_count": 4_194_304,
         "sram_request_accept_count": 1048576,
         "sram_response_accept_count": 1048576,
         "cluster_row_count": 8192,
@@ -199,6 +199,7 @@ def test_generated_testbench_is_real_memh_backed_composed_traffic() -> None:
     assert 'localparam integer TB_TIMEOUT_CYCLES = 50000;' in tb
     assert '$readmemh("query.memh", query_mem);' in tb
     assert '$readmemh("key.memh", key_mem);' in tb
+    assert '$readmemh("last.memh", last_mem);' in tb
     assert '$readmemh("fill.memh", fill_mem);' in tb
     assert "input_valid[producer_index] = 1'b1;" in tb
     assert "input_query = '0;" in tb
@@ -206,6 +207,7 @@ def test_generated_testbench_is_real_memh_backed_composed_traffic() -> None:
     assert "109568'd0" not in tb
     assert "input_query[(producer_index * 128) +: 128] = query_mem[flat_index];" in tb
     assert "input_key[(producer_index * 128) +: 128] = key_mem[flat_index];" in tb
+    assert "input_last[producer_index] = last_mem[flat_index];" in tb
     assert "input_valid[producer_index] && input_ready[producer_index]" in tb
     assert "$countones(input_valid & input_ready)" in tb
     assert "fill_target_valid[cluster_index] = 1'b1;" in tb
@@ -293,6 +295,7 @@ def test_fill_sidecar_uses_cluster_major_wave_command_order(
             "wave_commands": fake_wave_commands,
             "query_words": [0],
             "key_words": [0],
+            "last_words": [1],
             "max_beats_per_producer": 1,
             "beat_limits": [[0]],
         },
@@ -447,6 +450,8 @@ def test_compositional_cluster_testbenches_use_concrete_rtl_and_local_sidecars()
     assert "if (out_valid && out_ready)" in p54
     assert "$readmemh(\"query.memh\", query_mem)" in p54
     assert "$readmemh(\"fill.memh\", fill_mem)" in p54
+    assert "$readmemh(\"last.memh\", last_mem)" in p54
+    assert "input_last[producer] = last_mem[flat_index]" in p54
     assert "input_query = '0" in p54
     assert "score32_top__cluster_p53 dut (" in p53
     assert "localparam integer PRODUCERS = 53;" in p53
@@ -686,6 +691,8 @@ def test_fine_compositional_producer_harness_uses_one_real_producer_and_sidecars
     assert "__cluster_p54 dut" not in tb
     assert '$readmemh("producer_commands.memh",command_mem);' in tb
     assert '$readmemh("value.memh",value_mem);' in tb
+    assert '$readmemh("last.memh",last_mem);' in tb
+    assert ".input_last(last_mem[input_drive])" in tb
     assert "PRODUCER_REQUEST" in tb
     assert "PRODUCER_RESULT cluster=2 producer=7" in tb
 
@@ -934,7 +941,7 @@ def test_observation_evaluator_validates_every_exact_total_and_row() -> None:
     assert expected_counts()["totals"] == {
         "fill_target_accept_count": 128,
         "fill_row_accept_count": 262144,
-        "producer_handshake_count": 8192,
+        "producer_handshake_count": 1_048_576,
         "sram_request_accept_count": 262144,
         "sram_response_accept_count": 262144,
         "cluster_row_count": 2048,
@@ -1129,6 +1136,8 @@ def test_markdown_failure_report_keeps_bounded_subprocess_diagnostics() -> None:
     stderr_tail = "first meaningful error\n" + ("warning\n" * 400) + "Killed\n"
     report = {
         "passed": False,
+        "head_dimension": 128,
+        "score_accumulation_beats_per_block": 128,
         "classification": "failed_inconclusive",
         "simulation_status": "resource_failure",
         "sim_backend": VERILATOR_HIERARCHICAL_BACKEND,
@@ -1158,6 +1167,8 @@ def test_markdown_failure_report_keeps_bounded_subprocess_diagnostics() -> None:
 def test_markdown_pass_report_omits_failure_diagnostics() -> None:
     report = {
         "passed": True,
+        "head_dimension": 128,
+        "score_accumulation_beats_per_block": 128,
         "classification": "passed",
         "simulation_status": "ok",
         "sim_backend": DEFAULT_SIM_BACKEND,
@@ -1462,6 +1473,8 @@ def test_main_writes_bounded_json_and_markdown_reports(
 ) -> None:
     fake_report = {
         "passed": True,
+        "head_dimension": 128,
+        "score_accumulation_beats_per_block": 128,
         "classification": "passed",
         "simulation_status": "ok",
         "sim_backend": DEFAULT_SIM_BACKEND,
@@ -1523,6 +1536,8 @@ def test_main_writes_bounded_json_and_markdown_reports(
     assert "expected_root_rows" not in payload
     markdown = out_md.read_text(encoding="utf-8")
     assert "# attention_score32_exact_local16_global_tree_cluster_sram_gqa8_probe" in markdown
-    assert "- producer_handshakes: `8192`" in markdown
+    assert "- head_dimension: `128`" in markdown
+    assert "- score_accumulation_beats_per_block: `128`" in markdown
+    assert "- producer_handshakes: `1048576`" in markdown
     stdout = capsys.readouterr().out
     assert json.loads(stdout) == payload

--- a/tests/test_attention_score32_exact_local16_global_tree_gqa8.py
+++ b/tests/test_attention_score32_exact_local16_global_tree_gqa8.py
@@ -10,11 +10,14 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from npu.eval.probe_attention_score32_exact_local16_global_tree_gqa8 import (
+    HEAD_DIM,
     _default_config,
     _expected_cluster_summary_counts,
     _hierarchy_driver_data,
     _logical_commands,
+    _raw_scores,
     _resolve_workload,
+    _stream_block_beats,
     _testbench,
     _wave_command_schedule,
     compare_compositional_rows,
@@ -145,11 +148,89 @@ def test_hierarchy_driver_populates_all_producer_and_value_lanes() -> None:
     assert len(driver["key_mem"]) == 856
     assert len(driver["last_mem"]) == 856
     assert len(driver["value_mem"]) == 1712
-    assert driver["max_beats_per_producer"] == 16
+    assert driver["max_beats_per_producer"] == 16 * HEAD_DIM
     assert driver["max_blocks_per_producer"] == 16
     assert all(len(stream) > 0 for stream in driver["query_mem"])
     assert all(len(stream) > 0 for stream in driver["value_mem"])
     assert all(limit > 0 for limit in driver["beat_limits"][-1])
+    assert all(
+        len(last) == len(query) == len(key)
+        for last, query, key in zip(driver["last_mem"], driver["query_mem"], driver["key_mem"])
+    )
+    assert all(
+        sum(last) == len(last) // HEAD_DIM
+        for last in driver["last_mem"]
+    )
+
+
+def test_each_block_contains_all_128_dimensions_and_reference_sums_them() -> None:
+    blocks = _stream_block_beats(
+        cluster=0,
+        producer=0,
+        group_index=0,
+        wave_index=0,
+        stream=0,
+        block_count=1,
+        seed=29,
+    )
+    assert len(blocks) == 1
+    assert len(blocks[0]) == HEAD_DIM
+    expected = [
+        sum(query[3] * key[token] for query, key in blocks[0])
+        for token in range(8)
+    ]
+    assert _raw_scores(blocks[0], 3) == expected
+
+
+def test_dimension_zero_preserves_the_prior_deterministic_stimulus() -> None:
+    cluster = 2
+    producer = 7
+    group_index = 1
+    wave_index = 3
+    stream = 1
+    block_index = 0
+    seed = 29
+    block = _stream_block_beats(
+        cluster=cluster,
+        producer=producer,
+        group_index=group_index,
+        wave_index=wave_index,
+        stream=stream,
+        block_count=1,
+        seed=seed,
+    )[block_index]
+    queries, keys = block[0]
+    assert queries == tuple(
+        (
+            seed * 17
+            + cluster * 19
+            + producer * 23
+            + group_index * 29
+            + wave_index * 31
+            + stream * 37
+            + block_index * 41
+            + head_lane * 43
+        )
+        % 127
+        - 63
+        for head_lane in range(8)
+    )
+    assert keys == tuple(
+        (
+            seed * 47
+            + cluster * 53
+            + producer * 59
+            + group_index * 61
+            + wave_index * 67
+            + stream * 71
+            + block_index * 73
+            + token_lane * 79
+        )
+        % 127
+        - 63
+        for token_lane in range(8)
+    )
+    assert block[1] != block[0]
 
 
 def test_hierarchy_driver_rotates_p54_and_p53_extra_blocks_by_head_group() -> None:
@@ -196,6 +277,10 @@ def test_generated_testbench_drives_real_interfaces_and_wave_schedule() -> None:
     assert "reg [31:0] cmd_beat_limit_mem [0:WAVE_COMMANDS-1][0:TOTAL_PRODUCERS-1];" in tb
     assert "if (rst_n && (active_command_index >= 0) && (beat_issue[producer_index] < cmd_beat_limit_mem[active_command_index][producer_index])) begin" in tb
     assert "input_valid[producer_index] = 1'b1;" in tb
+    assert "input_last[producer_index] = last_mem[flat_index];" in tb
+    assert '$readmemh("query.memh", query_mem);' in tb
+    assert '$readmemh("last.memh", last_mem);' in tb
+    assert '$readmemh("value.memh", value_mem);' in tb
     assert "if (value_read_req_valid[lane_index] && value_read_req_ready[lane_index]) begin" in tb
     assert "value_response_valid[lane_index] <= 1'b1;" in tb
     assert 'COMMAND_ACCEPT idx=%0d cmd=%0d head_base=%0d logical=%0d wave=%0d cycle=%0d' in tb

--- a/tests/test_audit_llm_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank.py
+++ b/tests/test_audit_llm_decoder_attention_score32_exact_reduction_gqa8_full_equivalence_rerank.py
@@ -17,7 +17,7 @@ def _write(path: Path, payload: dict) -> None:
 def _equivalence_payload(*, logical_head_groups: int, source_links: dict | None = None) -> dict:
     totals = {
         1: {
-            "producer_handshake_count": 8192,
+            "producer_handshake_count": 1_048_576,
             "fill_target_accept_count": 128,
             "fill_row_accept_count": 262144,
             "sram_request_accept_count": 262144,
@@ -28,7 +28,7 @@ def _equivalence_payload(*, logical_head_groups: int, source_links: dict | None 
             "cadence_command_accept_count": 8,
         },
         4: {
-            "producer_handshake_count": 32768,
+            "producer_handshake_count": 4_194_304,
             "fill_target_accept_count": 512,
             "fill_row_accept_count": 1048576,
             "sram_request_accept_count": 1048576,
@@ -72,6 +72,8 @@ def _equivalence_payload(*, logical_head_groups: int, source_links: dict | None 
         "simulation_status": "ok",
         "normalized_returncode": 0,
         "logical_head_groups": logical_head_groups,
+        "head_dimension": 128,
+        "score_accumulation_beats_per_block": 128,
         "head_bases": head_bases,
         "command_ids": command_ids,
         "summary": {**totals, "protocol_error": 0},
@@ -210,9 +212,9 @@ def _inputs(tmp_path: Path) -> Namespace:
         _equivalence_payload(
             logical_head_groups=1,
             source_links={
-                "proposal_id": "prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1",
-                "proposal_path": "docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1/proposal.json",
-                "item_id": "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r7",
+                "proposal_id": "prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1",
+                "proposal_path": "docs/proposals/prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1/proposal.json",
+                "item_id": "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r8",
             },
         ),
     )
@@ -221,9 +223,9 @@ def _inputs(tmp_path: Path) -> Namespace:
         _equivalence_payload(
             logical_head_groups=4,
             source_links={
-                "proposal_id": "prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1",
-                "proposal_path": "docs/proposals/prop_l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1/proposal.json",
-                "item_id": "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1",
+                "proposal_id": "prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1",
+                "proposal_path": "docs/proposals/prop_l2_decoder_attention_score32_gqa8_full_head_dimension_revision_v1/proposal.json",
+                "item_id": "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_rotation_equivalence_llama7b_v1_r2",
             },
         ),
     )
@@ -269,7 +271,7 @@ def test_exact_reduction_full_gqa8_rerank_recosts_score32_row_and_preserves_rank
         "provisional_pending_reducer_and_global_tree_activity_power_measurement"
     )
     assert report["equivalence_prerequisites"]["one_group"]["source_links"]["item_id"] == (
-        "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r7"
+        "l2_decoder_attention_score32_exact_local16_global_tree_cluster_sram_gqa8_equivalence_llama7b_v1_r8"
     )
 
 
@@ -293,9 +295,31 @@ def test_exact_reduction_full_gqa8_rerank_rejects_failed_four_group_equivalence(
         build_report(args)
 
 
-def test_exact_reduction_full_gqa8_rerank_rejects_missing_r7_one_group_artifact(tmp_path: Path) -> None:
+def test_exact_reduction_full_gqa8_rerank_rejects_legacy_one_dimension_evidence(tmp_path: Path) -> None:
     args = _inputs(tmp_path)
-    args.one_group_equivalence_json = tmp_path / "missing_r7.json"
+    payload = json.loads(args.one_group_equivalence_json.read_text(encoding="utf-8"))
+    payload["head_dimension"] = 1
+    payload["score_accumulation_beats_per_block"] = 1
+    payload["summary"]["producer_handshake_count"] = 8192
+    _write(args.one_group_equivalence_json, payload)
+
+    with pytest.raises(ValueError, match="one-group head_dimension must be 128"):
+        build_report(args)
+
+
+def test_exact_reduction_full_gqa8_rerank_requires_explicit_head_dimension_contract(tmp_path: Path) -> None:
+    args = _inputs(tmp_path)
+    payload = json.loads(args.four_group_equivalence_json.read_text(encoding="utf-8"))
+    del payload["head_dimension"]
+    _write(args.four_group_equivalence_json, payload)
+
+    with pytest.raises(ValueError, match="four-group head_dimension must be a finite number"):
+        build_report(args)
+
+
+def test_exact_reduction_full_gqa8_rerank_rejects_missing_r8_one_group_artifact(tmp_path: Path) -> None:
+    args = _inputs(tmp_path)
+    args.one_group_equivalence_json = tmp_path / "missing_r8.json"
 
     with pytest.raises(FileNotFoundError):
         build_report(args)


### PR DESCRIPTION
## Summary

- drive all 128 Llama7B head dimensions through the GQA8 attention equivalence path
- use sidecar-backed stimuli and verify complete producer handshake counts
- retract the legacy one-dimensional evidence and add bounded replacement and rerank requests

## Root cause

The prior evidence exercised one scalar per head instead of the complete 128-dimensional head vector, so it could not establish full-head RTL/performance-model equivalence.

## Validation

- focused implementation and equivalence suite: 62 passed
- scoped L2 task-generator suite: 2 passed, 272 deselected
- git diff --check: clean

The replacement requests are dependency ordered: run the one-group correction first, then the four-group rotation, then rerank. Timeout, OOM, and resource stops are explicitly inconclusive. This PR does not contain routed PPA results.