### PR TITLE
[codex] Add exact shared-SRAM stream scheduling

### DIFF
--- a/control_plane/control_plane/services/l1_task_generator.py
+++ b/control_plane/control_plane/services/l1_task_generator.py
@@ -1726,6 +1726,140 @@ def _read_config_target(
         )
     elif (
         "top_name" in cfg
+        and "attention_shared_sram_read_group_adapter_ppa_harness" in cfg
+    ):
+        top_name = str(cfg["top_name"]).strip()
+        if not top_name:
+            raise Layer1TaskGenerationError(f"top_name must not be empty in {config_path}")
+        try:
+            design_dir = str(config_path.parent.resolve().relative_to(repo_root.resolve()))
+        except ValueError as exc:
+            raise Layer1TaskGenerationError(
+                "shared-SRAM read-adapter physical config must live under "
+                f"repo_root/runs/designs/...: {config_path}"
+            ) from exc
+        design_name = config_path.parent.name
+        command_slug = "attention_shared_sram_read_group_adapter_ppa_harness"
+        return Layer1ConfigTarget(
+            design_kind="block",
+            design_name=design_name,
+            expected_metrics_path=block_metrics_path(design_name),
+            expected_report_paths=[f"{design_dir}/timing_debug_report.md"],
+            commands=[
+                {
+                    "name": f"generate_{command_slug}_rtl",
+                    "run": _with_oss_cad_path(
+                        (
+                            "python3 npu/rtlgen/"
+                            "gen_attention_shared_sram_read_group_adapter_ppa_harness.py "
+                            f"--config {config_rel} "
+                            f"--out {design_dir}/verilog"
+                        )
+                    ),
+                },
+                {
+                    "name": "check_attention_shared_sram_read_group_adapter_ppa_guard",
+                    "run": (
+                        "python3 npu/eval/"
+                        "check_attention_shared_sram_read_group_adapter_ppa_guard.py "
+                        f"--design-dir {design_dir}"
+                    ),
+                },
+                {
+                    "name": "run_block_sweep",
+                    "run": _with_oss_cad_path(
+                        (
+                            "python3 npu/synth/run_block_sweep.py "
+                            f"--design_dir {design_dir} "
+                            "--platform {platform} "
+                            f"--top {top_name} "
+                            f"--sweep {{sweep_path}} "
+                            f"--out_root {out_root} "
+                            + (f"--make_target {make_target} " if make_target else "")
+                            + "--skip_existing"
+                        )
+                    ),
+                },
+                {
+                    "name": f"extract_{command_slug}_timing_paths",
+                    "run": (
+                        "python3 npu/eval/extract_openroad_timing_summary.py "
+                        f"--design-dir {design_dir} "
+                        f"--out {design_dir}/timing_debug_report.md "
+                        "--max-paths 8"
+                    ),
+                },
+            ],
+        )
+    elif (
+        "top_name" in cfg
+        and "attention_shared_sram_k_round_scheduler_ppa_harness" in cfg
+    ):
+        top_name = str(cfg["top_name"]).strip()
+        if not top_name:
+            raise Layer1TaskGenerationError(f"top_name must not be empty in {config_path}")
+        try:
+            design_dir = str(config_path.parent.resolve().relative_to(repo_root.resolve()))
+        except ValueError as exc:
+            raise Layer1TaskGenerationError(
+                "shared-SRAM K-round scheduler physical config must live under "
+                f"repo_root/runs/designs/...: {config_path}"
+            ) from exc
+        design_name = config_path.parent.name
+        command_slug = "attention_shared_sram_k_round_scheduler_ppa_harness"
+        return Layer1ConfigTarget(
+            design_kind="block",
+            design_name=design_name,
+            expected_metrics_path=block_metrics_path(design_name),
+            expected_report_paths=[f"{design_dir}/timing_debug_report.md"],
+            commands=[
+                {
+                    "name": f"generate_{command_slug}_rtl",
+                    "run": _with_oss_cad_path(
+                        (
+                            "python3 npu/rtlgen/"
+                            "gen_attention_shared_sram_k_round_scheduler_ppa_harness.py "
+                            f"--config {config_rel} "
+                            f"--out {design_dir}/verilog"
+                        )
+                    ),
+                },
+                {
+                    "name": "check_attention_shared_sram_k_round_scheduler_ppa_guard",
+                    "run": (
+                        "python3 npu/eval/"
+                        "check_attention_shared_sram_k_round_scheduler_ppa_guard.py "
+                        f"--design-dir {design_dir}"
+                    ),
+                },
+                {
+                    "name": "run_block_sweep",
+                    "run": _with_oss_cad_path(
+                        (
+                            "python3 npu/synth/run_block_sweep.py "
+                            f"--design_dir {design_dir} "
+                            "--platform {platform} "
+                            f"--top {top_name} "
+                            f"--sweep {{sweep_path}} "
+                            f"--out_root {out_root} "
+                            + (f"--make_target {make_target} " if make_target else "")
+                            + "--skip_existing"
+                        )
+                    ),
+                },
+                {
+                    "name": f"extract_{command_slug}_timing_paths",
+                    "run": (
+                        "python3 npu/eval/extract_openroad_timing_summary.py "
+                        f"--design-dir {design_dir} "
+                        f"--out {design_dir}/timing_debug_report.md "
+                        "--max-paths 8"
+                    ),
+                },
+            ],
+        )
+    elif (
+        "top_name" in cfg
         and "attention_score32_exact_shared_root_storage_physical_harness" in cfg
     ):
         top_name = str(cfg["top_name"]).strip()

--- a/control_plane/control_plane/tests/test_l1_task_generator.py
+++ b/control_plane/control_plane/tests/test_l1_task_generator.py
@@ -24,8 +24,88 @@ from control_plane.services.l1_task_generator import (
     Layer1SweepGenerateRequest,
     Layer1TaskGenerationError,
     _multivalue_cluster_binary_fsm_profile,
+    _read_config_target,
     generate_l1_sweep_task,
 )
+
+
+def test_read_config_target_builds_shared_sram_adapter_remote_commands(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    design_dir = repo_root / "runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w256_s2"
+    design_dir.mkdir(parents=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": design_dir.name,
+                "attention_shared_sram_read_group_adapter_ppa_harness": {
+                    "beat_width": 256,
+                    "group_slots": 2,
+                    "groups": 64,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    config_rel = str(config_path.relative_to(repo_root))
+    target = _read_config_target(
+        config_path,
+        repo_root=repo_root,
+        config_rel=config_rel,
+        out_root="runs/designs/npu_blocks",
+        make_target=None,
+    )
+    assert target.design_name == design_dir.name
+    assert target.expected_metrics_path == f"runs/designs/npu_blocks/{design_dir.name}/metrics.csv"
+    assert [command["name"] for command in target.commands] == [
+        "generate_attention_shared_sram_read_group_adapter_ppa_harness_rtl",
+        "check_attention_shared_sram_read_group_adapter_ppa_guard",
+        "run_block_sweep",
+        "extract_attention_shared_sram_read_group_adapter_ppa_harness_timing_paths",
+    ]
+    assert "gen_attention_shared_sram_read_group_adapter_ppa_harness.py" in target.commands[0]["run"]
+    assert "check_attention_shared_sram_read_group_adapter_ppa_guard.py" in target.commands[1]["run"]
+    assert "--top attention_shared_sram_read_group_adapter_w256_s2" in target.commands[2]["run"]
+
+
+def test_read_config_target_builds_shared_sram_k_round_scheduler_commands(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    design_dir = repo_root / "runs/designs/npu_blocks/attention_shared_sram_k_round_scheduler_b17_w17"
+    design_dir.mkdir(parents=True)
+    config_path = design_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "top_name": design_dir.name,
+                "attention_shared_sram_k_round_scheduler_ppa_harness": {
+                    "banks": 17,
+                    "words_per_group": 128,
+                    "dimension_groups": 8,
+                    "dimensions_per_group": 16,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    config_rel = str(config_path.relative_to(repo_root))
+    target = _read_config_target(
+        config_path,
+        repo_root=repo_root,
+        config_rel=config_rel,
+        out_root="runs/designs/npu_blocks",
+        make_target=None,
+    )
+    assert target.design_name == design_dir.name
+    assert target.expected_metrics_path == f"runs/designs/npu_blocks/{design_dir.name}/metrics.csv"
+    assert [command["name"] for command in target.commands] == [
+        "generate_attention_shared_sram_k_round_scheduler_ppa_harness_rtl",
+        "check_attention_shared_sram_k_round_scheduler_ppa_guard",
+        "run_block_sweep",
+        "extract_attention_shared_sram_k_round_scheduler_ppa_harness_timing_paths",
+    ]
+    assert "gen_attention_shared_sram_k_round_scheduler_ppa_harness.py" in target.commands[0]["run"]
+    assert "check_attention_shared_sram_k_round_scheduler_ppa_guard.py" in target.commands[1]["run"]
+    assert "--top attention_shared_sram_k_round_scheduler_b17_w17" in target.commands[2]["run"]
 
 
 def _write_example_repo(repo_root: Path) -> tuple[str, str]:

--- a/docs/proposals/prop_l1_attention_shared_sram_k_round_scheduler_ppa_v1/README.md
+++ b/docs/proposals/prop_l1_attention_shared_sram_k_round_scheduler_ppa_v1/README.md
@@ -1,0 +1,39 @@
+# Shared-SRAM K round scheduler PPA
+
+This package measures the physically bank-ordered, double-buffered K-prefetch
+scheduler for one Llama7B GQA8 KV head.  It replaces the synthesis-intractable
+two-by-16-KiB full-window register point with two 17-word windows.
+
+The functional gate compares the executable performance model and RTL across
+all 1,024 requests, responses, and compute beats.  It checks the exact
+block-major stride-8 address layout, 17-bank routing, final nine-word round,
+backpressure, and fail-closed response metadata.
+
+The physical harness retains all 34,816 live payload bits and narrows only the
+top-level pins.  Its checksum prevents dead-output removal for activity/PPA;
+it is explicitly not equivalence evidence.  The run excludes full shared-SRAM
+capacity area/access energy, downstream score arithmetic, and external
+HBM/DRAM.
+
+The synthetic response source derives one 64-bit lane from request metadata
+and replicates it across the 1024-bit word.  This keeps all payload registers
+active without synthesizing seventeen wide arithmetic stimulus generators.
+The small narrow-I/O harness overhead remains included and is identified in
+the generated manifest.
+
+As a bounded preflight, the complete hierarchy passes Nangate45 generic
+technology mapping and post-map structural checks in 152.43 seconds at 2.223
+GiB peak RSS.  The resulting 403,922.862 um2 estimate is pre-route evidence
+only; this proposal's OpenROAD sweep is the physical calibration authority.
+The 1,000-by-1,000 um core uses placement density 0.50: the pre-route DUT
+estimate alone is 40.39% of core area, so the former 0.40 setting had no margin
+for harness and implementation cells.
+
+The generated top also passes bounded Nangate45 mapping with zero structural
+problems.  It retains all 34,816 payload flip-flops and estimates 414,621.116
+um2 total area.  The 10,698.254 um2 difference from the bare hierarchy is 2.58%
+explicit harness overhead, and total pre-route core utilization is 41.46%.
+
+The full-window point remains recorded as functionally valid but
+`synthesis_infeasible_flat_register_window`.  It must not be ranked using the
+round point's PPA.

--- a/docs/proposals/prop_l1_attention_shared_sram_k_round_scheduler_ppa_v1/design_brief.md
+++ b/docs/proposals/prop_l1_attention_shared_sram_k_round_scheduler_ppa_v1/design_brief.md
@@ -1,0 +1,13 @@
+# Design Brief
+
+A complete 128-word K window gives a 128-cycle compute interface but expands
+two 16 KiB windows into synthesis-intractable register state.  The round
+scheduler stores only one 17-bank conflict-free round in each of two buffers,
+then emits sixteen dimension beats before reusing the buffer.  This retains
+the exact 1,024 shared-SRAM requests while trading the interface schedule to
+1,024 compute beats and reducing live storage to 34,816 bits.
+
+Storage is physically bank ordered.  Tagged responses write a fixed bank leaf,
+and the compute side applies the bounded bank permutation.  Full macro capacity
+and access energy, score arithmetic, NoC, and external DRAM are composed
+separately.

--- a/docs/proposals/prop_l1_attention_shared_sram_k_round_scheduler_ppa_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l1_attention_shared_sram_k_round_scheduler_ppa_v1/evaluation_gate.md
@@ -1,0 +1,9 @@
+# Evaluation Gate
+
+Require the complete model/RTL equivalence suite and generated-artifact guard
+before OpenROAD.  Reject a physical result if payload storage is optimized
+away, structural checks fail, or harness logic dominates the mapped hierarchy.
+Run the six requested periods at placement density 0.50 and record infeasible
+timing or placement points explicitly.  Keep scheduler standard-cell PPA,
+shared-SRAM macro area/access energy, downstream arithmetic, and HBM/DRAM as
+separate quantities.

--- a/docs/proposals/prop_l1_attention_shared_sram_k_round_scheduler_ppa_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_attention_shared_sram_k_round_scheduler_ppa_v1/evaluation_requests.json
@@ -1,0 +1,27 @@
+{
+  "proposal_id": "prop_l1_attention_shared_sram_k_round_scheduler_ppa_v1",
+  "source_commit": "TBD",
+  "source_commit_note": "Queue only after merge and pin source_requirement.required_sha to the merged origin/master commit containing the model, RTL, exact-data tests, physical harness, guard, config, sweep, and task-generator support.",
+  "requested_items": [
+    {
+      "item_id": "l1_attention_shared_sram_k_round_scheduler_b17_w17_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the exact 17-bank double-buffered K round scheduler on Nangate45.",
+      "evaluation_mode": "physical_calibration",
+      "abstraction_layer": "decoder_attention_shared_sram_k_prefetch_scheduler",
+      "comparison_role": "bounded_round_window_candidate",
+      "config_paths": [
+        "runs/designs/npu_blocks/attention_shared_sram_k_round_scheduler_b17_w17/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_shared_sram_k_round_scheduler_ppa_v1/sweeps/nangate45.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_shared_sram_k_round_scheduler_b17_w17/metrics.csv",
+        "runs/designs/npu_blocks/attention_shared_sram_k_round_scheduler_b17_w17/timing_debug_report.md"
+      ],
+      "status": "pending_after_proposal_merge",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_attention_shared_sram_k_round_scheduler_ppa_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_attention_shared_sram_k_round_scheduler_ppa_v1/implementation_summary.md
@@ -1,0 +1,12 @@
+# Implementation Summary
+
+- Added an executable 17-bank, eight-round, double-buffered K scheduler and a
+  synthesizable RTL implementation with explicit physical-bank storage leaves.
+- Proved exact behavior over 1,024 requests, responses, and compute beats,
+  including backpressure, counters, the nine-word tail, and malformed metadata.
+- Removed payload reset and logical-slot multiwrite structures that caused
+  synthesis growth while preserving the checked interface schedule.
+- Added a guarded narrow-I/O PPA harness whose explicit overhead is 2.58% in
+  bounded pre-route mapping, plus Nangate45 sweep and remote task support.
+- Recorded the full-window point as functionally valid but synthesis
+  infeasible, without fabricating PPA for it.

--- a/docs/proposals/prop_l1_attention_shared_sram_k_round_scheduler_ppa_v1/promotion_gate.md
+++ b/docs/proposals/prop_l1_attention_shared_sram_k_round_scheduler_ppa_v1/promotion_gate.md
@@ -1,0 +1,8 @@
+# Promotion Gate
+
+Promote this point only after routed PPA is feasible and composition with the
+score consumer shows that its 1,024-beat cadence does not reduce Llama7B token
+throughput beyond the area and energy benefit.  Compare it against the
+full-window functional schedule and any narrower serial points using separately
+accounted shared-SRAM macro area and access energy.  Do not rank the generic
+mapping estimate or vectorless power as final physical evidence.

--- a/docs/proposals/prop_l1_attention_shared_sram_k_round_scheduler_ppa_v1/proposal.json
+++ b/docs/proposals/prop_l1_attention_shared_sram_k_round_scheduler_ppa_v1/proposal.json
@@ -1,0 +1,69 @@
+{
+  "proposal_id": "prop_l1_attention_shared_sram_k_round_scheduler_ppa_v1",
+  "created_utc": "2026-08-22T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "title": "Shared-SRAM 17-bank K round scheduler physical calibration",
+  "abstraction_layer": "decoder_attention_shared_sram_k_prefetch_scheduler",
+  "hypothesis": "Physical-bank-ordered 17-word double buffering removes the full-window synthesis explosion while preserving exact K data and sustaining one compute beat per cycle for SRAM response latency no greater than sixteen cycles.",
+  "direct_comparison": {
+    "primary_question": "What routed timing, standard-cell area, and vectorless power does the concrete 17-bank K round scheduler add, and is its 1,024-cycle interface physically feasible?",
+    "baselines": [
+      "attention_shared_sram_k_window_scheduler full-window functional point",
+      "attention_shared_sram_read_group_adapter physical calibration",
+      "checked shared-SRAM CACTI macro registry"
+    ],
+    "candidate": [
+      "attention_shared_sram_k_round_scheduler_b17_w17"
+    ],
+    "include": [
+      "synthesizable request scheduling and tagged response validation",
+      "two concrete 17x1024-bit live K windows",
+      "physical-bank write layout and 64-bit compute-side permutation",
+      "minimal narrow-I/O deterministic activity harness, with overhead explicitly included"
+    ],
+    "exclude": [
+      "full shared-SRAM capacity macro area and access energy",
+      "downstream score multiply-accumulate arithmetic",
+      "NoC endpoint and mesh PPA",
+      "external HBM/DRAM"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "stdcell_area_um2",
+      "total_power_mw",
+      "flow_status"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l1_attention_shared_sram_k_round_scheduler_b17_w17_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure the exact 17-bank, two-round-window scheduler across a broad Nangate45 timing sweep.",
+      "status": "pending",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": [
+        "runs/designs/npu_blocks/attention_shared_sram_k_round_scheduler_b17_w17/config.json"
+      ],
+      "sweep_path": "runs/campaigns/npu/attention_shared_sram_k_round_scheduler_ppa_v1/sweeps/nangate45.json",
+      "out_root": "runs/designs/npu_blocks"
+    }
+  ],
+  "remaining_abstractions": [
+    "Full shared-SRAM capacity area and access energy are composed from the checked macro registry rather than instantiated as resettable RTL.",
+    "The narrow-I/O harness supplies replicated metadata-derived SRAM response payloads and contributes small explicitly declared overhead; full macro timing is composed separately.",
+    "Downstream score arithmetic must be composed before the 1,024-cycle scheduler cadence can replace the current Llama7B frontier service time.",
+    "Vectorless power is a screening metric until workload activity is supplied.",
+    "HBM/DRAM and its controller remain external."
+  ],
+  "source_refs": [
+    "npu/docs/attention_shared_sram_k_window_scheduler_contract.md",
+    "npu/sim/perf/attention_shared_sram_k_round_scheduler.py",
+    "npu/sim/rtl/attention_shared_sram_k_round_bank.sv",
+    "npu/sim/rtl/attention_shared_sram_k_round_scheduler.sv",
+    "npu/rtlgen/gen_attention_shared_sram_k_round_scheduler_ppa_harness.py",
+    "npu/eval/check_attention_shared_sram_k_round_scheduler_ppa_guard.py"
+  ]
+}

--- a/docs/proposals/prop_l1_attention_shared_sram_k_round_scheduler_ppa_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_attention_shared_sram_k_round_scheduler_ppa_v1/quality_gate.md
@@ -1,0 +1,10 @@
+# Quality Gate
+
+- Match all 1,024 block-major stride-8 addresses, bank assignments, response
+  identities, and compute beats between RTL and the executable model.
+- Preserve the final round's nine-word valid mask and all output ordering.
+- Hold requests and compute output stable under independent backpressure.
+- Reject stale, duplicate, wrong-bank, and out-of-round responses fail closed.
+- Retain exactly 34,816 live payload bits through physical-harness synthesis.
+- Treat the checksum and replicated synthetic response source as activity/PPA
+  support only, never as equivalence evidence.

--- a/docs/proposals/prop_l1_attention_shared_sram_read_group_adapter_ppa_v1/README.md
+++ b/docs/proposals/prop_l1_attention_shared_sram_read_group_adapter_ppa_v1/README.md
@@ -1,0 +1,42 @@
+# Shared-SRAM read-group adapter PPA
+
+This package measures the logic that converts ordered 256-bit NoC reads or
+512-bit local-fill reads into 1024-bit shared-SRAM macro accesses.  The four
+points cross output width (256/512) with one/two collection slots.
+
+RTL equivalence proves exact ordered payload and address replay, stable
+backpressure, fail-closed malformed metadata handling, and access ratios of
+four 256-bit or two 512-bit beats per macro read.  Two slots sustain one
+output beat per cycle after fill with a macro response latency up to two
+cycles.
+
+These runs measure adapter and narrow-I/O activity-harness standard cells
+only.  They must not include a fabricated 68 MiB RTL array.  Full shared-SRAM
+capacity area and per-access energy come from the checked CACTI macro registry
+and are composed separately by
+`npu/eval/audit_llama7b_shared_sram_access_energy.py`.
+
+The physical harness keeps the complete response bus and all payload state but
+folds only the endpoint lanes into its narrow checksum.  Its metadata-derived
+macro response repeats one 32-bit lane, avoiding a wide arithmetic stimulus
+generator.  Payload registers are intentionally unreset because slot-valid
+state guards every architectural read.
+
+Bounded Nangate45 generic mapping retains 1,024 payload DFFs for one-slot
+points and 2,048 for two-slot points, with zero structural problems:
+
+| Point | Adapter um2 | Generated top um2 | Core utilization |
+|---|---:|---:|---:|
+| w256/s1 | 14,642.502 | 16,736.454 | 24.76% |
+| w256/s2 | 23,825.354 | 25,919.306 | 38.34% |
+| w512/s1 | 14,154.392 | 16,248.078 | 24.04% |
+| w512/s2 | 23,743.958 | 25,837.644 | 38.22% |
+
+These are pre-route estimates only.  The corrected OpenROAD sweep uses a
+260-by-260 um core at placement density 0.50; the former 200-by-200 um core at
+0.45 density could not place either two-slot point.
+
+The adapter is one macro-port building block, not a complete K producer.  The
+exact tensor-layout model shows that each home needs 17 interleaved macro
+banks and a double-buffered 16 KiB K word window to sustain the 128-dimension
+producer cadence.  That bank scheduler remains the next physical gate.

--- a/docs/proposals/prop_l1_attention_shared_sram_read_group_adapter_ppa_v1/design_brief.md
+++ b/docs/proposals/prop_l1_attention_shared_sram_read_group_adapter_ppa_v1/design_brief.md
@@ -1,0 +1,12 @@
+# Design Brief
+
+The shared-SRAM macros expose 1024-bit words while the remote NoC path emits
+256-bit beats and the local value-fill path emits 512-bit beats.  The adapter
+collects four or two ordered beats into one macro write and replays a macro
+read as the corresponding ordered output beats.  One-slot points establish the
+minimum control cost; two-slot points test whether fill and drain can overlap.
+
+The adapter owns only grouping, metadata, buffering, ready/valid behavior, and
+malformed-transaction rejection.  Shared-SRAM capacity, macro timing and
+energy, the 17-bank K scheduler, the NoC, and external DRAM remain separate
+composition terms.

--- a/docs/proposals/prop_l1_attention_shared_sram_read_group_adapter_ppa_v1/evaluation_gate.md
+++ b/docs/proposals/prop_l1_attention_shared_sram_read_group_adapter_ppa_v1/evaluation_gate.md
@@ -1,0 +1,13 @@
+# Evaluation Gate
+
+Require RTL/performance-model agreement for addresses, complete payloads,
+ordering, transaction counts, backpressure, and protocol rejection for all
+four width/slot points.  Generated artifacts must pass the proposal-link and
+manifest guard before OpenROAD.  Report routed timing, standard-cell area,
+power, and failures separately for each point; do not mix macro area or access
+energy into adapter metrics.
+
+Use the checked 260-by-260 um core at placement density 0.50.  Reject any run
+that removes the declared 1,024 payload bits per slot or reintroduces reset on
+payload state.  The generated manifest must identify the kept full response
+bus, minimal synthetic response source, and included narrow-I/O overhead.

--- a/docs/proposals/prop_l1_attention_shared_sram_read_group_adapter_ppa_v1/evaluation_requests.json
+++ b/docs/proposals/prop_l1_attention_shared_sram_read_group_adapter_ppa_v1/evaluation_requests.json
@@ -1,0 +1,79 @@
+{
+  "proposal_id": "prop_l1_attention_shared_sram_read_group_adapter_ppa_v1",
+  "source_commit": "TBD",
+  "source_commit_note": "Queue only after merge and pin source_requirement.required_sha to the merged origin/master commit containing the adapter, generator, guard, configs, sweep, and task-generator support.",
+  "requested_items": [
+    {
+      "item_id": "l1_attention_shared_sram_read_group_adapter_w256_s1_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure serialized 256-bit shared-SRAM adaptation.",
+      "evaluation_mode": "physical_calibration",
+      "abstraction_layer": "decoder_attention_shared_sram_macro_port_adapter",
+      "comparison_role": "remote_serial_control",
+      "config_paths": ["runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w256_s1/config.json"],
+      "sweep_path": "runs/campaigns/npu/attention_shared_sram_read_group_adapter_ppa_v1/sweeps/nangate45.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w256_s1/metrics.csv",
+        "runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w256_s1/timing_debug_report.md"
+      ],
+      "status": "pending_after_proposal_merge",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    },
+    {
+      "item_id": "l1_attention_shared_sram_read_group_adapter_w256_s2_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure overlapped 256-bit shared-SRAM adaptation.",
+      "evaluation_mode": "physical_calibration",
+      "abstraction_layer": "decoder_attention_shared_sram_macro_port_adapter",
+      "comparison_role": "remote_throughput_candidate",
+      "config_paths": ["runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w256_s2/config.json"],
+      "sweep_path": "runs/campaigns/npu/attention_shared_sram_read_group_adapter_ppa_v1/sweeps/nangate45.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w256_s2/metrics.csv",
+        "runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w256_s2/timing_debug_report.md"
+      ],
+      "status": "pending_after_proposal_merge",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    },
+    {
+      "item_id": "l1_attention_shared_sram_read_group_adapter_w512_s1_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure serialized 512-bit shared-SRAM adaptation.",
+      "evaluation_mode": "physical_calibration",
+      "abstraction_layer": "decoder_attention_shared_sram_macro_port_adapter",
+      "comparison_role": "local_fill_serial_control",
+      "config_paths": ["runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w512_s1/config.json"],
+      "sweep_path": "runs/campaigns/npu/attention_shared_sram_read_group_adapter_ppa_v1/sweeps/nangate45.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w512_s1/metrics.csv",
+        "runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w512_s1/timing_debug_report.md"
+      ],
+      "status": "pending_after_proposal_merge",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    },
+    {
+      "item_id": "l1_attention_shared_sram_read_group_adapter_w512_s2_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure overlapped 512-bit shared-SRAM adaptation.",
+      "evaluation_mode": "physical_calibration",
+      "abstraction_layer": "decoder_attention_shared_sram_macro_port_adapter",
+      "comparison_role": "local_fill_throughput_candidate",
+      "config_paths": ["runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w512_s2/config.json"],
+      "sweep_path": "runs/campaigns/npu/attention_shared_sram_read_group_adapter_ppa_v1/sweeps/nangate45.json",
+      "out_root": "runs/designs/npu_blocks",
+      "expected_outputs": [
+        "runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w512_s2/metrics.csv",
+        "runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w512_s2/timing_debug_report.md"
+      ],
+      "status": "pending_after_proposal_merge",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true
+    }
+  ]
+}

--- a/docs/proposals/prop_l1_attention_shared_sram_read_group_adapter_ppa_v1/implementation_summary.md
+++ b/docs/proposals/prop_l1_attention_shared_sram_read_group_adapter_ppa_v1/implementation_summary.md
@@ -1,0 +1,14 @@
+# Implementation Summary
+
+- Added synthesizable 256/512-to-1024-bit ordered read-group adaptation with
+  one or two collection slots.
+- Added executable behavior tests and RTL checks for exact data, ordering,
+  backpressure, access ratios, and fail-closed metadata handling.
+- Added guarded narrow-I/O PPA generation, four Nangate45 design points, and
+  remote task-generator support.
+- Removed unnecessary payload reset, retained every payload bit explicitly,
+  and reduced synthetic response/checksum logic before physical calibration.
+- Corrected the floorplan after bounded mapping proved the original density
+  infeasible for two-slot points.
+- Kept full shared-SRAM macro capacity and energy as separately identified
+  composition terms.

--- a/docs/proposals/prop_l1_attention_shared_sram_read_group_adapter_ppa_v1/promotion_gate.md
+++ b/docs/proposals/prop_l1_attention_shared_sram_read_group_adapter_ppa_v1/promotion_gate.md
@@ -1,0 +1,8 @@
+# Promotion Gate
+
+Promote the lowest-area point that meets the required stream cadence.  A
+one-slot point may replace a two-slot point only if measured macro latency and
+consumer backpressure do not reduce token throughput.  Compose the selected
+adapter with measured macro access energy and the 17-bank K scheduler before
+using it in the Llama7B frontier; adapter PPA alone is not an architecture
+ranking.

--- a/docs/proposals/prop_l1_attention_shared_sram_read_group_adapter_ppa_v1/proposal.json
+++ b/docs/proposals/prop_l1_attention_shared_sram_read_group_adapter_ppa_v1/proposal.json
@@ -1,0 +1,99 @@
+{
+  "proposal_id": "prop_l1_attention_shared_sram_read_group_adapter_ppa_v1",
+  "created_utc": "2026-08-21T00:00:00Z",
+  "created_by": "developer_agent",
+  "layer": "layer1",
+  "kind": "circuit",
+  "title": "Shared-SRAM 1024-bit read-group adapter physical calibration",
+  "abstraction_layer": "decoder_attention_shared_sram_macro_port_adapter",
+  "hypothesis": "A two-slot adapter can preserve exact 256-bit NoC and 512-bit local-fill streams while sustaining one output beat per cycle, with modest logic cost relative to the separately accounted SRAM macros.",
+  "direct_comparison": {
+    "primary_question": "What timing, standard-cell area, and vectorless power does 1024-bit macro adaptation add for remote and local shared-SRAM paths?",
+    "baselines": [
+      "local_capacity_chunk_02_256kib CACTI macro entry",
+      "noc_sram_packet_endpoint Phase-2 transport"
+    ],
+    "candidate": [
+      "attention_shared_sram_read_group_adapter_w256_s1",
+      "attention_shared_sram_read_group_adapter_w256_s2",
+      "attention_shared_sram_read_group_adapter_w512_s1",
+      "attention_shared_sram_read_group_adapter_w512_s2"
+    ],
+    "include": [
+      "synthesizable group collection, macro request metadata, response buffering, and ordered emission",
+      "narrow-I/O deterministic activity harness",
+      "one-slot serialization and two-slot overlap points"
+    ],
+    "exclude": [
+      "68 MiB shared-SRAM capacity area",
+      "CACTI macro access energy",
+      "17-bank K prefetch scheduler and 16 KiB word window",
+      "NoC endpoint and mesh PPA",
+      "external HBM/DRAM"
+    ],
+    "metrics": [
+      "critical_path_ns",
+      "stdcell_area_um2",
+      "total_power_mw",
+      "flow_status"
+    ]
+  },
+  "required_evaluations": [
+    {
+      "item_id": "l1_attention_shared_sram_read_group_adapter_w256_s1_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure serialized 256-bit remote-path adaptation.",
+      "status": "pending",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": ["runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w256_s1/config.json"],
+      "sweep_path": "runs/campaigns/npu/attention_shared_sram_read_group_adapter_ppa_v1/sweeps/nangate45.json",
+      "out_root": "runs/designs/npu_blocks"
+    },
+    {
+      "item_id": "l1_attention_shared_sram_read_group_adapter_w256_s2_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure overlapped 256-bit remote-path adaptation.",
+      "status": "pending",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": ["runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w256_s2/config.json"],
+      "sweep_path": "runs/campaigns/npu/attention_shared_sram_read_group_adapter_ppa_v1/sweeps/nangate45.json",
+      "out_root": "runs/designs/npu_blocks"
+    },
+    {
+      "item_id": "l1_attention_shared_sram_read_group_adapter_w512_s1_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure serialized 512-bit local-fill adaptation.",
+      "status": "pending",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": ["runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w512_s1/config.json"],
+      "sweep_path": "runs/campaigns/npu/attention_shared_sram_read_group_adapter_ppa_v1/sweeps/nangate45.json",
+      "out_root": "runs/designs/npu_blocks"
+    },
+    {
+      "item_id": "l1_attention_shared_sram_read_group_adapter_w512_s2_ppa_v1",
+      "task_type": "l1_sweep",
+      "objective": "Measure overlapped 512-bit local-fill adaptation.",
+      "status": "pending",
+      "requires_merged_inputs": true,
+      "requires_materialized_refs": true,
+      "configs": ["runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w512_s2/config.json"],
+      "sweep_path": "runs/campaigns/npu/attention_shared_sram_read_group_adapter_ppa_v1/sweeps/nangate45.json",
+      "out_root": "runs/designs/npu_blocks"
+    }
+  ],
+  "remaining_abstractions": [
+    "Full capacity macro area and access energy are composed from the checked registry rather than instantiated in RTL.",
+    "The 17-bank K prefetch scheduler and double-buffered word window are not part of this adapter run.",
+    "Vectorless power is a screening metric until workload activity is supplied."
+  ],
+  "source_refs": [
+    "npu/docs/attention_phase2_shared_stream_transport_contract.md",
+    "npu/sim/rtl/attention_shared_sram_read_group_adapter.sv",
+    "npu/sim/perf/attention_shared_sram_gqa8_tensor_layout.py",
+    "npu/rtlgen/gen_attention_shared_sram_read_group_adapter_ppa_harness.py",
+    "npu/eval/check_attention_shared_sram_read_group_adapter_ppa_guard.py"
+  ]
+}

--- a/docs/proposals/prop_l1_attention_shared_sram_read_group_adapter_ppa_v1/quality_gate.md
+++ b/docs/proposals/prop_l1_attention_shared_sram_read_group_adapter_ppa_v1/quality_gate.md
@@ -1,0 +1,9 @@
+# Quality Gate
+
+- Preserve every input payload bit and emit beats in accepted order.
+- Issue exactly one 1024-bit macro transaction per four 256-bit beats or two
+  512-bit beats.
+- Hold all ready/valid payload and metadata stable under backpressure.
+- Reject malformed or stale response metadata without emitting data.
+- Do not instantiate or claim PPA for the full shared-SRAM capacity.
+- Treat activity checksums as PPA retention diagnostics, not equivalence proof.

--- a/npu/docs/attention_phase2_shared_stream_transport_contract.md
+++ b/npu/docs/attention_phase2_shared_stream_transport_contract.md
@@ -1,0 +1,159 @@
+# Phase-2 Shared-SRAM Stream Transport Contract
+
+This contract defines the exact transport boundary for the shared-SRAM part of
+the checked Llama7B Phase-2 schedule.  It replaces the historical synthetic
+`data_seed` payload with address-preserving SRAM transfers.  It does not reuse
+the retracted reduction traffic; exact reducer-to-root traffic remains a
+separate VC1 composition.
+
+## Canonical Regression Quantities
+
+- mesh endpoints: 16
+- logical waves: 8
+- local-only wave: 4
+- remote contexts: `7 waves x 16 destinations = 112`
+- payload per context: 17,408 bytes
+- packets per context: 68
+- payload per packet: 256 bytes
+- flits per packet: 8
+- flit width: 256 bits / 32 bytes
+- total remote packets: 7,616
+- total remote flits: 60,928
+- shared-stream virtual channel: VC0
+
+These quantities reproduce the historical fractional-smear placement only.
+For destination cluster `c`, that policy chooses source endpoint `(c +
+shift[wave]) mod 16`, where `shift = [4, 7, 10, 13, 0, 3, 6, 9]`.  Wave 4 is
+local and must not be admitted to the mesh.
+
+The 112 remote contexts are not implied by 68 MiB of capacity.  Whole-token
+or whole-tile residency can produce fewer, larger contexts, and a
+capacity-balanced locality-aware assignment can make resident contexts local.
+The hardware interface therefore supports a layer-specific expected remote
+context count, explicit source endpoints, and a variable positive packet
+count up to its elaborated maximum.  A layer with zero remote contexts
+completes admission without using this transport.
+
+## Producer and Residency Boundary
+
+A readiness event means that the complete declared source window is resident
+in source SRAM and that its source base address is stable.  The admission
+scheduler accepts readiness independently for all 16 clusters and emits one
+context command at a time.  It must not create release timing or derive a
+placement policy.
+
+The context command carries:
+
+- wave index
+- source endpoint
+- destination endpoint
+- source byte base address
+- destination byte base address reserved by the consumer
+- packet count
+
+At most one live context may own a source endpoint and at most one may own a
+destination endpoint.  These resource rules allow up to 16 contexts to run in
+parallel without descriptor-port arbitration and prevent address-slot reuse
+while packets remain in flight.
+
+## Packet and Address Mapping
+
+For packet index `p` in `[0, packet_count)` and fragment index `f` in `[0, 7]`:
+
+```text
+tag             = p
+TX byte address = source_base      + 256*p + 32*f
+RX byte address = destination_base + 256*p + 32*f
+last            = (f == 7)
+```
+
+The canonical regression uses `packet_count = 68`.  Larger whole-tile
+contexts reuse the eight-bit wire tag as `p mod 256`; ordered completion and
+the bounded eight-packet live window must prove that an earlier packet with
+the same tag has completed before reuse.
+
+Each packet's RX descriptor must be accepted before its TX descriptor may be
+exposed.  A context may have at most eight installed, incomplete packet
+contexts, matching the endpoint's bounded RX context table.  Packet tags are
+unique within a live `(source, destination, VC0)` stream.  A tag may be reused
+by a later context only after every packet of the previous context has
+completed and the context completion has been accepted.
+
+The endpoint writes each flit directly to destination SRAM.  No packet-wide
+register reassembly buffer is permitted.
+
+## Completion and Consumer Ownership
+
+Packet completion means that the final flit write for that packet was
+accepted by destination SRAM.  Context completion is emitted only after all
+declared packet completions have been validated in order.  Context completion must
+remain valid and stable under backpressure.
+
+Acceptance of context completion is the destination consumer's residency
+acknowledgement.  Only that handshake releases the source and destination
+endpoint ownership and permits either address window to be reused.  The mesh
+and packet endpoint do not independently release a logical context.
+
+## GQA8 Tensor Layout
+
+The semantic payload for one complete 1024-token Llama7B GQA8 tile is 1 MiB.
+It contains four KV-head regions in ascending KV-head order.  Each 256 KiB
+head region contains:
+
+1. 128 KiB of K data ordered by stream, 8-token block slot, then head
+   dimension.  Each 64-bit K beat holds the eight token lanes for one
+   dimension.
+2. 128 KiB of V data ordered by stream, 8-token block slot, then 8-dimension
+   slice.  Each 512-bit V row holds an 8-token by 8-dimension matrix in
+   token-major byte order.
+
+The executable definition is
+`npu/sim/perf/attention_shared_sram_gqa8_tensor_layout.py`.  It is the sole
+byte-offset authority for producer K beats and local value-SRAM fill rows.
+Shared 1024-bit words are interleaved over the 17 physical macros in each
+4.25 MiB home by `bank = word_index mod 17` and
+`row = floor(word_index / 17)`.
+
+One shared word holds sixteen K dimension beats for one token block.  A
+complete dimension window therefore contains 128 words, or 16 KiB.  With 17
+single-read-port banks it has an eight-cycle conflict-free lower bound.  A
+two-window prefetch buffer can overlap that fetch with the corresponding
+sixteen compute cycles.  The full two-window register realization is
+functionally checked but synthesis-intractable.  The bounded alternative uses
+two 17-word round windows and exposes sixteen dimensions over eight rounds;
+its exact contract and current physical-evidence boundary are recorded in
+`npu/docs/attention_shared_sram_k_window_scheduler_contract.md`.  The bounded
+17-bank hierarchy now completes generic Nangate45 mapping with zero structural
+problems, but routed PPA is still required; a single shared-macro adapter
+cannot supply all 53/54 dual-stream producers.
+
+## Equivalence Boundary
+
+Transport equivalence must compare the complete declared source and
+destination windows, plus wave, source, destination, packet count, packet ordering, and
+completion identity.  Hashes may be used as a compact diagnostic only when
+the test also proves every expected address was written exactly once and no
+unexpected address was written.
+
+The transport window is no longer semantically opaque: every byte has a K or
+V coordinate under the layout above.  RTL composition with the banked K
+prefetch scheduler and local value-SRAM fill consumer remains a required
+gate.  The existing GQA8 probe also drives only one accepted dimension beat
+per block even though the compute RTL supports accumulation until
+`input_last`; it must be upgraded to all 128 dimensions before this evidence
+is presented as end-to-end exact Llama7B attention equivalence.
+
+## Physical Accounting Boundary
+
+The controller, packet endpoints, mesh, and concurrent transfer-window SRAM
+ports are synthesizable RTL.  The full shared-SRAM capacity is accounted from
+the checked CACTI/macro registry; it must not be replaced by resettable state
+registers or by a fabricated full-capacity RTL array.  Physical reports must
+state separately:
+
+- transport/controller standard-cell area and power
+- endpoint and mesh area and power
+- concurrent source/destination window macro area and access energy
+- full shared-SRAM capacity macro area and access energy
+
+HBM/DRAM service and its controller remain external.

--- a/npu/docs/attention_shared_sram_k_window_scheduler_contract.md
+++ b/npu/docs/attention_shared_sram_k_window_scheduler_contract.md
@@ -1,0 +1,179 @@
+# Shared-SRAM K Window Scheduler Contract
+
+This contract closes the K-prefetch scheduler boundary identified by the
+Phase-2 shared-stream transport contract.  It covers one Llama7B GQA8 KV head
+for one 1024-token tile.  The shared-SRAM capacity remains a separately
+accounted physical macro array; the scheduler and its live compute window are
+synthesizable RTL.
+
+## Checked Geometry
+
+- K head dimension: 128
+- compute dimensions per beat group: 16
+- dimension groups per head: 8
+- shared word width: 1024 bits
+- K words per dimension group: 128
+- physical shared-SRAM banks: 17
+- complete K requests and responses per head: 1,024
+
+The sole tensor-layout authority is
+`npu/sim/perf/attention_shared_sram_gqa8_tensor_layout.py`.  For dimension
+group `g` and global word slot `s`, the shared word address is:
+
+```text
+base_word + 8*s + g
+```
+
+This block-major stride-8 mapping is intentionally not the contiguous
+`base_word + 128*g + s` layout.  Since 8 and 17 are coprime, any consecutive
+17-word round has one request per bank.  Round seven contains the remaining
+nine words.
+
+Every response carries buffer, group, round, and global-word-slot metadata.
+The RTL fails closed on a response that is stale, duplicated, outside the
+active round, or returned by the wrong bank.  A window cannot be overwritten
+until its final compute beat has been accepted.
+
+## Architecture Points
+
+### Full 128-word windows
+
+`attention_shared_sram_k_window_scheduler.sv` holds two complete 128-word
+windows:
+
+- live storage: `2 * 128 * 1024 = 262,144` bits (32 KiB)
+- compute boundary: `128 * 64 = 8,192` bits
+- compute beats: `8 groups * 16 dimensions = 128`
+- ideal SRAM issue lower bound: eight cycles per group
+
+The executable model and RTL tests prove exact request addresses, exact data,
+ordered compute beats, backpressure behavior, and fail-closed response
+metadata.  This point is not a physical result.  Two local Yosys elaboration
+runs expanded the resettable array into registers and exceeded approximately
+6.8 GiB RSS before technology mapping; both were terminated.  It is recorded
+as `synthesis_infeasible_flat_register_window`, not as a failed timing point.
+
+### 17-word round windows
+
+`attention_shared_sram_k_round_scheduler.sv` holds two bank-width windows and
+serializes each dimension group over eight rounds:
+
+- live storage: `2 * 17 * 1024 = 34,816` bits (4.25 KiB)
+- compute boundary: `17 * 64 = 1,088` bits plus a 17-bit valid mask
+- rounds: `8 groups * 8 rounds = 64`
+- compute beats: `64 rounds * 16 dimensions = 1,024`
+- complete requests and responses: 1,024, unchanged from the full-window point
+
+The Python model and RTL agree on all 64 windows and 1,024 compute beats.  The
+testbench checks every request address and bank, every output lane, the final
+nine-word mask, independent bank/output backpressure, counters, and malformed
+metadata rejection.
+
+Each physical bank's two live words are implemented by
+`attention_shared_sram_k_round_bank.sv`.  This explicit hierarchy fixes each
+response bank's write target and moves the bank permutation to the 64-bit
+compute lanes.
+
+A memory-bounded Yosys `proc; opt; check; stat` diagnostic of the initial
+logical-slot implementation completed in 59.4 s with 1.188 GiB peak RSS and
+zero structural errors.  An initial bounded generic technology-mapping run
+reached its 180 s limit at 2.103 GiB peak RSS before ABC.  Those diagnostics
+led to three structural changes: payload reset removal, storage by physical
+bank rather than logical slot, and explicit 17-way bank-leaf hierarchy.
+
+The resulting hierarchy completed bounded Nangate45 generic technology
+mapping in 152.43 s with 2.223 GiB peak RSS and zero post-map structural
+problems.  The mapped estimate contains 298,988 cells and 34,816 payload
+flip-flops.  Its area decomposition is:
+
+- one bank leaf: 17,352.244 um2
+- scheduler, validation, and compute-side permutation excluding leaves:
+  108,934.714 um2
+- scheduler plus all 17 leaves: 403,922.862 um2
+
+The final structural check must load the Liberty cell declarations with
+`read_liberty -lib`; passing the Liberty path only to `dfflibmap` and `abc`
+does not provide mapped-cell port directions to `check` and produces false
+undriven-output warnings.  The three remaining synthesis warnings report only
+that small scheduler metadata arrays were lowered to registers.
+
+This is a pre-route standard-cell estimate, not routed area, timing, or power.
+The point still requires the proposal-backed OpenROAD sweep before it may
+replace a measured component in the Llama7B frontier.
+
+The physical sweep uses a 1,000-by-1,000 um core at placement density 0.50.
+The hierarchy's pre-route area is already 40.39% of that core, making the
+earlier 0.40 density physically infeasible after harness and implementation
+overhead.  The narrow-I/O response source repeats a metadata-derived 64-bit
+lane across each 1024-bit word so stimulus generation does not dominate the
+calibration.
+
+The generated top completes the same bounded mapping in 156.98 s with 2.217
+GiB peak RSS and zero structural problems.  It retains all 34,816 payload
+flip-flops and estimates 414,621.116 um2 total area.  The wrapper contributes
+10,698.254 um2, or 2.58% of that estimate, for total pre-route core utilization
+of 41.46% before placement buffers and routing.
+
+## Throughput Interpretation
+
+The round point trades eight times more compute-interface cycles for 7.53
+times less live storage and a 7.53 times narrower compute boundary.  At SRAM
+response latency no greater than the sixteen compute cycles of one round,
+double buffering sustains one accepted compute beat per cycle after initial
+fill.  Longer response latency or bank/output backpressure creates explicit
+stalls in both the executable model and RTL counters.
+
+The 1,024 scheduler beats are not automatically 1,024 additional end-to-end
+attention cycles.  The consumer arithmetic must accept the 17 parallel K
+words for one dimension each cycle for the scheduler rate to be realizable.
+Frontier recosting must use the slower of this measured interface schedule and
+the composed score-compute service.
+
+## Physical Accounting and Remaining Abstraction
+
+Physical reports must separate:
+
+- scheduler standard-cell area and power, including the concrete live windows
+- 17 shared-SRAM bank macro area and access energy
+- full shared-SRAM capacity macro area and access energy
+- downstream score-compute standard-cell area and power
+
+The shared-SRAM macro contents are not duplicated as resettable RTL state.
+HBM/DRAM and its controller remain external.  Until routed PPA exists, the
+round scheduler must not replace a measured component in the Llama7B frontier
+ranking.
+
+## Verification Commands
+
+```bash
+PYTHONPATH=. pytest \
+  npu/sim/perf/tests/test_attention_shared_sram_k_round_scheduler.py \
+  tests/test_attention_shared_sram_k_round_scheduler_rtl.py -q
+
+iverilog -g2012 -s attention_shared_sram_k_round_scheduler \
+  -o /tmp/k-round.vvp \
+  npu/sim/rtl/attention_shared_sram_k_round_bank.sv \
+  npu/sim/rtl/attention_shared_sram_k_round_scheduler.sv
+
+verilator --lint-only -Wall -Wno-fatal \
+  --top-module attention_shared_sram_k_round_scheduler \
+  npu/sim/rtl/attention_shared_sram_k_round_bank.sv \
+  npu/sim/rtl/attention_shared_sram_k_round_scheduler.sv
+
+yosys -p 'read_liberty -lib \
+    /orfs/flow/platforms/nangate45/lib/NangateOpenCellLibrary_typical.lib; \
+  read_verilog -sv \
+    npu/sim/rtl/attention_shared_sram_k_round_bank.sv \
+    npu/sim/rtl/attention_shared_sram_k_round_scheduler.sv; \
+  hierarchy -top attention_shared_sram_k_round_scheduler; \
+  synth -noabc -top attention_shared_sram_k_round_scheduler; \
+  dfflibmap -liberty \
+    /orfs/flow/platforms/nangate45/lib/NangateOpenCellLibrary_typical.lib; \
+  opt; setundef -zero; \
+  abc -fast -liberty \
+    /orfs/flow/platforms/nangate45/lib/NangateOpenCellLibrary_typical.lib; \
+  splitnets; opt_clean -purge; \
+  stat -liberty \
+    /orfs/flow/platforms/nangate45/lib/NangateOpenCellLibrary_typical.lib; \
+  check'
+```

--- a/npu/eval/audit_llama7b_shared_sram_access_energy.py
+++ b/npu/eval/audit_llama7b_shared_sram_access_energy.py
@@ -1,0 +1,1046 @@
+#!/usr/bin/env python3
+"""Audit SRAM access granularity and energy for the Llama 7B shared stream.
+
+The audit consumes the checked-in residency model and CACTI per-macro metrics.
+It deliberately keeps SRAM traffic separate from HBM accounting: transient
+and persistent residency select the residency-model traffic input, but this
+module does not invent an HBM controller or HBM energy model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval.model_llama7b_shared_sram_residency import (
+    DEFAULT_CLUSTERS,
+    DEFAULT_HEAD_DIM,
+    DEFAULT_KV_BITS,
+    DEFAULT_KV_HEADS,
+    DEFAULT_LAYERS,
+    DEFAULT_PACKET_PAYLOAD,
+    DEFAULT_SEQUENCE_LENGTH,
+    DEFAULT_TILE_TOKENS,
+    FRACTIONAL_SMEAR,
+    LOCALITY_AWARE,
+    PERSISTENT,
+    TRANSIENT,
+    build_residency_report,
+)
+
+
+LOCAL_CAPACITY_METRICS = (
+    REPO_ROOT / "runs/designs/sram/llama7b_attention_local_capacity_v1/sram_metrics.json"
+)
+TILE_BUFFER_METRICS = (
+    REPO_ROOT / "runs/designs/sram/llama7b_attention_tile_buffers_v1/sram_metrics.json"
+)
+
+DEFAULT_FRACTIONAL_TILE_BYTES = 17_408
+DEFAULT_SHARED_CAPACITY_BYTES = 68 * 1024 * 1024
+FLIT_BYTES = 32
+BURST_FLITS = 4
+NATIVE_256_WIDTH = 256
+
+
+class SramAuditError(ValueError):
+    """Raised when a CACTI entry or access accounting contract is invalid."""
+
+
+JsonDict = dict[str, Any]
+
+
+def _ceil_div(numerator: int, denominator: int) -> int:
+    return (numerator + denominator - 1) // denominator
+
+
+def _positive_number(value: Any, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+        raise SramAuditError(f"CACTI field {field!r} must be a finite number")
+    if value <= 0:
+        raise SramAuditError(f"CACTI field {field!r} must be positive")
+    return float(value)
+
+
+@dataclass(frozen=True)
+class CactiMacro:
+    """One physical SRAM macro and its per-access CACTI values."""
+
+    name: str
+    source_path: str
+    pdk: str
+    capacity_bytes: int
+    width_bits: int
+    bus_width_bits: int
+    word_size_bytes: int
+    access_time_ns: float
+    read_energy_pj: float
+    write_energy_pj: float
+    area_um2: float
+
+    @classmethod
+    def from_entry(cls, entry: JsonDict, *, source_path: Path) -> "CactiMacro":
+        instance = entry.get("instance")
+        metrics = entry.get("metrics")
+        if not isinstance(instance, dict) or not isinstance(metrics, dict):
+            raise SramAuditError(f"invalid CACTI entry in {source_path}")
+        raw = metrics.get("raw")
+        if not isinstance(raw, dict):
+            raise SramAuditError(f"CACTI entry {instance.get('name')!r} has no raw metrics")
+
+        def positive_int(field: str) -> int:
+            value = instance.get(field)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise SramAuditError(
+                    f"CACTI entry {instance.get('name')!r} field {field!r} must be a positive integer"
+                )
+            return value
+
+        name = instance.get("name")
+        pdk = instance.get("pdk")
+        if not isinstance(name, str) or not name or not isinstance(pdk, str) or not pdk:
+            raise SramAuditError(f"CACTI entry in {source_path} lacks name/pdk")
+        width_bits = positive_int("width")
+        word_size_bytes = positive_int("word_size_bytes")
+        if word_size_bytes != _ceil_div(width_bits, 8):
+            raise SramAuditError(
+                f"CACTI entry {name!r} width/word mismatch: {width_bits} bits, "
+                f"{word_size_bytes} bytes"
+            )
+        capacity_bytes = positive_int("size_bytes")
+        bus_width_bits = positive_int("bus_width_bits")
+        return cls(
+            name=name,
+            source_path=str(source_path),
+            pdk=pdk,
+            capacity_bytes=capacity_bytes,
+            width_bits=width_bits,
+            bus_width_bits=bus_width_bits,
+            word_size_bytes=word_size_bytes,
+            access_time_ns=_positive_number(raw.get("access_time_ns"), "access_time_ns"),
+            read_energy_pj=_positive_number(raw.get("read_energy_nj"), "read_energy_nj") * 1000.0,
+            write_energy_pj=_positive_number(raw.get("write_energy_nj"), "write_energy_nj") * 1000.0,
+            area_um2=_positive_number(raw.get("area_mm2"), "area_mm2") * 1_000_000.0,
+        )
+
+    def as_dict(self) -> JsonDict:
+        return {
+            "name": self.name,
+            "source_path": self.source_path,
+            "pdk": self.pdk,
+            "capacity_bytes": self.capacity_bytes,
+            "capacity_kib": self.capacity_bytes / 1024,
+            "width_bits": self.width_bits,
+            "bus_width_bits": self.bus_width_bits,
+            "word_size_bytes": self.word_size_bytes,
+            "access_time_ns": self.access_time_ns,
+            "read_energy_pj_per_access": self.read_energy_pj,
+            "write_energy_pj_per_access": self.write_energy_pj,
+            "area_um2": self.area_um2,
+            "area_mm2": self.area_um2 / 1_000_000.0,
+        }
+
+
+def load_cacti_entries(path: Path) -> dict[str, CactiMacro]:
+    """Load all usable per-macro CACTI entries from one metrics JSON file."""
+
+    try:
+        document = json.loads(path.read_text())
+    except FileNotFoundError as exc:
+        raise SramAuditError(f"CACTI metrics file not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise SramAuditError(f"invalid CACTI JSON in {path}: {exc}") from exc
+    entries = document.get("instances") if isinstance(document, dict) else None
+    if not isinstance(entries, list) or not entries:
+        raise SramAuditError(f"CACTI metrics file has no instances: {path}")
+    macros: dict[str, CactiMacro] = {}
+    for entry in entries:
+        # Some manifests declare logical buffers whose CACTI run is absent.
+        # They are not usable comparison points, but should not invalidate
+        # complete entries from the same manifest.
+        if not isinstance(entry, dict) or not isinstance(entry.get("metrics"), dict):
+            continue
+        raw = entry["metrics"].get("raw")
+        if not isinstance(raw, dict) or any(
+            raw.get(field) is None
+            for field in ("access_time_ns", "read_energy_nj", "write_energy_nj", "area_mm2")
+        ):
+            continue
+        macro = CactiMacro.from_entry(entry, source_path=path)
+        if macro.name in macros:
+            raise SramAuditError(f"duplicate CACTI instance {macro.name!r} in {path}")
+        macros[macro.name] = macro
+    return macros
+
+
+def load_selected_macros(
+    *,
+    local_capacity_path: Path = LOCAL_CAPACITY_METRICS,
+    tile_buffer_path: Path = TILE_BUFFER_METRICS,
+) -> tuple[CactiMacro, CactiMacro]:
+    """Load the selected 1024-bit macro and the available native 256-bit macro."""
+
+    local = load_cacti_entries(local_capacity_path)
+    try:
+        selected = local["local_capacity_chunk_02_256kib"]
+    except KeyError as exc:
+        raise SramAuditError("selected 256 KiB/1024-bit CACTI macro is missing") from exc
+    if selected.capacity_bytes != 256 * 1024 or selected.width_bits != 1024:
+        raise SramAuditError("selected CACTI macro is not 256 KiB/1024-bit")
+
+    tile = load_cacti_entries(tile_buffer_path)
+    native_candidates = [macro for macro in tile.values() if macro.width_bits == NATIVE_256_WIDTH]
+    if not native_candidates:
+        raise SramAuditError("no native 256-bit CACTI macro is available")
+    native = next(
+        (macro for macro in native_candidates if macro.name == "kv_tile_read_buffer"),
+        max(native_candidates, key=lambda macro: macro.capacity_bytes),
+    )
+    return selected, native
+
+
+def _residency_traffic(
+    *,
+    mode: str,
+    fractional_tile_bytes: int,
+    persistence_mode: str,
+    scope: str,
+    shared_capacity_bytes: int,
+    placement: str,
+    sequence_length: int,
+    tile_tokens: int,
+    layers: int,
+    kv_heads: int,
+    head_dim: int,
+    kv_bits: int,
+    clusters: int,
+    packet_payload: int,
+) -> JsonDict:
+    report = build_residency_report(
+        mode,
+        sequence_length=sequence_length,
+        tile_tokens=tile_tokens,
+        layers=layers,
+        kv_heads=kv_heads,
+        head_dim=head_dim,
+        kv_bits=kv_bits,
+        clusters=clusters,
+        packet_payload=packet_payload,
+        fractional_tile_bytes=fractional_tile_bytes if mode == FRACTIONAL_SMEAR else None,
+        persistence_mode=persistence_mode,
+        shared_capacity_bytes=shared_capacity_bytes,
+    )
+    if placement not in {"remote", "local"}:
+        raise SramAuditError("placement must be 'remote' or 'local'")
+    contexts = [
+        context
+        for context in report["placement"]["resident_contexts"]
+        if bool(context["remote"]) == (placement == "remote")
+        and (scope == "full_model" or context["layer"] == 0)
+    ]
+    if not contexts:
+        raise SramAuditError(
+            f"residency model produced no {placement} contexts for scope {scope!r}"
+        )
+    payload_bytes = sum(int(context["payload_bytes"]) for context in contexts)
+    packet_count = sum(int(context["packet_count"]) for context in contexts)
+    flit_count = sum(int(context["flit_count"]) for context in contexts)
+    model_flit_bytes = flit_count * FLIT_BYTES
+    if packet_count <= 0 or flit_count <= 0:
+        raise SramAuditError("residency model produced non-positive transport counts")
+    return {
+        "scope": scope,
+        "mode": mode,
+        "placement": placement,
+        "shape": report["shape"],
+        "clusters": report["placement"]["clusters"],
+        "shared_capacity_bytes": report["residency"]["capacity_bytes"],
+        "packet_payload_bytes": report["transport"]["packet_payload_bytes"],
+        "persistence_mode": persistence_mode,
+        "context_count": len(contexts),
+        "payload_bytes": payload_bytes,
+        "packet_count": packet_count,
+        "flit_count": flit_count,
+        "flit_bytes": FLIT_BYTES,
+        "flit_payload_bytes": model_flit_bytes,
+        "flit_padding_bytes": model_flit_bytes - payload_bytes,
+        "context_payload_bytes": [int(context["payload_bytes"]) for context in contexts],
+        "source_read_bytes": payload_bytes,
+        "destination_write_bytes": payload_bytes if placement == "remote" else 0,
+        "source_read_is_remote_transport": placement == "remote",
+        "destination_write_is_remote_transport": placement == "remote",
+        "transport_packet_count": packet_count if placement == "remote" else 0,
+        "transport_flit_count": flit_count if placement == "remote" else 0,
+        "persistence_note": (
+            "Transient/persistent selection is inherited as a residency-model input. "
+            "It does not change this SRAM access count and "
+            "does not model HBM behavior."
+        ),
+        "placement_note": (
+            "Remote placement reads shared source storage and writes every flit into the "
+            "destination local buffer."
+            if placement == "remote"
+            else "Locality-aware placement reads local shared storage without transport or destination writes."
+        ),
+        "residency_model": report["model"],
+    }
+
+
+def _combine_historical_source_traffic(remote: JsonDict, local_bypass: JsonDict) -> JsonDict:
+    """Combine remote and bypassed contexts into the complete source-read workload."""
+
+    for field in (
+        "scope",
+        "mode",
+        "persistence_mode",
+        "shape",
+        "clusters",
+        "shared_capacity_bytes",
+        "packet_payload_bytes",
+    ):
+        if remote[field] != local_bypass[field]:
+            raise SramAuditError(f"remote/local historical traffic disagrees on {field}")
+    payload_bytes = int(remote["payload_bytes"]) + int(local_bypass["payload_bytes"])
+    packet_count = int(remote["packet_count"]) + int(local_bypass["packet_count"])
+    flit_count = int(remote["flit_count"]) + int(local_bypass["flit_count"])
+    context_payload_bytes = [
+        *remote["context_payload_bytes"],
+        *local_bypass["context_payload_bytes"],
+    ]
+    if sum(context_payload_bytes) != payload_bytes:
+        raise SramAuditError("combined source traffic does not conserve payload bytes")
+    return {
+        "scope": remote["scope"],
+        "mode": remote["mode"],
+        "placement": "historical_remote_plus_local_bypass",
+        "persistence_mode": remote["persistence_mode"],
+        "shape": remote["shape"],
+        "clusters": remote["clusters"],
+        "shared_capacity_bytes": remote["shared_capacity_bytes"],
+        "packet_payload_bytes": remote["packet_payload_bytes"],
+        "context_count": int(remote["context_count"]) + int(local_bypass["context_count"]),
+        "remote_context_count": int(remote["context_count"]),
+        "local_bypass_context_count": int(local_bypass["context_count"]),
+        "payload_bytes": payload_bytes,
+        "remote_payload_bytes": int(remote["payload_bytes"]),
+        "local_bypass_payload_bytes": int(local_bypass["payload_bytes"]),
+        "packet_count": packet_count,
+        "flit_count": flit_count,
+        "flit_bytes": FLIT_BYTES,
+        "flit_payload_bytes": flit_count * FLIT_BYTES,
+        "flit_padding_bytes": flit_count * FLIT_BYTES - payload_bytes,
+        "context_payload_bytes": context_payload_bytes,
+        "source_read_bytes": payload_bytes,
+        "destination_write_bytes": int(remote["payload_bytes"]),
+        "transport_packet_count": int(remote["transport_packet_count"]),
+        "transport_flit_count": int(remote["transport_flit_count"]),
+        "local_bypass_packet_count": int(local_bypass["packet_count"]),
+        "local_bypass_flit_count": int(local_bypass["flit_count"]),
+        "residency_model": remote["residency_model"],
+        "source_read_note": (
+            "Source shared SRAM serves every resident context: remote transport plus local bypass."
+        ),
+        "destination_write_note": (
+            "Only remote transport flits write the existing destination local buffer."
+        ),
+    }
+
+
+def _access_accounting(
+    *,
+    macro: CactiMacro,
+    payload_bytes: int,
+    flit_count: int,
+    context_payload_bytes: list[int],
+    coalesce_flits: int,
+    label: str,
+) -> JsonDict:
+    if payload_bytes <= 0 or flit_count <= 0 or coalesce_flits <= 0:
+        raise SramAuditError("access accounting requires positive payload, flits, and coalescing")
+    if not context_payload_bytes or sum(context_payload_bytes) != payload_bytes:
+        raise SramAuditError("context payloads do not conserve the residency payload")
+    expected_flits = sum(_ceil_div(context_payload, FLIT_BYTES) for context_payload in context_payload_bytes)
+    if flit_count != expected_flits:
+        raise SramAuditError(
+            f"residency flit count {flit_count} does not match payload {payload_bytes}"
+        )
+    if coalesce_flits * FLIT_BYTES > macro.word_size_bytes:
+        raise SramAuditError(
+            f"{label} coalesces {coalesce_flits} flits into more bytes than macro word"
+        )
+    full_groups = 0
+    tail_flits = 0
+    access_count = 0
+    useful_flit_bytes = 0
+    partial_access_count = 0
+    for context_payload in context_payload_bytes:
+        context_flits = _ceil_div(context_payload, FLIT_BYTES)
+        context_full_groups, context_tail_flits = divmod(context_flits, coalesce_flits)
+        full_groups += context_full_groups
+        tail_flits += context_tail_flits
+        access_count += context_full_groups + (1 if context_tail_flits else 0)
+        useful_flit_bytes += context_flits * FLIT_BYTES
+        if coalesce_flits * FLIT_BYTES < macro.word_size_bytes:
+            partial_access_count += context_full_groups
+        if context_tail_flits:
+            partial_access_count += 1
+        elif context_payload % (coalesce_flits * FLIT_BYTES):
+            # A final flit can be only partially useful even when it occupies
+            # a complete coalescing group (notably the native 256-bit case).
+            partial_access_count += 1
+    macro_touched_bytes = access_count * macro.word_size_bytes
+    flit_padding_bytes = useful_flit_bytes - payload_bytes
+    macro_word_padding_bytes = macro_touched_bytes - payload_bytes
+    coalesced_flit_groups = full_groups if coalesce_flits > 1 else 0
+    useful_bytes_per_access = payload_bytes / access_count
+    return {
+        "label": label,
+        "macro": macro.as_dict(),
+        "coalesce_flits": coalesce_flits,
+        "coalesced_flit_groups": coalesced_flit_groups,
+        "coalesced_flit_count": coalesced_flit_groups * coalesce_flits,
+        "full_group_count": full_groups,
+        "tail_flit_count": tail_flits,
+        "access_count": access_count,
+        "macro_bytes_per_access": macro.word_size_bytes,
+        "useful_bytes_per_access": useful_bytes_per_access,
+        "flit_padding_bytes": flit_padding_bytes,
+        "macro_word_padding_bytes": macro_word_padding_bytes,
+        "byte_masked_access_count": partial_access_count,
+        "fully_utilized_access_count": access_count - partial_access_count,
+        "aligned_payload": all(
+            context_payload % (coalesce_flits * FLIT_BYTES) == 0
+            for context_payload in context_payload_bytes
+        ),
+        "coalescing_note": (
+            f"{coalesce_flits} {FLIT_BYTES * 8}-bit flits are coalesced per macro access"
+            if coalesce_flits > 1
+            else "one flit is issued per macro access; no flit coalescing"
+        ),
+    }
+
+
+def _with_directional_energy(profile: JsonDict, *, macro: CactiMacro) -> JsonDict:
+    read_energy = profile["access_count"] * macro.read_energy_pj
+    write_energy = profile["access_count"] * macro.write_energy_pj
+    payload_bytes = profile["useful_bytes_per_access"] * profile["access_count"]
+    profile["source_read"] = {
+        "access_count": profile["access_count"],
+        "energy_pj": read_energy,
+        "energy_nj": read_energy / 1000.0,
+        "energy_per_useful_byte_pj": read_energy / payload_bytes,
+        "energy_basis": "CACTI read_energy per one macro access",
+    }
+    profile["destination_write"] = {
+        "access_count": profile["access_count"],
+        "energy_pj": write_energy,
+        "energy_nj": write_energy / 1000.0,
+        "energy_per_useful_byte_pj": write_energy / payload_bytes,
+        "energy_basis": "CACTI write_energy per one macro access",
+    }
+    profile["total_sram_energy_pj"] = read_energy + write_energy
+    profile["total_sram_energy_nj"] = (read_energy + write_energy) / 1000.0
+    profile["total_energy_per_useful_byte_pj"] = (read_energy + write_energy) / payload_bytes
+    return profile
+
+
+def _operation(
+    profile: JsonDict,
+    *,
+    macro: CactiMacro,
+    operation: str,
+    role: str,
+) -> JsonDict:
+    if operation not in {"read", "write"}:
+        raise SramAuditError("operation must be 'read' or 'write'")
+    energy_per_access = macro.read_energy_pj if operation == "read" else macro.write_energy_pj
+    access_count = int(profile["access_count"])
+    payload_bytes = profile["useful_bytes_per_access"] * access_count
+    energy_pj = access_count * energy_per_access
+    return {
+        "role": role,
+        "operation": operation,
+        "macro": macro.as_dict(),
+        "access_count": access_count,
+        "energy_pj_per_access": energy_per_access,
+        "energy_pj": energy_pj,
+        "energy_nj": energy_pj / 1000.0,
+        "energy_per_useful_byte_pj": energy_pj / payload_bytes,
+        "access_time_ns": macro.access_time_ns,
+        "coalesce_flits": profile["coalesce_flits"],
+        "useful_bytes_per_access": profile["useful_bytes_per_access"],
+        "flit_padding_bytes": profile["flit_padding_bytes"],
+        "macro_word_padding_bytes": profile["macro_word_padding_bytes"],
+        "byte_masked_access_count": profile["byte_masked_access_count"],
+        "fully_utilized_access_count": profile["fully_utilized_access_count"],
+    }
+
+
+def _zero_destination_write() -> JsonDict:
+    return {
+        "role": "destination_local_buffer",
+        "operation": "write",
+        "macro": None,
+        "access_count": 0,
+        "energy_pj_per_access": 0.0,
+        "energy_pj": 0.0,
+        "energy_nj": 0.0,
+        "energy_per_useful_byte_pj": 0.0,
+        "access_time_ns": 0.0,
+        "transport_write": False,
+        "reason": "locality-aware residency supplies the consumer locally",
+    }
+
+
+def _capacity_pack(macro: CactiMacro, capacity_bytes: int) -> JsonDict:
+    macro_count = _ceil_div(capacity_bytes, macro.capacity_bytes)
+    provided = macro_count * macro.capacity_bytes
+    return {
+        "required_capacity_bytes": capacity_bytes,
+        "macro_count": macro_count,
+        "provided_capacity_bytes": provided,
+        "slack_bytes": provided - capacity_bytes,
+        "area_um2": macro_count * macro.area_um2,
+        "area_mm2": macro_count * macro.area_um2 / 1_000_000.0,
+        "capacity_note": (
+            "Area is the macro count needed for the source shared-SRAM capacity pack only."
+        ),
+    }
+
+
+def _primitive_profiles(
+    traffic: JsonDict,
+    *,
+    selected: CactiMacro,
+    native: CactiMacro,
+) -> dict[str, JsonDict]:
+    payload_bytes = int(traffic["payload_bytes"])
+    flit_count = int(traffic["flit_count"])
+    context_payload_bytes = traffic["context_payload_bytes"]
+    profiles = {
+        "selected_1024b_macro_burst4": _access_accounting(
+            macro=selected,
+            payload_bytes=payload_bytes,
+            flit_count=flit_count,
+            context_payload_bytes=context_payload_bytes,
+            coalesce_flits=BURST_FLITS,
+            label="256KiB/1024-bit macro with 4x256-bit burst adapter",
+        ),
+        "selected_1024b_macro_naive_flit": _access_accounting(
+            macro=selected,
+            payload_bytes=payload_bytes,
+            flit_count=flit_count,
+            context_payload_bytes=context_payload_bytes,
+            coalesce_flits=1,
+            label="256KiB/1024-bit macro, one macro access per 256-bit flit",
+        ),
+        "native_256b_macro": _access_accounting(
+            macro=native,
+            payload_bytes=payload_bytes,
+            flit_count=flit_count,
+            context_payload_bytes=context_payload_bytes,
+            coalesce_flits=1,
+            label="native 256-bit-width macro",
+        ),
+    }
+    for profile in profiles.values():
+        macro = selected if profile["macro"]["name"] == selected.name else native
+        _with_directional_energy(profile, macro=macro)
+        profile["access_time_ns"] = macro.access_time_ns
+    return profiles
+
+
+def _compose_profile(
+    *,
+    label: str,
+    source_primitive_name: str,
+    source_primitive: JsonDict,
+    source_macro: CactiMacro,
+    payload_bytes: int,
+    shared_capacity_bytes: int,
+    destination_primitive: JsonDict | None,
+    destination_macro: CactiMacro | None,
+    locality_aware: bool,
+) -> JsonDict:
+    source_read = _operation(
+        source_primitive,
+        macro=source_macro,
+        operation="read",
+        role="local_shared_storage" if locality_aware else "remote_shared_source_storage",
+    )
+    if locality_aware:
+        destination_write = _zero_destination_write()
+    else:
+        if destination_primitive is None or destination_macro is None:
+            raise SramAuditError("remote composition requires a destination primitive and macro")
+        destination_write = _operation(
+            destination_primitive,
+            macro=destination_macro,
+            operation="write",
+            role="destination_local_kv_tile_read_buffer",
+        )
+        destination_write["transport_write"] = True
+    total_energy_pj = source_read["energy_pj"] + destination_write["energy_pj"]
+    source_capacity_pack = _capacity_pack(source_macro, shared_capacity_bytes)
+    endpoint_times = [source_read["access_time_ns"]]
+    if destination_write["access_count"]:
+        endpoint_times.append(destination_write["access_time_ns"])
+    return {
+        "label": label,
+        "path": "locality_aware_local_read" if locality_aware else "remote_shared_to_local_buffer",
+        "source_primitive": source_primitive_name,
+        "source_read": source_read,
+        "destination_write": destination_write,
+        "source_shared_capacity_pack": source_capacity_pack,
+        "destination_capacity_pack": None,
+        "destination_area_note": (
+            "The destination is the existing local kv_tile_read_buffer; no second 68 MiB "
+            "capacity pack or ranked destination area is added."
+            if not locality_aware
+            else "No destination transport buffer is accessed for locality-aware residency."
+        ),
+        "total_sram_energy_pj": total_energy_pj,
+        "total_sram_energy_nj": total_energy_pj / 1000.0,
+        "total_energy_per_useful_byte_pj": total_energy_pj / payload_bytes,
+        "total_layer_energy_pj": total_energy_pj,
+        "total_layer_energy_nj": total_energy_pj / 1000.0,
+        "total_layer_energy_per_total_source_byte_pj": total_energy_pj / payload_bytes,
+        "total_source_read_bytes": payload_bytes,
+        "remote_only_energy_per_useful_byte_pj": None,
+        "source_capacity_area_um2": source_capacity_pack["area_um2"],
+        "source_capacity_area_mm2": source_capacity_pack["area_mm2"],
+        "endpoint_access_time_bound_ns": max(endpoint_times),
+    }
+
+
+def _compose_historical_remote_profile(
+    *,
+    label: str,
+    source_primitive_name: str,
+    total_source_primitive: JsonDict,
+    remote_source_primitive: JsonDict,
+    local_bypass_primitive: JsonDict,
+    source_macro: CactiMacro,
+    destination_primitive: JsonDict,
+    destination_macro: CactiMacro,
+    total_source_bytes: int,
+    remote_payload_bytes: int,
+    local_bypass_bytes: int,
+    shared_capacity_bytes: int,
+) -> JsonDict:
+    total_source_read = _operation(
+        total_source_primitive,
+        macro=source_macro,
+        operation="read",
+        role="historical_total_shared_source_storage",
+    )
+    remote_source_read = _operation(
+        remote_source_primitive,
+        macro=source_macro,
+        operation="read",
+        role="remote_shared_source_component",
+    )
+    local_bypass_source_read = _operation(
+        local_bypass_primitive,
+        macro=source_macro,
+        operation="read",
+        role="local_bypass_shared_source_component",
+    )
+    if (
+        remote_source_read["access_count"] + local_bypass_source_read["access_count"]
+        != total_source_read["access_count"]
+    ):
+        raise SramAuditError("remote and local-bypass source accesses do not sum to total source")
+    if not math.isclose(
+        remote_source_read["energy_pj"] + local_bypass_source_read["energy_pj"],
+        total_source_read["energy_pj"],
+        rel_tol=1e-12,
+        abs_tol=1e-9,
+    ):
+        raise SramAuditError("remote and local-bypass source energies do not sum to total source")
+    destination_write = _operation(
+        destination_primitive,
+        macro=destination_macro,
+        operation="write",
+        role="destination_local_kv_tile_read_buffer",
+    )
+    destination_write["transport_write"] = True
+    total_layer_energy_pj = total_source_read["energy_pj"] + destination_write["energy_pj"]
+    remote_only_energy_pj = remote_source_read["energy_pj"] + destination_write["energy_pj"]
+    source_capacity_pack = _capacity_pack(source_macro, shared_capacity_bytes)
+    return {
+        "label": label,
+        "path": "historical_remote_plus_local_bypass",
+        "source_primitive": source_primitive_name,
+        "source_read": total_source_read,
+        "total_source_read": total_source_read,
+        "remote_source_read": remote_source_read,
+        "local_bypass_source_read": local_bypass_source_read,
+        "destination_write": destination_write,
+        "total_source_read_bytes": total_source_bytes,
+        "remote_source_read_bytes": remote_payload_bytes,
+        "local_bypass_source_read_bytes": local_bypass_bytes,
+        "destination_write_bytes": remote_payload_bytes,
+        "source_shared_capacity_pack": source_capacity_pack,
+        "destination_capacity_pack": None,
+        "destination_area_note": (
+            "The destination is the existing local kv_tile_read_buffer; no second 68 MiB "
+            "capacity pack or ranked destination area is added."
+        ),
+        "total_layer_energy_pj": total_layer_energy_pj,
+        "total_layer_energy_nj": total_layer_energy_pj / 1000.0,
+        "total_layer_energy_per_total_source_byte_pj": total_layer_energy_pj / total_source_bytes,
+        "remote_only_energy_pj": remote_only_energy_pj,
+        "remote_only_energy_nj": remote_only_energy_pj / 1000.0,
+        "remote_only_energy_per_useful_byte_pj": remote_only_energy_pj / remote_payload_bytes,
+        "remote_only_diagnostic_note": (
+            "Remote-only energy excludes local-bypass source reads and is not the ranking metric."
+        ),
+        "total_sram_energy_pj": total_layer_energy_pj,
+        "total_sram_energy_nj": total_layer_energy_pj / 1000.0,
+        "total_energy_per_useful_byte_pj": total_layer_energy_pj / total_source_bytes,
+        "source_capacity_area_um2": source_capacity_pack["area_um2"],
+        "source_capacity_area_mm2": source_capacity_pack["area_mm2"],
+        "endpoint_access_time_bound_ns": max(
+            total_source_read["access_time_ns"], destination_write["access_time_ns"]
+        ),
+    }
+
+
+def _rank_composed(profiles: dict[str, JsonDict]) -> list[JsonDict]:
+    ordered = sorted(
+        profiles.items(),
+        key=lambda item: (
+            item[1]["total_layer_energy_pj"],
+            item[1]["source_capacity_area_mm2"],
+            item[1]["endpoint_access_time_bound_ns"],
+        ),
+    )
+    return [
+        {
+            "rank": rank,
+            "profile": name,
+            "total_layer_energy_pj": profile["total_layer_energy_pj"],
+            "total_layer_energy_nj": profile["total_layer_energy_nj"],
+            "total_layer_energy_per_total_source_byte_pj": profile[
+                "total_layer_energy_per_total_source_byte_pj"
+            ],
+            "remote_only_energy_per_useful_byte_pj": profile[
+                "remote_only_energy_per_useful_byte_pj"
+            ],
+            "total_energy_per_useful_byte_pj": profile["total_energy_per_useful_byte_pj"],
+            "total_sram_energy_pj": profile["total_sram_energy_pj"],
+            "source_capacity_area_mm2": profile["source_capacity_area_mm2"],
+            "endpoint_access_time_bound_ns": profile["endpoint_access_time_bound_ns"],
+        }
+        for rank, (name, profile) in enumerate(ordered, start=1)
+    ]
+
+
+def build_audit_report(
+    *,
+    mode: str = FRACTIONAL_SMEAR,
+    fractional_tile_bytes: int = DEFAULT_FRACTIONAL_TILE_BYTES,
+    persistence_mode: str = TRANSIENT,
+    scope: str = "one_layer_remote",
+    sequence_length: int = DEFAULT_SEQUENCE_LENGTH,
+    tile_tokens: int = DEFAULT_TILE_TOKENS,
+    layers: int = DEFAULT_LAYERS,
+    kv_heads: int = DEFAULT_KV_HEADS,
+    head_dim: int = DEFAULT_HEAD_DIM,
+    kv_bits: int = DEFAULT_KV_BITS,
+    clusters: int = DEFAULT_CLUSTERS,
+    packet_payload: int = DEFAULT_PACKET_PAYLOAD,
+    shared_capacity_bytes: int = DEFAULT_SHARED_CAPACITY_BYTES,
+    local_capacity_path: Path = LOCAL_CAPACITY_METRICS,
+    tile_buffer_path: Path = TILE_BUFFER_METRICS,
+) -> JsonDict:
+    """Return exact source-read/destination-write accounting for three options."""
+
+    if scope not in {"one_layer_remote", "full_model"}:
+        raise SramAuditError("scope must be 'one_layer_remote' or 'full_model'")
+    if mode == FRACTIONAL_SMEAR and fractional_tile_bytes <= 0:
+        raise SramAuditError("fractional_tile_bytes must be positive")
+    selected, native = load_selected_macros(
+        local_capacity_path=local_capacity_path,
+        tile_buffer_path=tile_buffer_path,
+    )
+    remote_traffic = _residency_traffic(
+        mode=mode,
+        fractional_tile_bytes=fractional_tile_bytes,
+        persistence_mode=persistence_mode,
+        scope=scope,
+        shared_capacity_bytes=shared_capacity_bytes,
+        placement="remote",
+        sequence_length=sequence_length,
+        tile_tokens=tile_tokens,
+        layers=layers,
+        kv_heads=kv_heads,
+        head_dim=head_dim,
+        kv_bits=kv_bits,
+        clusters=clusters,
+        packet_payload=packet_payload,
+    )
+    historical_local_bypass_traffic = _residency_traffic(
+        mode=mode,
+        fractional_tile_bytes=fractional_tile_bytes,
+        persistence_mode=persistence_mode,
+        scope=scope,
+        shared_capacity_bytes=shared_capacity_bytes,
+        placement="local",
+        sequence_length=sequence_length,
+        tile_tokens=tile_tokens,
+        layers=layers,
+        kv_heads=kv_heads,
+        head_dim=head_dim,
+        kv_bits=kv_bits,
+        clusters=clusters,
+        packet_payload=packet_payload,
+    )
+    total_source_traffic = _combine_historical_source_traffic(
+        remote_traffic,
+        historical_local_bypass_traffic,
+    )
+    locality_traffic = _residency_traffic(
+        mode=LOCALITY_AWARE,
+        fractional_tile_bytes=fractional_tile_bytes,
+        persistence_mode=persistence_mode,
+        scope=scope,
+        shared_capacity_bytes=shared_capacity_bytes,
+        placement="local",
+        sequence_length=sequence_length,
+        tile_tokens=tile_tokens,
+        layers=layers,
+        kv_heads=kv_heads,
+        head_dim=head_dim,
+        kv_bits=kv_bits,
+        clusters=clusters,
+        packet_payload=packet_payload,
+    )
+    remote_primitives = _primitive_profiles(remote_traffic, selected=selected, native=native)
+    historical_local_bypass_primitives = _primitive_profiles(
+        historical_local_bypass_traffic,
+        selected=selected,
+        native=native,
+    )
+    total_source_primitives = _primitive_profiles(
+        total_source_traffic,
+        selected=selected,
+        native=native,
+    )
+    locality_primitives = _primitive_profiles(locality_traffic, selected=selected, native=native)
+    destination_primitive = remote_primitives["native_256b_macro"]
+    remote_composed = {
+        "shared1024_burst4_source_local256_destination": _compose_historical_remote_profile(
+            label="shared 1024-bit burst4 source + local 256-bit destination",
+            source_primitive_name="selected_1024b_macro_burst4",
+            total_source_primitive=total_source_primitives["selected_1024b_macro_burst4"],
+            remote_source_primitive=remote_primitives["selected_1024b_macro_burst4"],
+            local_bypass_primitive=historical_local_bypass_primitives[
+                "selected_1024b_macro_burst4"
+            ],
+            source_macro=selected,
+            destination_primitive=destination_primitive,
+            destination_macro=native,
+            total_source_bytes=int(total_source_traffic["payload_bytes"]),
+            remote_payload_bytes=int(remote_traffic["payload_bytes"]),
+            local_bypass_bytes=int(historical_local_bypass_traffic["payload_bytes"]),
+            shared_capacity_bytes=shared_capacity_bytes,
+        ),
+        "shared1024_naive_source_local256_destination": _compose_historical_remote_profile(
+            label="shared 1024-bit naive source + local 256-bit destination",
+            source_primitive_name="selected_1024b_macro_naive_flit",
+            total_source_primitive=total_source_primitives["selected_1024b_macro_naive_flit"],
+            remote_source_primitive=remote_primitives["selected_1024b_macro_naive_flit"],
+            local_bypass_primitive=historical_local_bypass_primitives[
+                "selected_1024b_macro_naive_flit"
+            ],
+            source_macro=selected,
+            destination_primitive=destination_primitive,
+            destination_macro=native,
+            total_source_bytes=int(total_source_traffic["payload_bytes"]),
+            remote_payload_bytes=int(remote_traffic["payload_bytes"]),
+            local_bypass_bytes=int(historical_local_bypass_traffic["payload_bytes"]),
+            shared_capacity_bytes=shared_capacity_bytes,
+        ),
+        "native256_shared_source_local256_destination": _compose_historical_remote_profile(
+            label="native 256-bit shared source + local 256-bit destination",
+            source_primitive_name="native_256b_macro",
+            total_source_primitive=total_source_primitives["native_256b_macro"],
+            remote_source_primitive=remote_primitives["native_256b_macro"],
+            local_bypass_primitive=historical_local_bypass_primitives["native_256b_macro"],
+            source_macro=native,
+            destination_primitive=destination_primitive,
+            destination_macro=native,
+            total_source_bytes=int(total_source_traffic["payload_bytes"]),
+            remote_payload_bytes=int(remote_traffic["payload_bytes"]),
+            local_bypass_bytes=int(historical_local_bypass_traffic["payload_bytes"]),
+            shared_capacity_bytes=shared_capacity_bytes,
+        ),
+    }
+    locality_composed = {
+        "shared1024_burst4_local_read": _compose_profile(
+            label="locality-aware shared 1024-bit burst4 read",
+            source_primitive_name="selected_1024b_macro_burst4",
+            source_primitive=locality_primitives["selected_1024b_macro_burst4"],
+            source_macro=selected,
+            payload_bytes=int(locality_traffic["payload_bytes"]),
+            shared_capacity_bytes=shared_capacity_bytes,
+            destination_primitive=None,
+            destination_macro=None,
+            locality_aware=True,
+        ),
+        "shared1024_naive_local_read": _compose_profile(
+            label="locality-aware shared 1024-bit naive read",
+            source_primitive_name="selected_1024b_macro_naive_flit",
+            source_primitive=locality_primitives["selected_1024b_macro_naive_flit"],
+            source_macro=selected,
+            payload_bytes=int(locality_traffic["payload_bytes"]),
+            shared_capacity_bytes=shared_capacity_bytes,
+            destination_primitive=None,
+            destination_macro=None,
+            locality_aware=True,
+        ),
+        "native256_shared_local_read": _compose_profile(
+            label="locality-aware native 256-bit shared read",
+            source_primitive_name="native_256b_macro",
+            source_primitive=locality_primitives["native_256b_macro"],
+            source_macro=native,
+            payload_bytes=int(locality_traffic["payload_bytes"]),
+            shared_capacity_bytes=shared_capacity_bytes,
+            destination_primitive=None,
+            destination_macro=None,
+            locality_aware=True,
+        ),
+    }
+    remote_ranking = _rank_composed(remote_composed)
+    locality_ranking = _rank_composed(locality_composed)
+    return {
+        "model": "llama7b_shared_sram_access_energy_audit_v3",
+        "shape": total_source_traffic["shape"],
+        "configuration": {
+            "shape": total_source_traffic["shape"],
+            "clusters": total_source_traffic["clusters"],
+            "packet_payload_bytes": total_source_traffic["packet_payload_bytes"],
+            "shared_capacity_bytes": total_source_traffic["shared_capacity_bytes"],
+            "persistence_mode": persistence_mode,
+        },
+        "traffic": remote_traffic,
+        "historical_local_bypass_traffic": historical_local_bypass_traffic,
+        "total_source_traffic": total_source_traffic,
+        "locality_aware_traffic": locality_traffic,
+        "cacti": {
+            "selected_1024b_macro": selected.as_dict(),
+            "native_256b_macro": native.as_dict(),
+        },
+        "profiles": total_source_primitives,
+        "profiles_note": (
+            "Diagnostic historical total-source symmetric primitives only; they are not ranked."
+        ),
+        "remote_only_primitives": remote_primitives,
+        "historical_local_bypass_primitives": historical_local_bypass_primitives,
+        "locality_aware_primitives": locality_primitives,
+        "composed_profiles": remote_composed,
+        "locality_aware_composed_profiles": locality_composed,
+        "ranking": {
+            "basis": "total layer energy of composed source-read and destination-write paths",
+            "remote": remote_ranking,
+            "locality_aware": locality_ranking,
+        },
+        "summary": {
+            "best_remote_profile": remote_ranking[0]["profile"],
+            "best_locality_aware_profile": locality_ranking[0]["profile"],
+            "ranking_metric": "total_layer_energy_pj",
+            "remote_destination_macro": native.name,
+            "remote_destination_write_accesses": remote_traffic["flit_count"],
+            "historical_total_source_read_bytes": total_source_traffic["payload_bytes"],
+            "historical_remote_source_read_bytes": remote_traffic["payload_bytes"],
+            "historical_local_bypass_source_read_bytes": historical_local_bypass_traffic[
+                "payload_bytes"
+            ],
+            "historical_burst4_total_source_read_accesses": remote_composed[
+                "shared1024_burst4_source_local256_destination"
+            ]["source_read"]["access_count"],
+            "locality_aware_destination_write_accesses": 0,
+            "ranked_area_scope": "source shared-storage capacity pack only",
+        },
+        "method": {
+            "source_read": (
+                "historical remote-policy paths charge source reads for remote and local-bypass "
+                "resident contexts; locality-aware paths charge all-local source reads"
+            ),
+            "destination_write": (
+                "remote paths charge one kv_tile_read_buffer CACTI write per 256-bit flit; "
+                "locality-aware paths charge zero destination writes"
+            ),
+            "useful_bytes": "residency payload bytes, excluding flit and macro-word padding",
+            "ranking_energy": (
+                "Remote-policy ranking uses total layer energy: total source reads plus remote-only "
+                "destination writes. Remote-only pJ/useful-byte is retained as a diagnostic."
+            ),
+            "padding": "flit padding and macro-word padding are reported independently",
+            "dimensional_guard": (
+                "Energy is access_count * per_macro_access_energy. It is never divided by "
+                "aggregate capacity; energy_per_useful_byte divides only by useful payload."
+            ),
+            "area_boundary": (
+                "Only the source shared-storage capacity pack is ranked. The existing local "
+                "destination buffer is not expanded into a second 68 MiB pack."
+            ),
+            "hbm_boundary": "HBM is external and is not modeled by this audit",
+        },
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scope", choices=("one_layer_remote", "full_model"), default="one_layer_remote")
+    parser.add_argument("--mode", default=FRACTIONAL_SMEAR)
+    parser.add_argument("--fractional-tile-bytes", type=int, default=DEFAULT_FRACTIONAL_TILE_BYTES)
+    parser.add_argument("--persistence-mode", choices=(TRANSIENT, PERSISTENT), default=TRANSIENT)
+    parser.add_argument("--sequence-length", type=int, default=DEFAULT_SEQUENCE_LENGTH)
+    parser.add_argument("--tile-tokens", type=int, default=DEFAULT_TILE_TOKENS)
+    parser.add_argument("--layers", type=int, default=DEFAULT_LAYERS)
+    parser.add_argument("--kv-heads", type=int, default=DEFAULT_KV_HEADS)
+    parser.add_argument("--head-dim", type=int, default=DEFAULT_HEAD_DIM)
+    parser.add_argument("--kv-bits", type=int, default=DEFAULT_KV_BITS)
+    parser.add_argument("--clusters", type=int, default=DEFAULT_CLUSTERS)
+    parser.add_argument("--packet-payload", type=int, default=DEFAULT_PACKET_PAYLOAD)
+    parser.add_argument("--shared-capacity-bytes", type=int, default=DEFAULT_SHARED_CAPACITY_BYTES)
+    parser.add_argument("--pretty", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    report = build_audit_report(
+        mode=args.mode,
+        fractional_tile_bytes=args.fractional_tile_bytes,
+        persistence_mode=args.persistence_mode,
+        scope=args.scope,
+        sequence_length=args.sequence_length,
+        tile_tokens=args.tile_tokens,
+        layers=args.layers,
+        kv_heads=args.kv_heads,
+        head_dim=args.head_dim,
+        kv_bits=args.kv_bits,
+        clusters=args.clusters,
+        packet_payload=args.packet_payload,
+        shared_capacity_bytes=args.shared_capacity_bytes,
+    )
+    print(json.dumps(report, indent=2 if args.pretty else None, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/check_attention_phase2_shared_stream_contract.py
+++ b/npu/eval/check_attention_phase2_shared_stream_contract.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Fail-closed checker for the exact Phase-2 shared-stream artifact contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.sim.perf.attention_phase2_shared_stream_transport import (
+    CONTEXT_BYTES,
+    CONTEXT_COUNT,
+    DESTINATION_SPACE_BASE,
+    FLITS_PER_PACKET,
+    MAPPING_SHIFTS,
+    PACKETS_PER_CONTEXT,
+    PACKET_BYTES,
+    TOTAL_FLITS,
+    TOTAL_PACKETS,
+    TOTAL_SHARED_BYTES,
+    REMOTE_WAVES,
+    TransportContractError,
+)
+
+
+DEFAULT_ARTIFACT = REPO_ROOT / (
+    "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+    "decoder_attention_score32_noc_phase2_schedule__"
+    "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1.json"
+)
+
+JsonDict = dict[str, Any]
+
+
+class ArtifactContractError(TransportContractError):
+    """Raised when a checked artifact cannot prove shared-stream consistency."""
+
+
+def _mapping(payload: JsonDict, key: str) -> Any:
+    value = payload.get(key)
+    if not isinstance(value, dict):
+        raise ArtifactContractError(f"artifact missing object {key!r}")
+    return value
+
+
+def _require(mapping: JsonDict, key: str, expected: Any, label: str) -> None:
+    if key not in mapping:
+        raise ArtifactContractError(f"{label} is missing required shared field {key!r}")
+    if mapping[key] != expected:
+        raise ArtifactContractError(
+            f"{label}.{key}={mapping[key]!r}; expected independent shared value {expected!r}"
+        )
+
+
+def _load(path: Path) -> JsonDict:
+    if not path.is_file():
+        raise ArtifactContractError(f"missing Phase-2 artifact: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ArtifactContractError(f"cannot read JSON artifact {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ArtifactContractError("Phase-2 artifact root must be a JSON object")
+    return payload
+
+
+def validate_artifact(path: str | Path = DEFAULT_ARTIFACT) -> JsonDict:
+    """Validate only shared transport evidence from the historical artifact.
+
+    The artifact also contains historical reduction fields.  They are
+    intentionally not used to satisfy any shared check.  Missing shared
+    fields fail closed even when similarly named reduction fields are present.
+    """
+
+    artifact_path = Path(path).resolve()
+    payload = _load(artifact_path)
+    flow_summary = _mapping(payload, "flow_summary")
+    traffic = _mapping(payload, "traffic_quantities")
+    mapping = _mapping(payload, "mapping")
+    schedule = _mapping(payload, "schedule_parameters")
+    simulation = _mapping(payload, "simulation")
+    delivered_by_class = _mapping(simulation, "delivery_flit_count_by_class")
+
+    # These are the only fields allowed to establish shared-stream totals.
+    _require(flow_summary, "remote_shared_flow_count", CONTEXT_COUNT, "flow_summary")
+    _require(flow_summary, "remote_shared_packet_count", TOTAL_PACKETS, "flow_summary")
+    _require(flow_summary, "remote_shared_bytes", TOTAL_SHARED_BYTES, "flow_summary")
+    _require(traffic, "shared_tile_payload_bytes", CONTEXT_BYTES, "traffic_quantities")
+    _require(traffic, "simulated_tiles", 128, "traffic_quantities")
+    _require(schedule, "packet_payload_bytes", PACKET_BYTES, "schedule_parameters")
+    _require(schedule, "shared_vc", 0, "schedule_parameters")
+    _require(delivered_by_class, "shared", TOTAL_FLITS, "simulation.delivery_flit_count_by_class")
+    _require(simulation, "remote_shared_worst_hops_observed", 6, "simulation")
+    _require(simulation, "remote_shared_average_hops_observed", 3.0, "simulation")
+
+    _require(mapping, "cluster_endpoints", list(range(16)), "mapping")
+    _require(mapping, "shared_sram_home_offset", 1, "mapping")
+    _require(mapping, "shared_sram_home_stride", 3, "mapping")
+    _require(mapping, "shared_sram_worst_remote_hops", 6, "mapping")
+    _require(mapping, "shared_sram_average_remote_hops", 3.0, "mapping")
+    expected_load = {str(endpoint): 8 for endpoint in range(16)}
+    _require(mapping, "shared_sram_home_load_tiles", expected_load, "mapping")
+
+    expected_shifts = tuple((1 + (wave + 1) * 3) % 16 for wave in range(8))
+    if expected_shifts != MAPPING_SHIFTS:
+        raise ArtifactContractError("reference mapping constants are internally inconsistent")
+    direct_shifts = mapping.get("shared_sram_home_shifts")
+    if direct_shifts is not None and tuple(direct_shifts) != MAPPING_SHIFTS:
+        raise ArtifactContractError("artifact shared_sram_home_shifts differ from the checked mapping")
+
+    # A capacity boundary is part of the address model, but not a reduction
+    # metric.  Keep this assertion here so changes to the reference cannot
+    # silently leave the checker accepting stale address assumptions.
+    if DESTINATION_SPACE_BASE != TOTAL_SHARED_BYTES:
+        raise ArtifactContractError("reference source/destination address spaces are inconsistent")
+    if tuple(REMOTE_WAVES) != (0, 1, 2, 3, 5, 6, 7):
+        raise ArtifactContractError("reference remote-wave set changed")
+
+    reduction_fields = {
+        "flow_summary.local_only_reduction_bytes",
+        "flow_summary.remote_reduction_bytes",
+        "flow_summary.remote_reduction_flow_count",
+        "flow_summary.remote_reduction_packet_count",
+        "simulation.delivery_flit_count_by_class.reduction",
+        "schedule_parameters.reduction_vc",
+    }
+    return {
+        "status": "ok",
+        "artifact": str(artifact_path),
+        "shared": {
+            "contexts": CONTEXT_COUNT,
+            "bytes": TOTAL_SHARED_BYTES,
+            "packets": TOTAL_PACKETS,
+            "flits": TOTAL_FLITS,
+            "packet_bytes": PACKET_BYTES,
+            "flits_per_packet": FLITS_PER_PACKET,
+            "mapping_shifts": list(MAPPING_SHIFTS),
+        },
+        "retracted_reduction_validation": "ignored",
+        "retracted_reduction_fields_not_used": sorted(reduction_fields),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
+    args = parser.parse_args(argv)
+    try:
+        result = validate_artifact(args.artifact)
+    except (ArtifactContractError, OSError, ValueError) as exc:
+        print(f"attention-phase2-shared-contract: FAIL: {exc}")
+        return 1
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/check_attention_shared_sram_k_round_scheduler_ppa_guard.py
+++ b/npu/eval/check_attention_shared_sram_k_round_scheduler_ppa_guard.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Guard generated shared-SRAM K-round scheduler physical artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Sequence
+
+
+CONFIG_KEY = "attention_shared_sram_k_round_scheduler_ppa_harness"
+MANIFEST_NAME = "attention_shared_sram_k_round_scheduler_ppa_harness_manifest.json"
+PROPOSAL_ID = "prop_l1_attention_shared_sram_k_round_scheduler_ppa_v1"
+
+
+def _load(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit(f"expected JSON object: {path}")
+    return payload
+
+
+def check(design_dir: Path) -> None:
+    config = _load(design_dir / "config.json")
+    body = config.get(CONFIG_KEY)
+    if not isinstance(body, dict):
+        raise SystemExit(f"config missing {CONFIG_KEY}")
+    top_name = str(config.get("top_name") or "").strip()
+    if top_name != design_dir.name:
+        raise SystemExit("top_name must match the design directory")
+    expected_geometry = {
+        "banks": 17,
+        "words_per_group": 128,
+        "dimension_groups": 8,
+        "dimensions_per_group": 16,
+    }
+    for key, value in expected_geometry.items():
+        if int(body.get(key, value)) != value:
+            raise SystemExit(f"unsupported K-round geometry: {key}")
+    links = config.get("report_links")
+    if not isinstance(links, dict) or links.get("proposal_id") != PROPOSAL_ID:
+        raise SystemExit("config proposal linkage is missing or incorrect")
+
+    verilog_dir = design_dir / "verilog"
+    rtl = (verilog_dir / "top.v").read_text(encoding="utf-8")
+    manifest = _load(verilog_dir / MANIFEST_NAME)
+    expected_manifest = {
+        "top_name": top_name,
+        "semantic_profile": "attention_shared_sram_k_round_scheduler_logic_ppa_activity_v1",
+        "banks": 17,
+        "words_per_group": 128,
+        "dimension_groups": 8,
+        "rounds_per_group": 8,
+        "dimensions_per_group": 16,
+        "requests_per_command": 1024,
+        "compute_beats_per_command": 1024,
+        "window_storage_bits": 34816,
+        "compute_boundary_bits": 1088,
+        "full_capacity_macro_area_included": False,
+        "shared_sram_access_energy_included": False,
+        "external_hbm_dram_included": False,
+        "activity_checksum_is_equivalence_proof": False,
+        "synthetic_response_profile": "metadata_lane_replicated_v1",
+        "synthetic_response_generator_is_dut": False,
+        "narrow_io_harness_overhead_included": True,
+        "linked_proposal_id": PROPOSAL_ID,
+    }
+    mismatches = {
+        key: (manifest.get(key), value)
+        for key, value in expected_manifest.items()
+        if manifest.get(key) != value
+    }
+    if mismatches:
+        raise SystemExit(f"generated harness manifest mismatch: {mismatches}")
+    if hashlib.sha256(rtl.encode("utf-8")).hexdigest() != manifest.get(
+        "generated_top_sha256"
+    ):
+        raise SystemExit("generated top hash does not match manifest")
+    required = (
+        "attention_shared_sram_k_round_scheduler",
+        "module attention_shared_sram_k_round_bank",
+        '(* keep = "true" *) reg [1023:0] buffer_mem0',
+        '(* keep = "true" *) reg [1023:0] buffer_mem1',
+        "build_word",
+        "build_word = {16{{lane ^ 32'ha5a5_5a5a, lane}}};",
+        "fold_compute",
+        "output wire [31:0] activity_checksum",
+        ".WORDS_PER_GROUP(128)",
+        ".DIM_GROUPS(8)",
+    )
+    missing = [fragment for fragment in required if fragment not in rtl]
+    if missing:
+        raise SystemExit(f"generated physical harness is incomplete: {missing}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--design-dir", type=Path, required=True)
+    args = parser.parse_args(argv)
+    check(args.design_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/check_attention_shared_sram_read_group_adapter_ppa_guard.py
+++ b/npu/eval/check_attention_shared_sram_read_group_adapter_ppa_guard.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Guard generated shared-SRAM read-adapter physical harness artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Sequence
+
+
+CONFIG_KEY = "attention_shared_sram_read_group_adapter_ppa_harness"
+MANIFEST_NAME = "attention_shared_sram_read_group_adapter_ppa_harness_manifest.json"
+PROPOSAL_ID = "prop_l1_attention_shared_sram_read_group_adapter_ppa_v1"
+
+
+def _load(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit(f"expected JSON object: {path}")
+    return payload
+
+
+def check(design_dir: Path) -> None:
+    config = _load(design_dir / "config.json")
+    body = config.get(CONFIG_KEY)
+    if not isinstance(body, dict):
+        raise SystemExit(f"config missing {CONFIG_KEY}")
+    top_name = str(config.get("top_name") or "").strip()
+    if top_name != design_dir.name:
+        raise SystemExit("top_name must match the design directory")
+    beat_width = int(body.get("beat_width", 0))
+    group_slots = int(body.get("group_slots", 0))
+    if beat_width not in {256, 512} or group_slots not in {1, 2}:
+        raise SystemExit("unsupported adapter geometry")
+    links = config.get("report_links")
+    if not isinstance(links, dict) or links.get("proposal_id") != PROPOSAL_ID:
+        raise SystemExit("config proposal linkage is missing or incorrect")
+
+    verilog_dir = design_dir / "verilog"
+    rtl = (verilog_dir / "top.v").read_text(encoding="utf-8")
+    manifest = _load(verilog_dir / MANIFEST_NAME)
+    expected = {
+        "top_name": top_name,
+        "beat_width": beat_width,
+        "group_slots": group_slots,
+        "segments_per_macro_read": 1024 // beat_width,
+        "buffer_payload_bits": 1024 * group_slots,
+        "payload_reset_required": False,
+        "linked_proposal_id": PROPOSAL_ID,
+        "full_capacity_macro_area_included": False,
+        "synthetic_response_profile": "metadata_lane_replicated_v1",
+        "synthetic_response_generator_is_dut": False,
+        "narrow_io_harness_overhead_included": True,
+        "response_bus_retention": "kept_full_bus_endpoint_lane_fold_v1",
+    }
+    mismatches = {key: (manifest.get(key), value) for key, value in expected.items() if manifest.get(key) != value}
+    if mismatches:
+        raise SystemExit(f"generated harness manifest mismatch: {mismatches}")
+    required = (
+        "attention_shared_sram_read_group_adapter",
+        f".BEAT_W(BEAT_W)",
+        f"localparam integer BEAT_W = {beat_width};",
+        f"localparam integer GROUP_SLOTS = {group_slots};",
+        '(* keep = "true" *) reg [MACRO_W-1:0] slot_data',
+        "build_macro_word",
+        "build_macro_word = {32{lane}};",
+        "fold_beat",
+        '(* keep = "true" *) wire [BEAT_W-1:0] rsp_data;',
+        "fold_beat = value[31:0] ^ value[BEAT_W-1 -: 32];",
+        "access_reduction_proven",
+    )
+    missing = [fragment for fragment in required if fragment not in rtl]
+    if missing:
+        raise SystemExit(f"generated physical harness is incomplete: {missing}")
+    forbidden = (
+        "slot_data[reset_i] <=",
+        "32'h9e37_79b9 *",
+    )
+    present = [fragment for fragment in forbidden if fragment in rtl]
+    if present:
+        raise SystemExit(f"generated physical harness contains forbidden payload logic: {present}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--design-dir", type=Path, required=True)
+    args = parser.parse_args(argv)
+    check(args.design_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/model_llama7b_shared_sram_residency.py
+++ b/npu/eval/model_llama7b_shared_sram_residency.py
@@ -1,0 +1,708 @@
+#!/usr/bin/env python3
+"""Analytical shared-SRAM residency and placement model for Llama 7B.
+
+This module is intentionally read-only.  It models the placement of a KV
+cache in a shared SRAM and the packetization needed to move resident ranges
+between compute clusters.  It does not model HBM timing or claim that a
+transient SRAM cache reduces the HBM capacity needed for the complete KV
+cache.
+
+The historical Phase-2 schedule used a fractional byte share per tile.  That
+policy is retained as an explicit mode so it can be compared with capacity-
+driven whole-token policies without silently treating the historical 112
+remote contexts as a consequence of SRAM capacity.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+DEFAULT_SEQUENCE_LENGTH = 131_072
+DEFAULT_TILE_TOKENS = 1_024
+DEFAULT_LAYERS = 32
+DEFAULT_KV_HEADS = 4
+DEFAULT_HEAD_DIM = 128
+DEFAULT_KV_BITS = 8
+DEFAULT_SHARED_CAPACITY_BYTES = 68 * 1024 * 1024
+DEFAULT_CLUSTERS = 16
+DEFAULT_PACKET_PAYLOAD = 256
+FLIT_BYTES = 32
+TRANSIENT = "transient"
+PERSISTENT = "persistent"
+SUPPORTED_PERSISTENCE = (TRANSIENT, PERSISTENT)
+
+FRACTIONAL_SMEAR = "fractional_smear"
+LAYER_BALANCED_CONTIGUOUS = "layer_balanced_contiguous"
+LOCALITY_AWARE = "locality_aware"
+SUPPORTED_MODES = (
+    FRACTIONAL_SMEAR,
+    LAYER_BALANCED_CONTIGUOUS,
+    LOCALITY_AWARE,
+)
+
+JsonDict = dict[str, Any]
+
+
+def _ceil_div(numerator: int, denominator: int) -> int:
+    if numerator < 0 or denominator <= 0:
+        raise ValueError("ceil division requires a non-negative numerator and positive denominator")
+    return (numerator + denominator - 1) // denominator
+
+
+def _require_positive(name: str, value: int) -> int:
+    if value <= 0:
+        raise ValueError(f"{name} must be positive")
+    return value
+
+
+@dataclass(frozen=True)
+class ResidencyConfig:
+    """Shape and transport parameters for one analytical residency run."""
+
+    sequence_length: int = DEFAULT_SEQUENCE_LENGTH
+    tile_tokens: int = DEFAULT_TILE_TOKENS
+    layers: int = DEFAULT_LAYERS
+    kv_heads: int = DEFAULT_KV_HEADS
+    head_dim: int = DEFAULT_HEAD_DIM
+    kv_bits: int = DEFAULT_KV_BITS
+    shared_capacity_bytes: int = DEFAULT_SHARED_CAPACITY_BYTES
+    clusters: int = DEFAULT_CLUSTERS
+    packet_payload: int = DEFAULT_PACKET_PAYLOAD
+    persistence_mode: str = TRANSIENT
+
+    def __post_init__(self) -> None:
+        for name in (
+            "sequence_length",
+            "tile_tokens",
+            "layers",
+            "kv_heads",
+            "head_dim",
+            "kv_bits",
+            "shared_capacity_bytes",
+            "clusters",
+            "packet_payload",
+        ):
+            _require_positive(name, int(getattr(self, name)))
+        if self.kv_bits % 8:
+            raise ValueError("kv_bits must be byte-aligned")
+        if self.packet_payload < FLIT_BYTES:
+            raise ValueError(f"packet_payload must be at least {FLIT_BYTES} bytes")
+        if self.packet_payload % FLIT_BYTES:
+            raise ValueError(f"packet_payload must be a multiple of {FLIT_BYTES} bytes")
+        if self.shared_capacity_bytes % self.clusters:
+            raise ValueError("shared_capacity_bytes must divide evenly across clusters")
+        if self.persistence_mode not in SUPPORTED_PERSISTENCE:
+            raise ValueError(
+                f"persistence_mode must be one of {SUPPORTED_PERSISTENCE}, "
+                f"got {self.persistence_mode!r}"
+            )
+
+    @property
+    def kv_bytes_per_token(self) -> int:
+        return 2 * self.kv_heads * self.head_dim * (self.kv_bits // 8)
+
+    @property
+    def tile_count(self) -> int:
+        return _ceil_div(self.sequence_length, self.tile_tokens)
+
+    @property
+    def full_kv_bytes(self) -> int:
+        return self.sequence_length * self.layers * self.kv_bytes_per_token
+
+    @property
+    def full_tile_bytes(self) -> int:
+        return self.tile_tokens * self.kv_bytes_per_token
+
+    def tile_token_count(self, tile_index: int) -> int:
+        if tile_index < 0 or tile_index >= self.tile_count:
+            raise ValueError(f"tile index {tile_index} is outside the configured sequence")
+        start = tile_index * self.tile_tokens
+        return min(self.tile_tokens, self.sequence_length - start)
+
+
+@dataclass(frozen=True)
+class ResidencyContext:
+    """One contiguous resident tile range and its explicit ownership/home."""
+
+    context_id: int
+    layer: int
+    tile_index: int
+    token_start: int
+    token_count: int
+    payload_bytes: int
+    owner_cluster: int
+    home_cluster: int
+    owner_rotation_offset: int
+    packet_count: int
+    flit_count: int
+
+    @property
+    def remote(self) -> bool:
+        return self.owner_cluster != self.home_cluster
+
+    def as_dict(self) -> JsonDict:
+        return {
+            "context_id": self.context_id,
+            "layer": self.layer,
+            "tile_index": self.tile_index,
+            "token_start": self.token_start,
+            "token_count": self.token_count,
+            "payload_bytes": self.payload_bytes,
+            "owner_cluster": self.owner_cluster,
+            "home_cluster": self.home_cluster,
+            "owner_rotation_offset": self.owner_rotation_offset,
+            "remote": self.remote,
+            "packet_count": self.packet_count,
+            "flit_count": self.flit_count,
+        }
+
+
+def _historical_home(*, owner_cluster: int, tile_index: int, clusters: int) -> int:
+    """Reproduce the old offset=1, stride=3 wave mapping.
+
+    With 16 clusters and eight waves this makes exactly wave four local and
+    the other seven waves remote: 112 remote contexts per layer.  This is a
+    placement policy, not a capacity calculation.
+    """
+
+    wave = tile_index // clusters
+    return (owner_cluster + 1 + ((wave + 1) * 3)) % clusters
+
+
+def _home_for(mode: str, *, owner_cluster: int, tile_index: int, clusters: int) -> int:
+    if mode == LOCALITY_AWARE:
+        return owner_cluster
+    return _historical_home(
+        owner_cluster=owner_cluster,
+        tile_index=tile_index,
+        clusters=clusters,
+    )
+
+
+def _context(
+    *,
+    context_id: int,
+    layer: int,
+    tile_index: int,
+    token_start: int,
+    token_count: int,
+    payload_bytes: int,
+    config: ResidencyConfig,
+    mode: str,
+    owner_rotation_offset: int = 0,
+) -> ResidencyContext:
+    if token_count <= 0 or payload_bytes <= 0:
+        raise ValueError("resident contexts must contain a positive token range and payload")
+    normalized_offset = owner_rotation_offset % config.clusters
+    owner_cluster = (normalized_offset + tile_index) % config.clusters
+    home_cluster = _home_for(
+        mode,
+        owner_cluster=owner_cluster,
+        tile_index=tile_index,
+        clusters=config.clusters,
+    )
+    return ResidencyContext(
+        context_id=context_id,
+        layer=layer,
+        tile_index=tile_index,
+        token_start=token_start,
+        token_count=token_count,
+        payload_bytes=payload_bytes,
+        owner_cluster=owner_cluster,
+        home_cluster=home_cluster,
+        owner_rotation_offset=normalized_offset,
+        packet_count=_ceil_div(payload_bytes, config.packet_payload),
+        flit_count=_ceil_div(payload_bytes, FLIT_BYTES),
+    )
+
+
+def _fractional_contexts(
+    config: ResidencyConfig,
+    *,
+    fractional_tile_bytes: int | None,
+    mode: str,
+) -> list[ResidencyContext]:
+    if fractional_tile_bytes is None:
+        raise ValueError(
+            "fractional_smear requires explicit fractional_tile_bytes; "
+            "the historical value is not a defaulted physical fact"
+        )
+    _require_positive("fractional_tile_bytes", fractional_tile_bytes)
+    contexts: list[ResidencyContext] = []
+    context_id = 0
+    for layer in range(config.layers):
+        for tile_index in range(config.tile_count):
+            token_count = config.tile_token_count(tile_index)
+            # Preserve a uniform share while scaling only a shortened final tile.
+            payload_bytes = _ceil_div(
+                fractional_tile_bytes * token_count,
+                config.tile_tokens,
+            )
+            actual_tile_bytes = token_count * config.kv_bytes_per_token
+            if payload_bytes > actual_tile_bytes:
+                raise ValueError(
+                    f"fractional payload {payload_bytes} exceeds tile {tile_index} "
+                    f"KV bytes {actual_tile_bytes}"
+                )
+            contexts.append(
+                _context(
+                    context_id=context_id,
+                    layer=layer,
+                    tile_index=tile_index,
+                    token_start=tile_index * config.tile_tokens,
+                    token_count=token_count,
+                    payload_bytes=payload_bytes,
+                    config=config,
+                    mode=mode,
+                )
+            )
+            context_id += 1
+    return contexts
+
+
+def _balanced_token_counts(config: ResidencyConfig) -> list[int]:
+    minimum_required = config.layers * config.kv_bytes_per_token
+    if config.shared_capacity_bytes < minimum_required:
+        raise ValueError(
+            "shared capacity cannot allocate one whole token to every layer: "
+            f"need {minimum_required} bytes, have {config.shared_capacity_bytes}"
+        )
+    total_slots = min(
+        config.sequence_length * config.layers,
+        config.shared_capacity_bytes // config.kv_bytes_per_token,
+    )
+    base, remainder = divmod(total_slots, config.layers)
+    return [base + (1 if layer < remainder else 0) for layer in range(config.layers)]
+
+
+def _whole_token_contexts(config: ResidencyConfig, *, mode: str) -> list[ResidencyContext]:
+    token_counts = _balanced_token_counts(config)
+    contexts: list[ResidencyContext] = []
+    context_id = 0
+    prior_context_count = 0
+    for layer, resident_tokens in enumerate(token_counts):
+        layer_context_count = _ceil_div(resident_tokens, config.tile_tokens)
+        owner_rotation_offset = prior_context_count % config.clusters
+        token_start = 0
+        tile_index = 0
+        while token_start < resident_tokens:
+            token_count = min(config.tile_tokens, resident_tokens - token_start)
+            payload_bytes = token_count * config.kv_bytes_per_token
+            contexts.append(
+                _context(
+                    context_id=context_id,
+                    layer=layer,
+                    tile_index=tile_index,
+                    token_start=token_start,
+                    token_count=token_count,
+                    payload_bytes=payload_bytes,
+                    config=config,
+                    mode=mode,
+                    owner_rotation_offset=owner_rotation_offset,
+                )
+            )
+            context_id += 1
+            token_start += token_count
+            tile_index += 1
+        if tile_index != layer_context_count:
+            raise AssertionError("whole-token layer context count mismatch")
+        prior_context_count += layer_context_count
+    return contexts
+
+
+def _distribution(contexts: Iterable[ResidencyContext]) -> list[JsonDict]:
+    counts = Counter(context.payload_bytes for context in contexts)
+    return [
+        {"payload_bytes": payload_bytes, "context_count": count}
+        for payload_bytes, count in sorted(counts.items())
+    ]
+
+
+def _layer_owner_offsets(
+    contexts: Iterable[ResidencyContext],
+    *,
+    layers: int,
+) -> list[int]:
+    offsets: list[int | None] = [None] * layers
+    for context in contexts:
+        current = offsets[context.layer]
+        if current is None:
+            offsets[context.layer] = context.owner_rotation_offset
+        elif current != context.owner_rotation_offset:
+            raise AssertionError(f"layer {context.layer} uses multiple owner rotation offsets")
+    if any(offset is None for offset in offsets):
+        raise AssertionError("every layer must have at least one resident context")
+    return [int(offset) for offset in offsets]
+
+
+def _wave_assignment_audit(
+    config: ResidencyConfig,
+    *,
+    layer_offsets: list[int],
+    rotation_rule: str,
+) -> JsonDict:
+    expected = list(range(config.clusters))
+    complete_waves_per_layer = config.tile_count // config.clusters
+    checked_wave_count = 0
+    for layer, offset in enumerate(layer_offsets):
+        for wave in range(complete_waves_per_layer):
+            first_tile = wave * config.clusters
+            owners = sorted(
+                (offset + tile_index) % config.clusters
+                for tile_index in range(first_tile, first_tile + config.clusters)
+            )
+            if owners != expected:
+                raise AssertionError(
+                    f"layer {layer} wave {wave} is not one tile per compute cluster: {owners}"
+                )
+            checked_wave_count += 1
+    return {
+        "wave_size_tiles": config.clusters,
+        "complete_waves_per_layer": complete_waves_per_layer,
+        "checked_wave_count": checked_wave_count,
+        "one_tile_per_cluster_per_complete_wave": True,
+        "layer_owner_rotation_offsets": layer_offsets,
+        "rotation_rule": rotation_rule,
+    }
+
+
+def _home_capacity_audit(
+    config: ResidencyConfig,
+    *,
+    contexts: list[ResidencyContext],
+    mode: str,
+) -> JsonDict:
+    per_home_capacity = config.shared_capacity_bytes // config.clusters
+    rows: list[JsonDict] = []
+    for home in range(config.clusters):
+        home_contexts = [context for context in contexts if context.home_cluster == home]
+        remote_contexts = [context for context in home_contexts if context.remote]
+        local_contexts = [context for context in home_contexts if not context.remote]
+        resident_load = sum(context.payload_bytes for context in home_contexts)
+        remote_bytes = sum(context.payload_bytes for context in remote_contexts)
+        local_bytes = sum(context.payload_bytes for context in local_contexts)
+        rows.append(
+            {
+                "home_cluster": home,
+                "capacity_bytes": per_home_capacity,
+                "resident_load_bytes": resident_load,
+                "unused_capacity_bytes": max(0, per_home_capacity - resident_load),
+                "overload_bytes": max(0, resident_load - per_home_capacity),
+                "context_count": len(home_contexts),
+                "remote_context_count": len(remote_contexts),
+                "local_context_count": len(local_contexts),
+                "remote_transport_bytes": remote_bytes,
+                "local_resident_bytes": local_bytes,
+            }
+        )
+    total_load = sum(int(row["resident_load_bytes"]) for row in rows)
+    expected_load = sum(context.payload_bytes for context in contexts)
+    if total_load != expected_load:
+        raise AssertionError(
+            f"per-home load accounting mismatch: expected {expected_load}, observed {total_load}"
+        )
+    overloaded = [row for row in rows if int(row["overload_bytes"]) > 0]
+    result = {
+        "total_capacity_bytes": config.shared_capacity_bytes,
+        "per_home_capacity_bytes": per_home_capacity,
+        "per_home_loads": rows,
+        "max_home_load_bytes": max(int(row["resident_load_bytes"]) for row in rows),
+        "min_home_load_bytes": min(int(row["resident_load_bytes"]) for row in rows),
+        "overloaded_home_count": len(overloaded),
+        "overloaded_home_clusters": [int(row["home_cluster"]) for row in overloaded],
+        "capacity_ok": not overloaded,
+        "load_conservation": total_load == expected_load,
+        "enforcement": "fail_closed" if mode == LOCALITY_AWARE else "diagnostic",
+    }
+    if overloaded and mode == LOCALITY_AWARE:
+        details = ", ".join(
+            f"home {row['home_cluster']} load={row['resident_load_bytes']} "
+            f"capacity={per_home_capacity}"
+            for row in overloaded
+        )
+        raise ValueError(f"locality-aware placement exceeds per-home capacity: {details}")
+    return result
+
+
+def _historical_window(config: ResidencyConfig, fractional_tile_bytes: int | None) -> JsonDict | None:
+    if fractional_tile_bytes is None:
+        return None
+    per_layer: list[ResidencyContext] = []
+    for tile_index in range(config.tile_count):
+        token_count = config.tile_token_count(tile_index)
+        payload_bytes = _ceil_div(fractional_tile_bytes * token_count, config.tile_tokens)
+        per_layer.append(
+            _context(
+                context_id=tile_index,
+                layer=0,
+                tile_index=tile_index,
+                token_start=tile_index * config.tile_tokens,
+                token_count=token_count,
+                payload_bytes=payload_bytes,
+                config=config,
+                mode=FRACTIONAL_SMEAR,
+            )
+        )
+    remote = [context for context in per_layer if context.remote]
+    local = [context for context in per_layer if not context.remote]
+    remote_bytes = sum(context.payload_bytes for context in remote)
+    local_bytes = sum(context.payload_bytes for context in local)
+    return {
+        "scope": "one_layer_full_sequence",
+        "contexts_per_layer": len(per_layer),
+        "context_count": len(per_layer),
+        "remote_context_count": len(remote),
+        "local_context_count": len(local),
+        "remote_context_count_per_layer": len(remote),
+        "local_context_count_per_layer": len(local),
+        "remote_bytes": remote_bytes,
+        "local_bytes": local_bytes,
+        "remote_transport_bytes_per_layer": remote_bytes,
+        "local_resident_bytes_per_layer": local_bytes,
+        "remote_packet_count": sum(context.packet_count for context in remote),
+        "remote_flit_count": sum(context.flit_count for context in remote),
+        "payload_bytes_per_full_tile": fractional_tile_bytes,
+        "full_model_layer_multiplier": config.layers,
+        "full_model_remote_context_count": len(remote) * config.layers,
+        "full_model_local_context_count": len(local) * config.layers,
+        "full_model_remote_transport_bytes": remote_bytes * config.layers,
+        "full_model_local_resident_bytes": local_bytes * config.layers,
+        "policy_note": (
+            "The 112 remote contexts arise from the historical eight-wave home "
+            "mapping for one layer; full-model counts multiply by the layer count. "
+            "They are not implied by shared capacity."
+        ),
+    }
+
+
+def build_residency_report(
+    mode: str,
+    *,
+    sequence_length: int = DEFAULT_SEQUENCE_LENGTH,
+    tile_tokens: int = DEFAULT_TILE_TOKENS,
+    layers: int = DEFAULT_LAYERS,
+    kv_heads: int = DEFAULT_KV_HEADS,
+    head_dim: int = DEFAULT_HEAD_DIM,
+    kv_bits: int = DEFAULT_KV_BITS,
+    shared_capacity_bytes: int = DEFAULT_SHARED_CAPACITY_BYTES,
+    clusters: int = DEFAULT_CLUSTERS,
+    packet_payload: int = DEFAULT_PACKET_PAYLOAD,
+    fractional_tile_bytes: int | None = None,
+    persistence_mode: str = TRANSIENT,
+) -> JsonDict:
+    """Build one placement report without touching RTL, files, or transport state."""
+
+    if mode not in SUPPORTED_MODES:
+        raise ValueError(f"unsupported residency mode {mode!r}; choose from {SUPPORTED_MODES}")
+    config = ResidencyConfig(
+        sequence_length=sequence_length,
+        tile_tokens=tile_tokens,
+        layers=layers,
+        kv_heads=kv_heads,
+        head_dim=head_dim,
+        kv_bits=kv_bits,
+        shared_capacity_bytes=shared_capacity_bytes,
+        clusters=clusters,
+        packet_payload=packet_payload,
+        persistence_mode=persistence_mode,
+    )
+    if mode == FRACTIONAL_SMEAR:
+        contexts = _fractional_contexts(
+            config,
+            fractional_tile_bytes=fractional_tile_bytes,
+            mode=mode,
+        )
+    else:
+        contexts = _whole_token_contexts(config, mode=mode)
+
+    resident_bytes = sum(context.payload_bytes for context in contexts)
+    if resident_bytes > config.shared_capacity_bytes:
+        raise ValueError(
+            f"residency requires {resident_bytes} bytes but shared capacity is "
+            f"{config.shared_capacity_bytes} bytes"
+        )
+    remote_contexts = [context for context in contexts if context.remote]
+    local_contexts = [context for context in contexts if not context.remote]
+    unused_capacity = config.shared_capacity_bytes - resident_bytes
+    if resident_bytes + unused_capacity != config.shared_capacity_bytes:
+        raise AssertionError("shared capacity conservation failed")
+    layer_offsets = _layer_owner_offsets(contexts, layers=config.layers)
+    wave_assignment = _wave_assignment_audit(
+        config,
+        layer_offsets=layer_offsets,
+        rotation_rule=(
+            "fixed_zero_offset_full_sequence_coverage"
+            if mode == FRACTIONAL_SMEAR
+            else "cumulative_prior_resident_context_count_modulo_clusters"
+        ),
+    )
+    home_capacity = _home_capacity_audit(config, contexts=contexts, mode=mode)
+
+    packet_count = sum(context.packet_count for context in contexts)
+    flit_count = sum(context.flit_count for context in contexts)
+    remote_packet_count = sum(context.packet_count for context in remote_contexts)
+    local_packet_count = sum(context.packet_count for context in local_contexts)
+    remote_flit_count = sum(context.flit_count for context in remote_contexts)
+    local_flit_count = sum(context.flit_count for context in local_contexts)
+    remote_payload_bytes = sum(context.payload_bytes for context in remote_contexts)
+    local_payload_bytes = sum(context.payload_bytes for context in local_contexts)
+    wire_bytes = flit_count * FLIT_BYTES
+    remote_wire_bytes = remote_flit_count * FLIT_BYTES
+    local_wire_bytes = local_flit_count * FLIT_BYTES
+    token_resident = all(
+        context.payload_bytes == context.token_count * config.kv_bytes_per_token
+        for context in contexts
+    )
+    max_payload = max(context.payload_bytes for context in contexts)
+    report: JsonDict = {
+        "model": "llama7b_shared_sram_residency_v1",
+        "mode": mode,
+        "shape": {
+            "sequence_length": config.sequence_length,
+            "tile_tokens": config.tile_tokens,
+            "tile_count": config.tile_count,
+            "layers": config.layers,
+            "kv_heads": config.kv_heads,
+            "head_dim": config.head_dim,
+            "kv_bits": config.kv_bits,
+            "kv_bytes_per_token": config.kv_bytes_per_token,
+            "full_tile_bytes": config.full_tile_bytes,
+            "full_kv_bytes": config.full_kv_bytes,
+        },
+        "placement": {
+            "owner_policy": (
+                "tile_index_modulo_clusters"
+                if mode == FRACTIONAL_SMEAR
+                else "tile_index_plus_layer_rotation_modulo_clusters"
+            ),
+            "home_policy": "owner_cluster" if mode == LOCALITY_AWARE else "historical_wave_offset_1_stride_3",
+            "clusters": config.clusters,
+            "wave_assignment": wave_assignment,
+            "home_capacity": home_capacity,
+            "resident_contexts": [context.as_dict() for context in contexts],
+        },
+        "residency": {
+            "resident_bytes": resident_bytes,
+            "resident_mib": resident_bytes / (1024 * 1024),
+            "context_count": len(contexts),
+            "remote_context_count": len(remote_contexts),
+            "local_context_count": len(local_contexts),
+            "max_context_payload_bytes": max_payload,
+            "context_payload_distribution": _distribution(contexts),
+            "whole_token_residency": token_resident,
+            "capacity_bytes": config.shared_capacity_bytes,
+            "unused_capacity_bytes": unused_capacity,
+            "capacity_conservation": {
+                "resident_bytes": resident_bytes,
+                "unused_capacity_bytes": unused_capacity,
+                "capacity_bytes": config.shared_capacity_bytes,
+                "conserved": resident_bytes + unused_capacity == config.shared_capacity_bytes,
+            },
+        },
+        "transport": {
+            "packet_payload_bytes": config.packet_payload,
+            "flit_bytes": FLIT_BYTES,
+            "packet_count": packet_count,
+            "flit_count": flit_count,
+            "payload_bytes": resident_bytes,
+            "wire_bytes": wire_bytes,
+            "flit_padding_bytes": wire_bytes - resident_bytes,
+            "remote_packet_count": remote_packet_count,
+            "local_packet_count": local_packet_count,
+            "remote_flit_count": remote_flit_count,
+            "local_flit_count": local_flit_count,
+            "remote_transport_bytes": remote_payload_bytes,
+            "local_resident_bytes": local_payload_bytes,
+            "remote_wire_bytes": remote_wire_bytes,
+            "local_wire_bytes": local_wire_bytes,
+            "remote_flit_padding_bytes": remote_wire_bytes - remote_payload_bytes,
+            "local_flit_padding_bytes": local_wire_bytes - local_payload_bytes,
+        },
+        "hbm": {
+            "persistence_mode": config.persistence_mode,
+            "hbm_bytes": config.full_kv_bytes,
+            "full_kv_storage_bytes": config.full_kv_bytes,
+            "resident_cache_bytes": resident_bytes,
+            "unresident_kv_bytes": config.full_kv_bytes - resident_bytes,
+            "storage_savings_bytes": 0,
+            "baseline_decode_read_bytes": config.full_kv_bytes,
+            "gross_read_avoidance": resident_bytes,
+            "gross_read_avoidance_bytes": resident_bytes,
+            "refill_bytes": resident_bytes if config.persistence_mode == TRANSIENT else 0,
+            "net_hbm_read_bytes": (
+                config.full_kv_bytes
+                - resident_bytes
+                + (resident_bytes if config.persistence_mode == TRANSIENT else 0)
+            ),
+            "net_read_avoidance_bytes": (
+                0 if config.persistence_mode == TRANSIENT else resident_bytes
+            ),
+            "note": (
+                "HBM bytes are complete KV backing storage. Gross read avoidance is "
+                "the resident payload; transient residency refills that payload each "
+                "decode, so its net read avoidance is zero. Persistent residency has "
+                "zero refill in this analytical accounting."
+            ),
+        },
+        "historical_comparison": _historical_window(config, fractional_tile_bytes),
+        "assumptions": [
+            "KV layout is two tensors (K and V), with kv_heads x head_dim values per token.",
+            "A context is one contiguous token range within one layer.",
+            "A packet carries at most packet_payload bytes and each flit carries 32 bytes.",
+            "Whole-token owner assignment rotates each layer by cumulative prior resident contexts.",
+            "Fractional smear retains tile_index modulo clusters because every layer covers all tiles.",
+            "Each SRAM home receives an equal share of aggregate shared capacity.",
+            "Home placement and overload enforcement are explicit.",
+            "HBM remains the complete KV backing store and is outside this model.",
+            "HBM read accounting assumes one full KV read per decode before residency effects.",
+        ],
+    }
+    return report
+
+
+def compare_residency_policies(
+    *,
+    fractional_tile_bytes: int = 17_408,
+    **kwargs: int,
+) -> dict[str, JsonDict]:
+    """Return all requested policies for one KV shape."""
+
+    return {
+        mode: build_residency_report(
+            mode,
+            fractional_tile_bytes=fractional_tile_bytes if mode == FRACTIONAL_SMEAR else None,
+            **kwargs,
+        )
+        for mode in SUPPORTED_MODES
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=SUPPORTED_MODES, default=LAYER_BALANCED_CONTIGUOUS)
+    parser.add_argument("--kv-heads", type=int, default=DEFAULT_KV_HEADS)
+    parser.add_argument("--fractional-tile-bytes", type=int, default=None)
+    parser.add_argument("--persistence-mode", choices=SUPPORTED_PERSISTENCE, default=TRANSIENT)
+    parser.add_argument("--pretty", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    report = build_residency_report(
+        args.mode,
+        kv_heads=args.kv_heads,
+        fractional_tile_bytes=args.fractional_tile_bytes,
+        persistence_mode=args.persistence_mode,
+    )
+    print(json.dumps(report, indent=2 if args.pretty else None, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/eval/tests/test_audit_llama7b_shared_sram_access_energy.py
+++ b/npu/eval/tests/test_audit_llama7b_shared_sram_access_energy.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import math
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval.audit_llama7b_shared_sram_access_energy import (  # noqa: E402
+    DEFAULT_SHARED_CAPACITY_BYTES,
+    _rank_composed,
+    build_audit_report,
+    load_selected_macros,
+    main,
+)
+
+
+class SharedSramAccessEnergyAuditTest(unittest.TestCase):
+    def test_loads_checked_numeric_cacti_values(self) -> None:
+        selected, native = load_selected_macros()
+        self.assertEqual(selected.name, "local_capacity_chunk_02_256kib")
+        self.assertEqual(selected.capacity_bytes, 262144)
+        self.assertEqual(selected.width_bits, 1024)
+        self.assertEqual(selected.word_size_bytes, 128)
+        self.assertAlmostEqual(selected.access_time_ns, 1.22148, places=8)
+        self.assertAlmostEqual(selected.read_energy_pj, 177.523, places=6)
+        self.assertAlmostEqual(selected.write_energy_pj, 623.1, places=6)
+        self.assertAlmostEqual(selected.area_um2, 882595.72388, places=5)
+        self.assertEqual(native.name, "kv_tile_read_buffer")
+        self.assertEqual(native.width_bits, 256)
+        self.assertEqual(native.word_size_bytes, 32)
+        self.assertAlmostEqual(native.access_time_ns, 1.4124, places=7)
+        self.assertAlmostEqual(native.read_energy_pj, 241.555, places=6)
+        self.assertAlmostEqual(native.write_energy_pj, 288.401, places=6)
+
+    def test_four_flit_coalescing_reduces_accesses_by_four(self) -> None:
+        report = build_audit_report(scope="one_layer_remote")
+        burst = report["profiles"]["selected_1024b_macro_burst4"]
+        naive = report["profiles"]["selected_1024b_macro_naive_flit"]
+        self.assertEqual(report["traffic"]["payload_bytes"], 112 * 17_408)
+        self.assertEqual(report["traffic"]["flit_count"], 112 * 544)
+        self.assertEqual(report["total_source_traffic"]["payload_bytes"], 128 * 17_408)
+        self.assertEqual(report["total_source_traffic"]["flit_count"], 128 * 544)
+        self.assertEqual(burst["access_count"] * 4, naive["access_count"])
+        self.assertEqual(burst["access_count"], 128 * 136)
+        self.assertEqual(
+            burst["coalesced_flit_count"],
+            report["total_source_traffic"]["flit_count"],
+        )
+        self.assertEqual(burst["macro_word_padding_bytes"], 0)
+        self.assertEqual(naive["macro_word_padding_bytes"], (4 - 1) * 32 * naive["access_count"])
+        self.assertEqual(burst["byte_masked_access_count"], 0)
+        self.assertEqual(naive["byte_masked_access_count"], naive["access_count"])
+
+    def test_energy_uses_access_count_not_capacity(self) -> None:
+        report = build_audit_report(scope="one_layer_remote")
+        burst = report["composed_profiles"][
+            "shared1024_burst4_source_local256_destination"
+        ]
+        source_access_count = 2_228_224 // 128
+        remote_source_access_count = 112 * 136
+        local_bypass_access_count = 16 * 136
+        destination_access_count = 112 * 544
+        total_source_bytes = 128 * 17_408
+        remote_payload_bytes = 112 * 17_408
+        expected_read_pj = source_access_count * 177.523
+        expected_write_pj = destination_access_count * 288.401
+        self.assertAlmostEqual(burst["source_read"]["energy_pj"], expected_read_pj, places=6)
+        self.assertAlmostEqual(burst["destination_write"]["energy_pj"], expected_write_pj, places=6)
+        self.assertAlmostEqual(
+            burst["total_sram_energy_pj"],
+            source_access_count * 177.523 + destination_access_count * 288.401,
+            places=6,
+        )
+        self.assertEqual(burst["source_read"]["access_count"], 17_408)
+        self.assertEqual(burst["remote_source_read"]["access_count"], remote_source_access_count)
+        self.assertEqual(
+            burst["local_bypass_source_read"]["access_count"],
+            local_bypass_access_count,
+        )
+        self.assertEqual(
+            burst["remote_source_read"]["access_count"]
+            + burst["local_bypass_source_read"]["access_count"],
+            burst["source_read"]["access_count"],
+        )
+        self.assertAlmostEqual(
+            burst["source_read"]["energy_per_useful_byte_pj"],
+            expected_read_pj / total_source_bytes,
+            places=12,
+        )
+        expected_remote_only_pj = remote_source_access_count * 177.523 + expected_write_pj
+        self.assertAlmostEqual(
+            burst["remote_only_energy_per_useful_byte_pj"],
+            expected_remote_only_pj / remote_payload_bytes,
+            places=12,
+        )
+        wrong_capacity_normalization = (
+            burst["source_shared_capacity_pack"]["macro_count"]
+            * 177.523
+            / DEFAULT_SHARED_CAPACITY_BYTES
+        )
+        self.assertFalse(
+            math.isclose(
+                burst["source_read"]["energy_per_useful_byte_pj"],
+                wrong_capacity_normalization,
+                rel_tol=1e-12,
+                abs_tol=1e-12,
+            )
+        )
+        self.assertEqual(burst["source_shared_capacity_pack"]["macro_count"], 272)
+        self.assertAlmostEqual(
+            burst["source_shared_capacity_pack"]["area_um2"],
+            272 * 882595.72388,
+            places=4,
+        )
+        self.assertIsNone(burst["destination_capacity_pack"])
+        self.assertEqual(
+            burst["destination_write"]["macro"]["name"],
+            "kv_tile_read_buffer",
+        )
+        self.assertEqual(burst["destination_write"]["access_count"], destination_access_count)
+
+    def test_native_256_width_pack_is_reported_separately(self) -> None:
+        report = build_audit_report(scope="one_layer_remote")
+        native = report["composed_profiles"][
+            "native256_shared_source_local256_destination"
+        ]
+        self.assertEqual(native["source_read"]["macro"]["width_bits"], 256)
+        self.assertEqual(native["source_read"]["macro"]["word_size_bytes"], 32)
+        self.assertEqual(
+            native["source_read"]["access_count"],
+            report["total_source_traffic"]["flit_count"],
+        )
+        self.assertEqual(native["source_read"]["macro_word_padding_bytes"], 0)
+        self.assertEqual(native["source_shared_capacity_pack"]["macro_count"], 136)
+        self.assertAlmostEqual(
+            native["source_shared_capacity_pack"]["area_um2"],
+            136 * 2082403.0404,
+            places=4,
+        )
+        self.assertIsNone(native["destination_capacity_pack"])
+
+    def test_unaligned_payload_marks_only_the_final_native_access(self) -> None:
+        report = build_audit_report(
+            scope="one_layer_remote",
+            fractional_tile_bytes=17_407,
+        )
+        native = report["profiles"]["native_256b_macro"]
+        burst = report["profiles"]["selected_1024b_macro_burst4"]
+        self.assertEqual(native["byte_masked_access_count"], 128)
+        self.assertEqual(native["fully_utilized_access_count"], native["access_count"] - 128)
+        self.assertEqual(burst["byte_masked_access_count"], 128)
+        self.assertGreater(native["macro_word_padding_bytes"], 0)
+        self.assertGreater(burst["macro_word_padding_bytes"], 0)
+
+    def test_source_and_destination_and_persistence_are_explicit(self) -> None:
+        transient = build_audit_report(persistence_mode="transient")
+        persistent = build_audit_report(persistence_mode="persistent")
+        transient_path = transient["composed_profiles"][
+            "shared1024_burst4_source_local256_destination"
+        ]
+        persistent_path = persistent["composed_profiles"][
+            "shared1024_burst4_source_local256_destination"
+        ]
+        self.assertEqual(transient_path["source_read"]["access_count"], 128 * 136)
+        self.assertEqual(transient_path["destination_write"]["access_count"], 112 * 544)
+        self.assertEqual(
+            transient_path["total_sram_energy_pj"],
+            persistent_path["total_sram_energy_pj"],
+        )
+        self.assertEqual(transient["traffic"]["payload_bytes"], persistent["traffic"]["payload_bytes"])
+        self.assertEqual(transient["traffic"]["source_read_bytes"], persistent["traffic"]["source_read_bytes"])
+        self.assertIn("does not model HBM behavior", persistent["traffic"]["persistence_note"])
+
+    def test_locality_aware_has_local_reads_and_zero_destination_writes(self) -> None:
+        report = build_audit_report(scope="one_layer_remote")
+        traffic = report["locality_aware_traffic"]
+        path = report["locality_aware_composed_profiles"][
+            "shared1024_burst4_local_read"
+        ]
+        self.assertEqual(traffic["placement"], "local")
+        self.assertGreater(traffic["source_read_bytes"], 0)
+        self.assertEqual(traffic["destination_write_bytes"], 0)
+        self.assertEqual(traffic["transport_packet_count"], 0)
+        self.assertEqual(traffic["transport_flit_count"], 0)
+        self.assertGreater(path["source_read"]["access_count"], 0)
+        self.assertEqual(path["destination_write"]["access_count"], 0)
+        self.assertEqual(path["destination_write"]["energy_pj"], 0.0)
+        self.assertIsNone(path["destination_capacity_pack"])
+
+    def test_historical_local_bypass_completes_total_source_workload(self) -> None:
+        report = build_audit_report(scope="one_layer_remote")
+        remote = report["traffic"]
+        bypass = report["historical_local_bypass_traffic"]
+        total = report["total_source_traffic"]
+        self.assertEqual(remote["context_count"], 112)
+        self.assertEqual(bypass["context_count"], 16)
+        self.assertEqual(total["context_count"], 128)
+        self.assertEqual(remote["payload_bytes"], 1_949_696)
+        self.assertEqual(bypass["payload_bytes"], 278_528)
+        self.assertEqual(total["payload_bytes"], 2_228_224)
+        self.assertEqual(total["payload_bytes"], remote["payload_bytes"] + bypass["payload_bytes"])
+        self.assertEqual(total["destination_write_bytes"], remote["payload_bytes"])
+        self.assertEqual(total["transport_flit_count"], 60_928)
+
+    def test_rankings_and_summary_use_only_composed_paths(self) -> None:
+        report = build_audit_report(scope="one_layer_remote")
+        remote_names = set(report["composed_profiles"])
+        local_names = set(report["locality_aware_composed_profiles"])
+        self.assertEqual(
+            {row["profile"] for row in report["ranking"]["remote"]},
+            remote_names,
+        )
+        self.assertEqual(
+            {row["profile"] for row in report["ranking"]["locality_aware"]},
+            local_names,
+        )
+        self.assertEqual(
+            report["summary"]["best_remote_profile"],
+            "shared1024_burst4_source_local256_destination",
+        )
+        self.assertEqual(report["summary"]["remote_destination_write_accesses"], 112 * 544)
+        self.assertEqual(report["summary"]["historical_burst4_total_source_read_accesses"], 17_408)
+        self.assertEqual(report["summary"]["locality_aware_destination_write_accesses"], 0)
+        self.assertNotIn("selected_1024b_macro_burst4", remote_names)
+        ranked_energies = [row["total_layer_energy_pj"] for row in report["ranking"]["remote"]]
+        self.assertEqual(ranked_energies, sorted(ranked_energies))
+        self.assertEqual(report["summary"]["ranking_metric"], "total_layer_energy_pj")
+
+    def test_ranking_uses_total_layer_energy_not_per_byte_diagnostic(self) -> None:
+        common = {
+            "total_layer_energy_nj": 0.0,
+            "total_layer_energy_per_total_source_byte_pj": 0.0,
+            "remote_only_energy_per_useful_byte_pj": 0.0,
+            "total_sram_energy_pj": 0.0,
+            "source_capacity_area_mm2": 1.0,
+            "endpoint_access_time_bound_ns": 1.0,
+        }
+        profiles = {
+            "lower_total_higher_per_byte": {
+                **common,
+                "total_layer_energy_pj": 10.0,
+                "total_energy_per_useful_byte_pj": 100.0,
+            },
+            "higher_total_lower_per_byte": {
+                **common,
+                "total_layer_energy_pj": 20.0,
+                "total_energy_per_useful_byte_pj": 1.0,
+            },
+        }
+        self.assertEqual(_rank_composed(profiles)[0]["profile"], "lower_total_higher_per_byte")
+
+    def test_shape_and_kv_heads_are_threaded_through_report_and_cli(self) -> None:
+        report = build_audit_report(kv_heads=32, head_dim=64, kv_bits=16)
+        self.assertEqual(report["shape"]["kv_heads"], 32)
+        self.assertEqual(report["shape"]["head_dim"], 64)
+        self.assertEqual(report["shape"]["kv_bits"], 16)
+        self.assertEqual(report["shape"], report["total_source_traffic"]["shape"])
+        self.assertEqual(report["configuration"]["shape"], report["shape"])
+        self.assertEqual(report["configuration"]["clusters"], 16)
+        self.assertEqual(report["configuration"]["packet_payload_bytes"], 256)
+        self.assertEqual(report["shape"]["full_kv_bytes"], 32 * 1024**3)
+        self.assertEqual(
+            report["summary"]["historical_burst4_total_source_read_accesses"],
+            17_408,
+        )
+
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            self.assertEqual(
+                main(["--kv-heads", "32", "--head-dim", "64", "--kv-bits", "16"]),
+                0,
+            )
+        cli_report = json.loads(stdout.getvalue())
+        self.assertEqual(cli_report["shape"]["kv_heads"], 32)
+        self.assertEqual(cli_report["shape"]["head_dim"], 64)
+        self.assertEqual(cli_report["shape"]["kv_bits"], 16)
+
+    def test_full_model_scope_scales_remote_and_total_source_inputs(self) -> None:
+        one_layer = build_audit_report(scope="one_layer_remote")
+        full_model = build_audit_report(scope="full_model")
+        self.assertEqual(full_model["traffic"]["context_count"], 32 * one_layer["traffic"]["context_count"])
+        self.assertEqual(full_model["traffic"]["payload_bytes"], 32 * one_layer["traffic"]["payload_bytes"])
+        self.assertEqual(
+            full_model["total_source_traffic"]["payload_bytes"],
+            32 * one_layer["total_source_traffic"]["payload_bytes"],
+        )
+        self.assertEqual(
+            full_model["composed_profiles"][
+                "shared1024_burst4_source_local256_destination"
+            ]["source_read"]["access_count"],
+            32
+            * one_layer["composed_profiles"][
+                "shared1024_burst4_source_local256_destination"
+            ]["source_read"]["access_count"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/npu/eval/tests/test_check_attention_phase2_shared_stream_contract.py
+++ b/npu/eval/tests/test_check_attention_phase2_shared_stream_contract.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from npu.eval.check_attention_phase2_shared_stream_contract import (
+    ArtifactContractError,
+    validate_artifact,
+)
+
+
+ARTIFACT = (
+    Path(__file__).resolve().parents[3]
+    / "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+    "decoder_attention_score32_noc_phase2_schedule__"
+    "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1.json"
+)
+
+
+def _load() -> dict[str, object]:
+    return json.loads(ARTIFACT.read_text(encoding="utf-8"))
+
+
+def _write(tmp_path: Path, payload: dict[str, object]) -> Path:
+    path = tmp_path / "phase2.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_checked_artifact_passes_and_reports_reduction_independence() -> None:
+    result = validate_artifact(ARTIFACT)
+    assert result["status"] == "ok"
+    assert result["shared"] == {
+        "contexts": 112,
+        "bytes": 1_949_696,
+        "packets": 7_616,
+        "flits": 60_928,
+        "packet_bytes": 256,
+        "flits_per_packet": 8,
+        "mapping_shifts": [4, 7, 10, 13, 0, 3, 6, 9],
+    }
+    assert result["retracted_reduction_validation"] == "ignored"
+
+
+@pytest.mark.parametrize(
+    ("section", "field", "value"),
+    [
+        ("flow_summary", "remote_shared_flow_count", 111),
+        ("flow_summary", "remote_shared_packet_count", 1),
+        ("flow_summary", "remote_shared_bytes", 0),
+        ("mapping", "shared_sram_home_offset", 2),
+        ("mapping", "shared_sram_home_stride", 5),
+        ("mapping", "shared_sram_home_load_tiles", {str(i): 7 for i in range(16)}),
+    ],
+)
+def test_shared_quantity_or_mapping_drift_fails_closed(
+    tmp_path: Path, section: str, field: str, value: object
+) -> None:
+    payload = _load()
+    section_payload = payload[section]
+    assert isinstance(section_payload, dict)
+    section_payload[field] = value
+    with pytest.raises(ArtifactContractError):
+        validate_artifact(_write(tmp_path, payload))
+
+
+def test_reduction_values_are_not_used_as_shared_evidence(tmp_path: Path) -> None:
+    payload = _load()
+    flow_summary = payload["flow_summary"]
+    assert isinstance(flow_summary, dict)
+    flow_summary["remote_reduction_packet_count"] = 7_616
+    flow_summary["remote_reduction_bytes"] = 1_949_696
+    flow_summary["remote_reduction_flow_count"] = 112
+    simulation = payload["simulation"]
+    assert isinstance(simulation, dict)
+    classes = simulation["delivery_flit_count_by_class"]
+    assert isinstance(classes, dict)
+    classes["reduction"] = 60_928
+    result = validate_artifact(_write(tmp_path, payload))
+    assert result["status"] == "ok"
+    assert result["retracted_reduction_validation"] == "ignored"
+
+
+def test_missing_shared_fields_do_not_fall_back_to_reduction(tmp_path: Path) -> None:
+    payload = _load()
+    flow_summary = payload["flow_summary"]
+    assert isinstance(flow_summary, dict)
+    del flow_summary["remote_shared_packet_count"]
+    flow_summary["remote_reduction_packet_count"] = 7_616
+    with pytest.raises(ArtifactContractError):
+        validate_artifact(_write(tmp_path, payload))
+
+
+def test_direct_shift_vector_if_present_must_match(tmp_path: Path) -> None:
+    payload = _load()
+    mapping = payload["mapping"]
+    assert isinstance(mapping, dict)
+    mapping["shared_sram_home_shifts"] = [4, 7, 10, 13, 1, 3, 6, 9]
+    with pytest.raises(ArtifactContractError):
+        validate_artifact(_write(tmp_path, payload))

--- a/npu/eval/tests/test_check_attention_shared_sram_k_round_scheduler_ppa_guard.py
+++ b/npu/eval/tests/test_check_attention_shared_sram_k_round_scheduler_ppa_guard.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from npu.eval.check_attention_shared_sram_k_round_scheduler_ppa_guard import check
+from npu.rtlgen.gen_attention_shared_sram_k_round_scheduler_ppa_harness import generate
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TOP_NAME = "attention_shared_sram_k_round_scheduler_b17_w17"
+
+
+def _config() -> dict[str, object]:
+    return json.loads(
+        (REPO_ROOT / "runs/designs/npu_blocks" / TOP_NAME / "config.json").read_text(encoding="utf-8")
+    )
+
+
+def test_guard_accepts_checked_round_geometry(tmp_path: Path) -> None:
+    config = _config()
+    design_dir = tmp_path / TOP_NAME
+    generate(config, design_dir / "verilog")
+    (design_dir / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    check(design_dir)
+
+
+def test_guard_rejects_missing_proposal_link(tmp_path: Path) -> None:
+    config = _config()
+    config["report_links"]["proposal_id"] = "wrong"  # type: ignore[index]
+    design_dir = tmp_path / TOP_NAME
+    generate(config, design_dir / "verilog")
+    (design_dir / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    with pytest.raises(SystemExit, match="proposal linkage"):
+        check(design_dir)
+
+
+def test_guard_rejects_manifest_that_claims_checksum_equivalence(tmp_path: Path) -> None:
+    config = _config()
+    design_dir = tmp_path / TOP_NAME
+    generate(config, design_dir / "verilog")
+    (design_dir / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    manifest_path = (
+        design_dir / "verilog" / "attention_shared_sram_k_round_scheduler_ppa_harness_manifest.json"
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["activity_checksum_is_equivalence_proof"] = True
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    with pytest.raises(SystemExit, match="manifest mismatch"):
+        check(design_dir)

--- a/npu/eval/tests/test_check_attention_shared_sram_read_group_adapter_ppa_guard.py
+++ b/npu/eval/tests/test_check_attention_shared_sram_read_group_adapter_ppa_guard.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from npu.eval.check_attention_shared_sram_read_group_adapter_ppa_guard import check
+from npu.rtlgen.gen_attention_shared_sram_read_group_adapter_ppa_harness import generate
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_guard_accepts_all_four_checked_geometries(tmp_path: Path) -> None:
+    for width in (256, 512):
+        for slots in (1, 2):
+            name = f"attention_shared_sram_read_group_adapter_w{width}_s{slots}"
+            design_dir = tmp_path / name
+            config = json.loads(
+                (REPO_ROOT / "runs/designs/npu_blocks" / name / "config.json").read_text(encoding="utf-8")
+            )
+            generate(config, design_dir / "verilog")
+            (design_dir / "config.json").write_text(json.dumps(config), encoding="utf-8")
+            check(design_dir)
+
+
+def test_guard_rejects_missing_proposal_link(tmp_path: Path) -> None:
+    name = "attention_shared_sram_read_group_adapter_w256_s2"
+    config = json.loads(
+        (REPO_ROOT / "runs/designs/npu_blocks" / name / "config.json").read_text(encoding="utf-8")
+    )
+    config["report_links"]["proposal_id"] = "wrong"
+    design_dir = tmp_path / name
+    generate(config, design_dir / "verilog")
+    (design_dir / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    with pytest.raises(SystemExit, match="proposal linkage"):
+        check(design_dir)

--- a/npu/eval/tests/test_model_llama7b_shared_sram_residency.py
+++ b/npu/eval/tests/test_model_llama7b_shared_sram_residency.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from npu.eval.model_llama7b_shared_sram_residency import (  # noqa: E402
+    FRACTIONAL_SMEAR,
+    LAYER_BALANCED_CONTIGUOUS,
+    LOCALITY_AWARE,
+    PERSISTENT,
+    TRANSIENT,
+    build_residency_report,
+    compare_residency_policies,
+)
+
+
+CAPACITY = 68 * 1024 * 1024
+
+
+def _payload_distribution(report: dict) -> dict[int, int]:
+    return {
+        int(row["payload_bytes"]): int(row["context_count"])
+        for row in report["residency"]["context_payload_distribution"]
+    }
+
+
+def _home_loads(report: dict) -> list[int]:
+    return [
+        int(row["resident_load_bytes"])
+        for row in report["placement"]["home_capacity"]["per_home_loads"]
+    ]
+
+
+def test_gqa_capacity_balances_two_full_and_one_partial_tile_per_layer() -> None:
+    report = build_residency_report(
+        LAYER_BALANCED_CONTIGUOUS,
+        kv_heads=4,
+        shared_capacity_bytes=CAPACITY,
+    )
+
+    assert report["shape"]["kv_bytes_per_token"] == 1024
+    assert report["shape"]["full_tile_bytes"] == 1_048_576
+    assert report["shape"]["full_kv_bytes"] == 4 * 1024**3
+    assert report["residency"]["resident_bytes"] == CAPACITY
+    assert report["residency"]["context_count"] == 96
+    assert report["residency"]["remote_context_count"] == 96
+    assert report["residency"]["local_context_count"] == 0
+    assert _payload_distribution(report) == {
+        1_048_576: 64,
+        131_072: 32,
+    }
+    assert report["transport"]["packet_count"] == 278_528
+    assert report["transport"]["flit_count"] == 2_228_224
+    assert report["transport"]["remote_transport_bytes"] == CAPACITY
+    assert report["transport"]["local_resident_bytes"] == 0
+    assert report["placement"]["home_capacity"]["capacity_ok"] is True
+    assert _home_loads(report) == [CAPACITY // 16] * 16
+    assert report["residency"]["capacity_conservation"]["conserved"] is True
+    assert report["hbm"]["full_kv_storage_bytes"] == 4 * 1024**3
+    assert report["hbm"]["hbm_bytes"] == 4 * 1024**3
+    assert report["hbm"]["storage_savings_bytes"] == 0
+    assert report["hbm"]["persistence_mode"] == TRANSIENT
+    assert report["hbm"]["gross_read_avoidance"] == CAPACITY
+    assert report["hbm"]["gross_read_avoidance_bytes"] == CAPACITY
+    assert report["hbm"]["refill_bytes"] == CAPACITY
+    assert report["hbm"]["net_hbm_read_bytes"] == 4 * 1024**3
+    assert report["hbm"]["net_read_avoidance_bytes"] == 0
+
+
+def test_mha_capacity_is_same_bytes_but_only_partial_contexts_fit() -> None:
+    report = build_residency_report(
+        LAYER_BALANCED_CONTIGUOUS,
+        kv_heads=32,
+        shared_capacity_bytes=CAPACITY,
+    )
+
+    assert report["shape"]["kv_bytes_per_token"] == 8192
+    assert report["shape"]["full_tile_bytes"] == 8 * 1024**2
+    assert report["shape"]["full_kv_bytes"] == 32 * 1024**3
+    assert report["residency"]["resident_bytes"] == CAPACITY
+    assert report["residency"]["context_count"] == 32
+    assert _payload_distribution(report) == {2_228_224: 32}
+    assert report["residency"]["whole_token_residency"] is True
+    assert report["transport"]["packet_count"] == 278_528
+    assert report["transport"]["flit_count"] == 2_228_224
+    assert report["transport"]["remote_transport_bytes"] == CAPACITY
+    assert report["transport"]["local_resident_bytes"] == 0
+    assert report["placement"]["home_capacity"]["capacity_ok"] is True
+    assert _home_loads(report) == [CAPACITY // 16] * 16
+    assert report["hbm"]["full_kv_storage_bytes"] == 32 * 1024**3
+    assert report["hbm"]["hbm_bytes"] == 32 * 1024**3
+    assert report["hbm"]["storage_savings_bytes"] == 0
+
+
+def test_fractional_smear_keeps_historical_bytes_explicit_and_is_not_mha_capacity_model() -> None:
+    gqa = build_residency_report(
+        FRACTIONAL_SMEAR,
+        kv_heads=4,
+        fractional_tile_bytes=17_408,
+        shared_capacity_bytes=CAPACITY,
+    )
+    mha = build_residency_report(
+        FRACTIONAL_SMEAR,
+        kv_heads=32,
+        fractional_tile_bytes=17_408,
+        shared_capacity_bytes=CAPACITY,
+    )
+
+    for report in (gqa, mha):
+        assert report["residency"]["context_count"] == 32 * 128
+        assert _payload_distribution(report) == {17_408: 32 * 128}
+        assert report["residency"]["resident_bytes"] == CAPACITY
+        assert report["transport"]["packet_count"] == 278_528
+        assert report["transport"]["flit_count"] == 2_228_224
+        assert report["transport"]["remote_transport_bytes"] == 3_584 * 17_408
+        assert report["transport"]["local_resident_bytes"] == 512 * 17_408
+        assert report["residency"]["whole_token_residency"] is False
+        assert report["hbm"]["storage_savings_bytes"] == 0
+        assert report["placement"]["home_capacity"]["capacity_ok"] is True
+        assert _home_loads(report) == [CAPACITY // 16] * 16
+
+    assert gqa["shape"]["full_kv_bytes"] == 4 * 1024**3
+    assert mha["shape"]["full_kv_bytes"] == 32 * 1024**3
+
+
+def test_historical_112_remote_contexts_are_one_layer_placement_policy() -> None:
+    report = build_residency_report(
+        FRACTIONAL_SMEAR,
+        kv_heads=4,
+        fractional_tile_bytes=17_408,
+    )
+    history = report["historical_comparison"]
+
+    assert history["context_count"] == 128
+    assert history["remote_context_count"] == 112
+    assert history["local_context_count"] == 16
+    assert history["remote_context_count_per_layer"] == 112
+    assert history["full_model_layer_multiplier"] == 32
+    assert history["full_model_remote_context_count"] == 3_584
+    assert history["full_model_local_context_count"] == 512
+    assert history["remote_bytes"] == 112 * 17_408
+    assert history["full_model_remote_transport_bytes"] == 3_584 * 17_408
+    assert history["remote_packet_count"] == 112 * 68
+    assert history["remote_flit_count"] == 112 * 544
+    assert report["residency"]["context_count"] == 4096
+    assert report["residency"]["remote_context_count"] == 112 * 32
+    assert report["residency"]["local_context_count"] == 16 * 32
+
+
+def test_locality_aware_assigns_every_resident_range_to_its_owner() -> None:
+    for kv_heads in (4, 32):
+        report = build_residency_report(
+            LOCALITY_AWARE,
+            kv_heads=kv_heads,
+            shared_capacity_bytes=CAPACITY,
+        )
+        contexts = report["placement"]["resident_contexts"]
+        assert contexts
+        assert report["residency"]["remote_context_count"] == 0
+        assert report["residency"]["local_context_count"] == report["residency"]["context_count"]
+        assert all(context["owner_cluster"] == context["home_cluster"] for context in contexts)
+        assert report["residency"]["capacity_conservation"]["conserved"] is True
+        assert report["placement"]["home_capacity"]["per_home_capacity_bytes"] == CAPACITY // 16
+        assert report["placement"]["home_capacity"]["capacity_ok"] is True
+        assert _home_loads(report) == [CAPACITY // 16] * 16
+
+
+def test_whole_token_layer_rotation_removes_old_endpoint_concentration() -> None:
+    gqa = build_residency_report(LOCALITY_AWARE, kv_heads=4)
+    mha = build_residency_report(LOCALITY_AWARE, kv_heads=32)
+
+    gqa_offsets = gqa["placement"]["wave_assignment"]["layer_owner_rotation_offsets"]
+    mha_offsets = mha["placement"]["wave_assignment"]["layer_owner_rotation_offsets"]
+    assert gqa_offsets == [(3 * layer) % 16 for layer in range(32)]
+    assert mha_offsets == [layer % 16 for layer in range(32)]
+
+    gqa_contexts = gqa["placement"]["resident_contexts"]
+    assert [row["owner_cluster"] for row in gqa_contexts if row["layer"] == 0] == [0, 1, 2]
+    assert [row["owner_cluster"] for row in gqa_contexts if row["layer"] == 1] == [3, 4, 5]
+    assert _home_loads(gqa) == [CAPACITY // 16] * 16
+    assert _home_loads(mha) == [CAPACITY // 16] * 16
+
+
+def test_rotated_compute_assignment_is_one_tile_per_cluster_per_complete_wave() -> None:
+    for mode in (LAYER_BALANCED_CONTIGUOUS, LOCALITY_AWARE):
+        for kv_heads in (4, 32):
+            report = build_residency_report(mode, kv_heads=kv_heads)
+            audit = report["placement"]["wave_assignment"]
+            assert audit["complete_waves_per_layer"] == 8
+            assert audit["checked_wave_count"] == 32 * 8
+            assert audit["one_tile_per_cluster_per_complete_wave"] is True
+            for offset in audit["layer_owner_rotation_offsets"]:
+                assert {(offset + tile) % 16 for tile in range(16)} == set(range(16))
+
+
+def test_historical_home_reports_overload_and_locality_fails_closed() -> None:
+    historical = build_residency_report(
+        LAYER_BALANCED_CONTIGUOUS,
+        layers=1,
+        kv_heads=4,
+    )
+    capacity = historical["placement"]["home_capacity"]
+    assert capacity["capacity_ok"] is False
+    assert capacity["enforcement"] == "diagnostic"
+    assert capacity["overloaded_home_count"] == 4
+    assert capacity["overloaded_home_clusters"] == [0, 1, 2, 3]
+    assert capacity["load_conservation"] is True
+
+    with pytest.raises(ValueError, match="exceeds per-home capacity"):
+        build_residency_report(LOCALITY_AWARE, layers=1, kv_heads=4)
+
+
+def test_fractional_smear_requires_explicit_bytes() -> None:
+    with pytest.raises(ValueError, match="explicit fractional_tile_bytes"):
+        build_residency_report(FRACTIONAL_SMEAR)
+
+
+def test_persistent_residency_avoids_reads_but_not_hbm_backing_storage() -> None:
+    report = build_residency_report(
+        LAYER_BALANCED_CONTIGUOUS,
+        kv_heads=4,
+        persistence_mode=PERSISTENT,
+    )
+
+    assert report["hbm"]["hbm_bytes"] == 4 * 1024**3
+    assert report["hbm"]["storage_savings_bytes"] == 0
+    assert report["hbm"]["gross_read_avoidance_bytes"] == CAPACITY
+    assert report["hbm"]["refill_bytes"] == 0
+    assert report["hbm"]["net_hbm_read_bytes"] == 4 * 1024**3 - CAPACITY
+    assert report["hbm"]["net_read_avoidance_bytes"] == CAPACITY
+
+
+def test_impossible_capacity_and_shape_fail_closed() -> None:
+    with pytest.raises(ValueError, match="one whole token"):
+        build_residency_report(
+            LAYER_BALANCED_CONTIGUOUS,
+            layers=2,
+            kv_heads=32,
+            shared_capacity_bytes=8192,
+        )
+    with pytest.raises(ValueError, match="byte-aligned"):
+        build_residency_report(LAYER_BALANCED_CONTIGUOUS, kv_bits=4)
+    with pytest.raises(ValueError, match="multiple of 32"):
+        build_residency_report(LAYER_BALANCED_CONTIGUOUS, packet_payload=33)
+    with pytest.raises(ValueError, match="divide evenly"):
+        build_residency_report(
+            LAYER_BALANCED_CONTIGUOUS,
+            shared_capacity_bytes=CAPACITY + 1,
+        )
+    with pytest.raises(ValueError, match="exceeds tile"):
+        build_residency_report(
+            FRACTIONAL_SMEAR,
+            kv_heads=4,
+            sequence_length=1024,
+            tile_tokens=1024,
+            fractional_tile_bytes=2_000_000,
+        )
+
+
+def test_compare_returns_all_three_explicit_policies() -> None:
+    reports = compare_residency_policies(kv_heads=4)
+    assert set(reports) == {
+        FRACTIONAL_SMEAR,
+        LAYER_BALANCED_CONTIGUOUS,
+        LOCALITY_AWARE,
+    }
+    assert reports[LOCALITY_AWARE]["placement"]["home_policy"] == "owner_cluster"

--- a/npu/rtlgen/gen_attention_shared_sram_k_round_scheduler_ppa_harness.py
+++ b/npu/rtlgen/gen_attention_shared_sram_k_round_scheduler_ppa_harness.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Generate a narrow-I/O physical harness for the shared-SRAM K round scheduler."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_KEY = "attention_shared_sram_k_round_scheduler_ppa_harness"
+MANIFEST_NAME = "attention_shared_sram_k_round_scheduler_ppa_harness_manifest.json"
+PROPOSAL_ID = "prop_l1_attention_shared_sram_k_round_scheduler_ppa_v1"
+SOURCES = (
+    REPO_ROOT / "npu/sim/rtl/attention_shared_sram_k_round_bank.sv",
+    REPO_ROOT / "npu/sim/rtl/attention_shared_sram_k_round_scheduler.sv",
+)
+
+
+def _load(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit(f"config must decode to an object: {path}")
+    return payload
+
+
+def _validate(config: dict[str, Any]) -> str:
+    top_name = str(config.get("top_name") or "").strip()
+    body = config.get(CONFIG_KEY)
+    if not top_name or not isinstance(body, dict):
+        raise SystemExit(f"config requires top_name and {CONFIG_KEY}")
+    expected = {"banks": 17, "words_per_group": 128, "dimension_groups": 8, "dimensions_per_group": 16}
+    for key, value in expected.items():
+        if int(body.get(key, value)) != value:
+            raise SystemExit(f"{key} must be {value} for the checked Llama7B geometry")
+    return top_name
+
+
+def _top(*, top_name: str) -> str:
+    return f"""// Generated K-round scheduler physical/activity harness.
+(* keep_hierarchy = 1 *)
+module {top_name} (
+  input wire clk,
+  input wire rst_n,
+  input wire start,
+  input wire [31:0] seed,
+  output wire done,
+  output wire [31:0] activity_checksum,
+  output wire [31:0] cycle_count,
+  output wire [31:0] bank_request_count,
+  output wire [31:0] bank_response_count,
+  output wire [31:0] compute_beat_count,
+  output wire protocol_error
+);
+  localparam integer ADDR_W = 16;
+  localparam integer BANKS = 17;
+
+  reg running_q;
+  reg done_q;
+  reg [31:0] seed_q;
+  reg [31:0] cycle_q;
+  reg [31:0] checksum_q;
+
+  wire command_ready;
+  wire command_valid = start && !running_q && !done_q;
+  wire [BANKS-1:0] bank_req_valid;
+  wire [BANKS-1:0] bank_req_ready = {{BANKS{{1'b1}}}};
+  wire [(BANKS*ADDR_W)-1:0] bank_req_word_addr;
+  wire [BANKS-1:0] bank_req_buffer;
+  wire [(BANKS*3)-1:0] bank_req_group;
+  wire [(BANKS*3)-1:0] bank_req_round;
+  wire [(BANKS*7)-1:0] bank_req_word_slot;
+
+  reg [BANKS-1:0] bank_rsp_valid_q;
+  wire [BANKS-1:0] bank_rsp_ready;
+  wire [(BANKS*1024)-1:0] bank_rsp_data;
+  reg [BANKS-1:0] bank_rsp_buffer_q;
+  reg [(BANKS*3)-1:0] bank_rsp_group_q;
+  reg [(BANKS*3)-1:0] bank_rsp_round_q;
+  reg [(BANKS*7)-1:0] bank_rsp_word_slot_q;
+  reg [(BANKS*ADDR_W)-1:0] bank_rsp_word_addr_q;
+
+  wire compute_valid;
+  wire compute_ready = running_q && cycle_q[3:0] != 4'd11;
+  wire [2:0] compute_group;
+  wire [2:0] compute_round;
+  wire [3:0] compute_dimension;
+  wire compute_last;
+  wire [BANKS-1:0] compute_word_valid;
+  wire [(BANKS*64)-1:0] compute_k_beats;
+  wire scheduler_done;
+  wire [63:0] bank_request_count_w;
+  wire [63:0] bank_response_count_w;
+  wire [63:0] compute_beat_count_w;
+  wire [63:0] unused_stall_0;
+  wire [63:0] unused_stall_1;
+  wire [63:0] unused_stall_2;
+
+  function automatic [1023:0] build_word;
+    input [ADDR_W-1:0] address;
+    input [2:0] group_value;
+    input [2:0] round_value;
+    input [6:0] slot_value;
+    input [4:0] bank_value;
+    input [31:0] seed_value;
+    reg [31:0] lane;
+    begin
+      // The stimulus source is deliberately small: it exercises every stored
+      // bit without adding seventeen wide arithmetic generators to DUT PPA.
+      lane = seed_value ^ {{16'd0, address}} ^
+        {{21'd0, bank_value, group_value, round_value}} ^
+        {{25'd0, slot_value}};
+      build_word = {{16{{{{lane ^ 32'ha5a5_5a5a, lane}}}}}};
+    end
+  endfunction
+
+  function automatic [31:0] fold_compute;
+    input [(BANKS*64)-1:0] value;
+    integer lane;
+    integer rotate;
+    reg [31:0] slice;
+    begin
+      fold_compute = 32'h6d2b_79f5;
+      for (lane = 0; lane < BANKS*2; lane = lane + 1) begin
+        slice = value[lane*32 +: 32];
+        rotate = (lane % 31) + 1;
+        fold_compute = fold_compute ^ (slice << rotate) ^
+          (slice >> (32-rotate)) ^ (32'h45d9_f3b * (lane + 1));
+      end
+    end
+  endfunction
+
+  genvar bank_g;
+  generate
+    for (bank_g = 0; bank_g < BANKS; bank_g = bank_g + 1) begin : gen_rsp_data
+      assign bank_rsp_data[bank_g*1024 +: 1024] = build_word(
+        bank_rsp_word_addr_q[bank_g*ADDR_W +: ADDR_W],
+        bank_rsp_group_q[bank_g*3 +: 3],
+        bank_rsp_round_q[bank_g*3 +: 3],
+        bank_rsp_word_slot_q[bank_g*7 +: 7],
+        5'(bank_g), seed_q
+      );
+    end
+  endgenerate
+
+  attention_shared_sram_k_round_scheduler #(
+    .ADDR_W(ADDR_W), .BANKS(BANKS), .WORDS_PER_GROUP(128),
+    .DIM_GROUPS(8), .DIMS_PER_GROUP(16)
+  ) scheduler (
+    .clk(clk), .rst_n(rst_n),
+    .command_valid(command_valid), .command_ready(command_ready),
+    .command_base_word_addr(ADDR_W'(16'h0100)),
+    .bank_req_valid(bank_req_valid), .bank_req_ready(bank_req_ready),
+    .bank_req_word_addr(bank_req_word_addr),
+    .bank_req_buffer(bank_req_buffer), .bank_req_group(bank_req_group),
+    .bank_req_round(bank_req_round), .bank_req_word_slot(bank_req_word_slot),
+    .bank_rsp_valid(bank_rsp_valid_q), .bank_rsp_ready(bank_rsp_ready),
+    .bank_rsp_data(bank_rsp_data), .bank_rsp_buffer(bank_rsp_buffer_q),
+    .bank_rsp_group(bank_rsp_group_q), .bank_rsp_round(bank_rsp_round_q),
+    .bank_rsp_word_slot(bank_rsp_word_slot_q),
+    .compute_valid(compute_valid), .compute_ready(compute_ready),
+    .compute_group(compute_group), .compute_round(compute_round),
+    .compute_dimension(compute_dimension), .compute_last(compute_last),
+    .compute_word_valid(compute_word_valid), .compute_k_beats(compute_k_beats),
+    .done(scheduler_done), .protocol_error(protocol_error),
+    .bank_request_count(bank_request_count_w),
+    .bank_response_count(bank_response_count_w),
+    .compute_beat_count(compute_beat_count_w),
+    .bank_request_stall_count(unused_stall_0),
+    .compute_output_stall_count(unused_stall_1),
+    .compute_wait_for_window_count(unused_stall_2)
+  );
+
+  assign done = done_q;
+  assign activity_checksum = checksum_q;
+  assign cycle_count = cycle_q;
+  assign bank_request_count = bank_request_count_w[31:0];
+  assign bank_response_count = bank_response_count_w[31:0];
+  assign compute_beat_count = compute_beat_count_w[31:0];
+
+  integer bank_i;
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      running_q <= 1'b0;
+      done_q <= 1'b0;
+      seed_q <= 32'd1;
+      cycle_q <= 32'd0;
+      checksum_q <= 32'd0;
+      bank_rsp_valid_q <= {{BANKS{{1'b0}}}};
+      bank_rsp_buffer_q <= {{BANKS{{1'b0}}}};
+      bank_rsp_group_q <= {{(BANKS*3){{1'b0}}}};
+      bank_rsp_round_q <= {{(BANKS*3){{1'b0}}}};
+      bank_rsp_word_slot_q <= {{(BANKS*7){{1'b0}}}};
+      bank_rsp_word_addr_q <= {{(BANKS*ADDR_W){{1'b0}}}};
+    end else begin
+      bank_rsp_valid_q <= bank_req_valid & bank_req_ready;
+      for (bank_i = 0; bank_i < BANKS; bank_i = bank_i + 1) begin
+        if (bank_req_valid[bank_i] && bank_req_ready[bank_i]) begin
+          bank_rsp_buffer_q[bank_i] <= bank_req_buffer[bank_i];
+          bank_rsp_group_q[bank_i*3 +: 3] <= bank_req_group[bank_i*3 +: 3];
+          bank_rsp_round_q[bank_i*3 +: 3] <= bank_req_round[bank_i*3 +: 3];
+          bank_rsp_word_slot_q[bank_i*7 +: 7] <= bank_req_word_slot[bank_i*7 +: 7];
+          bank_rsp_word_addr_q[bank_i*ADDR_W +: ADDR_W] <=
+            bank_req_word_addr[bank_i*ADDR_W +: ADDR_W];
+        end
+      end
+
+      if (command_valid && command_ready) begin
+        running_q <= 1'b1;
+        seed_q <= seed == 0 ? 32'd1 : seed;
+      end
+      if (running_q)
+        cycle_q <= cycle_q + 1'b1;
+      if (compute_valid && compute_ready)
+        checksum_q <= checksum_q ^ fold_compute(compute_k_beats) ^
+          {{20'd0, compute_last, compute_word_valid[0],
+            compute_group, compute_round, compute_dimension}};
+      if (scheduler_done) begin
+        running_q <= 1'b0;
+        done_q <= 1'b1;
+      end
+    end
+  end
+endmodule
+"""
+
+
+def generate(config: dict[str, Any], out_dir: Path) -> None:
+    top_name = _validate(json.loads(json.dumps(config)))
+    source = "\n\n".join(path.read_text(encoding="utf-8").rstrip() for path in SOURCES) + "\n"
+    rtl = source.rstrip() + "\n\n" + _top(top_name=top_name)
+    generated_rtl = rtl + "\n"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "top.v").write_text(generated_rtl, encoding="utf-8")
+    (out_dir / "config.json").write_text(
+        json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    manifest = {
+        "version": 1,
+        "generator": "npu/rtlgen/gen_attention_shared_sram_k_round_scheduler_ppa_harness.py",
+        "top_name": top_name,
+        "semantic_profile": "attention_shared_sram_k_round_scheduler_logic_ppa_activity_v1",
+        "banks": 17,
+        "words_per_group": 128,
+        "dimension_groups": 8,
+        "rounds_per_group": 8,
+        "dimensions_per_group": 16,
+        "requests_per_command": 1024,
+        "compute_beats_per_command": 1024,
+        "window_storage_bits": 34816,
+        "compute_boundary_bits": 1088,
+        "full_capacity_macro_area_included": False,
+        "shared_sram_access_energy_included": False,
+        "external_hbm_dram_included": False,
+        "activity_checksum_is_equivalence_proof": False,
+        "synthetic_response_profile": "metadata_lane_replicated_v1",
+        "synthetic_response_generator_is_dut": False,
+        "narrow_io_harness_overhead_included": True,
+        "linked_proposal_id": PROPOSAL_ID,
+        "source_rtl": [str(path.relative_to(REPO_ROOT)) for path in SOURCES],
+        "source_sha256": hashlib.sha256(source.encode("utf-8")).hexdigest(),
+        "generated_top_sha256": hashlib.sha256(generated_rtl.encode("utf-8")).hexdigest(),
+    }
+    (out_dir / MANIFEST_NAME).write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    generate(_load(args.config), args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/rtlgen/gen_attention_shared_sram_read_group_adapter_ppa_harness.py
+++ b/npu/rtlgen/gen_attention_shared_sram_read_group_adapter_ppa_harness.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Generate a narrow-I/O activity harness for the shared-SRAM read adapter."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_KEY = "attention_shared_sram_read_group_adapter_ppa_harness"
+MANIFEST_NAME = "attention_shared_sram_read_group_adapter_ppa_harness_manifest.json"
+PROPOSAL_ID = "prop_l1_attention_shared_sram_read_group_adapter_ppa_v1"
+SOURCE = REPO_ROOT / "npu/sim/rtl/attention_shared_sram_read_group_adapter.sv"
+
+
+def _load(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit(f"config must decode to an object: {path}")
+    return payload
+
+
+def _validate(config: dict[str, Any]) -> tuple[str, int, int, int]:
+    top_name = str(config.get("top_name") or "").strip()
+    body = config.get(CONFIG_KEY)
+    if not top_name or not isinstance(body, dict):
+        raise SystemExit(f"config requires top_name and {CONFIG_KEY}")
+    beat_width = int(body.get("beat_width", 0))
+    group_slots = int(body.get("group_slots", 0))
+    groups = int(body.get("groups", 64))
+    if beat_width not in {256, 512}:
+        raise SystemExit("beat_width must be 256 or 512")
+    if group_slots not in {1, 2}:
+        raise SystemExit("group_slots must be 1 or 2")
+    if groups < 2:
+        raise SystemExit("groups must be at least two")
+    return top_name, beat_width, group_slots, groups
+
+
+def _top(*, top_name: str, beat_width: int, group_slots: int, groups: int) -> str:
+    return f"""// Generated shared-SRAM read-adapter physical/activity harness.
+(* keep_hierarchy = 1 *)
+module {top_name} (
+  input wire clk,
+  input wire rst_n,
+  input wire start,
+  input wire [31:0] seed,
+  output wire done,
+  output wire [31:0] folded_result,
+  output wire [31:0] cycle_count,
+  output wire [31:0] beat_request_count,
+  output wire [31:0] macro_read_count,
+  output wire [31:0] beat_response_count,
+  output wire protocol_error,
+  output wire access_reduction_proven
+);
+  localparam integer ADDR_W = 32;
+  localparam integer BEAT_W = {beat_width};
+  localparam integer GROUP_SLOTS = {group_slots};
+  localparam integer GROUPS = {groups};
+  localparam integer MACRO_W = 1024;
+  localparam integer MACRO_BYTES = 128;
+  localparam integer BEAT_BYTES = BEAT_W / 8;
+  localparam integer SEGMENTS = MACRO_W / BEAT_W;
+  localparam integer TOTAL_BEATS = GROUPS * SEGMENTS;
+  localparam integer SLOT_W = (GROUP_SLOTS <= 1) ? 1 : $clog2(GROUP_SLOTS);
+
+  reg running_q;
+  reg done_q;
+  reg [31:0] seed_q;
+  reg [31:0] cycle_q;
+  reg [31:0] issued_q;
+  reg [31:0] received_q;
+  reg [31:0] fold_q;
+
+  wire req_valid = running_q && (issued_q < TOTAL_BEATS);
+  wire req_ready;
+  wire [ADDR_W-1:0] req_addr = 32'h0010_0000 + issued_q * BEAT_BYTES;
+  wire rsp_valid;
+  wire rsp_ready = running_q && (cycle_q[2:0] != 3'd5);
+  (* keep = "true" *) wire [BEAT_W-1:0] rsp_data;
+  wire [ADDR_W-1:0] rsp_addr;
+
+  wire macro_req_valid;
+  wire macro_req_ready = 1'b1;
+  wire [ADDR_W-1:0] macro_req_addr;
+  wire [SLOT_W-1:0] macro_req_slot;
+  reg macro_rsp_valid_q;
+  wire macro_rsp_ready;
+  reg [ADDR_W-1:0] macro_rsp_addr_q;
+  reg [SLOT_W-1:0] macro_rsp_slot_q;
+  wire [63:0] beat_request_count_w;
+  wire [63:0] macro_read_count_w;
+  wire [63:0] beat_response_count_w;
+  wire [63:0] unused_stalls_0;
+  wire [63:0] unused_stalls_1;
+  wire [63:0] unused_stalls_2;
+  wire [63:0] unused_stalls_3;
+
+  function automatic [1023:0] build_macro_word;
+    input [31:0] address;
+    input [31:0] seed_value;
+    reg [31:0] lane;
+    begin
+      // Keep stimulus logic small; the retained DUT payload state, not the
+      // synthetic macro response generator, is the physical target.
+      lane = seed_value ^ address;
+      build_macro_word = {{32{{lane}}}};
+    end
+  endfunction
+
+  function automatic [31:0] fold_beat;
+    input [BEAT_W-1:0] value;
+    begin
+      // rsp_data is kept in full; only endpoint lanes feed the narrow checksum.
+      fold_beat = value[31:0] ^ value[BEAT_W-1 -: 32];
+    end
+  endfunction
+
+  attention_shared_sram_read_group_adapter #(
+    .ADDR_W(ADDR_W), .BEAT_W(BEAT_W), .GROUP_SLOTS(GROUP_SLOTS)
+  ) adapter (
+    .clk(clk), .rst_n(rst_n),
+    .req_valid(req_valid), .req_ready(req_ready), .req_addr(req_addr),
+    .rsp_valid(rsp_valid), .rsp_ready(rsp_ready), .rsp_data(rsp_data),
+    .rsp_addr(rsp_addr),
+    .macro_req_valid(macro_req_valid), .macro_req_ready(macro_req_ready),
+    .macro_req_addr(macro_req_addr), .macro_req_slot(macro_req_slot),
+    .macro_rsp_valid(macro_rsp_valid_q), .macro_rsp_ready(macro_rsp_ready),
+    .macro_rsp_data(build_macro_word(macro_rsp_addr_q, seed_q)),
+    .macro_rsp_addr(macro_rsp_addr_q), .macro_rsp_slot(macro_rsp_slot_q),
+    .protocol_error(protocol_error),
+    .beat_request_count(beat_request_count_w),
+    .macro_read_count(macro_read_count_w),
+    .beat_response_count(beat_response_count_w),
+    .beat_request_stall_count(unused_stalls_0),
+    .beat_response_stall_count(unused_stalls_1),
+    .macro_request_stall_count(unused_stalls_2),
+    .macro_response_stall_count(unused_stalls_3),
+    .access_reduction_proven(access_reduction_proven)
+  );
+
+  assign done = done_q;
+  assign folded_result = fold_q;
+  assign cycle_count = cycle_q;
+  assign beat_request_count = beat_request_count_w[31:0];
+  assign macro_read_count = macro_read_count_w[31:0];
+  assign beat_response_count = beat_response_count_w[31:0];
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      running_q <= 1'b0;
+      done_q <= 1'b0;
+      seed_q <= 32'd1;
+      cycle_q <= 32'd0;
+      issued_q <= 32'd0;
+      received_q <= 32'd0;
+      fold_q <= 32'd0;
+      macro_rsp_valid_q <= 1'b0;
+      macro_rsp_addr_q <= 32'd0;
+      macro_rsp_slot_q <= {{SLOT_W{{1'b0}}}};
+    end else begin
+      if (start && !running_q && !done_q) begin
+        running_q <= 1'b1;
+        seed_q <= seed == 0 ? 32'd1 : seed;
+      end
+      if (running_q)
+        cycle_q <= cycle_q + 1'b1;
+      if (req_valid && req_ready)
+        issued_q <= issued_q + 1'b1;
+
+      if (macro_rsp_valid_q && macro_rsp_ready)
+        macro_rsp_valid_q <= 1'b0;
+      if (macro_req_valid && macro_req_ready) begin
+        macro_rsp_valid_q <= 1'b1;
+        macro_rsp_addr_q <= macro_req_addr;
+        macro_rsp_slot_q <= macro_req_slot;
+      end
+
+      if (rsp_valid && rsp_ready) begin
+        received_q <= received_q + 1'b1;
+        fold_q <= fold_q ^ fold_beat(rsp_data) ^ rsp_addr;
+        if (received_q + 1'b1 == TOTAL_BEATS) begin
+          running_q <= 1'b0;
+          done_q <= 1'b1;
+        end
+      end
+    end
+  end
+endmodule
+"""
+
+
+def generate(config: dict[str, Any], out_dir: Path) -> None:
+    top_name, beat_width, group_slots, groups = _validate(json.loads(json.dumps(config)))
+    source = SOURCE.read_text(encoding="utf-8")
+    rtl = source.rstrip() + "\n\n" + _top(
+        top_name=top_name,
+        beat_width=beat_width,
+        group_slots=group_slots,
+        groups=groups,
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "top.v").write_text(rtl + "\n", encoding="utf-8")
+    (out_dir / "config.json").write_text(
+        json.dumps(config, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    manifest = {
+        "version": 1,
+        "generator": "npu/rtlgen/gen_attention_shared_sram_read_group_adapter_ppa_harness.py",
+        "top_name": top_name,
+        "semantic_profile": "attention_shared_sram_read_group_adapter_logic_ppa_activity_v1",
+        "beat_width": beat_width,
+        "segments_per_macro_read": 1024 // beat_width,
+        "group_slots": group_slots,
+        "groups": groups,
+        "shared_macro_width_bits": 1024,
+        "buffer_payload_bits": 1024 * group_slots,
+        "payload_reset_required": False,
+        "full_capacity_macro_area_included": False,
+        "synthetic_response_profile": "metadata_lane_replicated_v1",
+        "synthetic_response_generator_is_dut": False,
+        "narrow_io_harness_overhead_included": True,
+        "response_bus_retention": "kept_full_bus_endpoint_lane_fold_v1",
+        "linked_proposal_id": PROPOSAL_ID,
+        "source_rtl": str(SOURCE.relative_to(REPO_ROOT)),
+        "source_sha256": hashlib.sha256(source.encode("utf-8")).hexdigest(),
+        "generated_top_sha256": hashlib.sha256(rtl.encode("utf-8")).hexdigest(),
+    }
+    (out_dir / MANIFEST_NAME).write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    generate(_load(args.config), args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npu/sim/perf/attention_phase2_shared_stream_transport.py
+++ b/npu/sim/perf/attention_phase2_shared_stream_transport.py
@@ -1,0 +1,616 @@
+#!/usr/bin/env python3
+"""Exact reference model for the Phase-2 shared-SRAM stream transport.
+
+The model is deliberately limited to the byte-preserving shared stream.  The
+historical Phase-2 reduction traffic is a different VC and is not represented
+here.  Addresses are logical byte addresses in two disjoint SRAM spaces:
+source space first, destination space second.  The separation makes address
+coverage checks unambiguous while preserving the endpoint-local layout.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, MutableMapping, Sequence
+
+
+MESH_ENDPOINTS = 16
+LOGICAL_WAVES = 8
+LOCAL_ONLY_WAVE = 4
+REMOTE_WAVES = tuple(wave for wave in range(LOGICAL_WAVES) if wave != LOCAL_ONLY_WAVE)
+MAPPING_SHIFTS = (4, 7, 10, 13, 0, 3, 6, 9)
+
+CONTEXT_COUNT = len(REMOTE_WAVES) * MESH_ENDPOINTS
+CONTEXT_BYTES = 17_408
+PACKETS_PER_CONTEXT = 68
+PACKET_BYTES = 256
+FLITS_PER_PACKET = 8
+FLIT_BYTES = 32
+SHARED_VC = 0
+MAX_IN_FLIGHT_PACKET_CONTEXTS = 8
+
+assert CONTEXT_BYTES == PACKETS_PER_CONTEXT * PACKET_BYTES
+assert PACKET_BYTES == FLITS_PER_PACKET * FLIT_BYTES
+
+CONTEXTS_PER_ENDPOINT = len(REMOTE_WAVES)
+ENDPOINT_WINDOW_BYTES = CONTEXTS_PER_ENDPOINT * CONTEXT_BYTES
+SOURCE_SPACE_BASE = 0
+DESTINATION_SPACE_BASE = MESH_ENDPOINTS * ENDPOINT_WINDOW_BYTES
+TOTAL_SHARED_BYTES = CONTEXT_COUNT * CONTEXT_BYTES
+TOTAL_PACKETS = CONTEXT_COUNT * PACKETS_PER_CONTEXT
+TOTAL_FLITS = TOTAL_PACKETS * FLITS_PER_PACKET
+
+
+class TransportContractError(ValueError):
+    """Raised when a transport invariant or equivalence check fails."""
+
+
+@dataclass(frozen=True)
+class SharedStreamContext:
+    """One remote wave-to-destination transfer context."""
+
+    context_id: int
+    wave_index: int
+    wave_ordinal: int
+    source_endpoint: int
+    destination_endpoint: int
+    source_base: int
+    destination_base: int
+    packets_per_context: int = PACKETS_PER_CONTEXT
+    payload_bytes: int | None = None
+    flits_per_packet: int = FLITS_PER_PACKET
+    vc: int = SHARED_VC
+
+    def __post_init__(self) -> None:
+        if self.packets_per_context <= 0:
+            raise TransportContractError("packets_per_context must be positive")
+        expected_bytes = self.packets_per_context * PACKET_BYTES
+        if self.payload_bytes is None:
+            object.__setattr__(self, "payload_bytes", expected_bytes)
+        elif self.payload_bytes != expected_bytes:
+            raise TransportContractError(
+                "payload_bytes must equal packets_per_context * packet payload bytes"
+            )
+
+    @property
+    def packet_count(self) -> int:
+        """Compatibility spelling for the packet count in older callers."""
+
+        return self.packets_per_context
+
+
+@dataclass(frozen=True)
+class PacketDescriptor:
+    """A complete packet descriptor before its eight flits are emitted."""
+
+    context_id: int
+    wave_index: int
+    source_endpoint: int
+    destination_endpoint: int
+    packet_index: int
+    tag: int
+    source_base: int
+    destination_base: int
+    payload_bytes: int = PACKET_BYTES
+    flit_count: int = FLITS_PER_PACKET
+    vc: int = SHARED_VC
+
+    @property
+    def source_packet_base(self) -> int:
+        return self.source_base + self.packet_index * PACKET_BYTES
+
+    @property
+    def destination_packet_base(self) -> int:
+        return self.destination_base + self.packet_index * PACKET_BYTES
+
+
+@dataclass(frozen=True)
+class MemoryWrite:
+    """One accepted destination SRAM flit write."""
+
+    context_id: int
+    wave_index: int
+    source_endpoint: int
+    destination_endpoint: int
+    packet_index: int
+    flit_index: int
+    source_address: int
+    destination_address: int
+    data: bytes
+    vc: int = SHARED_VC
+    tag: int = 0
+
+
+@dataclass(frozen=True)
+class PayloadEquivalenceResult:
+    """Byte-level evidence; no hash is used to establish equivalence."""
+
+    context_id: int
+    byte_count: int
+    write_count: int
+    unique_address_count: int
+    packet_count: int
+    flit_count: int
+
+
+@dataclass(frozen=True)
+class ContextStatus:
+    context_id: int
+    admitted: bool
+    completed_packet_count: int
+    completion_valid: bool
+    completion_accepted: bool
+    source_owned: bool
+    destination_owned: bool
+    inflight_packet_count: int = 0
+    next_packet_to_expose: int = 0
+    next_packet_to_complete: int = 0
+
+
+def _check_endpoint(endpoint: int) -> int:
+    endpoint = int(endpoint)
+    if not 0 <= endpoint < MESH_ENDPOINTS:
+        raise TransportContractError(f"endpoint must be in [0, 15], got {endpoint}")
+    return endpoint
+
+
+def _check_packets_per_context(packets_per_context: int) -> int:
+    packets_per_context = int(packets_per_context)
+    if packets_per_context <= 0:
+        raise TransportContractError("packets_per_context must be positive")
+    return packets_per_context
+
+
+def _check_remote_wave(wave_index: int) -> int:
+    wave_index = int(wave_index)
+    if not 0 <= wave_index < LOGICAL_WAVES:
+        raise TransportContractError(f"wave index must be in [0, 7], got {wave_index}")
+    if wave_index == LOCAL_ONLY_WAVE:
+        raise TransportContractError("local-only wave 4 must not be admitted to shared transport")
+    return wave_index
+
+
+def wave_ordinal(wave_index: int) -> int:
+    """Return the compact source/destination SRAM slot for a remote wave."""
+
+    wave_index = _check_remote_wave(wave_index)
+    return REMOTE_WAVES.index(wave_index)
+
+
+def mapping_shift(wave_index: int) -> int:
+    """Return the checked-in source-home rotation for a logical wave."""
+
+    wave_index = int(wave_index)
+    if not 0 <= wave_index < LOGICAL_WAVES:
+        raise TransportContractError(f"wave index must be in [0, 7], got {wave_index}")
+    return MAPPING_SHIFTS[wave_index]
+
+
+def source_endpoint_for(*, wave_index: int, destination_endpoint: int) -> int:
+    """Map a destination cluster to its source SRAM home."""
+
+    destination_endpoint = _check_endpoint(destination_endpoint)
+    return (destination_endpoint + mapping_shift(wave_index)) % MESH_ENDPOINTS
+
+
+def endpoint_window_bytes(*, packets_per_context: int = PACKETS_PER_CONTEXT) -> int:
+    """Return the per-endpoint SRAM window span for a packetized context."""
+
+    return CONTEXTS_PER_ENDPOINT * _check_packets_per_context(packets_per_context) * PACKET_BYTES
+
+
+def destination_space_base_for(*, packets_per_context: int = PACKETS_PER_CONTEXT) -> int:
+    """Return the first byte of the disjoint destination address space."""
+
+    return MESH_ENDPOINTS * endpoint_window_bytes(packets_per_context=packets_per_context)
+
+
+def source_base_for(
+    *, endpoint: int, wave_index: int, packets_per_context: int = PACKETS_PER_CONTEXT
+) -> int:
+    """Address formula for a source endpoint's remote-wave window."""
+
+    endpoint = _check_endpoint(endpoint)
+    packets_per_context = _check_packets_per_context(packets_per_context)
+    window_bytes = packets_per_context * PACKET_BYTES
+    return (
+        SOURCE_SPACE_BASE
+        + endpoint * endpoint_window_bytes(packets_per_context=packets_per_context)
+        + wave_ordinal(wave_index) * window_bytes
+    )
+
+
+def destination_base_for(
+    *, endpoint: int, wave_index: int, packets_per_context: int = PACKETS_PER_CONTEXT
+) -> int:
+    """Address formula for a destination endpoint's remote-wave window."""
+
+    endpoint = _check_endpoint(endpoint)
+    packets_per_context = _check_packets_per_context(packets_per_context)
+    window_bytes = packets_per_context * PACKET_BYTES
+    return (
+        destination_space_base_for(packets_per_context=packets_per_context)
+        + endpoint * endpoint_window_bytes(packets_per_context=packets_per_context)
+        + wave_ordinal(wave_index) * window_bytes
+    )
+
+
+def context_id_for(*, wave_index: int, destination_endpoint: int) -> int:
+    """Use the stable wave-major endpoint identity, leaving wave 4 unused."""
+
+    wave_index = _check_remote_wave(wave_index)
+    destination_endpoint = _check_endpoint(destination_endpoint)
+    return wave_index * MESH_ENDPOINTS + destination_endpoint
+
+
+def build_context(
+    *, wave_index: int, destination_endpoint: int, packets_per_context: int = PACKETS_PER_CONTEXT
+) -> SharedStreamContext:
+    """Build one exact remote context from the contract mapping."""
+
+    wave_index = _check_remote_wave(wave_index)
+    packets_per_context = _check_packets_per_context(packets_per_context)
+    destination_endpoint = _check_endpoint(destination_endpoint)
+    source_endpoint = source_endpoint_for(
+        wave_index=wave_index,
+        destination_endpoint=destination_endpoint,
+    )
+    return SharedStreamContext(
+        context_id=context_id_for(wave_index=wave_index, destination_endpoint=destination_endpoint),
+        wave_index=wave_index,
+        wave_ordinal=wave_ordinal(wave_index),
+        source_endpoint=source_endpoint,
+        destination_endpoint=destination_endpoint,
+        source_base=source_base_for(
+            endpoint=source_endpoint,
+            wave_index=wave_index,
+            packets_per_context=packets_per_context,
+        ),
+        destination_base=destination_base_for(
+            endpoint=destination_endpoint,
+            wave_index=wave_index,
+            packets_per_context=packets_per_context,
+        ),
+        packets_per_context=packets_per_context,
+    )
+
+
+def build_contexts(
+    *, packets_per_context: int = PACKETS_PER_CONTEXT
+) -> tuple[SharedStreamContext, ...]:
+    """Return all contexts in deterministic wave-major order."""
+
+    return tuple(
+        build_context(
+            wave_index=wave,
+            destination_endpoint=destination,
+            packets_per_context=packets_per_context,
+        )
+        for wave in REMOTE_WAVES
+        for destination in range(MESH_ENDPOINTS)
+    )
+
+
+def packet_descriptors(context: SharedStreamContext) -> tuple[PacketDescriptor, ...]:
+    """Return ordered packet descriptors for one context."""
+
+    if context.payload_bytes != context.packet_count * PACKET_BYTES:
+        raise TransportContractError("context payload does not match its packet count")
+    if context.flits_per_packet != FLITS_PER_PACKET:
+        raise TransportContractError("shared context flit count must be exactly 8")
+    return tuple(
+        PacketDescriptor(
+            context_id=context.context_id,
+            wave_index=context.wave_index,
+            source_endpoint=context.source_endpoint,
+            destination_endpoint=context.destination_endpoint,
+            packet_index=packet_index,
+            tag=packet_index % 256,
+            source_base=context.source_base,
+            destination_base=context.destination_base,
+        )
+        for packet_index in range(context.packet_count)
+    )
+
+
+def _coerce_window(
+    source_window: bytes | bytearray | memoryview,
+    *,
+    expected_bytes: int,
+) -> bytes:
+    payload = bytes(source_window)
+    if len(payload) != expected_bytes:
+        raise TransportContractError(
+            f"source window must contain exactly {expected_bytes} bytes, got {len(payload)}"
+        )
+    return payload
+
+
+def canonical_memory_writes(
+    context: SharedStreamContext,
+    source_window: bytes | bytearray | memoryview,
+) -> tuple[MemoryWrite, ...]:
+    """Create the exact ordered writes expected at the destination SRAM."""
+
+    payload = _coerce_window(source_window, expected_bytes=context.payload_bytes)
+    writes: list[MemoryWrite] = []
+    for descriptor in packet_descriptors(context):
+        for flit_index in range(FLITS_PER_PACKET):
+            offset = descriptor.packet_index * PACKET_BYTES + flit_index * FLIT_BYTES
+            writes.append(
+                MemoryWrite(
+                    context_id=context.context_id,
+                    wave_index=context.wave_index,
+                    source_endpoint=context.source_endpoint,
+                    destination_endpoint=context.destination_endpoint,
+                    packet_index=descriptor.packet_index,
+                    flit_index=flit_index,
+                    source_address=context.source_base + offset,
+                    destination_address=context.destination_base + offset,
+                    data=payload[offset : offset + FLIT_BYTES],
+                    tag=descriptor.tag,
+                )
+            )
+    return tuple(writes)
+
+
+def validate_payload_equivalence(
+    context: SharedStreamContext,
+    source_window: bytes | bytearray | memoryview,
+    writes: Sequence[MemoryWrite] | Iterable[MemoryWrite],
+) -> PayloadEquivalenceResult:
+    """Prove exact byte/address equivalence for one complete context.
+
+    The check is intentionally independent of any digest.  It validates the
+    ordered packet/flit identity, both address formulas, every byte payload,
+    and uniqueness of every destination byte address.
+    """
+
+    payload = _coerce_window(source_window, expected_bytes=context.payload_bytes)
+    observed = tuple(writes)
+    expected_count = context.packet_count * FLITS_PER_PACKET
+    if len(observed) != expected_count:
+        raise TransportContractError(
+            f"context {context.context_id} requires {expected_count} flit writes, got {len(observed)}"
+        )
+
+    destination_addresses: set[int] = set()
+    source_addresses: set[int] = set()
+    for ordinal, write in enumerate(observed):
+        packet_index, flit_index = divmod(ordinal, FLITS_PER_PACKET)
+        offset = packet_index * PACKET_BYTES + flit_index * FLIT_BYTES
+        expected_source_address = context.source_base + offset
+        expected_destination_address = context.destination_base + offset
+        expected_data = payload[offset : offset + FLIT_BYTES]
+        expected = {
+            "context_id": context.context_id,
+            "wave_index": context.wave_index,
+            "source_endpoint": context.source_endpoint,
+            "destination_endpoint": context.destination_endpoint,
+            "packet_index": packet_index,
+            "flit_index": flit_index,
+            "source_address": expected_source_address,
+            "destination_address": expected_destination_address,
+            "vc": SHARED_VC,
+            "tag": packet_index % 256,
+        }
+        for field, value in expected.items():
+            if getattr(write, field) != value:
+                raise TransportContractError(
+                    f"context {context.context_id} write {ordinal} has {field}={getattr(write, field)!r}; "
+                    f"expected {value!r}"
+                )
+        if bytes(write.data) != expected_data:
+            raise TransportContractError(f"context {context.context_id} write {ordinal} payload mismatch")
+        if len(write.data) != FLIT_BYTES:
+            raise TransportContractError(f"context {context.context_id} write {ordinal} is not one flit")
+        if expected_source_address in source_addresses:
+            raise TransportContractError(f"duplicate source byte address at {expected_source_address}")
+        if expected_destination_address in destination_addresses:
+            raise TransportContractError(
+                f"duplicate destination byte address at {expected_destination_address}"
+            )
+        source_addresses.update(range(expected_source_address, expected_source_address + FLIT_BYTES))
+        destination_addresses.update(
+            range(expected_destination_address, expected_destination_address + FLIT_BYTES)
+        )
+
+    expected_bytes = context.payload_bytes
+    if len(source_addresses) != expected_bytes or len(destination_addresses) != expected_bytes:
+        raise TransportContractError("payload write coverage is not exactly one complete context window")
+    return PayloadEquivalenceResult(
+        context_id=context.context_id,
+        byte_count=expected_bytes,
+        write_count=len(observed),
+        unique_address_count=len(destination_addresses),
+        packet_count=context.packet_count,
+        flit_count=context.packet_count * FLITS_PER_PACKET,
+    )
+
+
+def copy_payload_and_validate(
+    context: SharedStreamContext,
+    source_window: bytes | bytearray | memoryview,
+    destination_memory: MutableMapping[int, int],
+    writes: Sequence[MemoryWrite] | Iterable[MemoryWrite] | None = None,
+) -> PayloadEquivalenceResult:
+    """Validate first, then copy every accepted flit into destination SRAM.
+
+    The destination window must be unused before the copy.  Consequently an
+    attempted overwrite is reported instead of silently replacing a byte.
+    Invalid transfers never mutate ``destination_memory``.
+    """
+
+    payload = _coerce_window(source_window, expected_bytes=context.payload_bytes)
+    observed = tuple(canonical_memory_writes(context, payload) if writes is None else writes)
+    result = validate_payload_equivalence(context, payload, observed)
+    destination_range = range(context.destination_base, context.destination_base + context.payload_bytes)
+    if any(address in destination_memory for address in destination_range):
+        raise TransportContractError(f"destination window for context {context.context_id} is already occupied")
+    for write in observed:
+        for offset, value in enumerate(write.data):
+            destination_memory[write.destination_address + offset] = int(value)
+    return result
+
+
+def packet_tag(packet_index: int) -> int:
+    """Return the wire tag; packet indices may exceed the eight-bit tag space."""
+
+    packet_index = int(packet_index)
+    if packet_index < 0:
+        raise TransportContractError("packet index must be non-negative")
+    return packet_index % 256
+
+
+class PacketTagLifetimeTracker:
+    """Track bounded packet exposure and ordered completion for one context."""
+
+    def __init__(self, packet_count: int, *, max_in_flight: int = MAX_IN_FLIGHT_PACKET_CONTEXTS) -> None:
+        self.packet_count = _check_packets_per_context(packet_count)
+        self.max_in_flight = int(max_in_flight)
+        if self.max_in_flight <= 0:
+            raise TransportContractError("max_in_flight must be positive")
+        self.next_packet_to_expose = 0
+        self.next_packet_to_complete = 0
+        self._inflight_by_tag: dict[int, int] = {}
+
+    @property
+    def inflight_packet_count(self) -> int:
+        return len(self._inflight_by_tag)
+
+    def expose(self, packet_index: int) -> int:
+        packet_index = int(packet_index)
+        if packet_index != self.next_packet_to_expose:
+            raise TransportContractError(
+                f"packet exposure must be ordered: expected {self.next_packet_to_expose}, got {packet_index}"
+            )
+        if packet_index >= self.packet_count:
+            raise TransportContractError(f"packet index {packet_index} is out of range")
+        if self.inflight_packet_count >= self.max_in_flight:
+            raise TransportContractError("packet context table is full")
+        tag = packet_tag(packet_index)
+        prior = self._inflight_by_tag.get(tag)
+        if prior is not None:
+            raise TransportContractError(
+                f"tag {tag} cannot be reused before packet {prior} completes"
+            )
+        self._inflight_by_tag[tag] = packet_index
+        self.next_packet_to_expose += 1
+        return tag
+
+    def complete(self, packet_index: int) -> None:
+        packet_index = int(packet_index)
+        if packet_index != self.next_packet_to_complete:
+            raise TransportContractError(
+                f"packet completion must be ordered: expected {self.next_packet_to_complete}, got {packet_index}"
+            )
+        if packet_index >= self.packet_count:
+            raise TransportContractError(f"packet index {packet_index} is out of range")
+        tag = packet_tag(packet_index)
+        if self._inflight_by_tag.get(tag) != packet_index:
+            raise TransportContractError(f"packet {packet_index} was not exposed or tag ownership changed")
+        del self._inflight_by_tag[tag]
+        self.next_packet_to_complete += 1
+
+
+class ContextCompletionTracker:
+    """Model admission, ordered packet completion, and consumer-owned release."""
+
+    def __init__(
+        self,
+        contexts: Sequence[SharedStreamContext] | None = None,
+        *,
+        max_inflight_packet_contexts: int = MAX_IN_FLIGHT_PACKET_CONTEXTS,
+    ) -> None:
+        selected = tuple(build_contexts() if contexts is None else contexts)
+        self._contexts = {context.context_id: context for context in selected}
+        if len(self._contexts) != len(selected):
+            raise TransportContractError("context IDs must be unique")
+        self._admitted: set[int] = set()
+        self._completed_packets: dict[int, int] = {context_id: 0 for context_id in self._contexts}
+        self._completion_valid: set[int] = set()
+        self._completion_accepted: set[int] = set()
+        self._source_owners: dict[int, int] = {}
+        self._destination_owners: dict[int, int] = {}
+        self._packet_trackers = {
+            context_id: PacketTagLifetimeTracker(
+                context.packet_count,
+                max_in_flight=max_inflight_packet_contexts,
+            )
+            for context_id, context in self._contexts.items()
+        }
+
+    def admit(self, context_id: int) -> None:
+        context = self._context(context_id)
+        if context_id in self._admitted:
+            raise TransportContractError(f"context {context_id} is already admitted")
+        if context.source_endpoint in self._source_owners:
+            raise TransportContractError(f"source endpoint {context.source_endpoint} is still owned")
+        if context.destination_endpoint in self._destination_owners:
+            raise TransportContractError(f"destination endpoint {context.destination_endpoint} is still owned")
+        self._admitted.add(context_id)
+        self._source_owners[context.source_endpoint] = context_id
+        self._destination_owners[context.destination_endpoint] = context_id
+
+    def expose_packet(self, context_id: int, packet_index: int) -> int:
+        self._context(context_id)
+        if context_id not in self._admitted:
+            raise TransportContractError(f"context {context_id} is not admitted")
+        return self._packet_trackers[context_id].expose(packet_index)
+
+    def complete_packet(self, context_id: int, packet_index: int) -> None:
+        context = self._context(context_id)
+        if context_id not in self._admitted:
+            raise TransportContractError(f"context {context_id} is not admitted")
+        tracker = self._packet_trackers[context_id]
+        expected = tracker.next_packet_to_complete
+        if packet_index != expected:
+            raise TransportContractError(
+                f"context {context_id} packet completion must be ordered: expected {expected}, got {packet_index}"
+            )
+        # Direct completion remains a useful shorthand for the reference
+        # model; explicit users can call expose_packet first.
+        if tracker.next_packet_to_expose == packet_index:
+            tracker.expose(packet_index)
+        tracker.complete(packet_index)
+        self._completed_packets[context_id] = tracker.next_packet_to_complete
+        if self._completed_packets[context_id] == context.packet_count:
+            self._completion_valid.add(context_id)
+
+    def accept_completion(self, context_id: int) -> None:
+        context = self._context(context_id)
+        if context_id not in self._completion_valid:
+            raise TransportContractError(f"context {context_id} completion is not valid")
+        if context_id in self._completion_accepted:
+            raise TransportContractError(f"context {context_id} completion was already accepted")
+        self._completion_accepted.add(context_id)
+        self._admitted.remove(context_id)
+        self._source_owners.pop(context.source_endpoint, None)
+        self._destination_owners.pop(context.destination_endpoint, None)
+
+    def status(self, context_id: int) -> ContextStatus:
+        context = self._context(context_id)
+        return ContextStatus(
+            context_id=context_id,
+            admitted=context_id in self._admitted,
+            completed_packet_count=self._completed_packets[context_id],
+            completion_valid=context_id in self._completion_valid,
+            completion_accepted=context_id in self._completion_accepted,
+            source_owned=self._source_owners.get(context.source_endpoint) == context_id,
+            destination_owned=self._destination_owners.get(context.destination_endpoint) == context_id,
+            inflight_packet_count=self._packet_trackers[context_id].inflight_packet_count,
+            next_packet_to_expose=self._packet_trackers[context_id].next_packet_to_expose,
+            next_packet_to_complete=self._packet_trackers[context_id].next_packet_to_complete,
+        )
+
+    def _context(self, context_id: int) -> SharedStreamContext:
+        try:
+            return self._contexts[int(context_id)]
+        except KeyError as exc:
+            raise TransportContractError(f"unknown context {context_id}") from exc
+
+
+# Compatibility aliases for callers that use the contract's shorter terms.
+contexts = build_contexts
+packets_for_context = packet_descriptors
+copy_and_validate_payload = copy_payload_and_validate

--- a/npu/sim/perf/attention_shared_sram_gqa8_tensor_layout.py
+++ b/npu/sim/perf/attention_shared_sram_gqa8_tensor_layout.py
@@ -1,0 +1,214 @@
+"""Byte-exact GQA8 K/V layout for one 1024-token Llama7B tile.
+
+The layout matches the existing dual-stream producer and value-SRAM service:
+
+* one command handles one KV head and its eight query heads;
+* each stream owns 64 blocks of eight tokens;
+* a K beat contains eight token lanes for one head dimension (64 bits);
+* a V row contains an 8-token by 8-dimension slice (512 bits).
+
+Four 256 KiB head regions form one 1 MiB all-head tile context.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+KV_HEADS = 4
+QUERY_HEADS_PER_KV = 8
+HEAD_DIM = 128
+TILE_TOKENS = 1024
+STREAMS = 2
+BLOCK_TOKENS = 8
+BLOCKS_PER_STREAM = TILE_TOKENS // STREAMS // BLOCK_TOKENS
+VALUE_SLICES = HEAD_DIM // BLOCK_TOKENS
+
+K_BEAT_BYTES = BLOCK_TOKENS
+V_ROW_BYTES = BLOCK_TOKENS * BLOCK_TOKENS
+K_BYTES_PER_HEAD = TILE_TOKENS * HEAD_DIM
+V_BYTES_PER_HEAD = TILE_TOKENS * HEAD_DIM
+HEAD_CONTEXT_BYTES = K_BYTES_PER_HEAD + V_BYTES_PER_HEAD
+TILE_CONTEXT_BYTES = KV_HEADS * HEAD_CONTEXT_BYTES
+
+SHARED_WORD_BYTES = 128
+SHARED_MACROS_PER_HOME = 17
+
+
+def _check_index(name: str, value: int, limit: int) -> int:
+    resolved = int(value)
+    if resolved not in range(limit):
+        raise ValueError(f"{name} must be in [0, {limit}), got {resolved}")
+    return resolved
+
+
+def _encode_s8(value: int) -> int:
+    resolved = int(value)
+    if not -128 <= resolved <= 127:
+        raise ValueError(f"int8 tensor value is out of range: {resolved}")
+    return resolved & 0xFF
+
+
+def _decode_s8(value: int) -> int:
+    return value - 256 if value >= 128 else value
+
+
+def token_index(*, stream: int, block_slot: int, token_lane: int) -> int:
+    stream = _check_index("stream", stream, STREAMS)
+    block_slot = _check_index("block_slot", block_slot, BLOCKS_PER_STREAM)
+    token_lane = _check_index("token_lane", token_lane, BLOCK_TOKENS)
+    return ((stream * BLOCKS_PER_STREAM + block_slot) * BLOCK_TOKENS) + token_lane
+
+
+def head_region_offset(kv_head: int) -> int:
+    return _check_index("kv_head", kv_head, KV_HEADS) * HEAD_CONTEXT_BYTES
+
+
+def k_beat_offset(*, kv_head: int, stream: int, block_slot: int, dimension: int) -> int:
+    stream = _check_index("stream", stream, STREAMS)
+    block_slot = _check_index("block_slot", block_slot, BLOCKS_PER_STREAM)
+    dimension = _check_index("dimension", dimension, HEAD_DIM)
+    beat_index = ((stream * BLOCKS_PER_STREAM + block_slot) * HEAD_DIM) + dimension
+    return head_region_offset(kv_head) + beat_index * K_BEAT_BYTES
+
+
+def v_row_offset(*, kv_head: int, stream: int, block_slot: int, slice_index: int) -> int:
+    stream = _check_index("stream", stream, STREAMS)
+    block_slot = _check_index("block_slot", block_slot, BLOCKS_PER_STREAM)
+    slice_index = _check_index("slice_index", slice_index, VALUE_SLICES)
+    row_index = ((stream * BLOCKS_PER_STREAM + block_slot) * VALUE_SLICES) + slice_index
+    return head_region_offset(kv_head) + K_BYTES_PER_HEAD + row_index * V_ROW_BYTES
+
+
+def shared_word_address(byte_offset: int) -> int:
+    resolved = int(byte_offset)
+    if resolved < 0 or resolved >= TILE_CONTEXT_BYTES:
+        raise ValueError("byte_offset is outside one tile context")
+    return resolved // SHARED_WORD_BYTES
+
+
+def interleaved_bank(byte_offset: int, *, banks: int = SHARED_MACROS_PER_HOME) -> int:
+    if banks <= 0:
+        raise ValueError("banks must be positive")
+    return shared_word_address(byte_offset) % banks
+
+
+def interleaved_row(byte_offset: int, *, banks: int = SHARED_MACROS_PER_HOME) -> int:
+    if banks <= 0:
+        raise ValueError("banks must be positive")
+    return shared_word_address(byte_offset) // banks
+
+
+def pack_kv_tile(
+    keys: Sequence[Sequence[Sequence[int]]],
+    values: Sequence[Sequence[Sequence[int]]],
+) -> bytes:
+    """Pack ``[kv_head][token][dimension]`` signed-int8 tensors."""
+
+    if len(keys) != KV_HEADS or len(values) != KV_HEADS:
+        raise ValueError(f"keys and values must each contain {KV_HEADS} KV heads")
+    payload = bytearray(TILE_CONTEXT_BYTES)
+    for head in range(KV_HEADS):
+        if len(keys[head]) != TILE_TOKENS or len(values[head]) != TILE_TOKENS:
+            raise ValueError(f"head {head} must contain {TILE_TOKENS} tokens")
+        for stream in range(STREAMS):
+            for block_slot in range(BLOCKS_PER_STREAM):
+                for dimension in range(HEAD_DIM):
+                    offset = k_beat_offset(
+                        kv_head=head,
+                        stream=stream,
+                        block_slot=block_slot,
+                        dimension=dimension,
+                    )
+                    for lane in range(BLOCK_TOKENS):
+                        token = token_index(
+                            stream=stream,
+                            block_slot=block_slot,
+                            token_lane=lane,
+                        )
+                        if len(keys[head][token]) != HEAD_DIM:
+                            raise ValueError(f"key head {head} token {token} must have {HEAD_DIM} dimensions")
+                        payload[offset + lane] = _encode_s8(keys[head][token][dimension])
+                for slice_index in range(VALUE_SLICES):
+                    offset = v_row_offset(
+                        kv_head=head,
+                        stream=stream,
+                        block_slot=block_slot,
+                        slice_index=slice_index,
+                    )
+                    for token_lane in range(BLOCK_TOKENS):
+                        token = token_index(
+                            stream=stream,
+                            block_slot=block_slot,
+                            token_lane=token_lane,
+                        )
+                        if len(values[head][token]) != HEAD_DIM:
+                            raise ValueError(f"value head {head} token {token} must have {HEAD_DIM} dimensions")
+                        for dimension_lane in range(BLOCK_TOKENS):
+                            dimension = slice_index * BLOCK_TOKENS + dimension_lane
+                            payload[offset + token_lane * BLOCK_TOKENS + dimension_lane] = _encode_s8(
+                                values[head][token][dimension]
+                            )
+    return bytes(payload)
+
+
+def unpack_k_beat(payload: bytes, *, kv_head: int, stream: int, block_slot: int, dimension: int) -> tuple[int, ...]:
+    offset = k_beat_offset(
+        kv_head=kv_head,
+        stream=stream,
+        block_slot=block_slot,
+        dimension=dimension,
+    )
+    if len(payload) != TILE_CONTEXT_BYTES:
+        raise ValueError(f"payload must contain exactly {TILE_CONTEXT_BYTES} bytes")
+    return tuple(_decode_s8(value) for value in payload[offset : offset + K_BEAT_BYTES])
+
+
+def unpack_v_row(payload: bytes, *, kv_head: int, stream: int, block_slot: int, slice_index: int) -> tuple[tuple[int, ...], ...]:
+    offset = v_row_offset(
+        kv_head=kv_head,
+        stream=stream,
+        block_slot=block_slot,
+        slice_index=slice_index,
+    )
+    if len(payload) != TILE_CONTEXT_BYTES:
+        raise ValueError(f"payload must contain exactly {TILE_CONTEXT_BYTES} bytes")
+    flat = tuple(_decode_s8(value) for value in payload[offset : offset + V_ROW_BYTES])
+    return tuple(
+        flat[token_lane * BLOCK_TOKENS : (token_lane + 1) * BLOCK_TOKENS]
+        for token_lane in range(BLOCK_TOKENS)
+    )
+
+
+@dataclass(frozen=True)
+class KPrefetchGeometry:
+    banks: int
+    words_per_dimension_group: int
+    dimension_group: int
+    minimum_read_cycles: int
+    compute_cycles: int
+    buffer_bytes: int
+
+
+def k_prefetch_geometry(*, banks: int = SHARED_MACROS_PER_HOME) -> KPrefetchGeometry:
+    """Return the no-conflict lower bound for one 16-dimension K window.
+
+    One 1024-bit word holds 16 dimension beats for one 8-token block.  All 128
+    stream/block slots therefore need 128 words per dimension window.  A
+    double-buffered 16 KiB word window hides the eight-cycle, 17-bank fetch
+    behind sixteen compute cycles.
+    """
+
+    if banks <= 0:
+        raise ValueError("banks must be positive")
+    words = STREAMS * BLOCKS_PER_STREAM
+    dimension_group = SHARED_WORD_BYTES // K_BEAT_BYTES
+    minimum_read_cycles = (words + banks - 1) // banks
+    return KPrefetchGeometry(
+        banks=banks,
+        words_per_dimension_group=words,
+        dimension_group=dimension_group,
+        minimum_read_cycles=minimum_read_cycles,
+        compute_cycles=dimension_group,
+        buffer_bytes=words * SHARED_WORD_BYTES,
+    )

--- a/npu/sim/perf/attention_shared_sram_k_round_scheduler.py
+++ b/npu/sim/perf/attention_shared_sram_k_round_scheduler.py
@@ -1,0 +1,541 @@
+"""Physically conservative 17-bank shared-SRAM K round scheduler reference model.
+
+The model represents one KV head of the shared-SRAM K service after replacing
+the 2x16 KiB full-window buffers with two alternating round buffers.  One
+16-dimension group contains 128 checked tensor-layout words, split into
+``ceil(128 / 17) == 8`` rounds.  Each round issues at most one request per bank
+per cycle, accepts fixed-latency tagged responses, and exposes the completed
+round to the compute side for exactly 16 cycles while the opposite buffer
+prefetches the next round.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable
+
+from npu.sim.perf.attention_shared_sram_gqa8_tensor_layout import (
+    BLOCKS_PER_STREAM,
+    HEAD_DIM,
+    SHARED_MACROS_PER_HOME,
+    STREAMS,
+    interleaved_bank,
+    interleaved_row,
+    k_beat_offset,
+    k_prefetch_geometry,
+    shared_word_address,
+)
+
+
+BankReadyFn = Callable[[int, int, int, int, int, int], bool]
+
+GEOMETRY = k_prefetch_geometry()
+BANKS = GEOMETRY.banks
+WORDS_PER_GROUP = GEOMETRY.words_per_dimension_group
+GROUP_DIMENSIONS = GEOMETRY.dimension_group
+GROUP_COUNT = HEAD_DIM // GROUP_DIMENSIONS
+COMPUTE_CYCLES = GEOMETRY.compute_cycles
+WINDOW_WORDS = BANKS
+ROUNDS_PER_GROUP = (WORDS_PER_GROUP + WINDOW_WORDS - 1) // WINDOW_WORDS
+TOTAL_ROUNDS = GROUP_COUNT * ROUNDS_PER_GROUP
+WINDOW_STORAGE_BITS = WINDOW_WORDS * 1024
+TOTAL_STORAGE_BITS = 2 * WINDOW_STORAGE_BITS
+
+
+class SchedulerProtocolError(RuntimeError):
+    """Raised when the bounded scheduler would violate the contract."""
+
+
+@dataclass(frozen=True)
+class KRoundWordAddress:
+    kv_head: int
+    group_index: int
+    round_index: int
+    round_slot: int
+    global_word_slot: int
+    stream: int
+    block_slot: int
+    dimension_base: int
+    byte_offset: int
+    word_index: int
+    bank: int
+    row: int
+
+
+@dataclass(frozen=True)
+class SchedulerEvent:
+    cycle: int
+    kind: str
+    linear_round: int | None = None
+    group_index: int | None = None
+    round_index: int | None = None
+    buffer_id: int | None = None
+    round_slot: int | None = None
+    global_word_slot: int | None = None
+    bank: int | None = None
+    row: int | None = None
+    response_cycle: int | None = None
+
+
+@dataclass(frozen=True)
+class RoundTrace:
+    linear_round: int
+    group_index: int
+    round_index: int
+    valid_words: int
+    buffer_id: int
+    issue_cycles: tuple[int, ...]
+    ready_cycle: int
+    compute_start_cycle: int
+    compute_end_cycle: int
+    request_count: int
+    response_count: int
+
+
+@dataclass(frozen=True)
+class SchedulerResult:
+    total_cycles: int
+    events: tuple[SchedulerEvent, ...]
+    round_traces: tuple[RoundTrace, ...]
+    counters: dict[str, int]
+
+    def events_of(self, kind: str) -> tuple[SchedulerEvent, ...]:
+        return tuple(event for event in self.events if event.kind == kind)
+
+
+@dataclass
+class _MutableRoundTrace:
+    linear_round: int
+    group_index: int
+    round_index: int
+    valid_words: int
+    buffer_id: int
+    issue_cycles: list[int] = field(default_factory=list)
+    ready_cycle: int | None = None
+    compute_start_cycle: int | None = None
+    compute_end_cycle: int | None = None
+    request_count: int = 0
+    response_count: int = 0
+
+    def freeze(self) -> RoundTrace:
+        if self.ready_cycle is None:
+            raise SchedulerProtocolError(f"round {self.linear_round} never became ready")
+        if self.compute_start_cycle is None or self.compute_end_cycle is None:
+            raise SchedulerProtocolError(f"round {self.linear_round} never completed compute")
+        return RoundTrace(
+            linear_round=self.linear_round,
+            group_index=self.group_index,
+            round_index=self.round_index,
+            valid_words=self.valid_words,
+            buffer_id=self.buffer_id,
+            issue_cycles=tuple(self.issue_cycles),
+            ready_cycle=self.ready_cycle,
+            compute_start_cycle=self.compute_start_cycle,
+            compute_end_cycle=self.compute_end_cycle,
+            request_count=self.request_count,
+            response_count=self.response_count,
+        )
+
+
+@dataclass
+class _BufferState:
+    buffer_id: int
+    state: str = "free"
+    linear_round: int | None = None
+    requested: set[int] = field(default_factory=set)
+    received: set[int] = field(default_factory=set)
+
+    def clear(self) -> None:
+        self.state = "free"
+        self.linear_round = None
+        self.requested.clear()
+        self.received.clear()
+
+
+@dataclass(frozen=True)
+class _PendingResponse:
+    cycle: int
+    buffer_id: int
+    linear_round: int
+    round_slot: int
+    bank: int
+    row: int
+
+
+def _check_non_negative(name: str, value: int) -> int:
+    resolved = int(value)
+    if resolved < 0:
+        raise ValueError(f"{name} must be non-negative")
+    return resolved
+
+
+def _always_ready(_cycle: int, _bank: int, _group: int, _round: int, _slot: int, _row: int) -> bool:
+    return True
+
+
+def _round_to_group(round_linear_index: int) -> tuple[int, int]:
+    resolved = _check_non_negative("round_linear_index", round_linear_index)
+    return resolved // ROUNDS_PER_GROUP, resolved % ROUNDS_PER_GROUP
+
+
+def round_valid_words(round_index: int, *, window_words: int = WINDOW_WORDS) -> int:
+    resolved = _check_non_negative("round_index", round_index)
+    if resolved >= (WORDS_PER_GROUP + window_words - 1) // window_words:
+        raise ValueError("round_index is outside the configured group schedule")
+    remaining = WORDS_PER_GROUP - resolved * window_words
+    return min(window_words, remaining)
+
+
+def round_word_address(
+    *,
+    kv_head: int,
+    group_index: int,
+    round_index: int,
+    round_slot: int,
+    window_words: int = WINDOW_WORDS,
+) -> KRoundWordAddress:
+    kv_head = _check_non_negative("kv_head", kv_head)
+    group_index = _check_non_negative("group_index", group_index)
+    if group_index >= GROUP_COUNT:
+        raise ValueError(f"group_index must be in [0, {GROUP_COUNT}), got {group_index}")
+    valid_words = round_valid_words(round_index, window_words=window_words)
+    round_slot = _check_non_negative("round_slot", round_slot)
+    if round_slot >= valid_words:
+        raise ValueError(f"round_slot must be in [0, {valid_words}), got {round_slot}")
+
+    global_word_slot = round_index * window_words + round_slot
+    stream = global_word_slot // BLOCKS_PER_STREAM
+    if stream >= STREAMS:
+        raise ValueError("computed stream index exceeds checked tensor layout")
+    block_slot = global_word_slot % BLOCKS_PER_STREAM
+    dimension_base = group_index * GROUP_DIMENSIONS
+    byte_offset = k_beat_offset(
+        kv_head=kv_head,
+        stream=stream,
+        block_slot=block_slot,
+        dimension=dimension_base,
+    )
+    return KRoundWordAddress(
+        kv_head=kv_head,
+        group_index=group_index,
+        round_index=round_index,
+        round_slot=round_slot,
+        global_word_slot=global_word_slot,
+        stream=stream,
+        block_slot=block_slot,
+        dimension_base=dimension_base,
+        byte_offset=byte_offset,
+        word_index=shared_word_address(byte_offset),
+        bank=interleaved_bank(byte_offset),
+        row=interleaved_row(byte_offset),
+    )
+
+
+def round_word_addresses(
+    *,
+    kv_head: int,
+    group_index: int,
+    round_index: int,
+    window_words: int = WINDOW_WORDS,
+) -> tuple[KRoundWordAddress, ...]:
+    addresses = tuple(
+        round_word_address(
+            kv_head=kv_head,
+            group_index=group_index,
+            round_index=round_index,
+            round_slot=round_slot,
+            window_words=window_words,
+        )
+        for round_slot in range(round_valid_words(round_index, window_words=window_words))
+    )
+    seen_banks = {address.bank for address in addresses}
+    if len(seen_banks) != len(addresses):
+        raise ValueError(
+            "configured round contains duplicate bank targets; this model currently requires window_words <= banks"
+        )
+    return addresses
+
+
+class SharedSramKRoundScheduler:
+    """Bounded double-buffered round scheduler for one shared-SRAM K head."""
+
+    def __init__(
+        self,
+        *,
+        kv_head: int = 0,
+        response_latency: int = 1,
+        bank_ready_fn: BankReadyFn | None = None,
+        group_count: int = GROUP_COUNT,
+        window_words: int = WINDOW_WORDS,
+        banks: int = BANKS,
+    ) -> None:
+        self.kv_head = _check_non_negative("kv_head", kv_head)
+        self.response_latency = int(response_latency)
+        if self.response_latency < 1:
+            raise ValueError("response_latency must be at least one cycle")
+        self.group_count = int(group_count)
+        if self.group_count not in range(1, GROUP_COUNT + 1):
+            raise ValueError(f"group_count must be in [1, {GROUP_COUNT}], got {group_count}")
+        self.banks = int(banks)
+        if self.banks <= 0:
+            raise ValueError("banks must be positive")
+        self.window_words = int(window_words)
+        if self.window_words <= 0:
+            raise ValueError("window_words must be positive")
+        if self.window_words > self.banks:
+            raise ValueError("window_words must not exceed banks in the current reference model")
+        self.rounds_per_group = (WORDS_PER_GROUP + self.window_words - 1) // self.window_words
+        self.total_rounds = self.group_count * self.rounds_per_group
+        self.bank_ready_fn = bank_ready_fn or _always_ready
+
+        self._round_addresses: dict[tuple[int, int], tuple[KRoundWordAddress, ...]] = {}
+        for group_index in range(self.group_count):
+            for round_index in range(self.rounds_per_group):
+                self._round_addresses[(group_index, round_index)] = round_word_addresses(
+                    kv_head=self.kv_head,
+                    group_index=group_index,
+                    round_index=round_index,
+                    window_words=self.window_words,
+                )
+
+    def run(self) -> SchedulerResult:
+        cycle = 0
+        buffers = [_BufferState(buffer_id=0), _BufferState(buffer_id=1)]
+        pending_responses: list[_PendingResponse] = []
+        events: list[SchedulerEvent] = []
+        traces = {
+            linear_round: _MutableRoundTrace(
+                linear_round=linear_round,
+                group_index=_round_to_group(linear_round)[0],
+                round_index=_round_to_group(linear_round)[1],
+                valid_words=round_valid_words(_round_to_group(linear_round)[1], window_words=self.window_words),
+                buffer_id=linear_round % 2,
+            )
+            for linear_round in range(self.total_rounds)
+        }
+        counters = {
+            "request_count": 0,
+            "response_count": 0,
+            "rounds_ready": 0,
+            "rounds_completed": 0,
+            "compute_cycles": 0,
+            "bank_wait_cycles": 0,
+            "compute_stall_cycles": 0,
+            "steady_state_compute_stall_cycles": 0,
+        }
+
+        next_round_to_fill = 0
+        next_round_to_compute = 0
+        active_compute: tuple[int, int, int] | None = None
+
+        while counters["rounds_completed"] < self.total_rounds:
+            for response in tuple(sorted(pending_responses, key=lambda item: (item.cycle, item.buffer_id, item.round_slot))):
+                if response.cycle != cycle:
+                    continue
+                pending_responses.remove(response)
+                buffer_state = buffers[response.buffer_id]
+                if buffer_state.state != "filling" or buffer_state.linear_round != response.linear_round:
+                    raise SchedulerProtocolError(
+                        f"response for round {response.linear_round} arrived while buffer {response.buffer_id} "
+                        f"held state={buffer_state.state!r} round={buffer_state.linear_round!r}"
+                    )
+                if response.round_slot not in buffer_state.requested:
+                    raise SchedulerProtocolError(
+                        f"response for round {response.linear_round} slot {response.round_slot} had no request"
+                    )
+                if response.round_slot in buffer_state.received:
+                    raise SchedulerProtocolError(
+                        f"duplicate response for round {response.linear_round} slot {response.round_slot}"
+                    )
+                buffer_state.received.add(response.round_slot)
+                trace = traces[response.linear_round]
+                trace.response_count += 1
+                counters["response_count"] += 1
+                events.append(
+                    SchedulerEvent(
+                        cycle=cycle,
+                        kind="response",
+                        linear_round=response.linear_round,
+                        group_index=trace.group_index,
+                        round_index=trace.round_index,
+                        buffer_id=response.buffer_id,
+                        round_slot=response.round_slot,
+                        bank=response.bank,
+                        row=response.row,
+                    )
+                )
+                if len(buffer_state.received) == trace.valid_words:
+                    if trace.ready_cycle is not None:
+                        raise SchedulerProtocolError(f"round {response.linear_round} became ready twice")
+                    trace.ready_cycle = cycle
+                    buffer_state.state = "ready"
+                    counters["rounds_ready"] += 1
+                    events.append(
+                        SchedulerEvent(
+                            cycle=cycle,
+                            kind="round_ready",
+                            linear_round=response.linear_round,
+                            group_index=trace.group_index,
+                            round_index=trace.round_index,
+                            buffer_id=response.buffer_id,
+                        )
+                    )
+
+            if active_compute is None and next_round_to_compute < self.total_rounds:
+                buffer_id = next_round_to_compute % 2
+                buffer_state = buffers[buffer_id]
+                trace = traces[next_round_to_compute]
+                if buffer_state.state == "ready" and buffer_state.linear_round == next_round_to_compute:
+                    trace.compute_start_cycle = cycle
+                    active_compute = (buffer_id, next_round_to_compute, COMPUTE_CYCLES)
+                    events.append(
+                        SchedulerEvent(
+                            cycle=cycle,
+                            kind="compute_start",
+                            linear_round=next_round_to_compute,
+                            group_index=trace.group_index,
+                            round_index=trace.round_index,
+                            buffer_id=buffer_id,
+                        )
+                    )
+                else:
+                    counters["compute_stall_cycles"] += 1
+                    if next_round_to_compute > 0:
+                        counters["steady_state_compute_stall_cycles"] += 1
+                    events.append(
+                        SchedulerEvent(
+                            cycle=cycle,
+                            kind="compute_stall",
+                            linear_round=next_round_to_compute,
+                            group_index=trace.group_index,
+                            round_index=trace.round_index,
+                            buffer_id=buffer_id,
+                        )
+                    )
+
+            if next_round_to_fill < self.total_rounds:
+                buffer_id = next_round_to_fill % 2
+                buffer_state = buffers[buffer_id]
+                if buffer_state.state == "free":
+                    trace = traces[next_round_to_fill]
+                    buffer_state.state = "filling"
+                    buffer_state.linear_round = next_round_to_fill
+                    events.append(
+                        SchedulerEvent(
+                            cycle=cycle,
+                            kind="fill_start",
+                            linear_round=next_round_to_fill,
+                            group_index=trace.group_index,
+                            round_index=trace.round_index,
+                            buffer_id=buffer_id,
+                        )
+                    )
+                    next_round_to_fill += 1
+
+            issued_banks: set[int] = set()
+            saw_blocked_word = False
+            for buffer_state in sorted(buffers, key=lambda item: item.buffer_id):
+                if buffer_state.state != "filling" or buffer_state.linear_round is None:
+                    continue
+                trace = traces[buffer_state.linear_round]
+                addresses = self._round_addresses[(trace.group_index, trace.round_index)]
+                for address in addresses:
+                    if address.round_slot in buffer_state.requested:
+                        continue
+                    if address.bank in issued_banks:
+                        continue
+                    if not self.bank_ready_fn(
+                        cycle,
+                        address.bank,
+                        address.group_index,
+                        address.round_index,
+                        address.round_slot,
+                        address.row,
+                    ):
+                        saw_blocked_word = True
+                        continue
+                    buffer_state.requested.add(address.round_slot)
+                    issued_banks.add(address.bank)
+                    if not trace.issue_cycles or trace.issue_cycles[-1] != cycle:
+                        trace.issue_cycles.append(cycle)
+                    trace.request_count += 1
+                    counters["request_count"] += 1
+                    pending_responses.append(
+                        _PendingResponse(
+                            cycle=cycle + self.response_latency,
+                            buffer_id=buffer_state.buffer_id,
+                            linear_round=buffer_state.linear_round,
+                            round_slot=address.round_slot,
+                            bank=address.bank,
+                            row=address.row,
+                        )
+                    )
+                    events.append(
+                        SchedulerEvent(
+                            cycle=cycle,
+                            kind="request",
+                            linear_round=buffer_state.linear_round,
+                            group_index=trace.group_index,
+                            round_index=trace.round_index,
+                            buffer_id=buffer_state.buffer_id,
+                            round_slot=address.round_slot,
+                            global_word_slot=address.global_word_slot,
+                            bank=address.bank,
+                            row=address.row,
+                            response_cycle=cycle + self.response_latency,
+                        )
+                    )
+            if saw_blocked_word:
+                counters["bank_wait_cycles"] += 1
+                events.append(SchedulerEvent(cycle=cycle, kind="bank_wait"))
+
+            if active_compute is not None:
+                buffer_id, linear_round, cycles_left = active_compute
+                counters["compute_cycles"] += 1
+                cycles_left -= 1
+                if cycles_left == 0:
+                    buffer_state = buffers[buffer_id]
+                    if buffer_state.state != "ready" or buffer_state.linear_round != linear_round:
+                        raise SchedulerProtocolError(
+                            f"compute completed for round {linear_round} while buffer {buffer_id} "
+                            f"held state={buffer_state.state!r} round={buffer_state.linear_round!r}"
+                        )
+                    trace = traces[linear_round]
+                    trace.compute_end_cycle = cycle
+                    events.append(
+                        SchedulerEvent(
+                            cycle=cycle,
+                            kind="compute_end",
+                            linear_round=linear_round,
+                            group_index=trace.group_index,
+                            round_index=trace.round_index,
+                            buffer_id=buffer_id,
+                        )
+                    )
+                    buffer_state.clear()
+                    events.append(
+                        SchedulerEvent(
+                            cycle=cycle,
+                            kind="buffer_release",
+                            linear_round=linear_round,
+                            group_index=trace.group_index,
+                            round_index=trace.round_index,
+                            buffer_id=buffer_id,
+                        )
+                    )
+                    active_compute = None
+                    next_round_to_compute += 1
+                    counters["rounds_completed"] += 1
+                else:
+                    active_compute = (buffer_id, linear_round, cycles_left)
+
+            cycle += 1
+            if cycle > 100_000:
+                raise SchedulerProtocolError("scheduler exceeded 100000 cycles")
+
+        return SchedulerResult(
+            total_cycles=cycle,
+            events=tuple(events),
+            round_traces=tuple(traces[index].freeze() for index in range(self.total_rounds)),
+            counters=dict(counters),
+        )

--- a/npu/sim/perf/attention_shared_sram_k_window_scheduler.py
+++ b/npu/sim/perf/attention_shared_sram_k_window_scheduler.py
@@ -1,0 +1,444 @@
+"""Bounded reference model for the 17-bank shared-SRAM K-window scheduler.
+
+The model covers one KV head and the eight 16-dimension K windows used by a
+128-dimension Llama7B head.  Each window contains 128 shared 1024-bit words,
+interleaved across 17 banks by the checked-in tensor layout contract.  The
+scheduler alternates two 16 KiB buffers, issues at most one request per bank
+per cycle, models a fixed response latency, and records a deterministic event
+trace for overlap and stall analysis.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable
+
+from npu.sim.perf.attention_shared_sram_gqa8_tensor_layout import (
+    BLOCKS_PER_STREAM,
+    HEAD_DIM,
+    SHARED_MACROS_PER_HOME,
+    STREAMS,
+    interleaved_bank,
+    interleaved_row,
+    k_beat_offset,
+    k_prefetch_geometry,
+    shared_word_address,
+)
+
+
+BankReadyFn = Callable[[int, int, int, int, int], bool]
+
+GEOMETRY = k_prefetch_geometry()
+GROUP_DIMENSIONS = GEOMETRY.dimension_group
+GROUP_COUNT = HEAD_DIM // GROUP_DIMENSIONS
+WORDS_PER_GROUP = GEOMETRY.words_per_dimension_group
+COMPUTE_CYCLES = GEOMETRY.compute_cycles
+BUFFER_BYTES = GEOMETRY.buffer_bytes
+
+
+class SchedulerProtocolError(RuntimeError):
+    """Raised when the bounded scheduler would violate the contract."""
+
+
+@dataclass(frozen=True)
+class KWindowWordAddress:
+    kv_head: int
+    group_index: int
+    word_slot: int
+    stream: int
+    block_slot: int
+    dimension_base: int
+    byte_offset: int
+    word_index: int
+    bank: int
+    row: int
+
+
+@dataclass(frozen=True)
+class SchedulerEvent:
+    cycle: int
+    kind: str
+    group_index: int | None = None
+    buffer_id: int | None = None
+    word_slot: int | None = None
+    bank: int | None = None
+    row: int | None = None
+    response_cycle: int | None = None
+    note: str | None = None
+
+
+@dataclass(frozen=True)
+class GroupTrace:
+    group_index: int
+    buffer_id: int
+    issue_cycles: tuple[int, ...]
+    ready_cycle: int
+    compute_start_cycle: int
+    compute_end_cycle: int
+    request_count: int
+    response_count: int
+
+
+@dataclass(frozen=True)
+class SchedulerResult:
+    total_cycles: int
+    events: tuple[SchedulerEvent, ...]
+    group_traces: tuple[GroupTrace, ...]
+    counters: dict[str, int]
+
+    def events_of(self, kind: str) -> tuple[SchedulerEvent, ...]:
+        return tuple(event for event in self.events if event.kind == kind)
+
+
+@dataclass
+class _MutableGroupTrace:
+    group_index: int
+    buffer_id: int
+    issue_cycles: list[int] = field(default_factory=list)
+    ready_cycle: int | None = None
+    compute_start_cycle: int | None = None
+    compute_end_cycle: int | None = None
+    request_count: int = 0
+    response_count: int = 0
+
+    def freeze(self) -> GroupTrace:
+        if self.ready_cycle is None:
+            raise SchedulerProtocolError(f"group {self.group_index} never became ready")
+        if self.compute_start_cycle is None or self.compute_end_cycle is None:
+            raise SchedulerProtocolError(f"group {self.group_index} never completed compute")
+        return GroupTrace(
+            group_index=self.group_index,
+            buffer_id=self.buffer_id,
+            issue_cycles=tuple(self.issue_cycles),
+            ready_cycle=self.ready_cycle,
+            compute_start_cycle=self.compute_start_cycle,
+            compute_end_cycle=self.compute_end_cycle,
+            request_count=self.request_count,
+            response_count=self.response_count,
+        )
+
+
+@dataclass
+class _BufferState:
+    buffer_id: int
+    state: str = "free"
+    group_index: int | None = None
+    requested: set[int] = field(default_factory=set)
+    received: set[int] = field(default_factory=set)
+
+    def clear(self) -> None:
+        self.state = "free"
+        self.group_index = None
+        self.requested.clear()
+        self.received.clear()
+
+
+@dataclass(frozen=True)
+class _PendingResponse:
+    cycle: int
+    buffer_id: int
+    group_index: int
+    word_slot: int
+    bank: int
+    row: int
+
+
+def _check_kv_head(kv_head: int) -> int:
+    resolved = int(kv_head)
+    if resolved < 0:
+        raise ValueError("kv_head must be non-negative")
+    return resolved
+
+
+def _check_group_index(group_index: int) -> int:
+    resolved = int(group_index)
+    if resolved not in range(GROUP_COUNT):
+        raise ValueError(f"group_index must be in [0, {GROUP_COUNT}), got {resolved}")
+    return resolved
+
+
+def _check_word_slot(word_slot: int) -> int:
+    resolved = int(word_slot)
+    if resolved not in range(WORDS_PER_GROUP):
+        raise ValueError(f"word_slot must be in [0, {WORDS_PER_GROUP}), got {resolved}")
+    return resolved
+
+
+def group_word_address(*, kv_head: int, group_index: int, word_slot: int) -> KWindowWordAddress:
+    """Return the checked byte/bank/row address for one 1024-bit K word."""
+
+    kv_head = _check_kv_head(kv_head)
+    group_index = _check_group_index(group_index)
+    word_slot = _check_word_slot(word_slot)
+    stream = word_slot // BLOCKS_PER_STREAM
+    block_slot = word_slot % BLOCKS_PER_STREAM
+    dimension_base = group_index * GROUP_DIMENSIONS
+    byte_offset = k_beat_offset(
+        kv_head=kv_head,
+        stream=stream,
+        block_slot=block_slot,
+        dimension=dimension_base,
+    )
+    return KWindowWordAddress(
+        kv_head=kv_head,
+        group_index=group_index,
+        word_slot=word_slot,
+        stream=stream,
+        block_slot=block_slot,
+        dimension_base=dimension_base,
+        byte_offset=byte_offset,
+        word_index=shared_word_address(byte_offset),
+        bank=interleaved_bank(byte_offset),
+        row=interleaved_row(byte_offset),
+    )
+
+
+def group_word_addresses(*, kv_head: int, group_index: int) -> tuple[KWindowWordAddress, ...]:
+    return tuple(
+        group_word_address(kv_head=kv_head, group_index=group_index, word_slot=word_slot)
+        for word_slot in range(WORDS_PER_GROUP)
+    )
+
+
+def _always_ready(_cycle: int, _bank: int, _group_index: int, _word_slot: int, _row: int) -> bool:
+    return True
+
+
+class SharedSramKWindowScheduler:
+    """Bounded double-buffered prefetch scheduler for one K head."""
+
+    def __init__(
+        self,
+        *,
+        kv_head: int = 0,
+        response_latency: int = 1,
+        bank_ready_fn: BankReadyFn | None = None,
+        group_count: int = GROUP_COUNT,
+    ) -> None:
+        self.kv_head = _check_kv_head(kv_head)
+        self.response_latency = int(response_latency)
+        if self.response_latency < 1:
+            raise ValueError("response_latency must be at least one cycle")
+        self.group_count = int(group_count)
+        if self.group_count not in range(1, GROUP_COUNT + 1):
+            raise ValueError(f"group_count must be in [1, {GROUP_COUNT}], got {group_count}")
+        self.bank_ready_fn = bank_ready_fn or _always_ready
+        self._group_addresses = {
+            group_index: group_word_addresses(kv_head=self.kv_head, group_index=group_index)
+            for group_index in range(self.group_count)
+        }
+
+    def run(self) -> SchedulerResult:
+        cycle = 0
+        buffers = [_BufferState(buffer_id=0), _BufferState(buffer_id=1)]
+        pending_responses: list[_PendingResponse] = []
+        events: list[SchedulerEvent] = []
+        traces = {
+            group_index: _MutableGroupTrace(group_index=group_index, buffer_id=group_index % 2)
+            for group_index in range(self.group_count)
+        }
+        counters = {
+            "request_count": 0,
+            "response_count": 0,
+            "groups_completed": 0,
+            "bank_wait_cycles": 0,
+            "compute_stall_cycles": 0,
+            "steady_state_compute_stall_cycles": 0,
+        }
+
+        next_group_to_fill = 0
+        next_group_to_compute = 0
+        active_compute: tuple[int, int, int] | None = None
+
+        while counters["groups_completed"] < self.group_count:
+            for response in tuple(sorted(pending_responses, key=lambda item: (item.cycle, item.buffer_id, item.word_slot))):
+                if response.cycle != cycle:
+                    continue
+                pending_responses.remove(response)
+                buffer_state = buffers[response.buffer_id]
+                if buffer_state.state != "filling" or buffer_state.group_index != response.group_index:
+                    raise SchedulerProtocolError(
+                        f"response for group {response.group_index} arrived while buffer {response.buffer_id} "
+                        f"held state={buffer_state.state!r} group={buffer_state.group_index!r}"
+                    )
+                if response.word_slot not in buffer_state.requested:
+                    raise SchedulerProtocolError(
+                        f"response for group {response.group_index} word {response.word_slot} had no request"
+                    )
+                if response.word_slot in buffer_state.received:
+                    raise SchedulerProtocolError(
+                        f"duplicate response for group {response.group_index} word {response.word_slot}"
+                    )
+                buffer_state.received.add(response.word_slot)
+                trace = traces[response.group_index]
+                trace.response_count += 1
+                counters["response_count"] += 1
+                events.append(
+                    SchedulerEvent(
+                        cycle=cycle,
+                        kind="response",
+                        group_index=response.group_index,
+                        buffer_id=response.buffer_id,
+                        word_slot=response.word_slot,
+                        bank=response.bank,
+                        row=response.row,
+                    )
+                )
+                if len(buffer_state.received) == WORDS_PER_GROUP:
+                    buffer_state.state = "ready"
+                    if trace.ready_cycle is not None:
+                        raise SchedulerProtocolError(f"group {response.group_index} became ready twice")
+                    trace.ready_cycle = cycle
+                    events.append(
+                        SchedulerEvent(
+                            cycle=cycle,
+                            kind="buffer_ready",
+                            group_index=response.group_index,
+                            buffer_id=response.buffer_id,
+                        )
+                    )
+
+            if active_compute is None and next_group_to_compute < self.group_count:
+                buffer_id = next_group_to_compute % 2
+                buffer_state = buffers[buffer_id]
+                if buffer_state.state == "ready" and buffer_state.group_index == next_group_to_compute:
+                    active_compute = (buffer_id, next_group_to_compute, COMPUTE_CYCLES)
+                    trace = traces[next_group_to_compute]
+                    if trace.compute_start_cycle is not None:
+                        raise SchedulerProtocolError(f"group {next_group_to_compute} started compute twice")
+                    trace.compute_start_cycle = cycle
+                    events.append(
+                        SchedulerEvent(
+                            cycle=cycle,
+                            kind="compute_start",
+                            group_index=next_group_to_compute,
+                            buffer_id=buffer_id,
+                        )
+                    )
+                else:
+                    counters["compute_stall_cycles"] += 1
+                    if next_group_to_compute > 0:
+                        counters["steady_state_compute_stall_cycles"] += 1
+                    events.append(
+                        SchedulerEvent(
+                            cycle=cycle,
+                            kind="compute_stall",
+                            group_index=next_group_to_compute,
+                            buffer_id=buffer_id,
+                        )
+                    )
+
+            fill_in_progress = any(buffer.state == "filling" for buffer in buffers)
+            if next_group_to_fill < self.group_count and not fill_in_progress:
+                buffer_id = next_group_to_fill % 2
+                buffer_state = buffers[buffer_id]
+                if buffer_state.state == "free":
+                    buffer_state.state = "filling"
+                    buffer_state.group_index = next_group_to_fill
+                    events.append(
+                        SchedulerEvent(
+                            cycle=cycle,
+                            kind="fill_start",
+                            group_index=next_group_to_fill,
+                            buffer_id=buffer_id,
+                        )
+                    )
+                    next_group_to_fill += 1
+
+            issued_banks: set[int] = set()
+            saw_blocked_word = False
+            for buffer_state in sorted(buffers, key=lambda item: item.buffer_id):
+                if buffer_state.state != "filling" or buffer_state.group_index is None:
+                    continue
+                for address in self._group_addresses[buffer_state.group_index]:
+                    if address.word_slot in buffer_state.requested:
+                        continue
+                    if address.bank in issued_banks:
+                        continue
+                    if not self.bank_ready_fn(
+                        cycle,
+                        address.bank,
+                        address.group_index,
+                        address.word_slot,
+                        address.row,
+                    ):
+                        saw_blocked_word = True
+                        continue
+                    buffer_state.requested.add(address.word_slot)
+                    issued_banks.add(address.bank)
+                    trace = traces[address.group_index]
+                    trace.request_count += 1
+                    if not trace.issue_cycles or trace.issue_cycles[-1] != cycle:
+                        trace.issue_cycles.append(cycle)
+                    counters["request_count"] += 1
+                    pending_responses.append(
+                        _PendingResponse(
+                            cycle=cycle + self.response_latency,
+                            buffer_id=buffer_state.buffer_id,
+                            group_index=address.group_index,
+                            word_slot=address.word_slot,
+                            bank=address.bank,
+                            row=address.row,
+                        )
+                    )
+                    events.append(
+                        SchedulerEvent(
+                            cycle=cycle,
+                            kind="request",
+                            group_index=address.group_index,
+                            buffer_id=buffer_state.buffer_id,
+                            word_slot=address.word_slot,
+                            bank=address.bank,
+                            row=address.row,
+                            response_cycle=cycle + self.response_latency,
+                        )
+                    )
+            if saw_blocked_word:
+                counters["bank_wait_cycles"] += 1
+                events.append(SchedulerEvent(cycle=cycle, kind="bank_wait"))
+
+            if active_compute is not None:
+                buffer_id, group_index, cycles_left = active_compute
+                cycles_left -= 1
+                if cycles_left == 0:
+                    buffer_state = buffers[buffer_id]
+                    if buffer_state.state != "ready" or buffer_state.group_index != group_index:
+                        raise SchedulerProtocolError(
+                            f"compute completed for group {group_index} while buffer {buffer_id} "
+                            f"held state={buffer_state.state!r} group={buffer_state.group_index!r}"
+                        )
+                    trace = traces[group_index]
+                    trace.compute_end_cycle = cycle
+                    events.append(
+                        SchedulerEvent(
+                            cycle=cycle,
+                            kind="compute_end",
+                            group_index=group_index,
+                            buffer_id=buffer_id,
+                        )
+                    )
+                    buffer_state.clear()
+                    events.append(
+                        SchedulerEvent(
+                            cycle=cycle,
+                            kind="buffer_release",
+                            group_index=group_index,
+                            buffer_id=buffer_id,
+                        )
+                    )
+                    active_compute = None
+                    next_group_to_compute += 1
+                    counters["groups_completed"] += 1
+                else:
+                    active_compute = (buffer_id, group_index, cycles_left)
+
+            cycle += 1
+            if cycle > 100_000:
+                raise SchedulerProtocolError("scheduler exceeded 100000 cycles")
+
+        return SchedulerResult(
+            total_cycles=cycle,
+            events=tuple(events),
+            group_traces=tuple(traces[group_index].freeze() for group_index in range(self.group_count)),
+            counters=dict(counters),
+        )

--- a/npu/sim/perf/tests/test_attention_phase2_shared_stream_transport.py
+++ b/npu/sim/perf/tests/test_attention_phase2_shared_stream_transport.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from npu.sim.perf.attention_phase2_shared_stream_transport import (
+    CONTEXT_BYTES,
+    CONTEXT_COUNT,
+    DESTINATION_SPACE_BASE,
+    FLIT_BYTES,
+    FLITS_PER_PACKET,
+    LOCAL_ONLY_WAVE,
+    MAPPING_SHIFTS,
+    PACKETS_PER_CONTEXT,
+    PACKET_BYTES,
+    REMOTE_WAVES,
+    TOTAL_FLITS,
+    TOTAL_PACKETS,
+    TOTAL_SHARED_BYTES,
+    ContextCompletionTracker,
+    PacketTagLifetimeTracker,
+    TransportContractError,
+    build_context,
+    build_contexts,
+    canonical_memory_writes,
+    copy_payload_and_validate,
+    destination_base_for,
+    packet_descriptors,
+    packet_tag,
+    source_base_for,
+    source_endpoint_for,
+    validate_payload_equivalence,
+)
+
+
+def test_exact_transport_totals_and_packet_shape() -> None:
+    contexts = build_contexts()
+    assert len(contexts) == CONTEXT_COUNT == 112
+    assert sum(context.payload_bytes for context in contexts) == TOTAL_SHARED_BYTES == 1_949_696
+    assert sum(context.packet_count for context in contexts) == TOTAL_PACKETS == 7_616
+    assert sum(context.packet_count * context.flits_per_packet for context in contexts) == TOTAL_FLITS == 60_928
+    assert all(context.payload_bytes == CONTEXT_BYTES for context in contexts)
+    assert all(context.packet_count == PACKETS_PER_CONTEXT for context in contexts)
+    assert all(context.flits_per_packet == FLITS_PER_PACKET for context in contexts)
+    assert all(context.vc == 0 for context in contexts)
+
+
+def test_all_wave_mapping_shifts_and_local_wave_is_excluded() -> None:
+    contexts = build_contexts()
+    assert REMOTE_WAVES == (0, 1, 2, 3, 5, 6, 7)
+    assert len(MAPPING_SHIFTS) == 8
+    assert not any(context.wave_index == LOCAL_ONLY_WAVE for context in contexts)
+    for wave in range(8):
+        assert {source_endpoint_for(wave_index=wave, destination_endpoint=destination)
+                for destination in range(16)} == set(range(16)) if wave != 4 else True
+    for context in contexts:
+        assert context.source_endpoint == source_endpoint_for(
+            wave_index=context.wave_index,
+            destination_endpoint=context.destination_endpoint,
+        )
+
+
+def test_source_and_destination_windows_are_non_overlapping() -> None:
+    contexts = build_contexts()
+    source_windows = {(context.source_base, context.source_base + CONTEXT_BYTES) for context in contexts}
+    destination_windows = {
+        (context.destination_base, context.destination_base + CONTEXT_BYTES) for context in contexts
+    }
+    assert len(source_windows) == CONTEXT_COUNT
+    assert len(destination_windows) == CONTEXT_COUNT
+    assert max(end for _, end in source_windows) <= DESTINATION_SPACE_BASE
+    assert min(start for start, _ in destination_windows) >= DESTINATION_SPACE_BASE
+
+    def assert_disjoint(windows: set[tuple[int, int]]) -> None:
+        ordered = sorted(windows)
+        assert all(left[1] <= right[0] for left, right in zip(ordered, ordered[1:]))
+
+    assert_disjoint(source_windows)
+    assert_disjoint(destination_windows)
+
+
+def test_byte_address_formulas_cover_each_packet_and_flit() -> None:
+    context = build_contexts()[0]
+    writes = canonical_memory_writes(context, bytes(range(256)) * (CONTEXT_BYTES // 256) + bytes(0))
+    assert len(writes) == PACKETS_PER_CONTEXT * FLITS_PER_PACKET
+    for ordinal, write in enumerate(writes):
+        packet, flit = divmod(ordinal, FLITS_PER_PACKET)
+        offset = packet * PACKET_BYTES + flit * FLIT_BYTES
+        assert write.packet_index == packet
+        assert write.flit_index == flit
+        assert write.source_address == context.source_base + offset
+        assert write.destination_address == context.destination_base + offset
+        assert len(write.data) == FLIT_BYTES
+
+
+def test_payload_equivalence_copies_full_window_and_compares_bytes() -> None:
+    context = build_contexts()[37]
+    source = bytes((index * 17 + context.context_id) & 0xFF for index in range(CONTEXT_BYTES))
+    destination: dict[int, int] = {}
+    result = copy_payload_and_validate(context, source, destination)
+    assert result.byte_count == CONTEXT_BYTES
+    assert result.write_count == TOTAL_FLITS // CONTEXT_COUNT
+    assert result.unique_address_count == CONTEXT_BYTES
+    assert bytes(destination[context.destination_base + index] for index in range(CONTEXT_BYTES)) == source
+
+
+@pytest.mark.parametrize("mutation", ["corrupt", "missing", "duplicate"])
+def test_payload_equivalence_rejects_corruption_missing_and_duplicate_writes(mutation: str) -> None:
+    context = build_contexts()[0]
+    source = bytes(index & 0xFF for index in range(CONTEXT_BYTES))
+    writes = list(canonical_memory_writes(context, source))
+    if mutation == "corrupt":
+        writes[11] = dataclasses.replace(writes[11], data=bytes([writes[11].data[0] ^ 1]) + writes[11].data[1:])
+    elif mutation == "missing":
+        writes.pop(11)
+    else:
+        writes[11] = writes[10]
+    with pytest.raises(TransportContractError):
+        validate_payload_equivalence(context, source, writes)
+
+
+def test_invalid_payload_never_mutates_destination() -> None:
+    context = build_contexts()[0]
+    source = bytes([3]) * CONTEXT_BYTES
+    writes = list(canonical_memory_writes(context, source))
+    writes[-1] = dataclasses.replace(writes[-1], data=bytes([4]) * FLIT_BYTES)
+    destination: dict[int, int] = {}
+    with pytest.raises(TransportContractError):
+        copy_payload_and_validate(context, source, destination, writes)
+    assert destination == {}
+
+
+def test_context_completion_is_ordered_and_release_is_consumer_owned() -> None:
+    contexts = build_contexts()
+    tracker = ContextCompletionTracker(contexts)
+    first = contexts[:16]
+    for context in first:
+        tracker.admit(context.context_id)
+    with pytest.raises(TransportContractError):
+        tracker.admit(contexts[16].context_id)
+    context = first[0]
+    with pytest.raises(TransportContractError):
+        tracker.complete_packet(context.context_id, 1)
+    for packet_index in range(PACKETS_PER_CONTEXT):
+        tracker.complete_packet(context.context_id, packet_index)
+    status = tracker.status(context.context_id)
+    assert status.completion_valid
+    assert status.admitted
+    assert status.source_owned and status.destination_owned
+    tracker.accept_completion(context.context_id)
+    status = tracker.status(context.context_id)
+    assert status.completion_valid and status.completion_accepted
+    assert not status.admitted
+    assert not status.source_owned and not status.destination_owned
+
+
+def test_variable_packet_context_uses_modulo_256_tags_and_exact_payload() -> None:
+    context = build_context(wave_index=0, destination_endpoint=0, packets_per_context=257)
+    assert context.packet_count == 257
+    assert context.payload_bytes == 257 * PACKET_BYTES
+    descriptors = packet_descriptors(context)
+    assert descriptors[0].tag == 0
+    assert descriptors[255].tag == 255
+    assert descriptors[256].tag == 0
+    source = bytes(index & 0xFF for index in range(context.payload_bytes))
+    writes = canonical_memory_writes(context, source)
+    result = validate_payload_equivalence(context, source, writes)
+    assert result.byte_count == context.payload_bytes
+    assert result.packet_count == 257
+    assert result.flit_count == 257 * FLITS_PER_PACKET
+
+
+def test_default_packet_context_bound_is_eight_and_tag_reuse_is_safe() -> None:
+    context = build_context(wave_index=0, destination_endpoint=0, packets_per_context=257)
+    tracker = ContextCompletionTracker([context])
+    tracker.admit(context.context_id)
+    for packet_index in range(8):
+        assert tracker.expose_packet(context.context_id, packet_index) == packet_tag(packet_index)
+    assert tracker.status(context.context_id).inflight_packet_count == 8
+    with pytest.raises(TransportContractError, match="full"):
+        tracker.expose_packet(context.context_id, 8)
+    tracker.complete_packet(context.context_id, 0)
+    assert tracker.expose_packet(context.context_id, 8) == packet_tag(8)
+    assert tracker.status(context.context_id).inflight_packet_count == 8
+
+
+def test_same_tag_cannot_be_exposed_until_prior_packet_completes() -> None:
+    context = build_context(wave_index=0, destination_endpoint=0, packets_per_context=257)
+    tracker = PacketTagLifetimeTracker(257, max_in_flight=257)
+    for packet_index in range(256):
+        assert tracker.expose(packet_index) == packet_tag(packet_index)
+    with pytest.raises(TransportContractError, match="cannot be reused"):
+        tracker.expose(256)
+    tracker.complete(0)
+    assert tracker.expose(256) == 0
+    assert tracker.inflight_packet_count == 256
+
+
+def test_checked_old_artifact_has_independent_shared_contract() -> None:
+    from npu.eval.check_attention_phase2_shared_stream_contract import validate_artifact
+
+    artifact = (
+        Path(__file__).resolve().parents[4]
+        / "runs/datasets/llm_decoder_eval_gpt2_prompt_stress_v1/"
+        "decoder_attention_score32_noc_phase2_schedule__"
+        "l2_decoder_attention_score32_noc_phase2_schedule_llama7b_v1_r1.json"
+    )
+    result = validate_artifact(artifact)
+    assert result["status"] == "ok"
+    assert result["shared"]["contexts"] == CONTEXT_COUNT
+    assert result["retracted_reduction_validation"] == "ignored"

--- a/npu/sim/perf/tests/test_attention_shared_sram_gqa8_tensor_layout.py
+++ b/npu/sim/perf/tests/test_attention_shared_sram_gqa8_tensor_layout.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from npu.sim.perf.attention_shared_sram_gqa8_tensor_layout import (
+    BLOCKS_PER_STREAM,
+    HEAD_CONTEXT_BYTES,
+    HEAD_DIM,
+    K_BYTES_PER_HEAD,
+    KV_HEADS,
+    SHARED_MACROS_PER_HOME,
+    STREAMS,
+    TILE_CONTEXT_BYTES,
+    TILE_TOKENS,
+    V_BYTES_PER_HEAD,
+    interleaved_bank,
+    interleaved_row,
+    k_beat_offset,
+    k_prefetch_geometry,
+    pack_kv_tile,
+    token_index,
+    unpack_k_beat,
+    unpack_v_row,
+    v_row_offset,
+)
+
+
+def _tensor(seed: int) -> list[list[list[int]]]:
+    return [
+        [
+            [((seed + head * 17 + token * 7 + dimension * 3) % 256) - 128 for dimension in range(HEAD_DIM)]
+            for token in range(TILE_TOKENS)
+        ]
+        for head in range(KV_HEADS)
+    ]
+
+
+def test_layout_capacity_is_one_mebibyte_with_equal_k_and_v_regions() -> None:
+    assert K_BYTES_PER_HEAD == 128 * 1024
+    assert V_BYTES_PER_HEAD == 128 * 1024
+    assert HEAD_CONTEXT_BYTES == 256 * 1024
+    assert TILE_CONTEXT_BYTES == 1024 * 1024
+
+
+def test_offsets_cover_disjoint_contiguous_head_regions() -> None:
+    offsets: set[int] = set()
+    for head in range(KV_HEADS):
+        for stream in range(STREAMS):
+            for block in range(BLOCKS_PER_STREAM):
+                for dimension in range(HEAD_DIM):
+                    offset = k_beat_offset(kv_head=head, stream=stream, block_slot=block, dimension=dimension)
+                    offsets.update(range(offset, offset + 8))
+                for slice_index in range(16):
+                    offset = v_row_offset(kv_head=head, stream=stream, block_slot=block, slice_index=slice_index)
+                    offsets.update(range(offset, offset + 64))
+    assert len(offsets) == TILE_CONTEXT_BYTES
+    assert min(offsets) == 0
+    assert max(offsets) == TILE_CONTEXT_BYTES - 1
+
+
+def test_token_mapping_covers_each_tile_token_once() -> None:
+    tokens = {
+        token_index(stream=stream, block_slot=block, token_lane=lane)
+        for stream in range(STREAMS)
+        for block in range(BLOCKS_PER_STREAM)
+        for lane in range(8)
+    }
+    assert tokens == set(range(TILE_TOKENS))
+
+
+def test_round_trip_matches_dual_stream_k_beats_and_value_rows() -> None:
+    keys = _tensor(11)
+    values = _tensor(73)
+    payload = pack_kv_tile(keys, values)
+    assert len(payload) == TILE_CONTEXT_BYTES
+
+    for head, stream, block, dimension in ((0, 0, 0, 0), (1, 1, 7, 63), (3, 1, 63, 127)):
+        observed = unpack_k_beat(
+            payload,
+            kv_head=head,
+            stream=stream,
+            block_slot=block,
+            dimension=dimension,
+        )
+        expected = tuple(
+            keys[head][token_index(stream=stream, block_slot=block, token_lane=lane)][dimension]
+            for lane in range(8)
+        )
+        assert observed == expected
+
+    for head, stream, block, slice_index in ((0, 0, 0, 0), (2, 1, 11, 5), (3, 1, 63, 15)):
+        observed = unpack_v_row(
+            payload,
+            kv_head=head,
+            stream=stream,
+            block_slot=block,
+            slice_index=slice_index,
+        )
+        expected = tuple(
+            tuple(
+                values[head][token_index(stream=stream, block_slot=block, token_lane=token_lane)][
+                    slice_index * 8 + dimension_lane
+                ]
+                for dimension_lane in range(8)
+            )
+            for token_lane in range(8)
+        )
+        assert observed == expected
+
+
+def test_seventeen_way_interleave_is_reversible_at_word_granularity() -> None:
+    for word in range(TILE_CONTEXT_BYTES // 128):
+        offset = word * 128
+        bank = interleaved_bank(offset)
+        row = interleaved_row(offset)
+        assert bank in range(SHARED_MACROS_PER_HOME)
+        assert row * SHARED_MACROS_PER_HOME + bank == word
+
+
+def test_k_prefetch_window_hides_macro_reads_behind_compute_with_two_buffers() -> None:
+    geometry = k_prefetch_geometry()
+    assert geometry.words_per_dimension_group == 128
+    assert geometry.dimension_group == 16
+    assert geometry.minimum_read_cycles == 8
+    assert geometry.compute_cycles == 16
+    assert geometry.buffer_bytes == 16 * 1024
+    assert geometry.minimum_read_cycles <= geometry.compute_cycles

--- a/npu/sim/perf/tests/test_attention_shared_sram_k_round_scheduler.py
+++ b/npu/sim/perf/tests/test_attention_shared_sram_k_round_scheduler.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import pytest
+
+from npu.sim.perf.attention_shared_sram_gqa8_tensor_layout import (
+    interleaved_bank,
+    interleaved_row,
+    k_beat_offset,
+    shared_word_address,
+)
+from npu.sim.perf.attention_shared_sram_k_round_scheduler import (
+    COMPUTE_CYCLES,
+    GROUP_DIMENSIONS,
+    ROUNDS_PER_GROUP,
+    TOTAL_ROUNDS,
+    TOTAL_STORAGE_BITS,
+    WINDOW_WORDS,
+    WORDS_PER_GROUP,
+    SharedSramKRoundScheduler,
+    round_valid_words,
+    round_word_address,
+    round_word_addresses,
+)
+
+
+def test_round_word_addresses_follow_block_major_stride_eight_layout() -> None:
+    address0 = round_word_address(kv_head=2, group_index=3, round_index=0, round_slot=0)
+    expected0 = k_beat_offset(kv_head=2, stream=0, block_slot=0, dimension=3 * GROUP_DIMENSIONS)
+    assert address0.byte_offset == expected0
+    assert address0.word_index == shared_word_address(expected0)
+    assert address0.bank == interleaved_bank(expected0)
+    assert address0.row == interleaved_row(expected0)
+
+    address1 = round_word_address(kv_head=2, group_index=3, round_index=0, round_slot=1)
+    expected1 = k_beat_offset(kv_head=2, stream=0, block_slot=1, dimension=3 * GROUP_DIMENSIONS)
+    assert address1.byte_offset == expected1
+    assert address1.byte_offset - address0.byte_offset == 1024
+    assert address1.word_index - address0.word_index == 8
+
+    address17 = round_word_address(kv_head=2, group_index=3, round_index=1, round_slot=0)
+    expected17 = k_beat_offset(kv_head=2, stream=0, block_slot=17, dimension=3 * GROUP_DIMENSIONS)
+    assert address17.byte_offset == expected17
+    assert address17.word_index == shared_word_address(expected17)
+    assert address17.bank == interleaved_bank(expected17)
+    assert address17.row == interleaved_row(expected17)
+
+    address127 = round_word_address(kv_head=2, group_index=7, round_index=7, round_slot=8)
+    expected127 = k_beat_offset(kv_head=2, stream=1, block_slot=63, dimension=7 * GROUP_DIMENSIONS)
+    assert address127.byte_offset == expected127
+    assert address127.word_index == shared_word_address(expected127)
+    assert address127.bank == interleaved_bank(expected127)
+    assert address127.row == interleaved_row(expected127)
+
+    assert round_valid_words(7) == 9
+    assert len(round_word_addresses(kv_head=0, group_index=0, round_index=7)) == 9
+
+
+def test_scheduler_ideal_counts_match_full_eight_group_schedule() -> None:
+    result = SharedSramKRoundScheduler(response_latency=1).run()
+    assert len(result.round_traces) == TOTAL_ROUNDS == 64
+    assert result.counters["rounds_ready"] == TOTAL_ROUNDS
+    assert result.counters["rounds_completed"] == TOTAL_ROUNDS
+    assert result.counters["request_count"] == WORDS_PER_GROUP * 8 == 1024
+    assert result.counters["response_count"] == WORDS_PER_GROUP * 8 == 1024
+    assert result.counters["compute_cycles"] == COMPUTE_CYCLES * TOTAL_ROUNDS == 1024
+
+
+def test_latency_sixteen_has_no_steady_state_compute_stalls() -> None:
+    result = SharedSramKRoundScheduler(response_latency=16).run()
+    assert result.counters["steady_state_compute_stall_cycles"] == 0
+    for previous, current in zip(result.round_traces, result.round_traces[1:]):
+        assert current.compute_start_cycle == previous.compute_end_cycle + 1
+
+
+def test_bank_backpressure_stretches_round_issue_and_records_wait_cycles() -> None:
+    def bank_ready(cycle: int, bank: int, group_index: int, round_index: int, round_slot: int, row: int) -> bool:
+        del group_index, round_index, round_slot, row
+        return not (bank == 0 and cycle < 2)
+
+    result = SharedSramKRoundScheduler(response_latency=1, group_count=1, bank_ready_fn=bank_ready).run()
+    trace0 = result.round_traces[0]
+    assert trace0.issue_cycles == (0, 2)
+    assert result.counters["bank_wait_cycles"] >= 2
+
+
+def test_latency_above_compute_budget_introduces_steady_state_stalls() -> None:
+    result = SharedSramKRoundScheduler(response_latency=17, group_count=2).run()
+    assert result.counters["steady_state_compute_stall_cycles"] > 0
+    assert any(
+        current.compute_start_cycle > previous.compute_end_cycle + 1
+        for previous, current in zip(result.round_traces, result.round_traces[1:])
+    )
+
+
+def test_storage_budget_and_no_overwrite_hold_under_long_latency() -> None:
+    assert WINDOW_WORDS == 17
+    assert TOTAL_STORAGE_BITS == 2 * 17 * 1024
+
+    result = SharedSramKRoundScheduler(response_latency=17, group_count=1).run()
+    fill_start = {
+        (event.linear_round, event.buffer_id): event.cycle
+        for event in result.events_of("fill_start")
+    }
+    release = {
+        (event.linear_round, event.buffer_id): event.cycle
+        for event in result.events_of("buffer_release")
+    }
+
+    assert fill_start[(2, 0)] > release[(0, 0)]
+    assert fill_start[(3, 1)] > release[(1, 1)]
+
+
+def test_rejects_invalid_round_buffer_configuration() -> None:
+    with pytest.raises(ValueError, match="must not exceed banks"):
+        SharedSramKRoundScheduler(window_words=18)
+
+    with pytest.raises(ValueError, match="at least one cycle"):
+        SharedSramKRoundScheduler(response_latency=0)
+
+
+def test_round_counts_match_default_geometry() -> None:
+    assert WINDOW_WORDS == 17
+    assert WORDS_PER_GROUP == 128
+    assert ROUNDS_PER_GROUP == 8

--- a/npu/sim/perf/tests/test_attention_shared_sram_k_window_scheduler.py
+++ b/npu/sim/perf/tests/test_attention_shared_sram_k_window_scheduler.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import pytest
+
+from npu.sim.perf.attention_shared_sram_gqa8_tensor_layout import (
+    BLOCKS_PER_STREAM,
+    interleaved_bank,
+    interleaved_row,
+    k_beat_offset,
+    shared_word_address,
+)
+from npu.sim.perf.attention_shared_sram_k_window_scheduler import (
+    COMPUTE_CYCLES,
+    GROUP_DIMENSIONS,
+    WORDS_PER_GROUP,
+    SharedSramKWindowScheduler,
+    group_word_address,
+)
+
+
+def test_group_word_addresses_match_tensor_layout_offsets_and_bank_rows() -> None:
+    address0 = group_word_address(kv_head=2, group_index=3, word_slot=0)
+    expected0 = k_beat_offset(kv_head=2, stream=0, block_slot=0, dimension=3 * GROUP_DIMENSIONS)
+    assert address0.byte_offset == expected0
+    assert address0.word_index == shared_word_address(expected0)
+    assert address0.bank == interleaved_bank(expected0)
+    assert address0.row == interleaved_row(expected0)
+
+    address64 = group_word_address(kv_head=2, group_index=3, word_slot=BLOCKS_PER_STREAM)
+    expected64 = k_beat_offset(kv_head=2, stream=1, block_slot=0, dimension=3 * GROUP_DIMENSIONS)
+    assert address64.byte_offset == expected64
+    assert address64.bank == interleaved_bank(expected64)
+    assert address64.row == interleaved_row(expected64)
+
+    address127 = group_word_address(kv_head=2, group_index=7, word_slot=WORDS_PER_GROUP - 1)
+    expected127 = k_beat_offset(kv_head=2, stream=1, block_slot=BLOCKS_PER_STREAM - 1, dimension=7 * GROUP_DIMENSIONS)
+    assert address127.byte_offset == expected127
+    assert address127.word_index == shared_word_address(expected127)
+    assert address127.bank == interleaved_bank(expected127)
+    assert address127.row == interleaved_row(expected127)
+
+
+def test_ideal_scheduler_issues_one_group_in_exactly_eight_cycles() -> None:
+    result = SharedSramKWindowScheduler(response_latency=1, group_count=1).run()
+    trace = result.group_traces[0]
+    assert trace.request_count == WORDS_PER_GROUP
+    assert trace.response_count == WORDS_PER_GROUP
+    assert trace.issue_cycles == tuple(range(8))
+
+
+def test_scheduler_rejects_zero_cycle_responses() -> None:
+    with pytest.raises(ValueError, match="at least one cycle"):
+        SharedSramKWindowScheduler(response_latency=0)
+
+
+def test_latency_eight_overlaps_prefetch_with_no_steady_state_compute_stalls() -> None:
+    result = SharedSramKWindowScheduler(response_latency=8).run()
+    assert result.counters["steady_state_compute_stall_cycles"] == 0
+    for previous, current in zip(result.group_traces, result.group_traces[1:]):
+        assert current.compute_start_cycle == previous.compute_end_cycle + 1
+
+
+def test_bank_backpressure_stretches_issue_window_without_breaking_order() -> None:
+    def bank_ready(cycle: int, bank: int, group_index: int, word_slot: int, row: int) -> bool:
+        del group_index, word_slot, row
+        return not (bank == 0 and cycle < 2)
+
+    result = SharedSramKWindowScheduler(response_latency=1, bank_ready_fn=bank_ready, group_count=1).run()
+    trace = result.group_traces[0]
+    assert len(trace.issue_cycles) == 10
+    assert trace.issue_cycles[0] == 0
+    assert trace.issue_cycles[-1] == 9
+    assert result.counters["bank_wait_cycles"] >= 2
+
+
+def test_latency_above_overlap_budget_introduces_compute_stalls() -> None:
+    result = SharedSramKWindowScheduler(response_latency=10, group_count=3).run()
+    assert result.counters["steady_state_compute_stall_cycles"] > 0
+    gaps = [
+        current.compute_start_cycle - previous.compute_end_cycle
+        for previous, current in zip(result.group_traces, result.group_traces[1:])
+    ]
+    assert any(gap > 1 for gap in gaps)
+
+
+def test_double_buffer_never_overwrites_a_live_window_before_release() -> None:
+    result = SharedSramKWindowScheduler(response_latency=10, group_count=4).run()
+    fill_start = {
+        (event.group_index, event.buffer_id): event.cycle
+        for event in result.events_of("fill_start")
+    }
+    release = {
+        (event.group_index, event.buffer_id): event.cycle
+        for event in result.events_of("buffer_release")
+    }
+
+    assert fill_start[(2, 0)] > release[(0, 0)]
+    assert fill_start[(3, 1)] > release[(1, 1)]
+    assert result.group_traces[0].compute_end_cycle - result.group_traces[0].compute_start_cycle + 1 == COMPUTE_CYCLES

--- a/npu/sim/rtl/attention_shared_sram_k_round_bank.sv
+++ b/npu/sim/rtl/attention_shared_sram_k_round_bank.sv
@@ -1,0 +1,34 @@
+`timescale 1ns/1ps
+
+// One physical-bank leaf owns two 1024-bit round words.  Keeping this boundary
+// explicit lets hierarchical synthesis map the 17 identical storage leaves
+// independently instead of constructing one flat multiwrite state vector.
+(* keep_hierarchy = "true" *)
+module attention_shared_sram_k_round_bank (
+  input wire clk,
+  input wire write_valid,
+  input wire write_buffer,
+  input wire [1023:0] write_data,
+  input wire read_buffer,
+  input wire [3:0] read_dimension,
+  output reg [63:0] read_lane
+);
+  (* keep = "true" *) reg [1023:0] buffer_mem0;
+  (* keep = "true" *) reg [1023:0] buffer_mem1;
+
+  always @(posedge clk) begin
+    if (write_valid) begin
+      if (write_buffer)
+        buffer_mem1 <= write_data;
+      else
+        buffer_mem0 <= write_data;
+    end
+  end
+
+  always @* begin
+    if (read_buffer)
+      read_lane = buffer_mem1[read_dimension*64 +: 64];
+    else
+      read_lane = buffer_mem0[read_dimension*64 +: 64];
+  end
+endmodule

--- a/npu/sim/rtl/attention_shared_sram_k_round_scheduler.sv
+++ b/npu/sim/rtl/attention_shared_sram_k_round_scheduler.sv
@@ -1,0 +1,454 @@
+`timescale 1ns/1ps
+
+// Area-conservative K scheduler.  Two 17-word windows alternate over eight
+// block rounds per dimension group, avoiding the 2x128-word state vector of
+// the fully parallel window while preserving one request per SRAM bank.
+module attention_shared_sram_k_round_scheduler #(
+  parameter integer ADDR_W = 16,
+  parameter integer BANKS = 17,
+  parameter integer WORDS_PER_GROUP = 128,
+  parameter integer DIM_GROUPS = 8,
+  parameter integer DIMS_PER_GROUP = 16
+) (
+  input wire clk,
+  input wire rst_n,
+  input wire command_valid,
+  output wire command_ready,
+  input wire [ADDR_W-1:0] command_base_word_addr,
+
+  output reg [BANKS-1:0] bank_req_valid,
+  input wire [BANKS-1:0] bank_req_ready,
+  output reg [(BANKS*ADDR_W)-1:0] bank_req_word_addr,
+  output reg [BANKS-1:0] bank_req_buffer,
+  output reg [(BANKS*3)-1:0] bank_req_group,
+  output reg [(BANKS*3)-1:0] bank_req_round,
+  output reg [(BANKS*7)-1:0] bank_req_word_slot,
+
+  input wire [BANKS-1:0] bank_rsp_valid,
+  output wire [BANKS-1:0] bank_rsp_ready,
+  input wire [(BANKS*1024)-1:0] bank_rsp_data,
+  input wire [BANKS-1:0] bank_rsp_buffer,
+  input wire [(BANKS*3)-1:0] bank_rsp_group,
+  input wire [(BANKS*3)-1:0] bank_rsp_round,
+  input wire [(BANKS*7)-1:0] bank_rsp_word_slot,
+
+  output wire compute_valid,
+  input wire compute_ready,
+  output wire [2:0] compute_group,
+  output wire [2:0] compute_round,
+  output wire [3:0] compute_dimension,
+  output wire compute_last,
+  output wire [BANKS-1:0] compute_word_valid,
+  output wire [(BANKS*64)-1:0] compute_k_beats,
+
+  output reg done,
+  output reg protocol_error,
+  output reg [63:0] bank_request_count,
+  output reg [63:0] bank_response_count,
+  output reg [63:0] compute_beat_count,
+  output reg [63:0] bank_request_stall_count,
+  output reg [63:0] compute_output_stall_count,
+  output reg [63:0] compute_wait_for_window_count
+);
+  localparam integer ROUNDS_PER_GROUP = (WORDS_PER_GROUP + BANKS - 1) / BANKS;
+  localparam integer TOTAL_WINDOWS = DIM_GROUPS * ROUNDS_PER_GROUP;
+  localparam integer WINDOW_INDEX_W = $clog2(TOTAL_WINDOWS + 1);
+
+  localparam [1:0] BUF_EMPTY = 2'd0;
+  localparam [1:0] BUF_FILL = 2'd1;
+  localparam [1:0] BUF_READY = 2'd2;
+  localparam [1:0] BUF_COMPUTE = 2'd3;
+
+  reg busy_q;
+  reg [ADDR_W-1:0] base_word_addr_q;
+  reg [4:0] base_bank_q;
+  reg [1:0] buffer_state [0:1];
+  reg [2:0] buffer_group [0:1];
+  reg [2:0] buffer_round [0:1];
+  reg fill_active_q;
+  reg fill_buffer_q;
+  reg [2:0] fill_group_q;
+  reg [2:0] fill_round_q;
+  reg issuing_q;
+  reg [BANKS-1:0] issue_done_mask_q;
+  reg [BANKS-1:0] issued_local_q;
+  reg [BANKS-1:0] received_local_q;
+  reg [5:0] response_count_q;
+  reg [WINDOW_INDEX_W-1:0] next_fill_window_q;
+
+  reg compute_active_q;
+  reg compute_buffer_q;
+  reg [3:0] compute_dimension_q;
+  reg [WINDOW_INDEX_W-1:0] expected_compute_window_q;
+
+  reg [BANKS-1:0] window_valid_mask;
+  reg [BANKS-1:0] request_fire_mask;
+  reg [BANKS-1:0] request_issued_local_mask;
+  reg [BANKS-1:0] response_received_mask;
+  reg ready_buffer_found;
+  reg ready_buffer_select;
+  reg [63:0] request_stall_increment;
+  integer req_local_i;
+  integer req_bank_i;
+  integer stall_bank_i;
+  integer mask_bank_i;
+
+  function [ADDR_W-1:0] word_addr;
+    input [2:0] group_index;
+    input [6:0] word_slot;
+    begin
+      word_addr = base_word_addr_q + ADDR_W'(word_slot * DIM_GROUPS) +
+        ADDR_W'(group_index);
+    end
+  endfunction
+
+  function [BANKS-1:0] valid_mask_for_round;
+    input [2:0] round_index;
+    integer local_i;
+    begin
+      valid_mask_for_round = {BANKS{1'b0}};
+      for (local_i = 0; local_i < BANKS; local_i = local_i + 1)
+        if ((round_index * BANKS) + local_i < WORDS_PER_GROUP)
+          valid_mask_for_round[local_i] = 1'b1;
+    end
+  endfunction
+
+  function [4:0] bank_offset_for_local;
+    input [4:0] local_index;
+    begin
+      case (local_index)
+        5'd0: bank_offset_for_local = 5'd0;
+        5'd1: bank_offset_for_local = 5'd8;
+        5'd2: bank_offset_for_local = 5'd16;
+        5'd3: bank_offset_for_local = 5'd7;
+        5'd4: bank_offset_for_local = 5'd15;
+        5'd5: bank_offset_for_local = 5'd6;
+        5'd6: bank_offset_for_local = 5'd14;
+        5'd7: bank_offset_for_local = 5'd5;
+        5'd8: bank_offset_for_local = 5'd13;
+        5'd9: bank_offset_for_local = 5'd4;
+        5'd10: bank_offset_for_local = 5'd12;
+        5'd11: bank_offset_for_local = 5'd3;
+        5'd12: bank_offset_for_local = 5'd11;
+        5'd13: bank_offset_for_local = 5'd2;
+        5'd14: bank_offset_for_local = 5'd10;
+        5'd15: bank_offset_for_local = 5'd1;
+        5'd16: bank_offset_for_local = 5'd9;
+        default: bank_offset_for_local = 5'd0;
+      endcase
+    end
+  endfunction
+
+  function [4:0] bank_for_local;
+    input [4:0] base_bank;
+    input [2:0] group_index;
+    input [4:0] local_index;
+    reg [5:0] bank_sum;
+    begin
+      bank_sum = {1'b0, base_bank} + {3'd0, group_index} +
+        {1'b0, bank_offset_for_local(local_index)};
+      if (bank_sum >= 6'd34)
+        bank_for_local = 5'(bank_sum - 6'd34);
+      else if (bank_sum >= 6'd17)
+        bank_for_local = 5'(bank_sum - 6'd17);
+      else
+        bank_for_local = bank_sum[4:0];
+    end
+  endfunction
+
+  assign command_ready = !busy_q && !protocol_error;
+  wire command_fire = command_valid && command_ready;
+
+  always @* begin
+    bank_req_valid = {BANKS{1'b0}};
+    bank_req_word_addr = {(BANKS*ADDR_W){1'b0}};
+    bank_req_buffer = {BANKS{1'b0}};
+    bank_req_group = {(BANKS*3){1'b0}};
+    bank_req_round = {(BANKS*3){1'b0}};
+    bank_req_word_slot = {(BANKS*7){1'b0}};
+    window_valid_mask = valid_mask_for_round(fill_round_q);
+    req_bank_i = 0;
+    if (fill_active_q && issuing_q && !protocol_error) begin
+      for (req_local_i = 0; req_local_i < BANKS; req_local_i = req_local_i + 1) begin
+        if (window_valid_mask[req_local_i]) begin
+          req_bank_i = 32'(bank_for_local(
+            base_bank_q, fill_group_q, 5'(req_local_i)
+          ));
+          if (!issue_done_mask_q[req_bank_i]) begin
+            bank_req_valid[req_bank_i] = 1'b1;
+            bank_req_word_addr[req_bank_i*ADDR_W +: ADDR_W] = word_addr(
+              fill_group_q, 7'((fill_round_q * BANKS) + req_local_i)
+            );
+            bank_req_buffer[req_bank_i] = fill_buffer_q;
+            bank_req_group[req_bank_i*3 +: 3] = fill_group_q;
+            bank_req_round[req_bank_i*3 +: 3] = fill_round_q;
+            bank_req_word_slot[req_bank_i*7 +: 7] =
+              7'((fill_round_q * BANKS) + req_local_i);
+          end
+        end
+      end
+    end
+    request_fire_mask = bank_req_valid & bank_req_ready;
+  end
+
+  assign bank_rsp_ready = {BANKS{busy_q && !protocol_error}};
+  wire [BANKS-1:0] response_fire_mask = bank_rsp_valid & bank_rsp_ready;
+  wire [5:0] response_fire_count = 6'($countones(response_fire_mask));
+  wire [BANKS-1:0] response_error_mask;
+  wire [(BANKS*BANKS)-1:0] response_local_onehots;
+  wire [(BANKS*BANKS)-1:0] request_local_onehots;
+  wire response_batch_error = |response_error_mask;
+
+  genvar metadata_bank_g;
+  generate
+    for (metadata_bank_g = 0; metadata_bank_g < BANKS;
+         metadata_bank_g = metadata_bank_g + 1) begin : gen_response_metadata
+      wire [6:0] response_slot =
+        bank_rsp_word_slot[metadata_bank_g*7 +: 7];
+      wire [7:0] round_base = {1'b0, fill_round_q, 4'b0} +
+        {5'd0, fill_round_q};
+      wire [7:0] response_slot_ext = {1'b0, response_slot};
+      wire response_slot_in_range = response_slot_ext >= round_base &&
+        response_slot_ext < round_base + 8'(BANKS) &&
+        response_slot_ext < 8'(WORDS_PER_GROUP);
+      wire [4:0] response_local = 5'(response_slot_ext - round_base);
+      wire response_local_valid = response_slot_in_range &&
+        window_valid_mask[response_local];
+      wire response_local_issued = response_local_valid &&
+        issued_local_q[response_local];
+      wire response_local_received = response_local_valid &&
+        received_local_q[response_local];
+      wire [4:0] expected_response_bank = bank_for_local(
+        base_bank_q, fill_group_q, response_local
+      );
+      assign response_error_mask[metadata_bank_g] =
+        response_fire_mask[metadata_bank_g] &&
+        (!fill_active_q ||
+         bank_rsp_buffer[metadata_bank_g] != fill_buffer_q ||
+         bank_rsp_group[metadata_bank_g*3 +: 3] != fill_group_q ||
+         bank_rsp_round[metadata_bank_g*3 +: 3] != fill_round_q ||
+         !response_local_valid || !response_local_issued ||
+         response_local_received || expected_response_bank != 5'(metadata_bank_g));
+      assign response_local_onehots[metadata_bank_g*BANKS +: BANKS] =
+        (response_fire_mask[metadata_bank_g] && response_local_valid) ?
+          (BANKS'(1) << response_local) : {BANKS{1'b0}};
+
+      wire [7:0] request_slot_ext =
+        {1'b0, bank_req_word_slot[metadata_bank_g*7 +: 7]};
+      wire [4:0] request_local = 5'(request_slot_ext - round_base);
+      assign request_local_onehots[metadata_bank_g*BANKS +: BANKS] =
+        request_fire_mask[metadata_bank_g] ?
+          (BANKS'(1) << request_local) : {BANKS{1'b0}};
+    end
+  endgenerate
+
+  always @* begin
+    request_issued_local_mask = {BANKS{1'b0}};
+    response_received_mask = {BANKS{1'b0}};
+    for (mask_bank_i = 0; mask_bank_i < BANKS; mask_bank_i = mask_bank_i + 1) begin
+      request_issued_local_mask = request_issued_local_mask |
+        request_local_onehots[mask_bank_i*BANKS +: BANKS];
+      response_received_mask = response_received_mask |
+        response_local_onehots[mask_bank_i*BANKS +: BANKS];
+    end
+  end
+
+  // The checked Llama7B geometry has eight rounds per group.  Keeping the
+  // decode as bit selection avoids synthesizing generic divide/modulo logic.
+  wire [2:0] expected_group = expected_compute_window_q[5:3];
+  wire [2:0] expected_round = expected_compute_window_q[2:0];
+  always @* begin
+    ready_buffer_found = 1'b0;
+    ready_buffer_select = 1'b0;
+    if (buffer_state[0] == BUF_READY && buffer_group[0] == expected_group &&
+        buffer_round[0] == expected_round) begin
+      ready_buffer_found = 1'b1;
+      ready_buffer_select = 1'b0;
+    end else if (buffer_state[1] == BUF_READY && buffer_group[1] == expected_group &&
+                 buffer_round[1] == expected_round) begin
+      ready_buffer_found = 1'b1;
+      ready_buffer_select = 1'b1;
+    end
+  end
+
+  wire selected_buffer = compute_active_q ? compute_buffer_q : ready_buffer_select;
+  wire [3:0] selected_dimension = compute_active_q ? compute_dimension_q : 4'd0;
+  assign compute_valid = busy_q && !protocol_error &&
+    (compute_active_q || ready_buffer_found);
+  assign compute_group = expected_group;
+  assign compute_round = expected_round;
+  assign compute_dimension = selected_dimension;
+  assign compute_last = compute_valid && selected_dimension == 4'd15;
+  assign compute_word_valid = valid_mask_for_round(expected_round);
+  wire compute_fire = compute_valid && compute_ready;
+
+  (* keep = "true" *) wire [(BANKS*64)-1:0] selected_bank_lanes;
+  genvar storage_bank_g;
+  generate
+    for (storage_bank_g = 0; storage_bank_g < BANKS;
+         storage_bank_g = storage_bank_g + 1) begin : gen_bank_storage
+      attention_shared_sram_k_round_bank bank_storage (
+        .clk(clk),
+        .write_valid(
+          bank_rsp_valid[storage_bank_g] && bank_rsp_ready[storage_bank_g] &&
+          !response_batch_error && busy_q && !protocol_error
+        ),
+        .write_buffer(fill_buffer_q),
+        .write_data(bank_rsp_data[storage_bank_g*1024 +: 1024]),
+        .read_buffer(selected_buffer),
+        .read_dimension(selected_dimension),
+        .read_lane(selected_bank_lanes[storage_bank_g*64 +: 64])
+      );
+    end
+  endgenerate
+
+  genvar compute_local_g;
+  generate
+    for (compute_local_g = 0; compute_local_g < BANKS;
+         compute_local_g = compute_local_g + 1) begin : gen_compute
+      wire [4:0] compute_storage_bank = bank_for_local(
+        base_bank_q, expected_group, 5'(compute_local_g)
+      );
+      assign compute_k_beats[compute_local_g*64 +: 64] =
+        compute_word_valid[compute_local_g] ?
+          selected_bank_lanes[compute_storage_bank*64 +: 64] : 64'd0;
+    end
+  endgenerate
+
+  always @* begin
+    request_stall_increment = 64'd0;
+    for (stall_bank_i = 0; stall_bank_i < BANKS; stall_bank_i = stall_bank_i + 1)
+      if (bank_req_valid[stall_bank_i] && !bank_req_ready[stall_bank_i])
+        request_stall_increment = request_stall_increment + 1'b1;
+  end
+
+`ifndef SYNTHESIS
+  initial begin
+    if (BANKS != 17 || WORDS_PER_GROUP != 128 || DIM_GROUPS != 8 ||
+        DIMS_PER_GROUP != 16 || ROUNDS_PER_GROUP != 8) begin
+      $error("attention_shared_sram_k_round_scheduler requires Llama7B 17/128/8/16 geometry");
+      $finish(1);
+    end
+  end
+`endif
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      busy_q <= 1'b0;
+      base_word_addr_q <= {ADDR_W{1'b0}};
+      base_bank_q <= 5'd0;
+      buffer_state[0] <= BUF_EMPTY;
+      buffer_state[1] <= BUF_EMPTY;
+      buffer_group[0] <= 3'd0;
+      buffer_group[1] <= 3'd0;
+      buffer_round[0] <= 3'd0;
+      buffer_round[1] <= 3'd0;
+      fill_active_q <= 1'b0;
+      fill_buffer_q <= 1'b0;
+      fill_group_q <= 3'd0;
+      fill_round_q <= 3'd0;
+      issuing_q <= 1'b0;
+      issue_done_mask_q <= {BANKS{1'b0}};
+      issued_local_q <= {BANKS{1'b0}};
+      received_local_q <= {BANKS{1'b0}};
+      response_count_q <= 6'd0;
+      next_fill_window_q <= {WINDOW_INDEX_W{1'b0}};
+      compute_active_q <= 1'b0;
+      compute_buffer_q <= 1'b0;
+      compute_dimension_q <= 4'd0;
+      expected_compute_window_q <= {WINDOW_INDEX_W{1'b0}};
+      done <= 1'b0;
+      protocol_error <= 1'b0;
+      bank_request_count <= 64'd0;
+      bank_response_count <= 64'd0;
+      compute_beat_count <= 64'd0;
+      bank_request_stall_count <= 64'd0;
+      compute_output_stall_count <= 64'd0;
+      compute_wait_for_window_count <= 64'd0;
+    end else begin
+      done <= 1'b0;
+      bank_request_stall_count <= bank_request_stall_count + request_stall_increment;
+      if (compute_valid && !compute_ready)
+        compute_output_stall_count <= compute_output_stall_count + 1'b1;
+      if (busy_q && !compute_active_q && !ready_buffer_found)
+        compute_wait_for_window_count <= compute_wait_for_window_count + 1'b1;
+
+      if (command_fire) begin
+        busy_q <= 1'b1;
+        base_word_addr_q <= command_base_word_addr;
+        base_bank_q <= 5'(32'(command_base_word_addr) % BANKS);
+        buffer_state[0] <= BUF_EMPTY;
+        buffer_state[1] <= BUF_EMPTY;
+        fill_active_q <= 1'b0;
+        next_fill_window_q <= {WINDOW_INDEX_W{1'b0}};
+        compute_active_q <= 1'b0;
+        expected_compute_window_q <= {WINDOW_INDEX_W{1'b0}};
+      end
+
+      if (busy_q && !fill_active_q &&
+          next_fill_window_q < WINDOW_INDEX_W'(TOTAL_WINDOWS) &&
+          (buffer_state[0] == BUF_EMPTY || buffer_state[1] == BUF_EMPTY)) begin
+        fill_active_q <= 1'b1;
+        fill_buffer_q <= (buffer_state[0] == BUF_EMPTY) ? 1'b0 : 1'b1;
+        fill_group_q <= next_fill_window_q[5:3];
+        fill_round_q <= next_fill_window_q[2:0];
+        buffer_state[(buffer_state[0] == BUF_EMPTY) ? 0 : 1] <= BUF_FILL;
+        buffer_group[(buffer_state[0] == BUF_EMPTY) ? 0 : 1] <=
+          next_fill_window_q[5:3];
+        buffer_round[(buffer_state[0] == BUF_EMPTY) ? 0 : 1] <=
+          next_fill_window_q[2:0];
+        next_fill_window_q <= next_fill_window_q + 1'b1;
+        issuing_q <= 1'b1;
+        issue_done_mask_q <= {BANKS{1'b0}};
+        issued_local_q <= {BANKS{1'b0}};
+        received_local_q <= {BANKS{1'b0}};
+        response_count_q <= 6'd0;
+      end
+
+      if (|request_fire_mask) begin
+        bank_request_count <= bank_request_count + 64'($countones(request_fire_mask));
+        issued_local_q <= issued_local_q | request_issued_local_mask;
+        issue_done_mask_q <= issue_done_mask_q | request_fire_mask;
+        if ($countones(issue_done_mask_q | request_fire_mask) ==
+            $countones(window_valid_mask))
+          issuing_q <= 1'b0;
+      end
+
+      if (response_batch_error)
+        protocol_error <= 1'b1;
+      if ((|bank_rsp_valid) && !response_batch_error && busy_q && !protocol_error) begin
+        bank_response_count <= bank_response_count + 64'(response_fire_count);
+        received_local_q <= received_local_q | response_received_mask;
+        response_count_q <= response_count_q + response_fire_count;
+        if (response_count_q + response_fire_count ==
+            $countones(window_valid_mask)) begin
+          buffer_state[fill_buffer_q] <= BUF_READY;
+          fill_active_q <= 1'b0;
+          issuing_q <= 1'b0;
+        end
+      end
+
+      if (compute_fire) begin
+        compute_beat_count <= compute_beat_count + 1'b1;
+        if (!compute_active_q) begin
+          compute_buffer_q <= ready_buffer_select;
+          buffer_state[ready_buffer_select] <= BUF_COMPUTE;
+          compute_active_q <= 1'b1;
+          compute_dimension_q <= 4'd1;
+        end else if (compute_dimension_q == 4'd15) begin
+          buffer_state[compute_buffer_q] <= BUF_EMPTY;
+          compute_active_q <= 1'b0;
+          compute_dimension_q <= 4'd0;
+          if (expected_compute_window_q == WINDOW_INDEX_W'(TOTAL_WINDOWS-1)) begin
+            busy_q <= 1'b0;
+            done <= 1'b1;
+          end else begin
+            expected_compute_window_q <= expected_compute_window_q + 1'b1;
+          end
+        end else begin
+          compute_dimension_q <= compute_dimension_q + 1'b1;
+        end
+      end
+    end
+  end
+endmodule

--- a/npu/sim/rtl/attention_shared_sram_k_window_scheduler.sv
+++ b/npu/sim/rtl/attention_shared_sram_k_window_scheduler.sv
@@ -1,0 +1,382 @@
+`timescale 1ns/1ps
+
+// Prefetches eight 16-dimension Llama7B K groups from 17 interleaved shared
+// SRAM banks into two concrete 16 KiB windows.  A ready window exposes all
+// 128 eight-token K beats for one head dimension in a single compute cycle.
+module attention_shared_sram_k_window_scheduler #(
+  parameter integer ADDR_W = 16,
+  parameter integer BANKS = 17,
+  parameter integer WORDS_PER_GROUP = 128,
+  parameter integer DIM_GROUPS = 8,
+  parameter integer DIMS_PER_GROUP = 16
+) (
+  input wire clk,
+  input wire rst_n,
+
+  input wire command_valid,
+  output wire command_ready,
+  input wire [ADDR_W-1:0] command_base_word_addr,
+
+  output reg [BANKS-1:0] bank_req_valid,
+  input wire [BANKS-1:0] bank_req_ready,
+  output reg [(BANKS*ADDR_W)-1:0] bank_req_word_addr,
+  output reg [BANKS-1:0] bank_req_buffer,
+  output reg [(BANKS*((DIM_GROUPS <= 1) ? 1 : $clog2(DIM_GROUPS)))-1:0] bank_req_group,
+  output reg [(BANKS*((WORDS_PER_GROUP <= 1) ? 1 : $clog2(WORDS_PER_GROUP)))-1:0] bank_req_slot,
+
+  input wire [BANKS-1:0] bank_rsp_valid,
+  output wire [BANKS-1:0] bank_rsp_ready,
+  input wire [(BANKS*1024)-1:0] bank_rsp_data,
+  input wire [BANKS-1:0] bank_rsp_buffer,
+  input wire [(BANKS*((DIM_GROUPS <= 1) ? 1 : $clog2(DIM_GROUPS)))-1:0] bank_rsp_group,
+  input wire [(BANKS*((WORDS_PER_GROUP <= 1) ? 1 : $clog2(WORDS_PER_GROUP)))-1:0] bank_rsp_slot,
+
+  output wire compute_valid,
+  input wire compute_ready,
+  output wire [((DIM_GROUPS <= 1) ? 1 : $clog2(DIM_GROUPS))-1:0] compute_group,
+  output wire [((DIMS_PER_GROUP <= 1) ? 1 : $clog2(DIMS_PER_GROUP))-1:0] compute_dimension,
+  output wire compute_last,
+  output wire [(WORDS_PER_GROUP*64)-1:0] compute_k_beats,
+
+  output reg done,
+  output reg protocol_error,
+  output reg [63:0] bank_request_count,
+  output reg [63:0] bank_response_count,
+  output reg [63:0] compute_beat_count,
+  output reg [63:0] bank_request_stall_count,
+  output reg [63:0] bank_response_stall_count,
+  output reg [63:0] compute_output_stall_count,
+  output reg [63:0] compute_wait_for_window_count
+);
+  localparam integer GROUP_W = (DIM_GROUPS <= 1) ? 1 : $clog2(DIM_GROUPS);
+  localparam integer SLOT_W = (WORDS_PER_GROUP <= 1) ? 1 : $clog2(WORDS_PER_GROUP);
+  localparam integer DIM_W = (DIMS_PER_GROUP <= 1) ? 1 : $clog2(DIMS_PER_GROUP);
+  localparam integer ISSUE_ROUNDS = (WORDS_PER_GROUP + BANKS - 1) / BANKS;
+  localparam integer ROUND_W = (ISSUE_ROUNDS <= 1) ? 1 : $clog2(ISSUE_ROUNDS);
+  localparam integer RESPONSE_COUNT_W = $clog2(WORDS_PER_GROUP + 1);
+
+  localparam [1:0] BUF_EMPTY = 2'd0;
+  localparam [1:0] BUF_FILL = 2'd1;
+  localparam [1:0] BUF_READY = 2'd2;
+  localparam [1:0] BUF_COMPUTE = 2'd3;
+
+  reg busy_q;
+  reg [ADDR_W-1:0] base_word_addr_q;
+  reg [1:0] buffer_state [0:1];
+  reg [GROUP_W-1:0] buffer_group [0:1];
+  reg [1023:0] buffer_mem [0:(2*WORDS_PER_GROUP)-1];
+
+  reg fill_active_q;
+  reg fill_buffer_q;
+  reg [GROUP_W-1:0] fill_group_q;
+  reg [ROUND_W-1:0] issue_round_q;
+  reg issuing_q;
+  reg [BANKS-1:0] issue_done_mask_q;
+  reg [WORDS_PER_GROUP-1:0] issued_bitmap_q;
+  reg [WORDS_PER_GROUP-1:0] received_bitmap_q;
+  reg [RESPONSE_COUNT_W-1:0] response_count_q;
+  reg [GROUP_W:0] next_prefetch_group_q;
+
+  reg compute_active_q;
+  reg compute_buffer_q;
+  reg [GROUP_W-1:0] expected_compute_group_q;
+  reg [DIM_W-1:0] compute_dimension_q;
+
+  reg [BANKS-1:0] round_valid_mask;
+  reg response_batch_error;
+  reg [RESPONSE_COUNT_W-1:0] response_fire_count;
+  reg [SLOT_W-1:0] response_slot;
+  reg [GROUP_W-1:0] response_group;
+  reg [ADDR_W-1:0] response_global_word;
+  reg ready_buffer_found;
+  reg ready_buffer_select;
+  integer req_lane_i;
+  integer rsp_bank_i;
+  integer rsp_other_i;
+  integer stall_bank_i;
+  integer seq_bank_i;
+  integer word_offset_i;
+  integer target_bank_i;
+  integer reset_i;
+  reg [63:0] request_stall_increment;
+  reg [63:0] response_stall_increment;
+
+  wire command_fire = command_valid && command_ready;
+  assign command_ready = !busy_q && !protocol_error;
+
+  function [ADDR_W-1:0] window_word_addr;
+    input [GROUP_W-1:0] group_index;
+    input [SLOT_W-1:0] word_slot;
+    begin
+      window_word_addr = base_word_addr_q +
+        ADDR_W'(word_slot * DIM_GROUPS) + ADDR_W'(group_index);
+    end
+  endfunction
+
+  always @* begin
+    bank_req_valid = {BANKS{1'b0}};
+    bank_req_word_addr = {(BANKS*ADDR_W){1'b0}};
+    bank_req_buffer = {BANKS{1'b0}};
+    bank_req_group = {(BANKS*GROUP_W){1'b0}};
+    bank_req_slot = {(BANKS*SLOT_W){1'b0}};
+    round_valid_mask = {BANKS{1'b0}};
+    word_offset_i = 0;
+    target_bank_i = 0;
+    if (fill_active_q && issuing_q && !protocol_error) begin
+      for (req_lane_i = 0; req_lane_i < BANKS; req_lane_i = req_lane_i + 1) begin
+        word_offset_i = (issue_round_q * BANKS) + req_lane_i;
+        if (word_offset_i < WORDS_PER_GROUP) begin
+          target_bank_i = 32'(window_word_addr(
+            fill_group_q, SLOT_W'(word_offset_i)
+          )) % BANKS;
+          round_valid_mask[target_bank_i] = 1'b1;
+          if (!issue_done_mask_q[target_bank_i]) begin
+            bank_req_valid[target_bank_i] = 1'b1;
+            bank_req_word_addr[target_bank_i*ADDR_W +: ADDR_W] =
+              window_word_addr(fill_group_q, SLOT_W'(word_offset_i));
+            bank_req_buffer[target_bank_i] = fill_buffer_q;
+            bank_req_group[target_bank_i*GROUP_W +: GROUP_W] = fill_group_q;
+            bank_req_slot[target_bank_i*SLOT_W +: SLOT_W] = SLOT_W'(word_offset_i);
+          end
+        end
+      end
+    end
+  end
+  wire [BANKS-1:0] request_fire_mask = bank_req_valid & bank_req_ready;
+
+  assign bank_rsp_ready = {BANKS{busy_q && !protocol_error}};
+
+  // Validate the whole response batch before any window write.  Responses
+  // must carry a previously issued slot and the bank implied by interleaving.
+  always @* begin
+    response_batch_error = 1'b0;
+    response_fire_count = {RESPONSE_COUNT_W{1'b0}};
+    response_slot = {SLOT_W{1'b0}};
+    response_group = {GROUP_W{1'b0}};
+    response_global_word = {ADDR_W{1'b0}};
+    for (rsp_bank_i = 0; rsp_bank_i < BANKS; rsp_bank_i = rsp_bank_i + 1) begin
+      if (bank_rsp_valid[rsp_bank_i] && bank_rsp_ready[rsp_bank_i]) begin
+        response_fire_count = response_fire_count + 1'b1;
+        response_slot = bank_rsp_slot[rsp_bank_i*SLOT_W +: SLOT_W];
+        response_group = bank_rsp_group[rsp_bank_i*GROUP_W +: GROUP_W];
+        response_global_word = window_word_addr(response_group, response_slot);
+        if (!fill_active_q ||
+            bank_rsp_buffer[rsp_bank_i] != fill_buffer_q ||
+            response_group != fill_group_q ||
+            !issued_bitmap_q[response_slot] ||
+            received_bitmap_q[response_slot] ||
+            ((32'(response_global_word) % BANKS) != rsp_bank_i))
+          response_batch_error = 1'b1;
+        for (rsp_other_i = rsp_bank_i + 1; rsp_other_i < BANKS;
+             rsp_other_i = rsp_other_i + 1)
+          if (bank_rsp_valid[rsp_other_i] && bank_rsp_ready[rsp_other_i] &&
+              bank_rsp_buffer[rsp_other_i] == bank_rsp_buffer[rsp_bank_i] &&
+              bank_rsp_group[rsp_other_i*GROUP_W +: GROUP_W] ==
+                bank_rsp_group[rsp_bank_i*GROUP_W +: GROUP_W] &&
+              bank_rsp_slot[rsp_other_i*SLOT_W +: SLOT_W] ==
+                bank_rsp_slot[rsp_bank_i*SLOT_W +: SLOT_W])
+            response_batch_error = 1'b1;
+      end
+    end
+  end
+
+  always @* begin
+    ready_buffer_found = 1'b0;
+    ready_buffer_select = 1'b0;
+    if (buffer_state[0] == BUF_READY &&
+        buffer_group[0] == expected_compute_group_q) begin
+      ready_buffer_found = 1'b1;
+      ready_buffer_select = 1'b0;
+    end else if (buffer_state[1] == BUF_READY &&
+                 buffer_group[1] == expected_compute_group_q) begin
+      ready_buffer_found = 1'b1;
+      ready_buffer_select = 1'b1;
+    end
+  end
+
+  wire selected_compute_buffer = compute_active_q ? compute_buffer_q : ready_buffer_select;
+  wire [DIM_W-1:0] selected_compute_dimension =
+    compute_active_q ? compute_dimension_q : {DIM_W{1'b0}};
+  assign compute_valid = busy_q && !protocol_error &&
+    (compute_active_q || ready_buffer_found);
+  assign compute_group = expected_compute_group_q;
+  assign compute_dimension = selected_compute_dimension;
+  assign compute_last = compute_valid &&
+    (selected_compute_dimension == DIM_W'(DIMS_PER_GROUP - 1));
+  wire compute_fire = compute_valid && compute_ready;
+
+  always @* begin
+    request_stall_increment = 64'd0;
+    response_stall_increment = 64'd0;
+    for (stall_bank_i = 0; stall_bank_i < BANKS; stall_bank_i = stall_bank_i + 1) begin
+      if (bank_req_valid[stall_bank_i] && !bank_req_ready[stall_bank_i])
+        request_stall_increment = request_stall_increment + 1'b1;
+      if (bank_rsp_valid[stall_bank_i] && !bank_rsp_ready[stall_bank_i])
+        response_stall_increment = response_stall_increment + 1'b1;
+    end
+  end
+
+  genvar word_g;
+  generate
+    for (word_g = 0; word_g < WORDS_PER_GROUP; word_g = word_g + 1) begin : gen_compute_k
+      assign compute_k_beats[word_g*64 +: 64] =
+        buffer_mem[(selected_compute_buffer * WORDS_PER_GROUP) + word_g]
+          [selected_compute_dimension*64 +: 64];
+    end
+  endgenerate
+
+`ifndef SYNTHESIS
+  initial begin
+    if (BANKS != 17 || WORDS_PER_GROUP != 128 || DIM_GROUPS != 8 ||
+        DIMS_PER_GROUP != 16) begin
+      $error("attention_shared_sram_k_window_scheduler requires Llama7B 17/128/8/16 geometry");
+      $finish(1);
+    end
+  end
+`endif
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      busy_q <= 1'b0;
+      base_word_addr_q <= {ADDR_W{1'b0}};
+      buffer_state[0] <= BUF_EMPTY;
+      buffer_state[1] <= BUF_EMPTY;
+      buffer_group[0] <= {GROUP_W{1'b0}};
+      buffer_group[1] <= {GROUP_W{1'b0}};
+      fill_active_q <= 1'b0;
+      fill_buffer_q <= 1'b0;
+      fill_group_q <= {GROUP_W{1'b0}};
+      issue_round_q <= {ROUND_W{1'b0}};
+      issuing_q <= 1'b0;
+      issue_done_mask_q <= {BANKS{1'b0}};
+      issued_bitmap_q <= {WORDS_PER_GROUP{1'b0}};
+      received_bitmap_q <= {WORDS_PER_GROUP{1'b0}};
+      response_count_q <= {RESPONSE_COUNT_W{1'b0}};
+      next_prefetch_group_q <= {(GROUP_W+1){1'b0}};
+      compute_active_q <= 1'b0;
+      compute_buffer_q <= 1'b0;
+      expected_compute_group_q <= {GROUP_W{1'b0}};
+      compute_dimension_q <= {DIM_W{1'b0}};
+      done <= 1'b0;
+      protocol_error <= 1'b0;
+      bank_request_count <= 64'd0;
+      bank_response_count <= 64'd0;
+      compute_beat_count <= 64'd0;
+      bank_request_stall_count <= 64'd0;
+      bank_response_stall_count <= 64'd0;
+      compute_output_stall_count <= 64'd0;
+      compute_wait_for_window_count <= 64'd0;
+      for (reset_i = 0; reset_i < 2*WORDS_PER_GROUP; reset_i = reset_i + 1)
+        buffer_mem[reset_i] <= 1024'd0;
+    end else begin
+      done <= 1'b0;
+
+      bank_request_stall_count <= bank_request_stall_count + request_stall_increment;
+      bank_response_stall_count <= bank_response_stall_count + response_stall_increment;
+      if (compute_valid && !compute_ready)
+        compute_output_stall_count <= compute_output_stall_count + 1'b1;
+      if (busy_q && !compute_active_q && !ready_buffer_found)
+        compute_wait_for_window_count <= compute_wait_for_window_count + 1'b1;
+
+      if (command_fire) begin
+        busy_q <= 1'b1;
+        base_word_addr_q <= command_base_word_addr;
+        buffer_state[0] <= BUF_EMPTY;
+        buffer_state[1] <= BUF_EMPTY;
+        next_prefetch_group_q <= {(GROUP_W+1){1'b0}};
+        expected_compute_group_q <= {GROUP_W{1'b0}};
+        compute_active_q <= 1'b0;
+      end
+
+      // Start the next group whenever either concrete window is empty.
+      if (busy_q && !fill_active_q &&
+          next_prefetch_group_q < (GROUP_W+1)'(DIM_GROUPS)) begin
+        if (buffer_state[0] == BUF_EMPTY || buffer_state[1] == BUF_EMPTY) begin
+          fill_active_q <= 1'b1;
+          fill_buffer_q <= (buffer_state[0] == BUF_EMPTY) ? 1'b0 : 1'b1;
+          fill_group_q <= next_prefetch_group_q[GROUP_W-1:0];
+          buffer_group[(buffer_state[0] == BUF_EMPTY) ? 0 : 1] <=
+            next_prefetch_group_q[GROUP_W-1:0];
+          buffer_state[(buffer_state[0] == BUF_EMPTY) ? 0 : 1] <= BUF_FILL;
+          next_prefetch_group_q <= next_prefetch_group_q + 1'b1;
+          issue_round_q <= {ROUND_W{1'b0}};
+          issuing_q <= 1'b1;
+          issue_done_mask_q <= {BANKS{1'b0}};
+          issued_bitmap_q <= {WORDS_PER_GROUP{1'b0}};
+          received_bitmap_q <= {WORDS_PER_GROUP{1'b0}};
+          response_count_q <= {RESPONSE_COUNT_W{1'b0}};
+        end
+      end
+
+      if (|request_fire_mask) begin
+        bank_request_count <= bank_request_count + 64'($countones(request_fire_mask));
+        for (seq_bank_i = 0; seq_bank_i < BANKS; seq_bank_i = seq_bank_i + 1)
+          if (request_fire_mask[seq_bank_i])
+            issued_bitmap_q[bank_req_slot[seq_bank_i*SLOT_W +: SLOT_W]] <= 1'b1;
+        if (((issue_done_mask_q | request_fire_mask) & round_valid_mask) ==
+            round_valid_mask) begin
+          issue_done_mask_q <= {BANKS{1'b0}};
+          if (issue_round_q == ROUND_W'(ISSUE_ROUNDS - 1))
+            issuing_q <= 1'b0;
+          else
+            issue_round_q <= issue_round_q + 1'b1;
+        end else begin
+          issue_done_mask_q <= issue_done_mask_q | request_fire_mask;
+        end
+      end
+
+      if (response_batch_error)
+        protocol_error <= 1'b1;
+      if ((|bank_rsp_valid) && !response_batch_error && busy_q && !protocol_error) begin
+        bank_response_count <= bank_response_count + 64'(response_fire_count);
+        for (seq_bank_i = 0; seq_bank_i < BANKS; seq_bank_i = seq_bank_i + 1) begin
+          if (bank_rsp_valid[seq_bank_i] && bank_rsp_ready[seq_bank_i]) begin
+            received_bitmap_q[bank_rsp_slot[seq_bank_i*SLOT_W +: SLOT_W]] <= 1'b1;
+            buffer_mem[(fill_buffer_q * WORDS_PER_GROUP) +
+              32'(bank_rsp_slot[seq_bank_i*SLOT_W +: SLOT_W])] <=
+              bank_rsp_data[seq_bank_i*1024 +: 1024];
+          end
+        end
+        response_count_q <= response_count_q + response_fire_count;
+        if (response_count_q + response_fire_count ==
+            RESPONSE_COUNT_W'(WORDS_PER_GROUP)) begin
+          buffer_state[fill_buffer_q] <= BUF_READY;
+          fill_active_q <= 1'b0;
+          issuing_q <= 1'b0;
+        end
+      end
+
+      if (compute_fire) begin
+        compute_beat_count <= compute_beat_count + 1'b1;
+        if (!compute_active_q) begin
+          compute_buffer_q <= ready_buffer_select;
+          buffer_state[ready_buffer_select] <= BUF_COMPUTE;
+          if (DIMS_PER_GROUP == 1) begin
+            buffer_state[ready_buffer_select] <= BUF_EMPTY;
+            if (expected_compute_group_q == GROUP_W'(DIM_GROUPS - 1)) begin
+              busy_q <= 1'b0;
+              done <= 1'b1;
+            end else begin
+              expected_compute_group_q <= expected_compute_group_q + 1'b1;
+            end
+          end else begin
+            compute_active_q <= 1'b1;
+            compute_dimension_q <= DIM_W'(1);
+          end
+        end else if (compute_dimension_q == DIM_W'(DIMS_PER_GROUP - 1)) begin
+          buffer_state[compute_buffer_q] <= BUF_EMPTY;
+          compute_active_q <= 1'b0;
+          compute_dimension_q <= {DIM_W{1'b0}};
+          if (expected_compute_group_q == GROUP_W'(DIM_GROUPS - 1)) begin
+            busy_q <= 1'b0;
+            done <= 1'b1;
+          end else begin
+            expected_compute_group_q <= expected_compute_group_q + 1'b1;
+          end
+        end else begin
+          compute_dimension_q <= compute_dimension_q + 1'b1;
+        end
+      end
+    end
+  end
+endmodule

--- a/npu/sim/rtl/attention_shared_sram_read_group_adapter.sv
+++ b/npu/sim/rtl/attention_shared_sram_read_group_adapter.sv
@@ -1,0 +1,242 @@
+`timescale 1ns/1ps
+
+// Packs ordered endpoint SRAM reads into one aligned shared-SRAM macro read.
+//
+// The endpoint side is an ordered byte-addressed beat stream.  The macro side
+// returns one 1024-bit word and echoes the request slot and address as
+// metadata.  Two group slots are used by default so collection, macro access,
+// and ordered emission can overlap.
+module attention_shared_sram_read_group_adapter #(
+  parameter integer ADDR_W = 32,
+  parameter integer BEAT_W = 256,
+  parameter integer GROUP_SLOTS = 2
+) (
+  input wire clk,
+  input wire rst_n,
+
+  input wire req_valid,
+  output wire req_ready,
+  input wire [ADDR_W-1:0] req_addr,
+
+  output wire rsp_valid,
+  input wire rsp_ready,
+  output wire [BEAT_W-1:0] rsp_data,
+  output wire [ADDR_W-1:0] rsp_addr,
+
+  output wire macro_req_valid,
+  input wire macro_req_ready,
+  output wire [ADDR_W-1:0] macro_req_addr,
+  output wire [(GROUP_SLOTS <= 1 ? 1 : $clog2(GROUP_SLOTS))-1:0] macro_req_slot,
+
+  input wire macro_rsp_valid,
+  output wire macro_rsp_ready,
+  input wire [1023:0] macro_rsp_data,
+  input wire [ADDR_W-1:0] macro_rsp_addr,
+  input wire [(GROUP_SLOTS <= 1 ? 1 : $clog2(GROUP_SLOTS))-1:0] macro_rsp_slot,
+
+  output reg protocol_error,
+  output reg [63:0] beat_request_count,
+  output reg [63:0] macro_read_count,
+  output reg [63:0] beat_response_count,
+  output reg [63:0] beat_request_stall_count,
+  output reg [63:0] beat_response_stall_count,
+  output reg [63:0] macro_request_stall_count,
+  output reg [63:0] macro_response_stall_count,
+  output wire access_reduction_proven
+);
+  localparam integer MACRO_W = 1024;
+  localparam integer MACRO_BYTES = MACRO_W / 8;
+  localparam integer BEAT_BYTES = BEAT_W / 8;
+  localparam integer SEGMENTS = MACRO_W / BEAT_W;
+  localparam integer SLOT_W = (GROUP_SLOTS <= 1) ? 1 : $clog2(GROUP_SLOTS);
+  localparam integer BEAT_ALIGN_W = $clog2(BEAT_BYTES);
+  localparam integer MACRO_ALIGN_W = $clog2(MACRO_BYTES);
+  localparam integer SEGMENT_W = (SEGMENTS <= 1) ? 1 : $clog2(SEGMENTS);
+  localparam [SLOT_W-1:0] LAST_SLOT = SLOT_W'(GROUP_SLOTS - 1);
+  localparam [SEGMENT_W-1:0] LAST_SEGMENT = SEGMENT_W'(SEGMENTS - 1);
+
+  localparam [2:0] ST_EMPTY = 3'd0;
+  localparam [2:0] ST_COLLECT = 3'd1;
+  localparam [2:0] ST_READY = 3'd2;
+  localparam [2:0] ST_INFLIGHT = 3'd3;
+  localparam [2:0] ST_EMIT = 3'd4;
+
+  reg [2:0] slot_state [0:GROUP_SLOTS-1];
+  reg [ADDR_W-1:0] slot_base_addr [0:GROUP_SLOTS-1];
+  reg [ADDR_W-1:0] slot_next_addr [0:GROUP_SLOTS-1];
+  (* keep = "true" *) reg [MACRO_W-1:0] slot_data [0:GROUP_SLOTS-1];
+
+  reg [SLOT_W-1:0] collect_slot_q;
+  reg [SLOT_W-1:0] issue_slot_q;
+  reg [SLOT_W-1:0] emit_slot_q;
+  reg [SLOT_W-1:0] macro_slot_q;
+  reg [ADDR_W-1:0] macro_addr_q;
+  reg macro_inflight_q;
+  reg [SEGMENT_W-1:0] emit_index_q;
+
+  integer reset_i;
+
+  function [SLOT_W-1:0] slot_inc;
+    input [SLOT_W-1:0] slot;
+    begin
+      if (slot == LAST_SLOT)
+        slot_inc = {SLOT_W{1'b0}};
+      else
+        slot_inc = slot + 1'b1;
+    end
+  endfunction
+
+  wire collect_slot_empty = slot_state[collect_slot_q] == ST_EMPTY;
+  wire collect_slot_active = slot_state[collect_slot_q] == ST_COLLECT;
+  wire first_request_valid =
+    (req_addr[BEAT_ALIGN_W-1:0] == {BEAT_ALIGN_W{1'b0}}) &&
+    (req_addr[MACRO_ALIGN_W-1:0] == {MACRO_ALIGN_W{1'b0}});
+  wire continuing_request_valid = req_addr == slot_next_addr[collect_slot_q];
+  wire request_metadata_valid = collect_slot_empty ? first_request_valid :
+    (collect_slot_active ? continuing_request_valid : 1'b0);
+  wire request_slot_available = collect_slot_empty || collect_slot_active;
+  wire request_fire = req_valid && req_ready;
+  wire request_metadata_error = req_valid && !protocol_error &&
+    request_slot_available && !request_metadata_valid;
+
+  assign req_ready = !protocol_error && request_slot_available &&
+    request_metadata_valid;
+
+  wire macro_response_valid_for_request =
+    macro_rsp_valid && macro_inflight_q;
+  wire macro_response_metadata_valid =
+    (macro_rsp_slot == macro_slot_q) && (macro_rsp_addr == macro_addr_q);
+  wire macro_response_metadata_error =
+    macro_response_valid_for_request && !macro_response_metadata_valid;
+  wire macro_response_without_request = macro_rsp_valid && !macro_inflight_q;
+  wire macro_response_fire = macro_rsp_valid && macro_rsp_ready;
+  wire macro_response_accept = macro_response_fire &&
+    macro_response_metadata_valid;
+  wire macro_request_fire = macro_req_valid && macro_req_ready;
+
+  assign macro_req_valid = !protocol_error &&
+    (!macro_inflight_q || macro_response_accept) &&
+    (slot_state[issue_slot_q] == ST_READY);
+  assign macro_req_addr = slot_base_addr[issue_slot_q];
+  assign macro_req_slot = issue_slot_q;
+
+  // The macro word is captured as soon as its request is in flight.  A bad
+  // response is consumed only when it is for the active transaction; the
+  // sticky error then prevents any further architectural activity.
+  assign macro_rsp_ready = macro_inflight_q && !protocol_error;
+
+  assign rsp_valid = !protocol_error && (slot_state[emit_slot_q] == ST_EMIT);
+  assign rsp_data = slot_data[emit_slot_q][emit_index_q * BEAT_W +: BEAT_W];
+  assign rsp_addr = slot_base_addr[emit_slot_q] + (emit_index_q * BEAT_BYTES);
+  wire response_fire = rsp_valid && rsp_ready;
+
+  assign access_reduction_proven =
+    (macro_read_count != 0) &&
+    (beat_request_count == (macro_read_count * SEGMENTS)) &&
+    (beat_response_count == beat_request_count);
+
+`ifndef SYNTHESIS
+  initial begin
+    if (BEAT_W != 256 && BEAT_W != 512) begin
+      $error("attention_shared_sram_read_group_adapter BEAT_W must be 256 or 512");
+      $finish(1);
+    end
+    if ((MACRO_W % BEAT_W) != 0 || SEGMENTS < 1) begin
+      $error("attention_shared_sram_read_group_adapter invalid segment geometry");
+      $finish(1);
+    end
+    if (GROUP_SLOTS < 1) begin
+      $error("attention_shared_sram_read_group_adapter GROUP_SLOTS must be positive");
+      $finish(1);
+    end
+  end
+`endif
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      collect_slot_q <= {SLOT_W{1'b0}};
+      issue_slot_q <= {SLOT_W{1'b0}};
+      emit_slot_q <= {SLOT_W{1'b0}};
+      macro_slot_q <= {SLOT_W{1'b0}};
+      macro_addr_q <= {ADDR_W{1'b0}};
+      macro_inflight_q <= 1'b0;
+      emit_index_q <= {SEGMENT_W{1'b0}};
+      protocol_error <= 1'b0;
+      beat_request_count <= 64'd0;
+      macro_read_count <= 64'd0;
+      beat_response_count <= 64'd0;
+      beat_request_stall_count <= 64'd0;
+      beat_response_stall_count <= 64'd0;
+      macro_request_stall_count <= 64'd0;
+      macro_response_stall_count <= 64'd0;
+      for (reset_i = 0; reset_i < GROUP_SLOTS; reset_i = reset_i + 1) begin
+        slot_state[reset_i] <= ST_EMPTY;
+        slot_base_addr[reset_i] <= {ADDR_W{1'b0}};
+        slot_next_addr[reset_i] <= {ADDR_W{1'b0}};
+      end
+    end else begin
+      if (request_metadata_error || macro_response_metadata_error ||
+          macro_response_without_request)
+        protocol_error <= 1'b1;
+
+      if (req_valid && !req_ready)
+        beat_request_stall_count <= beat_request_stall_count + 1'b1;
+      if (rsp_valid && !rsp_ready)
+        beat_response_stall_count <= beat_response_stall_count + 1'b1;
+      if (macro_req_valid && !macro_req_ready)
+        macro_request_stall_count <= macro_request_stall_count + 1'b1;
+      if (macro_rsp_valid && !macro_rsp_ready)
+        macro_response_stall_count <= macro_response_stall_count + 1'b1;
+
+      if (request_fire) begin
+        beat_request_count <= beat_request_count + 1'b1;
+        if (collect_slot_empty) begin
+          slot_base_addr[collect_slot_q] <= req_addr;
+          slot_next_addr[collect_slot_q] <= req_addr + BEAT_BYTES;
+          if (SEGMENTS == 1) begin
+            slot_state[collect_slot_q] <= ST_READY;
+            collect_slot_q <= slot_inc(collect_slot_q);
+          end else begin
+            slot_state[collect_slot_q] <= ST_COLLECT;
+          end
+        end else begin
+          slot_next_addr[collect_slot_q] <= req_addr + BEAT_BYTES;
+          if (slot_next_addr[collect_slot_q] + BEAT_BYTES ==
+              slot_base_addr[collect_slot_q] + MACRO_BYTES) begin
+            slot_state[collect_slot_q] <= ST_READY;
+            collect_slot_q <= slot_inc(collect_slot_q);
+          end
+        end
+      end
+
+      if (macro_response_accept) begin
+        macro_inflight_q <= 1'b0;
+        slot_data[macro_slot_q] <= macro_rsp_data;
+        slot_state[macro_slot_q] <= ST_EMIT;
+      end
+
+      // Retire and launch may handshake together.  The new request
+      // assignment intentionally follows response retirement so the single
+      // macro port remains in flight for the next group.
+      if (macro_request_fire) begin
+        macro_inflight_q <= 1'b1;
+        macro_slot_q <= issue_slot_q;
+        macro_addr_q <= slot_base_addr[issue_slot_q];
+        slot_state[issue_slot_q] <= ST_INFLIGHT;
+        issue_slot_q <= slot_inc(issue_slot_q);
+        macro_read_count <= macro_read_count + 1'b1;
+      end
+
+      if (response_fire) begin
+        beat_response_count <= beat_response_count + 1'b1;
+        if (emit_index_q == LAST_SEGMENT) begin
+          slot_state[emit_slot_q] <= ST_EMPTY;
+          emit_slot_q <= slot_inc(emit_slot_q);
+          emit_index_q <= {SEGMENT_W{1'b0}};
+        end else begin
+          emit_index_q <= emit_index_q + 1'b1;
+        end
+      end
+    end
+  end
+endmodule

--- a/npu/sim/rtl/attention_shared_stream_context_admission.sv
+++ b/npu/sim/rtl/attention_shared_stream_context_admission.sv
@@ -1,0 +1,230 @@
+`timescale 1ns/1ps
+
+// Layer admission for the 112 remote shared-SRAM contexts.
+//
+// The producer reports readiness independently for each cluster lane.  Events
+// are retained by (wave, cluster), then selected with a round-robin scan.  A
+// selected context is held until the consumer accepts it; this keeps the
+// admission contract independent of downstream backpressure.
+module attention_shared_stream_context_admission #(
+  parameter integer ADDR_W = 32,
+  parameter integer MAX_PACKETS_PER_CONTEXT = 68,
+  parameter integer PACKET_INDEX_W = 7
+) (
+  input wire clk,
+  input wire rst_n,
+  input wire layer_start,
+  input wire layer_idle,
+  input wire [7:0] layer_expected_remote_contexts,
+  input wire [15:0] event_valid,
+  output wire [15:0] event_ready,
+  input wire [16*3-1:0] event_wave,
+  input wire [16*4-1:0] event_source,
+  input wire [16*ADDR_W-1:0] event_source_base_addr,
+  input wire [16*ADDR_W-1:0] event_destination_base_addr,
+  input wire [16*(PACKET_INDEX_W+1)-1:0] event_packet_count,
+
+  output wire context_valid,
+  input wire context_ready,
+  output wire [2:0] context_wave,
+  output wire [3:0] context_destination,
+  output wire [3:0] context_cluster,
+  output wire [3:0] context_source,
+  output wire [ADDR_W-1:0] context_source_base_addr,
+  output wire [ADDR_W-1:0] context_destination_base_addr,
+  output wire [PACKET_INDEX_W:0] context_packet_count,
+
+  output wire layer_active,
+  output wire layer_complete,
+  output reg [7:0] admitted_count,
+  output reg protocol_error
+);
+  localparam integer CLUSTERS = 16;
+  localparam integer WAVES = 8;
+  localparam integer MAX_REMOTE_CONTEXTS = 112;
+  localparam integer INDEX_W = 7;
+  localparam integer PACKET_COUNT_W = PACKET_INDEX_W + 1;
+
+  reg [15:0] seen_by_wave [0:WAVES-1];
+  reg [15:0] pending_by_wave [0:WAVES-1];
+  reg [ADDR_W-1:0] source_base_by_index [0:CLUSTERS*WAVES-1];
+  reg [ADDR_W-1:0] destination_base_by_index [0:CLUSTERS*WAVES-1];
+  reg [PACKET_COUNT_W-1:0] packet_count_by_index [0:CLUSTERS*WAVES-1];
+  reg [3:0] source_by_index [0:CLUSTERS*WAVES-1];
+  reg layer_active_r;
+  reg layer_complete_r;
+  reg [7:0] expected_remote_contexts_q;
+  reg hold_valid;
+  reg [INDEX_W-1:0] hold_index;
+  reg [INDEX_W-1:0] rr_pointer;
+
+  reg candidate_valid;
+  reg [INDEX_W-1:0] candidate_index;
+  reg [2:0] candidate_wave;
+  reg [3:0] candidate_cluster;
+  reg [3:0] candidate_source;
+  reg [ADDR_W-1:0] candidate_source_base;
+  reg [ADDR_W-1:0] candidate_destination_base;
+  reg [PACKET_COUNT_W-1:0] candidate_packet_count;
+  integer lane_i;
+  integer scan_offset;
+  integer scan_index;
+  integer scan_wave;
+  integer scan_cluster;
+  integer reset_i;
+
+  assign layer_active = layer_active_r;
+  assign layer_complete = layer_complete_r;
+  assign event_ready = {CLUSTERS{layer_active_r && !layer_complete_r && !protocol_error}};
+
+  always @(*) begin
+    candidate_valid = 1'b0;
+    candidate_index = {INDEX_W{1'b0}};
+    candidate_wave = 3'b0;
+    candidate_cluster = 4'b0;
+    candidate_source = 4'b0;
+    candidate_source_base = {ADDR_W{1'b0}};
+    candidate_destination_base = {ADDR_W{1'b0}};
+    candidate_packet_count = {PACKET_COUNT_W{1'b0}};
+    for (scan_offset = 0; scan_offset < CLUSTERS * WAVES; scan_offset = scan_offset + 1) begin
+      scan_index = rr_pointer + scan_offset;
+      if (scan_index >= CLUSTERS * WAVES)
+        scan_index = scan_index - CLUSTERS * WAVES;
+      scan_wave = scan_index / CLUSTERS;
+      scan_cluster = scan_index % CLUSTERS;
+      if (pending_by_wave[scan_wave][scan_cluster] && !candidate_valid) begin
+        candidate_valid = 1'b1;
+        candidate_index = scan_index[INDEX_W-1:0];
+        candidate_wave = scan_wave[2:0];
+        candidate_cluster = scan_cluster[3:0];
+        candidate_source = source_by_index[scan_index];
+        candidate_source_base = source_base_by_index[scan_index];
+        candidate_destination_base = destination_base_by_index[scan_index];
+        candidate_packet_count = packet_count_by_index[scan_index];
+      end
+    end
+  end
+
+  assign context_valid = !protocol_error && (hold_valid || candidate_valid);
+  assign context_wave = hold_valid ? hold_index[6:4] : candidate_wave;
+  assign context_destination = hold_valid ? hold_index[3:0] : candidate_cluster;
+  assign context_cluster = hold_valid ? hold_index[3:0] : candidate_cluster;
+  assign context_source = hold_valid
+    ? source_by_index[hold_index]
+    : candidate_source;
+  assign context_source_base_addr = hold_valid
+    ? source_base_by_index[hold_index]
+    : candidate_source_base;
+  assign context_destination_base_addr = hold_valid
+    ? destination_base_by_index[hold_index]
+    : candidate_destination_base;
+  assign context_packet_count = hold_valid
+    ? packet_count_by_index[hold_index]
+    : candidate_packet_count;
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      layer_active_r <= 1'b0;
+      layer_complete_r <= 1'b0;
+      hold_valid <= 1'b0;
+      hold_index <= {INDEX_W{1'b0}};
+      rr_pointer <= {INDEX_W{1'b0}};
+      admitted_count <= 8'b0;
+      expected_remote_contexts_q <= 8'b0;
+      protocol_error <= 1'b0;
+      for (reset_i = 0; reset_i < WAVES; reset_i = reset_i + 1) begin
+        seen_by_wave[reset_i] <= 16'b0;
+        pending_by_wave[reset_i] <= 16'b0;
+      end
+      for (reset_i = 0; reset_i < CLUSTERS * WAVES; reset_i = reset_i + 1) begin
+        source_base_by_index[reset_i] <= {ADDR_W{1'b0}};
+        destination_base_by_index[reset_i] <= {ADDR_W{1'b0}};
+        packet_count_by_index[reset_i] <= {PACKET_COUNT_W{1'b0}};
+        source_by_index[reset_i] <= 4'b0;
+      end
+    end else begin
+      if (layer_start) begin
+        if (protocol_error || layer_active_r || !layer_idle ||
+            layer_expected_remote_contexts > MAX_REMOTE_CONTEXTS) begin
+          protocol_error <= 1'b1;
+        end else begin
+          layer_active_r <= (layer_expected_remote_contexts != 0);
+          layer_complete_r <= (layer_expected_remote_contexts == 0);
+          hold_valid <= 1'b0;
+          rr_pointer <= {INDEX_W{1'b0}};
+          admitted_count <= 8'b0;
+          expected_remote_contexts_q <= layer_expected_remote_contexts;
+          for (reset_i = 0; reset_i < WAVES; reset_i = reset_i + 1) begin
+            seen_by_wave[reset_i] <= 16'b0;
+            pending_by_wave[reset_i] <= 16'b0;
+          end
+        end
+      end
+
+      if (layer_active_r && !layer_complete_r) begin
+        for (lane_i = 0; lane_i < CLUSTERS; lane_i = lane_i + 1) begin
+          if (event_valid[lane_i] && event_ready[lane_i]) begin
+            if (event_source[(lane_i*4) +: 4] == lane_i[3:0]) begin
+              protocol_error <= 1'b1;
+            end else if (seen_by_wave[event_wave[(lane_i*3) +: 3]][lane_i]) begin
+              protocol_error <= 1'b1;
+            end else if ((event_source_base_addr[(lane_i*ADDR_W) +: ADDR_W] & 8'hff) != 0 ||
+                         (event_destination_base_addr[(lane_i*ADDR_W) +: ADDR_W] & 8'hff) != 0) begin
+              protocol_error <= 1'b1;
+            end else if (event_packet_count[(lane_i*PACKET_COUNT_W) +: PACKET_COUNT_W] == 0 ||
+                         event_packet_count[(lane_i*PACKET_COUNT_W) +: PACKET_COUNT_W] > MAX_PACKETS_PER_CONTEXT) begin
+              protocol_error <= 1'b1;
+            end else begin
+              seen_by_wave[event_wave[(lane_i*3) +: 3]][lane_i] <= 1'b1;
+              pending_by_wave[event_wave[(lane_i*3) +: 3]][lane_i] <= 1'b1;
+              source_by_index[(event_wave[(lane_i*3) +: 3] * CLUSTERS) + lane_i] <=
+                event_source[(lane_i*4) +: 4];
+              source_base_by_index[(event_wave[(lane_i*3) +: 3] * CLUSTERS) + lane_i] <=
+                event_source_base_addr[(lane_i*ADDR_W) +: ADDR_W];
+              destination_base_by_index[(event_wave[(lane_i*3) +: 3] * CLUSTERS) + lane_i] <=
+                event_destination_base_addr[(lane_i*ADDR_W) +: ADDR_W];
+              packet_count_by_index[(event_wave[(lane_i*3) +: 3] * CLUSTERS) + lane_i] <=
+                event_packet_count[(lane_i*PACKET_COUNT_W) +: PACKET_COUNT_W];
+            end
+          end
+        end
+
+        if (context_valid && context_ready) begin
+          if (hold_valid) begin
+            pending_by_wave[hold_index[6:4]][hold_index[3:0]] <= 1'b0;
+            hold_valid <= 1'b0;
+            rr_pointer <= (hold_index == 7'd127) ? 7'd0 : hold_index + 1'b1;
+          end else begin
+            pending_by_wave[candidate_wave][candidate_cluster] <= 1'b0;
+            rr_pointer <= (candidate_index == 7'd127) ? 7'd0 : candidate_index + 1'b1;
+          end
+          admitted_count <= admitted_count + 1'b1;
+          if (admitted_count == expected_remote_contexts_q - 1'b1) begin
+            layer_active_r <= 1'b0;
+            layer_complete_r <= 1'b1;
+          end else if (!hold_valid && candidate_valid && !context_ready) begin
+            hold_valid <= 1'b1;
+            hold_index <= candidate_index;
+          end
+        end else if (!hold_valid && candidate_valid) begin
+          hold_valid <= 1'b1;
+          hold_index <= candidate_index;
+        end
+      end
+
+      if (event_valid != 16'b0 && !layer_active_r)
+        protocol_error <= 1'b1;
+    end
+  end
+
+`ifndef SYNTHESIS
+  initial begin
+    if (ADDR_W < 8)
+      $error("attention_shared_stream_context_admission ADDR_W must expose 256-byte alignment");
+    if (MAX_PACKETS_PER_CONTEXT < 1)
+      $error("attention_shared_stream_context_admission requires a positive packet bound");
+    if (PACKET_INDEX_W < $clog2(MAX_PACKETS_PER_CONTEXT))
+      $error("attention_shared_stream_context_admission PACKET_INDEX_W cannot represent packet counts");
+  end
+`endif
+endmodule

--- a/npu/sim/rtl/attention_shared_stream_context_engine.sv
+++ b/npu/sim/rtl/attention_shared_stream_context_engine.sv
@@ -1,0 +1,387 @@
+`timescale 1ns/1ps
+
+// Exact shared-SRAM transport controller for a parameterized packet context.
+//
+// The controller owns context admission and packet ordering.  The existing
+// descriptor-driven endpoint and 4x4 mesh own SRAM reads, writes, buffering,
+// routing, and flit handshakes.  A context has eight flits per packet and an
+// eight-packet receive window.  The default context has 68 packets; tags carry
+// the low eight bits of the full packet index and safely reuse modulo 256.
+module attention_shared_stream_context_engine #(
+  parameter integer ADDR_W = 32,
+  parameter integer MAX_PACKETS_PER_CONTEXT = 68,
+  parameter integer PACKET_INDEX_W = 7,
+  parameter integer TAG_W = 8,
+  parameter integer TX_DESC_DEPTH = 8
+) (
+  input wire clk,
+  input wire rst_n,
+
+  input wire context_valid,
+  output wire context_ready,
+  input wire [2:0] context_wave,
+  input wire [3:0] context_destination,
+  input wire [3:0] context_source,
+  input wire [ADDR_W-1:0] context_source_base_addr,
+  input wire [ADDR_W-1:0] context_destination_base_addr,
+  input wire [PACKET_INDEX_W:0] context_packet_count,
+
+  output wire context_completion_valid,
+  input wire context_completion_ready,
+  output wire [2:0] context_completion_wave,
+  output wire [3:0] context_completion_destination,
+
+  // Descriptor ports are exposed for exact transport accounting and tests.
+  output reg [15:0] tx_desc_valid,
+  output wire [15:0] tx_desc_ready,
+  output reg [16*4-1:0] tx_desc_destination,
+  output reg [16*2-1:0] tx_desc_vc,
+  output reg [16*8-1:0] tx_desc_tag,
+  output reg [16*ADDR_W-1:0] tx_desc_base_addr,
+  output reg [16*4-1:0] tx_desc_flit_count,
+
+  output reg [15:0] rx_desc_valid,
+  output wire [15:0] rx_desc_ready,
+  output reg [16*4-1:0] rx_desc_source,
+  output reg [16*2-1:0] rx_desc_vc,
+  output reg [16*8-1:0] rx_desc_tag,
+  output reg [16*ADDR_W-1:0] rx_desc_base_addr,
+  output reg [16*4-1:0] rx_desc_flit_count,
+
+  output wire [15:0] tx_mem_req_valid,
+  input wire [15:0] tx_mem_req_ready,
+  output wire [16*ADDR_W-1:0] tx_mem_req_addr,
+  input wire [15:0] tx_mem_rsp_valid,
+  output wire [15:0] tx_mem_rsp_ready,
+  input wire [16*256-1:0] tx_mem_rsp_data,
+
+  output wire [15:0] rx_mem_write_valid,
+  input wire [15:0] rx_mem_write_ready,
+  output wire [16*ADDR_W-1:0] rx_mem_write_addr,
+  output wire [16*256-1:0] rx_mem_write_data,
+
+  output wire [15:0] endpoint_protocol_error,
+  output wire protocol_error
+);
+  localparam integer NODES = 16;
+  localparam integer FLITS_PER_PACKET = 8;
+  localparam integer PACKET_BYTES = 256;
+  localparam integer CONTEXTS = 16;
+  localparam integer PACKET_COUNT_W = PACKET_INDEX_W + 1;
+  localparam integer COUNTER_INDEX_W = (PACKET_INDEX_W < 8) ? 8 : PACKET_INDEX_W;
+
+  reg context_active [0:CONTEXTS-1];
+  reg [2:0] context_wave_q [0:CONTEXTS-1];
+  reg [3:0] context_source_q [0:CONTEXTS-1];
+  reg [3:0] context_destination_q [0:CONTEXTS-1];
+  reg [ADDR_W-1:0] context_src_base_q [0:CONTEXTS-1];
+  reg [ADDR_W-1:0] context_dst_base_q [0:CONTEXTS-1];
+  reg [PACKET_COUNT_W-1:0] context_packet_count_q [0:CONTEXTS-1];
+  // These are counts, so the extra bit represents MAX_PACKETS_PER_CONTEXT.
+  reg [COUNTER_INDEX_W:0] rx_installed_count [0:CONTEXTS-1];
+  reg [COUNTER_INDEX_W:0] tx_issued_count [0:CONTEXTS-1];
+  reg [COUNTER_INDEX_W:0] completed_count [0:CONTEXTS-1];
+  reg context_done_pending [0:CONTEXTS-1];
+
+  reg [15:0] source_busy;
+  reg [15:0] destination_busy;
+  reg protocol_error_q;
+
+  reg free_context_found;
+  reg [3:0] free_context_index;
+  reg [15:0] descriptor_rx_context_valid;
+  reg [15:0] descriptor_tx_context_valid;
+  integer comb_i;
+  integer reset_i;
+
+  wire transport_error = protocol_error_q | (|endpoint_protocol_error);
+  wire context_command_fire = context_valid && context_ready;
+  wire context_command_is_valid =
+    (context_source != context_destination) &&
+    !source_busy[context_source] &&
+    !destination_busy[context_destination] &&
+    (context_packet_count != 0) &&
+    (context_packet_count <= MAX_PACKETS_PER_CONTEXT) &&
+    (context_source_base_addr[7:0] == 8'b0) &&
+    (context_destination_base_addr[7:0] == 8'b0);
+
+  wire context_command_metadata_invalid =
+    (context_source == context_destination) ||
+    (context_packet_count == 0) ||
+    (context_packet_count > MAX_PACKETS_PER_CONTEXT) ||
+    (context_source_base_addr[7:0] != 8'b0) ||
+    (context_destination_base_addr[7:0] != 8'b0);
+
+  // Ready advertises structural capacity only.  A malformed command still
+  // handshakes so it cannot wedge the producer; it sets protocol_error and
+  // is discarded without reserving an endpoint.
+  // Valid commands wait for endpoint reservations.  Metadata-invalid
+  // commands may handshake and become a sticky protocol error, preventing a
+  // producer from wedging on a command that can never be allocated.
+  assign context_ready = !transport_error && free_context_found &&
+    (context_command_metadata_invalid ||
+     (!source_busy[context_source] && !destination_busy[context_destination]));
+  assign protocol_error = transport_error;
+
+  // The engine uses the existing exact endpoint/mesh composition.  The
+  // endpoint parameters are widened only for the byte addresses; flit width,
+  // VC, tag, and packet-count contracts remain fixed.
+  wire [15:0] mesh_rx_completion_valid;
+  wire [15:0] mesh_rx_completion_ready;
+  wire [16*4-1:0] mesh_rx_completion_source;
+  wire [16*2-1:0] mesh_rx_completion_vc;
+  wire [16*8-1:0] mesh_rx_completion_tag;
+
+  assign mesh_rx_completion_ready = 16'hffff;
+
+  noc_sram_packet_mesh4x4 #(
+    .DATA_W(256),
+    .ENDPOINT_W(4),
+    .VC_W(2),
+    .VC_COUNT(4),
+    .TAG_W(TAG_W),
+    .FRAGMENT_W(3),
+    .ADDR_W(ADDR_W),
+    .FLIT_COUNT_W(4),
+    .TX_DESC_DEPTH(TX_DESC_DEPTH),
+    .TX_OUTSTANDING(8),
+    .RX_CONTEXTS(8),
+    .ROUTER_FIFO_DEPTH(4),
+    .COUNTER_W(32)
+  ) transport_mesh (
+    .clk(clk), .rst_n(rst_n),
+    .tx_desc_valid(tx_desc_valid), .tx_desc_ready(tx_desc_ready),
+    .tx_desc_destination(tx_desc_destination), .tx_desc_vc(tx_desc_vc),
+    .tx_desc_tag(tx_desc_tag), .tx_desc_base_addr(tx_desc_base_addr),
+    .tx_desc_flit_count(tx_desc_flit_count),
+    .tx_mem_req_valid(tx_mem_req_valid), .tx_mem_req_ready(tx_mem_req_ready),
+    .tx_mem_req_addr(tx_mem_req_addr), .tx_mem_rsp_valid(tx_mem_rsp_valid),
+    .tx_mem_rsp_ready(tx_mem_rsp_ready), .tx_mem_rsp_data(tx_mem_rsp_data),
+    .rx_desc_valid(rx_desc_valid), .rx_desc_ready(rx_desc_ready),
+    .rx_desc_source(rx_desc_source), .rx_desc_vc(rx_desc_vc),
+    .rx_desc_tag(rx_desc_tag), .rx_desc_base_addr(rx_desc_base_addr),
+    .rx_desc_flit_count(rx_desc_flit_count),
+    .rx_mem_write_valid(rx_mem_write_valid),
+    .rx_mem_write_ready(rx_mem_write_ready),
+    .rx_mem_write_addr(rx_mem_write_addr),
+    .rx_mem_write_data(rx_mem_write_data),
+    .rx_completion_valid(mesh_rx_completion_valid),
+    .rx_completion_ready(mesh_rx_completion_ready),
+    .rx_completion_source(mesh_rx_completion_source),
+    .rx_completion_vc(mesh_rx_completion_vc),
+    .rx_completion_tag(mesh_rx_completion_tag),
+    .endpoint_protocol_error(endpoint_protocol_error),
+    .router_accepted_flit_count(), .router_forwarded_flit_count(),
+    .router_input_stall_cycles(), .router_output_stall_cycles(),
+    .router_contention_cycles(), .router_current_input_occupancy(),
+    .router_max_input_occupancy(), .router_route_flit_count()
+  );
+
+  // Reservations make source and destination endpoints unique per active
+  // context.  Therefore every eligible context can issue one descriptor in
+  // the same cycle; there is no global descriptor arbiter on this path.
+  always @(*) begin
+    free_context_found = 1'b0;
+    free_context_index = 4'b0;
+    descriptor_rx_context_valid = 16'b0;
+    descriptor_tx_context_valid = 16'b0;
+    tx_desc_valid = 16'b0;
+    tx_desc_destination = {16*4{1'b0}};
+    tx_desc_vc = {16*2{1'b0}};
+    tx_desc_tag = {16*8{1'b0}};
+    tx_desc_base_addr = {16*ADDR_W{1'b0}};
+    tx_desc_flit_count = {16*4{1'b0}};
+    rx_desc_valid = 16'b0;
+    rx_desc_source = {16*4{1'b0}};
+    rx_desc_vc = {16*2{1'b0}};
+    rx_desc_tag = {16*8{1'b0}};
+    rx_desc_base_addr = {16*ADDR_W{1'b0}};
+    rx_desc_flit_count = {16*4{1'b0}};
+
+    for (comb_i = 0; comb_i < CONTEXTS; comb_i = comb_i + 1) begin
+      if (!context_active[comb_i] && !free_context_found) begin
+        free_context_found = 1'b1;
+        free_context_index = comb_i[3:0];
+      end
+      if (!transport_error && context_active[comb_i] &&
+          (rx_installed_count[comb_i] < context_packet_count_q[comb_i]) &&
+          (rx_installed_count[comb_i] >= completed_count[comb_i]) &&
+          ((rx_installed_count[comb_i] - completed_count[comb_i]) < 8)) begin
+        descriptor_rx_context_valid[comb_i] = 1'b1;
+        rx_desc_valid[context_destination_q[comb_i]] = 1'b1;
+        rx_desc_source[(context_destination_q[comb_i]*4) +: 4] = context_source_q[comb_i];
+        rx_desc_vc[(context_destination_q[comb_i]*2) +: 2] = 2'b0;
+        rx_desc_tag[(context_destination_q[comb_i]*8) +: 8] = rx_installed_count[comb_i][7:0];
+        rx_desc_base_addr[(context_destination_q[comb_i]*ADDR_W) +: ADDR_W] =
+          context_dst_base_q[comb_i] + (rx_installed_count[comb_i] * PACKET_BYTES);
+        rx_desc_flit_count[(context_destination_q[comb_i]*4) +: 4] = FLITS_PER_PACKET;
+      end
+      if (!transport_error && context_active[comb_i] &&
+          (tx_issued_count[comb_i] < context_packet_count_q[comb_i]) &&
+          (tx_issued_count[comb_i] < rx_installed_count[comb_i])) begin
+        descriptor_tx_context_valid[comb_i] = 1'b1;
+        tx_desc_valid[context_source_q[comb_i]] = 1'b1;
+        tx_desc_destination[(context_source_q[comb_i]*4) +: 4] = context_destination_q[comb_i];
+        tx_desc_vc[(context_source_q[comb_i]*2) +: 2] = 2'b0;
+        tx_desc_tag[(context_source_q[comb_i]*8) +: 8] = tx_issued_count[comb_i][7:0];
+        tx_desc_base_addr[(context_source_q[comb_i]*ADDR_W) +: ADDR_W] =
+          context_src_base_q[comb_i] + (tx_issued_count[comb_i] * PACKET_BYTES);
+        tx_desc_flit_count[(context_source_q[comb_i]*4) +: 4] = FLITS_PER_PACKET;
+      end
+    end
+  end
+
+  // Match each endpoint completion to the unique context occupying its
+  // destination endpoint and require the next packet tag in sequence.
+  reg [15:0] completion_good;
+  reg [15:0] completion_match;
+  reg [3:0] completion_context [0:NODES-1];
+  integer completion_ep;
+  integer completion_ctx_i;
+  always @(*) begin
+    completion_good = 16'b0;
+    completion_match = 16'b0;
+    for (completion_ep = 0; completion_ep < NODES; completion_ep = completion_ep + 1) begin
+      completion_context[completion_ep] = 4'b0;
+      for (completion_ctx_i = 0; completion_ctx_i < CONTEXTS; completion_ctx_i = completion_ctx_i + 1) begin
+        if (context_active[completion_ctx_i] &&
+            context_destination_q[completion_ctx_i] == completion_ep[3:0] &&
+            !completion_match[completion_ep]) begin
+          completion_match[completion_ep] = 1'b1;
+          completion_context[completion_ep] = completion_ctx_i[3:0];
+          if (!context_done_pending[completion_ctx_i] &&
+              completed_count[completion_ctx_i] < rx_installed_count[completion_ctx_i] &&
+              mesh_rx_completion_source[(completion_ep*4) +: 4] == context_source_q[completion_ctx_i] &&
+              mesh_rx_completion_vc[(completion_ep*2) +: 2] == 2'b0 &&
+              mesh_rx_completion_tag[(completion_ep*8) +: 8] == completed_count[completion_ctx_i][7:0])
+            completion_good[completion_ep] = 1'b1;
+        end
+      end
+    end
+  end
+
+  // One context completion is arbitrated independently of packet completion.
+  reg completion_hold_valid;
+  reg [3:0] completion_hold_context;
+  reg completion_candidate_valid;
+  reg [3:0] completion_candidate_context;
+  integer candidate_i;
+  always @(*) begin
+    completion_candidate_valid = 1'b0;
+    completion_candidate_context = 4'b0;
+    for (candidate_i = 0; candidate_i < CONTEXTS; candidate_i = candidate_i + 1) begin
+      if (context_active[candidate_i] && context_done_pending[candidate_i] &&
+          !completion_candidate_valid) begin
+        completion_candidate_valid = 1'b1;
+        completion_candidate_context = candidate_i[3:0];
+      end
+    end
+  end
+
+  assign context_completion_valid = completion_hold_valid || completion_candidate_valid;
+  assign context_completion_wave = completion_hold_valid
+    ? context_wave_q[completion_hold_context]
+    : context_wave_q[completion_candidate_context];
+  assign context_completion_destination = completion_hold_valid
+    ? context_destination_q[completion_hold_context]
+    : context_destination_q[completion_candidate_context];
+
+  integer state_i;
+  integer completion_i;
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      source_busy <= 16'b0;
+      destination_busy <= 16'b0;
+      protocol_error_q <= 1'b0;
+      completion_hold_valid <= 1'b0;
+      completion_hold_context <= 4'b0;
+      for (reset_i = 0; reset_i < CONTEXTS; reset_i = reset_i + 1) begin
+        context_active[reset_i] <= 1'b0;
+        context_wave_q[reset_i] <= 3'b0;
+        context_source_q[reset_i] <= 4'b0;
+        context_destination_q[reset_i] <= 4'b0;
+        context_src_base_q[reset_i] <= {ADDR_W{1'b0}};
+        context_dst_base_q[reset_i] <= {ADDR_W{1'b0}};
+        context_packet_count_q[reset_i] <= {PACKET_COUNT_W{1'b0}};
+        rx_installed_count[reset_i] <= {(COUNTER_INDEX_W+1){1'b0}};
+        tx_issued_count[reset_i] <= {(COUNTER_INDEX_W+1){1'b0}};
+        completed_count[reset_i] <= {(COUNTER_INDEX_W+1){1'b0}};
+        context_done_pending[reset_i] <= 1'b0;
+      end
+    end else begin
+      if (context_command_fire) begin
+        if (!context_command_is_valid) begin
+          protocol_error_q <= 1'b1;
+        end else begin
+          context_active[free_context_index] <= 1'b1;
+          context_wave_q[free_context_index] <= context_wave;
+          context_source_q[free_context_index] <= context_source;
+          context_destination_q[free_context_index] <= context_destination;
+          context_src_base_q[free_context_index] <= context_source_base_addr;
+          context_dst_base_q[free_context_index] <= context_destination_base_addr;
+          context_packet_count_q[free_context_index] <= context_packet_count;
+          rx_installed_count[free_context_index] <= {(COUNTER_INDEX_W+1){1'b0}};
+          tx_issued_count[free_context_index] <= {(COUNTER_INDEX_W+1){1'b0}};
+          completed_count[free_context_index] <= {(COUNTER_INDEX_W+1){1'b0}};
+          context_done_pending[free_context_index] <= 1'b0;
+          source_busy[context_source] <= 1'b1;
+          destination_busy[context_destination] <= 1'b1;
+        end
+      end
+
+      for (state_i = 0; state_i < CONTEXTS; state_i = state_i + 1) begin
+        if (descriptor_rx_context_valid[state_i] &&
+            rx_desc_ready[context_destination_q[state_i]])
+          rx_installed_count[state_i] <= rx_installed_count[state_i] + 1'b1;
+        if (descriptor_tx_context_valid[state_i] &&
+            tx_desc_ready[context_source_q[state_i]])
+          tx_issued_count[state_i] <= tx_issued_count[state_i] + 1'b1;
+      end
+
+      for (completion_i = 0; completion_i < NODES; completion_i = completion_i + 1) begin
+        if (mesh_rx_completion_valid[completion_i]) begin
+          if (!completion_good[completion_i]) begin
+            protocol_error_q <= 1'b1;
+          end else begin
+            completed_count[completion_context[completion_i]] <=
+              completed_count[completion_context[completion_i]] + 1'b1;
+            if (completed_count[completion_context[completion_i]] ==
+                context_packet_count_q[completion_context[completion_i]] - 1'b1)
+              context_done_pending[completion_context[completion_i]] <= 1'b1;
+          end
+        end
+      end
+
+      if (context_completion_valid && context_completion_ready) begin
+        if (completion_hold_valid) begin
+          context_active[completion_hold_context] <= 1'b0;
+          context_done_pending[completion_hold_context] <= 1'b0;
+          source_busy[context_source_q[completion_hold_context]] <= 1'b0;
+          destination_busy[context_destination_q[completion_hold_context]] <= 1'b0;
+          completion_hold_valid <= 1'b0;
+        end else begin
+          context_active[completion_candidate_context] <= 1'b0;
+          context_done_pending[completion_candidate_context] <= 1'b0;
+          source_busy[context_source_q[completion_candidate_context]] <= 1'b0;
+          destination_busy[context_destination_q[completion_candidate_context]] <= 1'b0;
+        end
+      end else if (!completion_hold_valid && completion_candidate_valid) begin
+        completion_hold_valid <= 1'b1;
+        completion_hold_context <= completion_candidate_context;
+      end
+    end
+  end
+
+`ifndef SYNTHESIS
+  initial begin
+    if (ADDR_W < 8)
+      $error("attention_shared_stream_context_engine ADDR_W must expose 256-byte alignment");
+    if (MAX_PACKETS_PER_CONTEXT < 1)
+      $error("attention_shared_stream_context_engine requires a positive packet count");
+    if (PACKET_INDEX_W < $clog2(MAX_PACKETS_PER_CONTEXT))
+      $error("attention_shared_stream_context_engine PACKET_INDEX_W cannot represent packet indices");
+    if (TAG_W != 8)
+      $error("attention_shared_stream_context_engine requires an 8-bit packet tag");
+  end
+`endif
+endmodule

--- a/runs/campaigns/npu/attention_shared_sram_k_round_scheduler_ppa_v1/sweeps/nangate45.json
+++ b/runs/campaigns/npu/attention_shared_sram_k_round_scheduler_ppa_v1/sweeps/nangate45.json
@@ -1,0 +1,10 @@
+{
+  "tag_prefix": "attention_shared_sram_k_round_scheduler_ppa_v1",
+  "flow_params": {
+    "CLOCK_PERIOD": [4.0, 6.0, 8.0, 10.0, 12.0, 16.0],
+    "DIE_AREA": ["0 0 1100 1100"],
+    "CORE_AREA": ["50 50 1050 1050"],
+    "PLACE_DENSITY": [0.5],
+    "SYNTH_HIERARCHICAL": [1]
+  }
+}

--- a/runs/campaigns/npu/attention_shared_sram_read_group_adapter_ppa_v1/sweeps/nangate45.json
+++ b/runs/campaigns/npu/attention_shared_sram_read_group_adapter_ppa_v1/sweeps/nangate45.json
@@ -1,0 +1,10 @@
+{
+  "tag_prefix": "attention_shared_sram_read_group_adapter_ppa_v1",
+  "flow_params": {
+    "CLOCK_PERIOD": [2.0, 3.0, 4.0, 6.0, 8.0, 10.0],
+    "DIE_AREA": ["0 0 320 320"],
+    "CORE_AREA": ["30 30 290 290"],
+    "PLACE_DENSITY": [0.5],
+    "SYNTH_HIERARCHICAL": [1]
+  }
+}

--- a/runs/designs/npu_blocks/attention_shared_sram_k_round_scheduler_b17_w17/config.json
+++ b/runs/designs/npu_blocks/attention_shared_sram_k_round_scheduler_b17_w17/config.json
@@ -1,0 +1,13 @@
+{
+  "top_name": "attention_shared_sram_k_round_scheduler_b17_w17",
+  "attention_shared_sram_k_round_scheduler_ppa_harness": {
+    "banks": 17,
+    "words_per_group": 128,
+    "dimension_groups": 8,
+    "dimensions_per_group": 16
+  },
+  "report_links": {
+    "proposal_id": "prop_l1_attention_shared_sram_k_round_scheduler_ppa_v1",
+    "proposal_path": "docs/proposals/prop_l1_attention_shared_sram_k_round_scheduler_ppa_v1/proposal.json"
+  }
+}

--- a/runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w256_s1/config.json
+++ b/runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w256_s1/config.json
@@ -1,0 +1,12 @@
+{
+  "top_name": "attention_shared_sram_read_group_adapter_w256_s1",
+  "attention_shared_sram_read_group_adapter_ppa_harness": {
+    "beat_width": 256,
+    "group_slots": 1,
+    "groups": 64
+  },
+  "report_links": {
+    "proposal_id": "prop_l1_attention_shared_sram_read_group_adapter_ppa_v1",
+    "proposal_path": "docs/proposals/prop_l1_attention_shared_sram_read_group_adapter_ppa_v1/proposal.json"
+  }
+}

--- a/runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w256_s2/config.json
+++ b/runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w256_s2/config.json
@@ -1,0 +1,12 @@
+{
+  "top_name": "attention_shared_sram_read_group_adapter_w256_s2",
+  "attention_shared_sram_read_group_adapter_ppa_harness": {
+    "beat_width": 256,
+    "group_slots": 2,
+    "groups": 64
+  },
+  "report_links": {
+    "proposal_id": "prop_l1_attention_shared_sram_read_group_adapter_ppa_v1",
+    "proposal_path": "docs/proposals/prop_l1_attention_shared_sram_read_group_adapter_ppa_v1/proposal.json"
+  }
+}

--- a/runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w512_s1/config.json
+++ b/runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w512_s1/config.json
@@ -1,0 +1,12 @@
+{
+  "top_name": "attention_shared_sram_read_group_adapter_w512_s1",
+  "attention_shared_sram_read_group_adapter_ppa_harness": {
+    "beat_width": 512,
+    "group_slots": 1,
+    "groups": 64
+  },
+  "report_links": {
+    "proposal_id": "prop_l1_attention_shared_sram_read_group_adapter_ppa_v1",
+    "proposal_path": "docs/proposals/prop_l1_attention_shared_sram_read_group_adapter_ppa_v1/proposal.json"
+  }
+}

--- a/runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w512_s2/config.json
+++ b/runs/designs/npu_blocks/attention_shared_sram_read_group_adapter_w512_s2/config.json
@@ -1,0 +1,12 @@
+{
+  "top_name": "attention_shared_sram_read_group_adapter_w512_s2",
+  "attention_shared_sram_read_group_adapter_ppa_harness": {
+    "beat_width": 512,
+    "group_slots": 2,
+    "groups": 64
+  },
+  "report_links": {
+    "proposal_id": "prop_l1_attention_shared_sram_read_group_adapter_ppa_v1",
+    "proposal_path": "docs/proposals/prop_l1_attention_shared_sram_read_group_adapter_ppa_v1/proposal.json"
+  }
+}

--- a/tests/attention_shared_sram_k_round_scheduler_tb.sv
+++ b/tests/attention_shared_sram_k_round_scheduler_tb.sv
@@ -1,0 +1,320 @@
+`timescale 1ns/1ps
+
+module attention_shared_sram_k_round_scheduler_tb;
+  localparam integer ADDR_W = 16;
+  localparam integer BANKS = 17;
+  localparam integer WORDS = 128;
+  localparam integer GROUPS = 8;
+  localparam integer ROUNDS = 8;
+  localparam integer DIMS = 16;
+  localparam integer BASE_WORD = 5;
+
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  integer cycle = 0;
+  reg command_valid = 1'b0;
+  wire command_ready;
+
+  wire [BANKS-1:0] bank_req_valid;
+  reg [BANKS-1:0] bank_req_ready;
+  wire [(BANKS*ADDR_W)-1:0] bank_req_word_addr;
+  wire [BANKS-1:0] bank_req_buffer;
+  wire [(BANKS*3)-1:0] bank_req_group;
+  wire [(BANKS*3)-1:0] bank_req_round;
+  wire [(BANKS*7)-1:0] bank_req_word_slot;
+
+  reg [BANKS-1:0] bank_rsp_valid = 0;
+  wire [BANKS-1:0] bank_rsp_ready;
+  reg [(BANKS*1024)-1:0] bank_rsp_data = 0;
+  reg [BANKS-1:0] bank_rsp_buffer = 0;
+  reg [(BANKS*3)-1:0] bank_rsp_group = 0;
+  reg [(BANKS*3)-1:0] bank_rsp_round = 0;
+  reg [(BANKS*7)-1:0] bank_rsp_word_slot = 0;
+
+  wire compute_valid;
+  reg compute_ready;
+  wire [2:0] compute_group;
+  wire [2:0] compute_round;
+  wire [3:0] compute_dimension;
+  wire compute_last;
+  wire [BANKS-1:0] compute_word_valid;
+  wire [(BANKS*64)-1:0] compute_k_beats;
+
+  wire done;
+  wire protocol_error;
+  wire [63:0] bank_request_count;
+  wire [63:0] bank_response_count;
+  wire [63:0] compute_beat_count;
+  wire [63:0] bank_request_stall_count;
+  wire [63:0] compute_output_stall_count;
+  wire [63:0] compute_wait_for_window_count;
+
+  reg request_seen [0:GROUPS-1][0:WORDS-1];
+  integer request_count_by_round [0:(GROUPS*ROUNDS)-1];
+  integer first_request_cycle [0:(GROUPS*ROUNDS)-1];
+  integer compute_start_cycle [0:(GROUPS*ROUNDS)-1];
+  integer compute_end_cycle [0:(GROUPS*ROUNDS)-1];
+  integer expected_group = 0;
+  integer expected_round = 0;
+  integer expected_dimension = 0;
+  integer compute_count = 0;
+  integer last_compute_cycle = -1;
+  integer max_compute_interval = 0;
+  integer req_bank_i;
+  integer rsp_bank_i;
+  integer check_bank_i;
+  integer init_group_i;
+  integer init_slot_i;
+  integer init_round_i;
+  integer group_i;
+  integer round_i;
+  integer slot_i;
+  integer local_i;
+  integer linear_i;
+  integer addr_i;
+  integer valid_words_i;
+  reg backpressure_case;
+  reg malformed_case;
+  reg malformed_sent = 1'b0;
+
+  attention_shared_sram_k_round_scheduler #(
+    .ADDR_W(ADDR_W),
+    .BANKS(BANKS),
+    .WORDS_PER_GROUP(WORDS),
+    .DIM_GROUPS(GROUPS),
+    .DIMS_PER_GROUP(DIMS)
+  ) dut (
+    .clk(clk), .rst_n(rst_n),
+    .command_valid(command_valid), .command_ready(command_ready),
+    .command_base_word_addr(ADDR_W'(BASE_WORD)),
+    .bank_req_valid(bank_req_valid), .bank_req_ready(bank_req_ready),
+    .bank_req_word_addr(bank_req_word_addr),
+    .bank_req_buffer(bank_req_buffer),
+    .bank_req_group(bank_req_group), .bank_req_round(bank_req_round),
+    .bank_req_word_slot(bank_req_word_slot),
+    .bank_rsp_valid(bank_rsp_valid), .bank_rsp_ready(bank_rsp_ready),
+    .bank_rsp_data(bank_rsp_data), .bank_rsp_buffer(bank_rsp_buffer),
+    .bank_rsp_group(bank_rsp_group), .bank_rsp_round(bank_rsp_round),
+    .bank_rsp_word_slot(bank_rsp_word_slot),
+    .compute_valid(compute_valid), .compute_ready(compute_ready),
+    .compute_group(compute_group), .compute_round(compute_round),
+    .compute_dimension(compute_dimension), .compute_last(compute_last),
+    .compute_word_valid(compute_word_valid), .compute_k_beats(compute_k_beats),
+    .done(done), .protocol_error(protocol_error),
+    .bank_request_count(bank_request_count),
+    .bank_response_count(bank_response_count),
+    .compute_beat_count(compute_beat_count),
+    .bank_request_stall_count(bank_request_stall_count),
+    .compute_output_stall_count(compute_output_stall_count),
+    .compute_wait_for_window_count(compute_wait_for_window_count)
+  );
+
+  always #5 clk = ~clk;
+
+  function [63:0] expected_lane;
+    input integer group_value;
+    input integer slot_value;
+    input integer dimension_value;
+    begin
+      expected_lane = 64'h4b00_0000_0000_0000 |
+        (group_value << 16) | (slot_value << 8) | dimension_value;
+    end
+  endfunction
+
+  function [1023:0] expected_word;
+    input integer group_value;
+    input integer slot_value;
+    integer dimension_value;
+    begin
+      expected_word = 1024'd0;
+      for (dimension_value = 0; dimension_value < DIMS;
+           dimension_value = dimension_value + 1)
+        expected_word[dimension_value*64 +: 64] =
+          expected_lane(group_value, slot_value, dimension_value);
+    end
+  endfunction
+
+  always @* begin
+    for (req_bank_i = 0; req_bank_i < BANKS; req_bank_i = req_bank_i + 1)
+      bank_req_ready[req_bank_i] = !backpressure_case ||
+        (((cycle + req_bank_i) % 4) != 0);
+    compute_ready = !backpressure_case || ((cycle % 5) != 2);
+  end
+
+  // A one-register SRAM response pipe.  The request and response metadata are
+  // preserved exactly so the DUT can reject stale, duplicate, or misrouted data.
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      cycle <= 0;
+      bank_rsp_valid <= {BANKS{1'b0}};
+      bank_rsp_data <= {(BANKS*1024){1'b0}};
+      bank_rsp_buffer <= {BANKS{1'b0}};
+      bank_rsp_group <= {(BANKS*3){1'b0}};
+      bank_rsp_round <= {(BANKS*3){1'b0}};
+      bank_rsp_word_slot <= {(BANKS*7){1'b0}};
+      malformed_sent <= 1'b0;
+    end else begin
+      cycle <= cycle + 1;
+      bank_rsp_valid <= bank_req_valid & bank_req_ready;
+      for (rsp_bank_i = 0; rsp_bank_i < BANKS; rsp_bank_i = rsp_bank_i + 1) begin
+        if (bank_req_valid[rsp_bank_i] && bank_req_ready[rsp_bank_i]) begin
+          group_i = bank_req_group[rsp_bank_i*3 +: 3];
+          round_i = bank_req_round[rsp_bank_i*3 +: 3];
+          slot_i = bank_req_word_slot[rsp_bank_i*7 +: 7];
+          bank_rsp_buffer[rsp_bank_i] <= bank_req_buffer[rsp_bank_i];
+          bank_rsp_group[rsp_bank_i*3 +: 3] <=
+            (malformed_case && !malformed_sent) ? 3'(group_i + 1) : 3'(group_i);
+          bank_rsp_round[rsp_bank_i*3 +: 3] <= 3'(round_i);
+          bank_rsp_word_slot[rsp_bank_i*7 +: 7] <= 7'(slot_i);
+          bank_rsp_data[rsp_bank_i*1024 +: 1024] <= expected_word(group_i, slot_i);
+          if (malformed_case && !malformed_sent)
+            malformed_sent <= 1'b1;
+        end
+      end
+    end
+  end
+
+  always @(posedge clk) begin
+    if (rst_n) begin
+      for (check_bank_i = 0; check_bank_i < BANKS; check_bank_i = check_bank_i + 1) begin
+        if (bank_req_valid[check_bank_i] && bank_req_ready[check_bank_i]) begin
+          group_i = bank_req_group[check_bank_i*3 +: 3];
+          round_i = bank_req_round[check_bank_i*3 +: 3];
+          slot_i = bank_req_word_slot[check_bank_i*7 +: 7];
+          linear_i = group_i*ROUNDS + round_i;
+          addr_i = bank_req_word_addr[check_bank_i*ADDR_W +: ADDR_W];
+          if (slot_i < round_i*BANKS || slot_i >= WORDS ||
+              slot_i >= (round_i+1)*BANKS)
+            $fatal(1, "request slot outside round g=%0d r=%0d slot=%0d",
+                   group_i, round_i, slot_i);
+          if (addr_i != BASE_WORD + slot_i*GROUPS + group_i)
+            $fatal(1, "request address mismatch bank=%0d g=%0d r=%0d slot=%0d addr=%0d",
+                   check_bank_i, group_i, round_i, slot_i, addr_i);
+          if ((addr_i % BANKS) != check_bank_i)
+            $fatal(1, "request routed to wrong bank");
+          if (request_seen[group_i][slot_i])
+            $fatal(1, "duplicate request g=%0d slot=%0d", group_i, slot_i);
+          request_seen[group_i][slot_i] <= 1'b1;
+          request_count_by_round[linear_i] = request_count_by_round[linear_i] + 1;
+          if (first_request_cycle[linear_i] < 0)
+            first_request_cycle[linear_i] <= cycle;
+        end
+      end
+
+      if (compute_valid && compute_ready) begin
+        if (compute_group != expected_group || compute_round != expected_round ||
+            compute_dimension != expected_dimension)
+          $fatal(1, "compute order mismatch got g=%0d r=%0d d=%0d expected g=%0d r=%0d d=%0d",
+                 compute_group, compute_round, compute_dimension,
+                 expected_group, expected_round, expected_dimension);
+        if (compute_last != (expected_dimension == DIMS-1))
+          $fatal(1, "compute_last mismatch");
+        valid_words_i = (expected_round == ROUNDS-1) ? 9 : BANKS;
+        for (local_i = 0; local_i < BANKS; local_i = local_i + 1) begin
+          if (compute_word_valid[local_i] != (local_i < valid_words_i))
+            $fatal(1, "compute valid mask mismatch r=%0d local=%0d",
+                   expected_round, local_i);
+          if (local_i < valid_words_i) begin
+            slot_i = expected_round*BANKS + local_i;
+            if (compute_k_beats[local_i*64 +: 64] !==
+                expected_lane(expected_group, slot_i, expected_dimension))
+              $fatal(1, "compute data mismatch g=%0d r=%0d d=%0d local=%0d got=%h expected=%h local0_bank=%0d bank_lanes=%h",
+                     expected_group, expected_round, expected_dimension, local_i,
+                     compute_k_beats[local_i*64 +: 64],
+                     expected_lane(expected_group, slot_i, expected_dimension),
+                     dut.gen_compute[0].compute_storage_bank,
+                     dut.selected_bank_lanes);
+          end else if (compute_k_beats[local_i*64 +: 64] !== 64'd0) begin
+            $fatal(1, "invalid compute lane was not zero");
+          end
+        end
+
+        linear_i = expected_group*ROUNDS + expected_round;
+        if (expected_dimension == 0)
+          compute_start_cycle[linear_i] <= cycle;
+        if (last_compute_cycle >= 0 && cycle-last_compute_cycle > max_compute_interval)
+          max_compute_interval <= cycle-last_compute_cycle;
+        last_compute_cycle <= cycle;
+        compute_count <= compute_count + 1;
+        if (expected_dimension == DIMS-1) begin
+          compute_end_cycle[linear_i] <= cycle;
+          expected_dimension <= 0;
+          if (expected_round == ROUNDS-1) begin
+            expected_round <= 0;
+            expected_group <= expected_group + 1;
+          end else begin
+            expected_round <= expected_round + 1;
+          end
+        end else begin
+          expected_dimension <= expected_dimension + 1;
+        end
+      end
+
+      if (malformed_case && protocol_error) begin
+        $display("PASS k_round malformed_response requests=%0d responses=%0d",
+                 bank_request_count, bank_response_count);
+        $finish;
+      end
+
+      if (done) begin
+        if (protocol_error)
+          $fatal(1, "protocol_error asserted in valid run");
+        if (bank_request_count != GROUPS*WORDS ||
+            bank_response_count != GROUPS*WORDS ||
+            compute_beat_count != GROUPS*ROUNDS*DIMS ||
+            compute_count != GROUPS*ROUNDS*DIMS)
+          $fatal(1, "counter mismatch req=%0d rsp=%0d compute=%0d observed=%0d",
+                 bank_request_count, bank_response_count,
+                 compute_beat_count, compute_count);
+        for (init_round_i = 0; init_round_i < GROUPS*ROUNDS;
+             init_round_i = init_round_i + 1) begin
+          valid_words_i = ((init_round_i % ROUNDS) == ROUNDS-1) ? 9 : BANKS;
+          if (request_count_by_round[init_round_i] != valid_words_i)
+            $fatal(1, "round request count mismatch linear=%0d count=%0d",
+                   init_round_i, request_count_by_round[init_round_i]);
+          $display("TRACE round=%0d first_req=%0d compute_start=%0d compute_end=%0d",
+                   init_round_i, first_request_cycle[init_round_i],
+                   compute_start_cycle[init_round_i], compute_end_cycle[init_round_i]);
+        end
+        if (!backpressure_case && max_compute_interval != 1)
+          $fatal(1, "round buffering did not sustain one compute beat/cycle interval=%0d",
+                 max_compute_interval);
+        if (backpressure_case &&
+            (bank_request_stall_count == 0 || compute_output_stall_count == 0))
+          $fatal(1, "backpressure counters were not exercised");
+        $display("PASS k_round backpressure=%0d requests=%0d responses=%0d compute=%0d max_compute_interval=%0d request_stalls=%0d compute_stalls=%0d wait=%0d",
+                 backpressure_case, bank_request_count, bank_response_count,
+                 compute_beat_count, max_compute_interval,
+                 bank_request_stall_count, compute_output_stall_count,
+                 compute_wait_for_window_count);
+        $finish;
+      end
+
+      if (cycle > 10000)
+        $fatal(1, "timeout");
+    end
+  end
+
+  initial begin
+    backpressure_case = $test$plusargs("BACKPRESSURE");
+    malformed_case = $test$plusargs("MALFORMED");
+    for (init_group_i = 0; init_group_i < GROUPS; init_group_i = init_group_i + 1)
+      for (init_slot_i = 0; init_slot_i < WORDS; init_slot_i = init_slot_i + 1)
+        request_seen[init_group_i][init_slot_i] = 1'b0;
+    for (init_round_i = 0; init_round_i < GROUPS*ROUNDS;
+         init_round_i = init_round_i + 1) begin
+      request_count_by_round[init_round_i] = 0;
+      first_request_cycle[init_round_i] = -1;
+      compute_start_cycle[init_round_i] = -1;
+      compute_end_cycle[init_round_i] = -1;
+    end
+    repeat (3) @(negedge clk);
+    rst_n = 1'b1;
+    @(negedge clk);
+    command_valid = 1'b1;
+    @(posedge clk);
+    while (!command_ready) @(posedge clk);
+    @(negedge clk);
+    command_valid = 1'b0;
+  end
+endmodule

--- a/tests/attention_shared_sram_k_window_scheduler_tb.sv
+++ b/tests/attention_shared_sram_k_window_scheduler_tb.sv
@@ -1,0 +1,285 @@
+`timescale 1ns/1ps
+
+module attention_shared_sram_k_window_scheduler_tb;
+  localparam integer ADDR_W = 16;
+  localparam integer BANKS = 17;
+  localparam integer WORDS = 128;
+  localparam integer GROUPS = 8;
+  localparam integer DIMS = 16;
+  localparam integer GROUP_W = 3;
+  localparam integer SLOT_W = 7;
+  localparam integer DIM_W = 4;
+  localparam integer BASE_WORD = 5;
+
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  integer cycle = 0;
+  reg command_valid = 1'b0;
+  wire command_ready;
+
+  wire [BANKS-1:0] bank_req_valid;
+  reg [BANKS-1:0] bank_req_ready;
+  wire [(BANKS*ADDR_W)-1:0] bank_req_word_addr;
+  wire [BANKS-1:0] bank_req_buffer;
+  wire [(BANKS*GROUP_W)-1:0] bank_req_group;
+  wire [(BANKS*SLOT_W)-1:0] bank_req_slot;
+
+  reg [BANKS-1:0] bank_rsp_valid = 0;
+  wire [BANKS-1:0] bank_rsp_ready;
+  reg [(BANKS*1024)-1:0] bank_rsp_data = 0;
+  reg [BANKS-1:0] bank_rsp_buffer = 0;
+  reg [(BANKS*GROUP_W)-1:0] bank_rsp_group = 0;
+  reg [(BANKS*SLOT_W)-1:0] bank_rsp_slot = 0;
+
+  wire compute_valid;
+  reg compute_ready;
+  wire [GROUP_W-1:0] compute_group;
+  wire [DIM_W-1:0] compute_dimension;
+  wire compute_last;
+  wire [(WORDS*64)-1:0] compute_k_beats;
+  wire done;
+  wire protocol_error;
+  wire [63:0] bank_request_count;
+  wire [63:0] bank_response_count;
+  wire [63:0] compute_beat_count;
+  wire [63:0] bank_request_stall_count;
+  wire [63:0] bank_response_stall_count;
+  wire [63:0] compute_output_stall_count;
+  wire [63:0] compute_wait_for_window_count;
+
+  reg request_seen [0:GROUPS-1][0:WORDS-1];
+  integer first_request_cycle [0:GROUPS-1];
+  integer last_request_cycle [0:GROUPS-1];
+  integer request_count_by_group [0:GROUPS-1];
+  integer compute_start_cycle [0:GROUPS-1];
+  integer compute_end_cycle [0:GROUPS-1];
+  integer expected_compute_group = 0;
+  integer expected_compute_dimension = 0;
+  integer last_compute_cycle = -1;
+  integer max_compute_interval = 0;
+  integer compute_count = 0;
+  integer bank_i;
+  integer group_i;
+  integer slot_i;
+  integer addr_i;
+  integer word_i;
+  reg backpressure_case;
+  reg malformed_case;
+  reg malformed_sent = 1'b0;
+
+  attention_shared_sram_k_window_scheduler #(
+    .ADDR_W(ADDR_W),
+    .BANKS(BANKS),
+    .WORDS_PER_GROUP(WORDS),
+    .DIM_GROUPS(GROUPS),
+    .DIMS_PER_GROUP(DIMS)
+  ) dut (
+    .clk(clk), .rst_n(rst_n),
+    .command_valid(command_valid), .command_ready(command_ready),
+    .command_base_word_addr(ADDR_W'(BASE_WORD)),
+    .bank_req_valid(bank_req_valid), .bank_req_ready(bank_req_ready),
+    .bank_req_word_addr(bank_req_word_addr),
+    .bank_req_buffer(bank_req_buffer), .bank_req_group(bank_req_group),
+    .bank_req_slot(bank_req_slot),
+    .bank_rsp_valid(bank_rsp_valid), .bank_rsp_ready(bank_rsp_ready),
+    .bank_rsp_data(bank_rsp_data), .bank_rsp_buffer(bank_rsp_buffer),
+    .bank_rsp_group(bank_rsp_group), .bank_rsp_slot(bank_rsp_slot),
+    .compute_valid(compute_valid), .compute_ready(compute_ready),
+    .compute_group(compute_group), .compute_dimension(compute_dimension),
+    .compute_last(compute_last), .compute_k_beats(compute_k_beats),
+    .done(done), .protocol_error(protocol_error),
+    .bank_request_count(bank_request_count),
+    .bank_response_count(bank_response_count),
+    .compute_beat_count(compute_beat_count),
+    .bank_request_stall_count(bank_request_stall_count),
+    .bank_response_stall_count(bank_response_stall_count),
+    .compute_output_stall_count(compute_output_stall_count),
+    .compute_wait_for_window_count(compute_wait_for_window_count)
+  );
+
+  always #5 clk = ~clk;
+
+  function [63:0] expected_lane;
+    input integer group_value;
+    input integer slot_value;
+    input integer dimension_value;
+    begin
+      expected_lane = 64'h4b00_0000_0000_0000 |
+        (group_value << 16) | (slot_value << 8) | dimension_value;
+    end
+  endfunction
+
+  function [1023:0] expected_word;
+    input integer group_value;
+    input integer slot_value;
+    integer dimension_value;
+    begin
+      expected_word = 1024'd0;
+      for (dimension_value = 0; dimension_value < DIMS;
+           dimension_value = dimension_value + 1)
+        expected_word[dimension_value*64 +: 64] =
+          expected_lane(group_value, slot_value, dimension_value);
+    end
+  endfunction
+
+  always @* begin
+    for (bank_i = 0; bank_i < BANKS; bank_i = bank_i + 1)
+      bank_req_ready[bank_i] = !backpressure_case ||
+        (((cycle + bank_i) % 4) != 0);
+    compute_ready = !backpressure_case || ((cycle % 5) != 2);
+  end
+
+  // One-cycle pipelined bank response.  Every bank can accept and return one
+  // word per cycle, matching the intended independently banked macro array.
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      cycle <= 0;
+      bank_rsp_valid <= {BANKS{1'b0}};
+      bank_rsp_data <= {(BANKS*1024){1'b0}};
+      bank_rsp_buffer <= {BANKS{1'b0}};
+      bank_rsp_group <= {(BANKS*GROUP_W){1'b0}};
+      bank_rsp_slot <= {(BANKS*SLOT_W){1'b0}};
+      malformed_sent <= 1'b0;
+    end else begin
+      cycle <= cycle + 1;
+      bank_rsp_valid <= bank_req_valid & bank_req_ready;
+      for (bank_i = 0; bank_i < BANKS; bank_i = bank_i + 1) begin
+        if (bank_req_valid[bank_i] && bank_req_ready[bank_i]) begin
+          group_i = bank_req_group[bank_i*GROUP_W +: GROUP_W];
+          slot_i = bank_req_slot[bank_i*SLOT_W +: SLOT_W];
+          bank_rsp_buffer[bank_i] <= bank_req_buffer[bank_i];
+          bank_rsp_group[bank_i*GROUP_W +: GROUP_W] <=
+            (malformed_case && !malformed_sent) ? GROUP_W'(group_i + 1) :
+            GROUP_W'(group_i);
+          bank_rsp_slot[bank_i*SLOT_W +: SLOT_W] <= SLOT_W'(slot_i);
+          bank_rsp_data[bank_i*1024 +: 1024] <= expected_word(group_i, slot_i);
+          if (malformed_case && !malformed_sent)
+            malformed_sent <= 1'b1;
+        end
+      end
+    end
+  end
+
+  always @(posedge clk) begin
+    if (rst_n) begin
+      for (bank_i = 0; bank_i < BANKS; bank_i = bank_i + 1) begin
+        if (bank_req_valid[bank_i] && bank_req_ready[bank_i]) begin
+          group_i = bank_req_group[bank_i*GROUP_W +: GROUP_W];
+          slot_i = bank_req_slot[bank_i*SLOT_W +: SLOT_W];
+          addr_i = bank_req_word_addr[bank_i*ADDR_W +: ADDR_W];
+          if (addr_i != BASE_WORD + slot_i*GROUPS + group_i)
+            $fatal(1, "request address mismatch bank=%0d group=%0d slot=%0d addr=%0d",
+                   bank_i, group_i, slot_i, addr_i);
+          if ((addr_i % BANKS) != bank_i)
+            $fatal(1, "request routed to wrong bank");
+          if (request_seen[group_i][slot_i])
+            $fatal(1, "duplicate request group=%0d slot=%0d", group_i, slot_i);
+          request_seen[group_i][slot_i] <= 1'b1;
+          request_count_by_group[group_i] = request_count_by_group[group_i] + 1;
+          if (first_request_cycle[group_i] < 0)
+            first_request_cycle[group_i] <= cycle;
+          last_request_cycle[group_i] <= cycle;
+        end
+      end
+
+      if (compute_valid && compute_ready) begin
+        if (compute_group != expected_compute_group ||
+            compute_dimension != expected_compute_dimension)
+          $fatal(1, "compute order mismatch got g=%0d d=%0d expected g=%0d d=%0d",
+                 compute_group, compute_dimension,
+                 expected_compute_group, expected_compute_dimension);
+        if (compute_last != (expected_compute_dimension == DIMS-1))
+          $fatal(1, "compute_last mismatch");
+        for (word_i = 0; word_i < WORDS; word_i = word_i + 1)
+          if (compute_k_beats[word_i*64 +: 64] !==
+              expected_lane(expected_compute_group, word_i,
+                            expected_compute_dimension))
+            $fatal(1, "compute K data mismatch g=%0d d=%0d word=%0d",
+                   expected_compute_group, expected_compute_dimension, word_i);
+        if (last_compute_cycle >= 0 &&
+            cycle - last_compute_cycle > max_compute_interval)
+          max_compute_interval <= cycle - last_compute_cycle;
+        last_compute_cycle <= cycle;
+        compute_count <= compute_count + 1;
+        if (expected_compute_dimension == 0)
+          compute_start_cycle[expected_compute_group] <= cycle;
+        if (expected_compute_dimension == DIMS-1) begin
+          compute_end_cycle[expected_compute_group] <= cycle;
+          expected_compute_dimension <= 0;
+          expected_compute_group <= expected_compute_group + 1;
+        end else begin
+          expected_compute_dimension <= expected_compute_dimension + 1;
+        end
+      end
+
+      if (malformed_case && protocol_error) begin
+        $display("PASS k_window malformed_response requests=%0d responses=%0d",
+                 bank_request_count, bank_response_count);
+        $finish;
+      end
+
+      if (done) begin
+        if (protocol_error)
+          $fatal(1, "protocol_error asserted in valid run");
+        if (bank_request_count != GROUPS*WORDS ||
+            bank_response_count != GROUPS*WORDS ||
+            compute_beat_count != GROUPS*DIMS ||
+            compute_count != GROUPS*DIMS)
+          $fatal(1, "counter mismatch req=%0d rsp=%0d compute=%0d observed=%0d",
+                 bank_request_count, bank_response_count,
+                 compute_beat_count, compute_count);
+        for (group_i = 0; group_i < GROUPS; group_i = group_i + 1) begin
+          if (request_count_by_group[group_i] != WORDS)
+            $fatal(1, "group request count mismatch group=%0d count=%0d",
+                   group_i, request_count_by_group[group_i]);
+          if (!backpressure_case &&
+              last_request_cycle[group_i] - first_request_cycle[group_i] != 7)
+            $fatal(1, "ideal group did not issue in eight cycles group=%0d span=%0d",
+                   group_i,
+                   last_request_cycle[group_i] - first_request_cycle[group_i]);
+          $display("TRACE group=%0d first_req=%0d last_req=%0d compute_start=%0d compute_end=%0d",
+                   group_i, first_request_cycle[group_i],
+                   last_request_cycle[group_i], compute_start_cycle[group_i],
+                   compute_end_cycle[group_i]);
+        end
+        if (!backpressure_case && max_compute_interval != 1)
+          $fatal(1, "double buffering did not sustain one compute beat/cycle interval=%0d",
+                 max_compute_interval);
+        if (backpressure_case &&
+            (bank_request_stall_count == 0 || compute_output_stall_count == 0))
+          $fatal(1, "backpressure counters were not exercised");
+        $display("PASS k_window backpressure=%0d requests=%0d responses=%0d compute=%0d max_compute_interval=%0d request_stalls=%0d compute_stalls=%0d wait=%0d",
+                 backpressure_case, bank_request_count, bank_response_count,
+                 compute_beat_count, max_compute_interval,
+                 bank_request_stall_count, compute_output_stall_count,
+                 compute_wait_for_window_count);
+        $finish;
+      end
+
+      if (cycle > 5000)
+        $fatal(1, "timeout");
+    end
+  end
+
+  initial begin
+    backpressure_case = $test$plusargs("BACKPRESSURE");
+    malformed_case = $test$plusargs("MALFORMED");
+    for (group_i = 0; group_i < GROUPS; group_i = group_i + 1) begin
+      first_request_cycle[group_i] = -1;
+      last_request_cycle[group_i] = -1;
+      request_count_by_group[group_i] = 0;
+      compute_start_cycle[group_i] = -1;
+      compute_end_cycle[group_i] = -1;
+      for (slot_i = 0; slot_i < WORDS; slot_i = slot_i + 1)
+        request_seen[group_i][slot_i] = 1'b0;
+    end
+    repeat (3) @(negedge clk);
+    rst_n = 1'b1;
+    @(negedge clk);
+    command_valid = 1'b1;
+    @(posedge clk);
+    while (!command_ready) @(posedge clk);
+    @(negedge clk);
+    command_valid = 1'b0;
+  end
+endmodule

--- a/tests/attention_shared_sram_read_group_adapter_tb.sv
+++ b/tests/attention_shared_sram_read_group_adapter_tb.sv
@@ -1,0 +1,357 @@
+`timescale 1ns/1ps
+
+module attention_shared_sram_read_group_adapter_tb #(
+  parameter integer BEAT_W = 256,
+  parameter integer GROUP_SLOTS = 2,
+  parameter integer TEST_GROUPS = 4
+);
+  localparam integer ADDR_W = 32;
+  localparam integer MACRO_W = 1024;
+  localparam integer MACRO_BYTES = MACRO_W / 8;
+  localparam integer BEAT_BYTES = BEAT_W / 8;
+  localparam integer SEGMENTS = MACRO_W / BEAT_W;
+  localparam integer SLOT_W = (GROUP_SLOTS <= 1) ? 1 : $clog2(GROUP_SLOTS);
+  localparam integer GROUP_COUNT = TEST_GROUPS;
+  localparam integer TOTAL_REQUESTS = GROUP_COUNT * SEGMENTS;
+
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  integer cycle = 0;
+
+  reg req_valid = 1'b0;
+  wire req_ready;
+  reg [ADDR_W-1:0] req_addr = 0;
+  wire rsp_valid;
+  reg rsp_ready = 1'b0;
+  wire [BEAT_W-1:0] rsp_data;
+  wire [ADDR_W-1:0] rsp_addr;
+
+  wire macro_req_valid;
+  reg macro_req_ready = 1'b1;
+  wire [ADDR_W-1:0] macro_req_addr;
+  wire [SLOT_W-1:0] macro_req_slot;
+  reg macro_rsp_valid = 1'b0;
+  wire macro_rsp_ready;
+  reg [MACRO_W-1:0] macro_rsp_data = 0;
+  reg [ADDR_W-1:0] macro_rsp_addr = 0;
+  reg [SLOT_W-1:0] macro_rsp_slot = 0;
+
+  wire protocol_error;
+  wire [63:0] beat_request_count;
+  wire [63:0] macro_read_count;
+  wire [63:0] beat_response_count;
+  wire [63:0] beat_request_stall_count;
+  wire [63:0] beat_response_stall_count;
+  wire [63:0] macro_request_stall_count;
+  wire [63:0] macro_response_stall_count;
+  wire access_reduction_proven;
+
+  reg macro_pending = 1'b0;
+  integer macro_delay = 0;
+  reg steady_case = 1'b0;
+  reg invalid_meta_case = 1'b0;
+  integer request_fire_cycle = -1;
+  integer first_response_cycle = -1;
+  integer response_count = 0;
+  integer last_response_cycle = -1;
+  integer max_response_interval = 0;
+  integer held_response_valid = 0;
+  reg [BEAT_W-1:0] held_response_data = 0;
+  reg [ADDR_W-1:0] held_response_addr = 0;
+  integer held_request_valid = 0;
+  reg [ADDR_W-1:0] held_request_addr = 0;
+  integer held_macro_request_valid = 0;
+  reg [ADDR_W-1:0] held_macro_request_addr = 0;
+  reg [SLOT_W-1:0] held_macro_request_slot = 0;
+
+  attention_shared_sram_read_group_adapter #(
+    .ADDR_W(ADDR_W),
+    .BEAT_W(BEAT_W),
+    .GROUP_SLOTS(GROUP_SLOTS)
+  ) dut (
+    .clk(clk), .rst_n(rst_n),
+    .req_valid(req_valid), .req_ready(req_ready), .req_addr(req_addr),
+    .rsp_valid(rsp_valid), .rsp_ready(rsp_ready), .rsp_data(rsp_data),
+    .rsp_addr(rsp_addr),
+    .macro_req_valid(macro_req_valid), .macro_req_ready(macro_req_ready),
+    .macro_req_addr(macro_req_addr), .macro_req_slot(macro_req_slot),
+    .macro_rsp_valid(macro_rsp_valid), .macro_rsp_ready(macro_rsp_ready),
+    .macro_rsp_data(macro_rsp_data), .macro_rsp_addr(macro_rsp_addr),
+    .macro_rsp_slot(macro_rsp_slot), .protocol_error(protocol_error),
+    .beat_request_count(beat_request_count),
+    .macro_read_count(macro_read_count),
+    .beat_response_count(beat_response_count),
+    .beat_request_stall_count(beat_request_stall_count),
+    .beat_response_stall_count(beat_response_stall_count),
+    .macro_request_stall_count(macro_request_stall_count),
+    .macro_response_stall_count(macro_response_stall_count),
+    .access_reduction_proven(access_reduction_proven)
+  );
+
+  always #5 clk = ~clk;
+
+  function [BEAT_W-1:0] expected_beat;
+    input [ADDR_W-1:0] address;
+    integer word_i;
+    begin
+      expected_beat = {BEAT_W{1'b0}};
+      for (word_i = 0; word_i < BEAT_W / 32; word_i = word_i + 1)
+        expected_beat[word_i*32 +: 32] = address[31:0] ^
+          (32'h5100_0000 + word_i);
+    end
+  endfunction
+
+  function [MACRO_W-1:0] expected_macro_word;
+    input [ADDR_W-1:0] address;
+    integer segment_i;
+    begin
+      expected_macro_word = {MACRO_W{1'b0}};
+      for (segment_i = 0; segment_i < SEGMENTS; segment_i = segment_i + 1)
+        expected_macro_word[segment_i*BEAT_W +: BEAT_W] =
+          expected_beat(address + segment_i * BEAT_BYTES);
+    end
+  endfunction
+
+  always @(*) begin
+    // Periodic request backpressure exercises descriptor stability.
+    macro_req_ready = steady_case || ((cycle % 5) != 2);
+    if (steady_case)
+      rsp_ready = 1'b1;
+    else
+      rsp_ready = (cycle >= 20) && ((cycle % 4) != 1);
+  end
+
+  // A two-cycle-or-less synchronous macro response model.  The response
+  // metadata is intentionally echoed so the adapter can validate ownership.
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      cycle <= 0;
+      macro_pending <= 1'b0;
+      macro_delay <= 0;
+      macro_rsp_valid <= 1'b0;
+      macro_rsp_data <= {MACRO_W{1'b0}};
+      macro_rsp_addr <= {ADDR_W{1'b0}};
+      macro_rsp_slot <= {SLOT_W{1'b0}};
+    end else begin
+      cycle <= cycle + 1;
+      if (macro_rsp_valid && macro_rsp_ready)
+        macro_rsp_valid <= 1'b0;
+
+      if (macro_req_valid && macro_req_ready) begin
+        if (macro_pending || (macro_rsp_valid && !macro_rsp_ready))
+          $fatal(1, "macro port accepted a second transaction");
+        macro_pending <= 1'b1;
+        macro_delay <= 0;
+        macro_rsp_data <= expected_macro_word(macro_req_addr);
+        macro_rsp_addr <= invalid_meta_case ?
+          (macro_req_addr + MACRO_BYTES) : macro_req_addr;
+        macro_rsp_slot <= macro_req_slot;
+      end
+
+      if (macro_pending && !macro_rsp_valid) begin
+        if (macro_delay == 0) begin
+          macro_pending <= 1'b0;
+          macro_rsp_valid <= 1'b1;
+        end else begin
+          macro_delay <= macro_delay - 1;
+        end
+      end
+    end
+  end
+
+  always @(posedge clk) begin
+    if (!rst_n) begin
+      request_fire_cycle <= -1;
+      first_response_cycle <= -1;
+      response_count <= 0;
+      last_response_cycle <= -1;
+      max_response_interval <= 0;
+      held_response_valid <= 0;
+      held_request_valid <= 0;
+      held_macro_request_valid <= 0;
+    end else begin
+      if (req_valid && req_ready && request_fire_cycle < 0)
+        request_fire_cycle <= cycle;
+
+      if (req_valid && !req_ready) begin
+        if (held_request_valid && held_request_addr !== req_addr)
+          $fatal(1, "request address changed under backpressure");
+        held_request_valid <= 1;
+        held_request_addr <= req_addr;
+      end else begin
+        held_request_valid <= 0;
+      end
+
+      if (macro_req_valid && !macro_req_ready) begin
+        if (held_macro_request_valid &&
+            (held_macro_request_addr !== macro_req_addr ||
+             held_macro_request_slot !== macro_req_slot))
+          $fatal(1, "macro request changed under backpressure");
+        held_macro_request_valid <= 1;
+        held_macro_request_addr <= macro_req_addr;
+        held_macro_request_slot <= macro_req_slot;
+      end else begin
+        held_macro_request_valid <= 0;
+      end
+
+      if (rsp_valid && !rsp_ready) begin
+        if (held_response_valid &&
+            (held_response_data !== rsp_data || held_response_addr !== rsp_addr))
+          $fatal(1, "response changed under backpressure");
+        held_response_valid <= 1;
+        held_response_data <= rsp_data;
+        held_response_addr <= rsp_addr;
+      end else begin
+        held_response_valid <= 0;
+      end
+
+      if (rsp_valid && rsp_ready) begin
+        if (first_response_cycle < 0)
+          first_response_cycle <= cycle;
+        if (last_response_cycle >= 0 &&
+            cycle - last_response_cycle > max_response_interval)
+          max_response_interval <= cycle - last_response_cycle;
+        last_response_cycle <= cycle;
+        if (rsp_data !== expected_beat(rsp_addr))
+          $fatal(1, "response payload mismatch addr=%h", rsp_addr);
+        if (rsp_addr[$clog2(BEAT_BYTES)-1:0] != 0)
+          $fatal(1, "response address is not beat aligned");
+        response_count <= response_count + 1;
+      end
+    end
+  end
+
+  task send_request;
+    input [ADDR_W-1:0] address;
+    begin
+      @(negedge clk);
+      req_valid = 1'b1;
+      req_addr = address;
+      @(posedge clk);
+      while (!req_ready) @(posedge clk);
+      @(negedge clk);
+      req_valid = 1'b0;
+    end
+  endtask
+
+  task send_request_stream;
+    integer request_i;
+    integer next_group;
+    integer next_segment;
+    begin
+      @(negedge clk);
+      req_valid = 1'b1;
+      req_addr = 32'h0000_1000;
+      for (request_i = 0; request_i < TOTAL_REQUESTS; request_i = request_i + 1) begin
+        @(posedge clk);
+        while (!req_ready) @(posedge clk);
+        if (request_i + 1 < TOTAL_REQUESTS) begin
+          next_group = (request_i + 1) / SEGMENTS;
+          next_segment = (request_i + 1) % SEGMENTS;
+          @(negedge clk);
+          req_addr = 32'h0000_1000 + next_group * MACRO_BYTES +
+                     next_segment * BEAT_BYTES;
+        end else begin
+          @(negedge clk);
+          req_valid = 1'b0;
+        end
+      end
+    end
+  endtask
+
+  task send_malformed_sequence;
+    begin
+      send_request(32'h0000_1000);
+      @(negedge clk);
+      req_valid = 1'b1;
+      req_addr = 32'h0000_1000 + (2 * BEAT_BYTES);
+      repeat (4) @(posedge clk);
+      if (!protocol_error)
+        $fatal(1, "nonsequential request did not set protocol_error");
+      @(negedge clk);
+      req_valid = 1'b0;
+      $display("PASS adapter malformed_sequence BEAT_W=%0d", BEAT_W);
+      $finish;
+    end
+  endtask
+
+  task send_orphan_response;
+    begin
+      @(negedge clk);
+      macro_rsp_valid = 1'b1;
+      macro_rsp_data = {MACRO_W{1'b0}};
+      macro_rsp_addr = 32'h0000_1000;
+      macro_rsp_slot = {SLOT_W{1'b0}};
+      repeat (3) @(posedge clk);
+      if (!protocol_error)
+        $fatal(1, "orphan macro response did not set protocol_error");
+      @(negedge clk);
+      macro_rsp_valid = 1'b0;
+      $display("PASS adapter orphan_response BEAT_W=%0d", BEAT_W);
+      $finish;
+    end
+  endtask
+
+  integer group_i;
+  integer segment_i;
+  initial begin
+    steady_case = $test$plusargs("STEADY");
+    invalid_meta_case = $test$plusargs("INVALID_META");
+    if ($test$plusargs("MALFORMED")) begin
+      repeat (3) @(negedge clk);
+      rst_n = 1'b1;
+      send_malformed_sequence;
+    end
+    if ($test$plusargs("ORPHAN")) begin
+      repeat (3) @(negedge clk);
+      rst_n = 1'b1;
+      send_orphan_response;
+    end
+
+    repeat (3) @(negedge clk);
+    rst_n = 1'b1;
+    fork
+      begin
+        send_request_stream;
+      end
+      begin
+        wait (protocol_error || response_count == TOTAL_REQUESTS);
+      end
+    join_any
+    if (invalid_meta_case) begin
+      if (!protocol_error)
+        $fatal(1, "invalid macro metadata did not set protocol_error");
+      $display("PASS adapter invalid_metadata BEAT_W=%0d", BEAT_W);
+      $finish;
+    end
+    if (protocol_error && !invalid_meta_case)
+      $fatal(1, "normal adapter case raised protocol_error");
+    if (response_count != TOTAL_REQUESTS) begin
+      repeat (200) @(posedge clk);
+      if (response_count != TOTAL_REQUESTS)
+        $fatal(1, "response timeout count=%0d expected=%0d",
+               response_count, TOTAL_REQUESTS);
+    end
+    if (beat_request_count !== TOTAL_REQUESTS ||
+        macro_read_count !== GROUP_COUNT ||
+        beat_response_count !== TOTAL_REQUESTS ||
+        !access_reduction_proven)
+      $fatal(1, "wrong final counters req=%0d macro=%0d rsp=%0d reduction=%0d",
+             beat_request_count, macro_read_count, beat_response_count,
+             access_reduction_proven);
+    if (steady_case && GROUP_SLOTS == 2 && max_response_interval > 1)
+      $fatal(1, "steady-state response interval=%0d", max_response_interval);
+
+    $display("PASS adapter BEAT_W=%0d GROUP_SLOTS=%0d requests=%0d macro_reads=%0d responses=%0d fill_latency=%0d steady_interval=%0d request_stalls=%0d response_stalls=%0d macro_request_stalls=%0d",
+             BEAT_W, GROUP_SLOTS, beat_request_count, macro_read_count,
+             beat_response_count, first_response_cycle - request_fire_cycle,
+             max_response_interval, beat_request_stall_count,
+             beat_response_stall_count, macro_request_stall_count);
+    $finish;
+  end
+
+  initial begin
+    #100000;
+    $fatal(1, "adapter simulation timeout");
+  end
+endmodule

--- a/tests/attention_shared_stream_context_admission_tb.sv
+++ b/tests/attention_shared_stream_context_admission_tb.sv
@@ -1,0 +1,252 @@
+`timescale 1ns/1ps
+
+module attention_shared_stream_context_admission_tb;
+  localparam integer ADDR_W = 32;
+  localparam integer PACKET_INDEX_W = 7;
+  localparam integer PACKET_COUNT_W = PACKET_INDEX_W + 1;
+  localparam integer LEGAL_WAVES = 7;
+  localparam integer CONTEXT_COUNT = 112;
+
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  reg layer_start = 1'b0;
+  reg layer_idle = 1'b1;
+  reg [7:0] layer_expected_remote_contexts = 0;
+  reg [15:0] event_valid = 16'b0;
+  wire [15:0] event_ready;
+  reg [16*3-1:0] event_wave = 0;
+  reg [16*4-1:0] event_source = 0;
+  reg [16*ADDR_W-1:0] event_source_base_addr = 0;
+  reg [16*ADDR_W-1:0] event_destination_base_addr = 0;
+  reg [16*PACKET_COUNT_W-1:0] event_packet_count = 0;
+  wire context_valid;
+  reg context_ready = 1'b0;
+  wire [2:0] context_wave;
+  wire [3:0] context_destination;
+  wire [3:0] context_cluster;
+  wire [3:0] context_source;
+  wire [ADDR_W-1:0] context_source_base_addr;
+  wire [ADDR_W-1:0] context_destination_base_addr;
+  wire [PACKET_INDEX_W:0] context_packet_count;
+  wire layer_active;
+  wire layer_complete;
+  wire [7:0] admitted_count;
+  wire protocol_error;
+
+  integer cycle = 0;
+  integer observed = 0;
+  integer wave_i;
+  integer lane_i;
+  integer output_index;
+  integer held_checks = 0;
+  reg error_mode = 1'b0;
+  reg held_valid = 1'b0;
+  reg [2:0] held_wave = 0;
+  reg [3:0] held_cluster = 0;
+  reg [3:0] held_source = 0;
+  reg [ADDR_W-1:0] held_source_base = 0;
+  reg [ADDR_W-1:0] held_destination_base = 0;
+  reg [PACKET_COUNT_W-1:0] held_packet_count = 0;
+  reg seen [0:127];
+
+  attention_shared_stream_context_admission #(.ADDR_W(ADDR_W)) dut (
+    .clk(clk), .rst_n(rst_n), .layer_start(layer_start), .layer_idle(layer_idle),
+    .layer_expected_remote_contexts(layer_expected_remote_contexts),
+    .event_valid(event_valid), .event_ready(event_ready), .event_wave(event_wave),
+    .event_source(event_source),
+    .event_source_base_addr(event_source_base_addr),
+    .event_destination_base_addr(event_destination_base_addr),
+    .event_packet_count(event_packet_count),
+    .context_valid(context_valid), .context_ready(context_ready),
+    .context_wave(context_wave), .context_cluster(context_cluster),
+    .context_destination(context_destination),
+    .context_source(context_source),
+    .context_source_base_addr(context_source_base_addr),
+    .context_destination_base_addr(context_destination_base_addr),
+    .context_packet_count(context_packet_count),
+    .layer_active(layer_active), .layer_complete(layer_complete),
+    .admitted_count(admitted_count), .protocol_error(protocol_error)
+  );
+
+  always #1 clk = ~clk;
+
+  function [3:0] expected_shift;
+    input integer wave;
+    begin
+      case (wave)
+        0: expected_shift = 4;
+        1: expected_shift = 7;
+        2: expected_shift = 10;
+        3: expected_shift = 13;
+        5: expected_shift = 3;
+        6: expected_shift = 6;
+        default: expected_shift = 9;
+      endcase
+    end
+  endfunction
+
+  function [ADDR_W-1:0] source_base;
+    input integer wave;
+    input integer lane;
+    begin
+      source_base = 32'h0010_0000 + (wave * 32'h0001_0000) + (lane * 32'h0000_0100);
+    end
+  endfunction
+
+  function [ADDR_W-1:0] destination_base;
+    input integer wave;
+    input integer lane;
+    begin
+      destination_base = 32'h0020_0000 + (wave * 32'h0001_0000) + (lane * 32'h0000_0100);
+    end
+  endfunction
+
+  task send_wave;
+    input integer wave;
+    begin
+      @(negedge clk);
+      event_valid = 16'hffff;
+      for (lane_i = 0; lane_i < 16; lane_i = lane_i + 1) begin
+        event_wave[(lane_i*3) +: 3] = wave[2:0];
+        event_source[(lane_i*4) +: 4] = lane_i[3:0] + expected_shift(wave);
+        event_source_base_addr[(lane_i*ADDR_W) +: ADDR_W] = source_base(wave, lane_i);
+        event_destination_base_addr[(lane_i*ADDR_W) +: ADDR_W] = destination_base(wave, lane_i);
+        event_packet_count[(lane_i*PACKET_COUNT_W) +: PACKET_COUNT_W] = 68;
+      end
+      @(posedge clk);
+      if (event_ready !== 16'hffff)
+        $fatal(1, "event lanes were not ready for wave %0d", wave);
+      @(negedge clk);
+      event_valid = 16'b0;
+    end
+  endtask
+
+  task start_layer;
+    input integer expected_count;
+    begin
+      @(negedge clk);
+      layer_expected_remote_contexts = expected_count;
+      layer_start = 1'b1;
+      @(posedge clk);
+      @(negedge clk);
+      layer_start = 1'b0;
+    end
+  endtask
+
+  task send_one;
+    input integer wave;
+    input integer lane;
+    input integer source;
+    begin
+      @(negedge clk);
+      event_valid = (16'b1 << lane);
+      event_wave[(lane*3) +: 3] = wave[2:0];
+      event_source[(lane*4) +: 4] = source[3:0];
+      event_source_base_addr[(lane*ADDR_W) +: ADDR_W] = source_base(wave, lane);
+      event_destination_base_addr[(lane*ADDR_W) +: ADDR_W] = destination_base(wave, lane);
+      event_packet_count[(lane*PACKET_COUNT_W) +: PACKET_COUNT_W] = 68;
+      @(posedge clk);
+      @(negedge clk);
+      event_valid = 16'b0;
+    end
+  endtask
+
+  always @(posedge clk) begin
+    if (rst_n) begin
+      cycle = cycle + 1;
+      context_ready <= error_mode ? 1'b0 : (((cycle % 7) != 3) && ((cycle % 11) != 5));
+      if (context_valid && !context_ready) begin
+        if (held_valid) begin
+          if (context_wave !== held_wave || context_cluster !== held_cluster ||
+              context_source !== held_source ||
+              context_source_base_addr !== held_source_base ||
+              context_destination_base_addr !== held_destination_base ||
+              context_packet_count !== held_packet_count)
+            $fatal(1, "admission output changed under backpressure");
+          held_checks = held_checks + 1;
+        end else begin
+          held_valid <= 1'b1;
+          held_wave <= context_wave;
+          held_cluster <= context_cluster;
+          held_source <= context_source;
+          held_source_base <= context_source_base_addr;
+          held_destination_base <= context_destination_base_addr;
+          held_packet_count <= context_packet_count;
+        end
+      end else begin
+        held_valid <= 1'b0;
+      end
+
+      if (context_valid && context_ready) begin
+        output_index = (context_wave * 16) + context_cluster;
+        if (context_destination !== context_cluster)
+          $fatal(1, "destination alias mismatch");
+        if (seen[output_index])
+          $fatal(1, "duplicate or local context wave=%0d cluster=%0d", context_wave, context_cluster);
+        seen[output_index] = 1'b1;
+        if (context_source !== context_cluster + expected_shift(context_wave))
+          $fatal(1, "source shift mismatch wave=%0d cluster=%0d source=%0d",
+            context_wave, context_cluster, context_source);
+        if (context_source_base_addr !== source_base(context_wave, context_cluster) ||
+            context_destination_base_addr !== destination_base(context_wave, context_cluster) ||
+            context_packet_count !== 68)
+          $fatal(1, "base address metadata mismatch wave=%0d cluster=%0d",
+            context_wave, context_cluster);
+        observed = observed + 1;
+      end
+    end
+  end
+
+  initial begin
+    for (lane_i = 0; lane_i < 128; lane_i = lane_i + 1)
+      seen[lane_i] = 1'b0;
+    repeat (3) @(negedge clk);
+    rst_n = 1'b1;
+    if ($test$plusargs("EMPTY_CASE")) begin
+      start_layer(0);
+      if (!layer_complete || layer_active || admitted_count != 0 || protocol_error)
+        $fatal(1, "zero-context layer did not complete cleanly");
+      $display("PASS admission empty_layer");
+      $finish;
+    end else if ($test$plusargs("ERROR_CASE")) begin
+      start_layer(1);
+      send_one(0, 0, 0);
+      if (!protocol_error || event_ready != 0 || context_valid)
+        $fatal(1, "local event did not fail closed");
+      send_one(0, 1, 5);
+      if (event_ready != 0 || context_valid)
+        $fatal(1, "admission resumed after invalid event");
+      $display("PASS admission invalid_event_fail_closed");
+      $finish;
+    end else if ($test$plusargs("DUPLICATE_CASE")) begin
+      error_mode = 1'b1;
+      start_layer(2);
+      send_one(0, 1, 5);
+      send_one(0, 1, 5);
+      if (!protocol_error || event_ready != 0 || context_valid)
+        $fatal(1, "duplicate event did not fail closed");
+      $display("PASS admission duplicate_event_fail_closed");
+      $finish;
+    end else begin
+      start_layer(CONTEXT_COUNT);
+      send_wave(5);
+      send_wave(2);
+      send_wave(0);
+      send_wave(7);
+      send_wave(1);
+      send_wave(6);
+      send_wave(3);
+      wait (layer_complete && observed == CONTEXT_COUNT);
+      if (admitted_count != CONTEXT_COUNT || protocol_error || held_checks == 0)
+        $fatal(1, "admission mismatch admitted=%0d observed=%0d error=%0d holds=%0d",
+          admitted_count, observed, protocol_error, held_checks);
+      $display("PASS admission contexts=%0d holds=%0d", observed, held_checks);
+      $finish;
+    end
+  end
+
+  initial begin
+    #100000;
+    $fatal(1, "admission simulation timeout");
+  end
+endmodule

--- a/tests/attention_shared_stream_context_engine_tb.sv
+++ b/tests/attention_shared_stream_context_engine_tb.sv
@@ -1,0 +1,459 @@
+`timescale 1ns/1ps
+
+module attention_shared_stream_context_engine_tb #(
+  parameter integer MAX_PACKETS_PER_CONTEXT = 68,
+  parameter integer PACKET_INDEX_W = 7,
+  parameter integer TEST_CONTEXT_COUNT = 112,
+  parameter integer TX_DESC_DEPTH = 1
+);
+  localparam integer ADDR_W = 32;
+  localparam integer CONTEXT_COUNT = 112;
+  localparam integer PACKET_COUNT_W = PACKET_INDEX_W + 1;
+
+  reg clk = 1'b0;
+  reg rst_n = 1'b0;
+  reg context_valid = 1'b0;
+  wire context_ready;
+  reg [2:0] context_wave = 0;
+  reg [3:0] context_destination = 0;
+  reg [3:0] context_source = 0;
+  reg [ADDR_W-1:0] context_source_base_addr = 0;
+  reg [ADDR_W-1:0] context_destination_base_addr = 0;
+  reg [PACKET_COUNT_W-1:0] context_packet_count = MAX_PACKETS_PER_CONTEXT;
+  wire context_completion_valid;
+  reg context_completion_ready = 1'b0;
+  wire [2:0] context_completion_wave;
+  wire [3:0] context_completion_destination;
+
+  wire [15:0] tx_desc_valid;
+  wire [15:0] tx_desc_ready;
+  wire [63:0] tx_desc_destination;
+  wire [31:0] tx_desc_vc;
+  wire [127:0] tx_desc_tag;
+  wire [16*ADDR_W-1:0] tx_desc_base_addr;
+  wire [63:0] tx_desc_flit_count;
+  wire [15:0] rx_desc_valid;
+  wire [15:0] rx_desc_ready;
+  wire [63:0] rx_desc_source;
+  wire [31:0] rx_desc_vc;
+  wire [127:0] rx_desc_tag;
+  wire [16*ADDR_W-1:0] rx_desc_base_addr;
+  wire [63:0] rx_desc_flit_count;
+
+  wire [15:0] tx_mem_req_valid;
+  reg [15:0] tx_mem_req_ready = 16'hffff;
+  wire [16*ADDR_W-1:0] tx_mem_req_addr;
+  reg [15:0] tx_mem_rsp_valid = 16'b0;
+  wire [15:0] tx_mem_rsp_ready;
+  reg [16*256-1:0] tx_mem_rsp_data = 0;
+  wire [15:0] rx_mem_write_valid;
+  reg [15:0] rx_mem_write_ready = 16'hffff;
+  wire [16*ADDR_W-1:0] rx_mem_write_addr;
+  wire [16*256-1:0] rx_mem_write_data;
+  wire [15:0] endpoint_protocol_error;
+  wire protocol_error;
+
+  reg rsp_pending [0:15];
+  reg [255:0] rsp_data [0:15];
+  integer cycle = 0;
+  integer wave_i;
+  integer lane_i;
+  integer endpoint_i;
+  integer command_count = 0;
+  integer tx_descriptor_count = 0;
+  integer rx_descriptor_count = 0;
+  integer write_count = 0;
+  integer completion_count = 0;
+  integer descriptor_backpressure = 0;
+  integer max_tx_valid_per_cycle = 0;
+  integer max_rx_valid_per_cycle = 0;
+  integer max_tx_descriptors_per_cycle = 0;
+  integer max_rx_descriptors_per_cycle = 0;
+  integer expected_descriptor_count = 0;
+  integer expected_flit_count = 0;
+  integer submitted_contexts = 0;
+  integer variable_count_case = 0;
+  integer invalid_case_mode = 0;
+  integer parallel_tx_count = 0;
+  integer parallel_rx_count = 0;
+  integer held_completion_checks = 0;
+  reg [ADDR_W-1:0] source_base_by_endpoint [0:15];
+  reg [ADDR_W-1:0] destination_base_by_endpoint [0:15];
+  reg [3:0] destination_by_source_endpoint [0:15];
+  reg [3:0] source_by_destination_endpoint [0:15];
+  integer expected_tx_packet [0:15];
+  integer expected_rx_packet [0:15];
+  reg completion_seen [0:127];
+  reg completion_held = 1'b0;
+  reg completion_stall_seen = 1'b0;
+  reg [2:0] held_completion_wave = 0;
+  reg [3:0] held_completion_destination = 0;
+
+  attention_shared_stream_context_engine #(
+    .ADDR_W(ADDR_W),
+    .MAX_PACKETS_PER_CONTEXT(MAX_PACKETS_PER_CONTEXT),
+    .PACKET_INDEX_W(PACKET_INDEX_W),
+    .TAG_W(8),
+    .TX_DESC_DEPTH(TX_DESC_DEPTH)
+  ) dut (
+    .clk(clk), .rst_n(rst_n),
+    .context_valid(context_valid), .context_ready(context_ready),
+    .context_wave(context_wave), .context_destination(context_destination),
+    .context_source(context_source),
+    .context_source_base_addr(context_source_base_addr),
+    .context_destination_base_addr(context_destination_base_addr),
+    .context_packet_count(context_packet_count),
+    .context_completion_valid(context_completion_valid),
+    .context_completion_ready(context_completion_ready),
+    .context_completion_wave(context_completion_wave),
+    .context_completion_destination(context_completion_destination),
+    .tx_desc_valid(tx_desc_valid), .tx_desc_ready(tx_desc_ready),
+    .tx_desc_destination(tx_desc_destination), .tx_desc_vc(tx_desc_vc),
+    .tx_desc_tag(tx_desc_tag), .tx_desc_base_addr(tx_desc_base_addr),
+    .tx_desc_flit_count(tx_desc_flit_count),
+    .rx_desc_valid(rx_desc_valid), .rx_desc_ready(rx_desc_ready),
+    .rx_desc_source(rx_desc_source), .rx_desc_vc(rx_desc_vc),
+    .rx_desc_tag(rx_desc_tag), .rx_desc_base_addr(rx_desc_base_addr),
+    .rx_desc_flit_count(rx_desc_flit_count),
+    .tx_mem_req_valid(tx_mem_req_valid), .tx_mem_req_ready(tx_mem_req_ready),
+    .tx_mem_req_addr(tx_mem_req_addr), .tx_mem_rsp_valid(tx_mem_rsp_valid),
+    .tx_mem_rsp_ready(tx_mem_rsp_ready), .tx_mem_rsp_data(tx_mem_rsp_data),
+    .rx_mem_write_valid(rx_mem_write_valid),
+    .rx_mem_write_ready(rx_mem_write_ready),
+    .rx_mem_write_addr(rx_mem_write_addr), .rx_mem_write_data(rx_mem_write_data),
+    .endpoint_protocol_error(endpoint_protocol_error), .protocol_error(protocol_error)
+  );
+
+  always #1 clk = ~clk;
+
+  function [3:0] shift_for_wave;
+    input integer wave;
+    begin
+      case (wave)
+        0: shift_for_wave = 4;
+        1: shift_for_wave = 7;
+        2: shift_for_wave = 10;
+        3: shift_for_wave = 13;
+        5: shift_for_wave = 3;
+        6: shift_for_wave = 6;
+        default: shift_for_wave = 9;
+      endcase
+    end
+  endfunction
+
+  function [ADDR_W-1:0] make_source_base;
+    input integer wave;
+    input integer cluster;
+    begin
+      make_source_base = 32'h0100_0000 + wave * 32'h0010_0000 + cluster * 32'h0000_1000;
+    end
+  endfunction
+
+  function [ADDR_W-1:0] make_destination_base;
+    input integer wave;
+    input integer cluster;
+    begin
+      make_destination_base = 32'h0200_0000 + wave * 32'h0010_0000 + cluster * 32'h0000_1000;
+    end
+  endfunction
+
+  function [255:0] memory_word;
+    input [3:0] endpoint;
+    input [ADDR_W-1:0] address;
+    begin
+      memory_word = {220'b0, endpoint, address};
+    end
+  endfunction
+
+  always @(*) begin
+    tx_mem_rsp_valid = 16'b0;
+    tx_mem_rsp_data = 0;
+    tx_mem_req_ready = 16'b0;
+    for (endpoint_i = 0; endpoint_i < 16; endpoint_i = endpoint_i + 1) begin
+      tx_mem_rsp_valid[endpoint_i] = rsp_pending[endpoint_i];
+      tx_mem_rsp_data[(endpoint_i*256) +: 256] = rsp_data[endpoint_i];
+      tx_mem_req_ready[endpoint_i] = !rsp_pending[endpoint_i] &&
+        (((cycle + endpoint_i) % 5) != 1);
+      rx_mem_write_ready[endpoint_i] = (((cycle + endpoint_i) % 13) != 3);
+    end
+    context_completion_ready = completion_stall_seen &&
+      ((cycle % 17) != 5) && ((cycle % 23) != 7);
+  end
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      cycle <= 0;
+      for (endpoint_i = 0; endpoint_i < 16; endpoint_i = endpoint_i + 1) begin
+        rsp_pending[endpoint_i] <= 1'b0;
+        rsp_data[endpoint_i] <= 0;
+      end
+    end else begin
+      cycle <= cycle + 1;
+      for (endpoint_i = 0; endpoint_i < 16; endpoint_i = endpoint_i + 1) begin
+        if (rsp_pending[endpoint_i]) begin
+          if (tx_mem_rsp_ready[endpoint_i])
+            rsp_pending[endpoint_i] <= 1'b0;
+        end else if (tx_mem_req_valid[endpoint_i] && tx_mem_req_ready[endpoint_i]) begin
+          rsp_pending[endpoint_i] <= 1'b1;
+          rsp_data[endpoint_i] <= memory_word(endpoint_i[3:0],
+            tx_mem_req_addr[(endpoint_i*ADDR_W) +: ADDR_W]);
+        end
+      end
+    end
+  end
+
+  task submit_context;
+    input integer wave;
+    input integer cluster;
+    integer packet_value;
+    begin
+      @(negedge clk);
+      context_wave = wave[2:0];
+      context_destination = cluster[3:0];
+      context_source = cluster[3:0] + shift_for_wave(wave);
+      context_source_base_addr = make_source_base(wave, cluster);
+      context_destination_base_addr = make_destination_base(wave, cluster);
+      packet_value = (variable_count_case && submitted_contexts == 0) ? 257 :
+        ((variable_count_case) ? 3 : MAX_PACKETS_PER_CONTEXT);
+      context_packet_count = packet_value;
+      expected_descriptor_count = expected_descriptor_count + packet_value;
+      expected_flit_count = expected_flit_count + (packet_value * 8);
+      context_valid = 1'b1;
+      @(posedge clk);
+      while (!context_ready)
+        @(posedge clk);
+      source_base_by_endpoint[context_source] = context_source_base_addr;
+      destination_base_by_endpoint[context_destination] = context_destination_base_addr;
+      destination_by_source_endpoint[context_source] = context_destination;
+      source_by_destination_endpoint[context_destination] = context_source;
+      expected_tx_packet[context_source] = 0;
+      expected_rx_packet[context_destination] = 0;
+      @(negedge clk);
+      context_valid = 1'b0;
+      submitted_contexts = submitted_contexts + 1;
+    end
+  endtask
+
+  always @(posedge clk) begin
+    if (rst_n) begin
+      integer cycle_tx_descriptors;
+      integer cycle_rx_descriptors;
+      integer cycle_tx_valid_count;
+      integer cycle_rx_valid_count;
+      if (context_valid && context_ready)
+        command_count = command_count + 1;
+      cycle_tx_descriptors = 0;
+      cycle_rx_descriptors = 0;
+      cycle_tx_valid_count = 0;
+      cycle_rx_valid_count = 0;
+      for (endpoint_i = 0; endpoint_i < 16; endpoint_i = endpoint_i + 1) begin
+        if (tx_desc_valid[endpoint_i] && !tx_desc_ready[endpoint_i])
+          descriptor_backpressure = descriptor_backpressure + 1;
+        if (rx_desc_valid[endpoint_i] && !rx_desc_ready[endpoint_i])
+          descriptor_backpressure = descriptor_backpressure + 1;
+        if (tx_desc_valid[endpoint_i])
+          cycle_tx_valid_count = cycle_tx_valid_count + 1;
+        if (rx_desc_valid[endpoint_i])
+          cycle_rx_valid_count = cycle_rx_valid_count + 1;
+        if (tx_desc_valid[endpoint_i] && tx_desc_ready[endpoint_i]) begin
+          cycle_tx_descriptors = cycle_tx_descriptors + 1;
+          tx_descriptor_count = tx_descriptor_count + 1;
+          if (tx_desc_vc[(endpoint_i*2) +: 2] !== 0 ||
+              tx_desc_destination[(endpoint_i*4) +: 4] !== destination_by_source_endpoint[endpoint_i] ||
+              tx_desc_tag[(endpoint_i*8) +: 8] !== (expected_tx_packet[endpoint_i] & 255) ||
+              tx_desc_base_addr[(endpoint_i*ADDR_W) +: ADDR_W] !==
+                source_base_by_endpoint[endpoint_i] + (expected_tx_packet[endpoint_i] * 256) ||
+              tx_desc_flit_count[(endpoint_i*4) +: 4] !== 8)
+            $fatal(1, "TX descriptor mismatch endpoint=%0d tag=%0d expected_tag=%0d dest=%0d expected_dest=%0d base=%h expected_base=%h flits=%0d",
+              endpoint_i, tx_desc_tag[(endpoint_i*8) +: 8], expected_tx_packet[endpoint_i] & 255,
+              tx_desc_destination[(endpoint_i*4) +: 4], destination_by_source_endpoint[endpoint_i],
+              tx_desc_base_addr[(endpoint_i*ADDR_W) +: ADDR_W],
+              source_base_by_endpoint[endpoint_i] + (expected_tx_packet[endpoint_i] * 256),
+              tx_desc_flit_count[(endpoint_i*4) +: 4]);
+          expected_tx_packet[endpoint_i] = expected_tx_packet[endpoint_i] + 1;
+        end
+        if (rx_desc_valid[endpoint_i] && rx_desc_ready[endpoint_i]) begin
+          cycle_rx_descriptors = cycle_rx_descriptors + 1;
+          rx_descriptor_count = rx_descriptor_count + 1;
+          if (rx_desc_vc[(endpoint_i*2) +: 2] !== 0 ||
+              rx_desc_source[(endpoint_i*4) +: 4] !== source_by_destination_endpoint[endpoint_i] ||
+              rx_desc_tag[(endpoint_i*8) +: 8] !== (expected_rx_packet[endpoint_i] & 255) ||
+              rx_desc_base_addr[(endpoint_i*ADDR_W) +: ADDR_W] !==
+                destination_base_by_endpoint[endpoint_i] + (expected_rx_packet[endpoint_i] * 256) ||
+              rx_desc_flit_count[(endpoint_i*4) +: 4] !== 8)
+            $fatal(1, "RX descriptor mismatch endpoint=%0d tag=%0d", endpoint_i,
+              rx_desc_tag[(endpoint_i*8) +: 8]);
+          expected_rx_packet[endpoint_i] = expected_rx_packet[endpoint_i] + 1;
+        end
+        if (rx_mem_write_valid[endpoint_i] && rx_mem_write_ready[endpoint_i])
+          write_count = write_count + 1;
+      end
+      if (cycle_tx_valid_count > max_tx_valid_per_cycle)
+        max_tx_valid_per_cycle = cycle_tx_valid_count;
+      if (cycle_rx_valid_count > max_rx_valid_per_cycle)
+        max_rx_valid_per_cycle = cycle_rx_valid_count;
+      if (cycle_tx_descriptors > max_tx_descriptors_per_cycle)
+        max_tx_descriptors_per_cycle = cycle_tx_descriptors;
+      if (cycle_rx_descriptors > max_rx_descriptors_per_cycle)
+        max_rx_descriptors_per_cycle = cycle_rx_descriptors;
+      if (context_completion_valid && !context_completion_ready) begin
+        completion_stall_seen <= 1'b1;
+        if (completion_held) begin
+          if (context_completion_wave !== held_completion_wave ||
+              context_completion_destination !== held_completion_destination)
+            $fatal(1, "context completion changed under backpressure");
+          held_completion_checks = held_completion_checks + 1;
+        end else begin
+          completion_held <= 1'b1;
+          held_completion_wave <= context_completion_wave;
+          held_completion_destination <= context_completion_destination;
+        end
+      end else begin
+        completion_held <= 1'b0;
+      end
+      if (context_completion_valid && context_completion_ready) begin
+        if (context_completion_wave == 4 ||
+            completion_seen[(context_completion_wave*16) + context_completion_destination])
+          $fatal(1, "duplicate context completion wave=%0d destination=%0d",
+            context_completion_wave, context_completion_destination);
+        completion_seen[(context_completion_wave*16) + context_completion_destination] = 1'b1;
+        completion_count = completion_count + 1;
+      end
+      if (protocol_error && !invalid_case_mode)
+        $fatal(1, "unexpected engine protocol error endpoint=%h", endpoint_protocol_error);
+    end
+  end
+
+  initial begin
+    for (endpoint_i = 0; endpoint_i < 16; endpoint_i = endpoint_i + 1) begin
+      source_base_by_endpoint[endpoint_i] = 0;
+      destination_base_by_endpoint[endpoint_i] = 0;
+      destination_by_source_endpoint[endpoint_i] = 0;
+      source_by_destination_endpoint[endpoint_i] = 0;
+      expected_tx_packet[endpoint_i] = 0;
+      expected_rx_packet[endpoint_i] = 0;
+    end
+    for (endpoint_i = 0; endpoint_i < 128; endpoint_i = endpoint_i + 1)
+      completion_seen[endpoint_i] = 1'b0;
+    repeat (3) @(negedge clk);
+    rst_n = 1'b1;
+    variable_count_case = $test$plusargs("VARIABLE_COUNT_CASE");
+    invalid_case_mode = $test$plusargs("INVALID_CASE");
+    if ($test$plusargs("PARALLEL_CASE")) begin
+      @(negedge clk);
+      dut.source_busy = 16'hffff;
+      dut.destination_busy = 16'hffff;
+      for (endpoint_i = 0; endpoint_i < 16; endpoint_i = endpoint_i + 1) begin
+        dut.context_active[endpoint_i] = 1'b1;
+        dut.context_wave_q[endpoint_i] = 3'd0;
+        dut.context_source_q[endpoint_i] = endpoint_i[3:0] + 4'd4;
+        dut.context_destination_q[endpoint_i] = endpoint_i[3:0];
+        dut.context_src_base_q[endpoint_i] = 32'h0100_0000 + endpoint_i * 32'h1000;
+        dut.context_dst_base_q[endpoint_i] = 32'h0200_0000 + endpoint_i * 32'h1000;
+        dut.context_packet_count_q[endpoint_i] = 68;
+        dut.rx_installed_count[endpoint_i] = 0;
+        dut.tx_issued_count[endpoint_i] = 0;
+        dut.completed_count[endpoint_i] = 0;
+        dut.context_done_pending[endpoint_i] = 1'b0;
+        destination_by_source_endpoint[endpoint_i] = endpoint_i[3:0];
+        source_by_destination_endpoint[endpoint_i] = endpoint_i[3:0] + 4'd4;
+        source_base_by_endpoint[endpoint_i] = 32'h0100_0000 + endpoint_i * 32'h1000;
+        destination_base_by_endpoint[endpoint_i] = 32'h0200_0000 + endpoint_i * 32'h1000;
+        expected_tx_packet[endpoint_i] = 0;
+        expected_rx_packet[endpoint_i] = 0;
+      end
+      #0;
+      parallel_tx_count = 0;
+      parallel_rx_count = 0;
+      for (endpoint_i = 0; endpoint_i < 16; endpoint_i = endpoint_i + 1) begin
+        if (tx_desc_valid[endpoint_i] && tx_desc_ready[endpoint_i])
+          parallel_tx_count = parallel_tx_count + 1;
+        if (rx_desc_valid[endpoint_i] && rx_desc_ready[endpoint_i])
+          parallel_rx_count = parallel_rx_count + 1;
+      end
+      if (parallel_tx_count != 0 || parallel_rx_count != 16 ||
+          tx_desc_valid != 16'h0000 || rx_desc_valid != 16'hffff)
+        $fatal(1, "parallel RX lead mismatch tx_valid=%h rx_valid=%h tx=%0d rx=%0d",
+          tx_desc_valid, rx_desc_valid, parallel_tx_count, parallel_rx_count);
+      @(posedge clk);
+      @(negedge clk);
+      #0;
+      parallel_tx_count = 0;
+      parallel_rx_count = 0;
+      for (endpoint_i = 0; endpoint_i < 16; endpoint_i = endpoint_i + 1) begin
+        if (tx_desc_valid[endpoint_i] && tx_desc_ready[endpoint_i])
+          parallel_tx_count = parallel_tx_count + 1;
+        if (rx_desc_valid[endpoint_i] && rx_desc_ready[endpoint_i])
+          parallel_rx_count = parallel_rx_count + 1;
+      end
+      if (parallel_tx_count != 16 || parallel_rx_count != 16 ||
+          tx_desc_valid != 16'hffff || rx_desc_valid != 16'hffff)
+        $fatal(1, "parallel descriptor issue mismatch tx_valid=%h rx_valid=%h tx=%0d rx=%0d",
+          tx_desc_valid, rx_desc_valid, parallel_tx_count, parallel_rx_count);
+      $display("PASS engine parallel_descriptors rx_lead=16 tx=%0d rx=%0d",
+        parallel_tx_count, parallel_rx_count);
+      $finish;
+    end else if ($test$plusargs("INVALID_CASE")) begin
+      @(negedge clk);
+      context_source = 4'd3;
+      context_destination = 4'd3;
+      context_source_base_addr = 32'h1000;
+      context_destination_base_addr = 32'h2000;
+      context_packet_count = MAX_PACKETS_PER_CONTEXT;
+      context_valid = 1'b1;
+      @(posedge clk);
+      if (!context_ready)
+        $fatal(1, "invalid command did not handshake structurally");
+      @(negedge clk);
+      context_valid = 1'b0;
+      if (!protocol_error)
+        $fatal(1, "invalid local command did not set protocol_error");
+      @(negedge clk);
+      context_source = 4'd1;
+      context_destination = 4'd2;
+      context_source_base_addr = 32'h3000;
+      context_destination_base_addr = 32'h4000;
+      context_packet_count = MAX_PACKETS_PER_CONTEXT;
+      context_valid = 1'b1;
+      @(posedge clk);
+      if (context_ready)
+        $fatal(1, "engine accepted a command after protocol_error");
+      @(negedge clk);
+      context_valid = 1'b0;
+      $display("PASS engine invalid_command_fail_closed");
+      $finish;
+    end else begin
+      for (wave_i = 0; wave_i < 8; wave_i = wave_i + 1) begin
+        if (wave_i != 4)
+          for (lane_i = 0; lane_i < 16; lane_i = lane_i + 1)
+            if (submitted_contexts < TEST_CONTEXT_COUNT)
+              submit_context(wave_i, lane_i);
+      end
+      wait (completion_count == TEST_CONTEXT_COUNT);
+      repeat (20) @(negedge clk);
+      if (command_count != TEST_CONTEXT_COUNT ||
+          tx_descriptor_count != expected_descriptor_count ||
+          rx_descriptor_count != expected_descriptor_count ||
+          write_count != expected_flit_count ||
+          completion_count != TEST_CONTEXT_COUNT ||
+          ((TEST_CONTEXT_COUNT >= 16) &&
+           (descriptor_backpressure == 0 || held_completion_checks == 0)) || protocol_error ||
+          (TEST_CONTEXT_COUNT >= 16 &&
+           (max_tx_valid_per_cycle < 2 || max_rx_valid_per_cycle < 2)))
+        $fatal(1,
+          "engine mismatch commands=%0d tx=%0d rx=%0d writes=%0d completions=%0d bp=%0d holds=%0d max_tx_valid=%0d max_rx_valid=%0d max_tx_fire=%0d max_rx_fire=%0d error=%0d",
+          command_count, tx_descriptor_count, rx_descriptor_count, write_count,
+          completion_count, descriptor_backpressure, held_completion_checks,
+          max_tx_valid_per_cycle, max_rx_valid_per_cycle,
+          max_tx_descriptors_per_cycle, max_rx_descriptors_per_cycle, protocol_error);
+      $display("PASS engine contexts=%0d descriptors=%0d flits=%0d", command_count,
+        tx_descriptor_count, write_count);
+      $finish;
+    end
+  end
+
+  initial begin
+    #100000000;
+    $fatal(1, "engine simulation timeout");
+  end
+endmodule

--- a/tests/test_attention_shared_sram_k_round_scheduler_ppa_harness.py
+++ b/tests/test_attention_shared_sram_k_round_scheduler_ppa_harness.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from npu.rtlgen.gen_attention_shared_sram_k_round_scheduler_ppa_harness import generate
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOP_NAME = "attention_shared_sram_k_round_scheduler_b17_w17"
+CONFIG_PATH = REPO_ROOT / "runs/designs/npu_blocks" / TOP_NAME / "config.json"
+
+
+def _tool(name: str) -> str | None:
+    return shutil.which(name) or (
+        f"/oss-cad-suite/bin/{name}" if Path(f"/oss-cad-suite/bin/{name}").exists() else None
+    )
+
+
+def test_generator_manifest_and_rtl_compile(tmp_path: Path) -> None:
+    config = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    generate(config, tmp_path)
+    manifest = json.loads(
+        (tmp_path / "attention_shared_sram_k_round_scheduler_ppa_harness_manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert manifest["top_name"] == TOP_NAME
+    assert manifest["window_storage_bits"] == 2 * 17 * 1024
+    assert manifest["compute_beats_per_command"] == 1024
+    assert manifest["full_capacity_macro_area_included"] is False
+    assert manifest["activity_checksum_is_equivalence_proof"] is False
+    assert manifest["synthetic_response_profile"] == "metadata_lane_replicated_v1"
+    assert manifest["synthetic_response_generator_is_dut"] is False
+    assert manifest["narrow_io_harness_overhead_included"] is True
+    rtl = (tmp_path / "top.v").read_text(encoding="utf-8")
+    assert "build_word = {16{{lane ^ 32'ha5a5_5a5a, lane}}};" in rtl
+    assert "32'h9e37_79b9 *" not in rtl
+
+    if _tool("iverilog") is not None:
+        subprocess.run(
+            [_tool("iverilog"), "-g2012", "-s", TOP_NAME, "-o", str(tmp_path / "top.vvp"), str(tmp_path / "top.v")],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+
+@pytest.mark.skipif(_tool("iverilog") is None or _tool("vvp") is None, reason="iverilog/vvp unavailable")
+def test_generated_harness_completes_full_checked_schedule(tmp_path: Path) -> None:
+    config = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    generate(config, tmp_path)
+    tb = f"""`timescale 1ns/1ps
+module tb;
+  reg clk = 0, rst_n = 0, start = 0;
+  wire done, protocol_error;
+  wire [31:0] activity_checksum, cycle_count;
+  wire [31:0] bank_request_count, bank_response_count, compute_beat_count;
+  {TOP_NAME} dut(
+    .clk(clk), .rst_n(rst_n), .start(start), .seed(32'h12345678),
+    .done(done), .activity_checksum(activity_checksum), .cycle_count(cycle_count),
+    .bank_request_count(bank_request_count), .bank_response_count(bank_response_count),
+    .compute_beat_count(compute_beat_count), .protocol_error(protocol_error));
+  always #5 clk = ~clk;
+  initial begin
+    repeat (3) @(negedge clk); rst_n = 1; start = 1;
+    @(negedge clk); start = 0;
+    wait(done); @(posedge clk);
+    if (protocol_error || bank_request_count != 1024 ||
+        bank_response_count != 1024 || compute_beat_count != 1024)
+      $fatal(1, "harness contract failed");
+    $display("PASS harness cycles=%0d checksum=%h", cycle_count, activity_checksum);
+    $finish;
+  end
+  initial begin #300000; $fatal(1, "timeout"); end
+endmodule
+"""
+    (tmp_path / "tb.sv").write_text(tb, encoding="utf-8")
+    sim = tmp_path / "harness.vvp"
+    subprocess.run(
+        [_tool("iverilog"), "-g2012", "-s", "tb", "-o", str(sim), str(tmp_path / "top.v"), str(tmp_path / "tb.sv")],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    run = subprocess.run(
+        [_tool("vvp"), str(sim)], cwd=REPO_ROOT, check=True, capture_output=True, text=True, timeout=30
+    )
+    assert "PASS harness" in run.stdout

--- a/tests/test_attention_shared_sram_k_round_scheduler_rtl.py
+++ b/tests/test_attention_shared_sram_k_round_scheduler_rtl.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from npu.sim.perf.attention_shared_sram_k_round_scheduler import (
+    SharedSramKRoundScheduler,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RTL = REPO_ROOT / "npu/sim/rtl/attention_shared_sram_k_round_scheduler.sv"
+BANK_RTL = REPO_ROOT / "npu/sim/rtl/attention_shared_sram_k_round_bank.sv"
+TB = REPO_ROOT / "tests/attention_shared_sram_k_round_scheduler_tb.sv"
+
+
+def _tool(name: str) -> str | None:
+    return shutil.which(name) or (
+        f"/oss-cad-suite/bin/{name}" if Path(f"/oss-cad-suite/bin/{name}").exists() else None
+    )
+
+
+pytestmark = pytest.mark.skipif(
+    _tool("iverilog") is None or _tool("vvp") is None,
+    reason="iverilog/vvp unavailable",
+)
+
+
+def _run(tmp_path: Path, *plusargs: str) -> subprocess.CompletedProcess[str]:
+    sim = tmp_path / "k-round.vvp"
+    subprocess.run(
+        [
+            _tool("iverilog"),
+            "-g2012",
+            "-s",
+            "attention_shared_sram_k_round_scheduler_tb",
+            "-o",
+            str(sim),
+            str(BANK_RTL),
+            str(RTL),
+            str(TB),
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return subprocess.run(
+        [_tool("vvp"), str(sim), *plusargs],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_ideal_round_scheduler_preserves_exact_data_and_order(tmp_path: Path) -> None:
+    result = _run(tmp_path)
+    assert "PASS k_round backpressure=0 requests=1024 responses=1024 compute=1024" in result.stdout
+    assert "max_compute_interval=1" in result.stdout
+
+    observed = [
+        tuple(int(value) for value in match.groups())
+        for match in re.finditer(
+            r"TRACE round=(\d+) first_req=(\d+) compute_start=(\d+) compute_end=(\d+)",
+            result.stdout,
+        )
+    ]
+    reference = SharedSramKRoundScheduler(response_latency=2).run().round_traces
+    assert len(observed) == len(reference) == 64
+
+    # Simulator reset/command setup adds a constant origin only.  Relative
+    # compute timing must match the executable performance model exactly.
+    rtl_origin = observed[0][2]
+    model_origin = reference[0].compute_start_cycle
+    for row, expected in zip(observed, reference):
+        linear_round, _first_req, compute_start, compute_end = row
+        assert linear_round == expected.linear_round
+        assert compute_start - rtl_origin == expected.compute_start_cycle - model_origin
+        assert compute_end - rtl_origin == expected.compute_end_cycle - model_origin
+
+
+def test_round_scheduler_handles_bank_and_compute_backpressure(tmp_path: Path) -> None:
+    result = _run(tmp_path, "+BACKPRESSURE")
+    assert "PASS k_round backpressure=1 requests=1024 responses=1024 compute=1024" in result.stdout
+    assert "request_stalls=" in result.stdout
+    assert "compute_stalls=" in result.stdout
+
+
+def test_round_scheduler_rejects_malformed_response_metadata(tmp_path: Path) -> None:
+    result = _run(tmp_path, "+MALFORMED")
+    assert "PASS k_round malformed_response" in result.stdout
+
+
+def test_round_rtl_has_bounded_storage_and_narrow_compute_boundary() -> None:
+    rtl = BANK_RTL.read_text(encoding="utf-8") + RTL.read_text(encoding="utf-8")
+    assert "module attention_shared_sram_k_round_bank" in rtl
+    assert "reg [1023:0] buffer_mem0" in rtl
+    assert "reg [1023:0] buffer_mem1" in rtl
+    assert "output wire [(BANKS*64)-1:0] compute_k_beats" in rtl
+    assert "output wire [BANKS-1:0] compute_word_valid" in rtl
+    assert '(* keep = "true" *) reg [1023:0] buffer_mem0' in rtl
+    assert '(* keep = "true" *) reg [1023:0] buffer_mem1' in rtl
+    assert "response_batch_error" in rtl

--- a/tests/test_attention_shared_sram_k_window_scheduler_rtl.py
+++ b/tests/test_attention_shared_sram_k_window_scheduler_rtl.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import re
+from pathlib import Path
+
+import pytest
+
+from npu.sim.perf.attention_shared_sram_k_window_scheduler import (
+    SharedSramKWindowScheduler,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RTL = REPO_ROOT / "npu/sim/rtl/attention_shared_sram_k_window_scheduler.sv"
+TB = REPO_ROOT / "tests/attention_shared_sram_k_window_scheduler_tb.sv"
+
+
+def _tool(name: str) -> str | None:
+    return shutil.which(name) or (
+        f"/oss-cad-suite/bin/{name}" if Path(f"/oss-cad-suite/bin/{name}").exists() else None
+    )
+
+
+pytestmark = pytest.mark.skipif(
+    _tool("iverilog") is None or _tool("vvp") is None,
+    reason="iverilog/vvp unavailable",
+)
+
+
+def _run(tmp_path: Path, *plusargs: str) -> subprocess.CompletedProcess[str]:
+    sim = tmp_path / "k-window.vvp"
+    subprocess.run(
+        [
+            _tool("iverilog"),
+            "-g2012",
+            "-s",
+            "attention_shared_sram_k_window_scheduler_tb",
+            "-o",
+            str(sim),
+            str(RTL),
+            str(TB),
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return subprocess.run(
+        [_tool("vvp"), str(sim), *plusargs],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_ideal_17_bank_double_buffer_sustains_compute_after_fill(tmp_path: Path) -> None:
+    result = _run(tmp_path)
+    assert "PASS k_window backpressure=0 requests=1024 responses=1024 compute=128" in result.stdout
+    assert "max_compute_interval=1" in result.stdout
+    observed = [
+        tuple(int(value) for value in match.groups())
+        for match in re.finditer(
+            r"TRACE group=(\d+) first_req=(\d+) last_req=(\d+) "
+            r"compute_start=(\d+) compute_end=(\d+)",
+            result.stdout,
+        )
+    ]
+    reference = SharedSramKWindowScheduler(response_latency=2).run().group_traces
+    assert len(observed) == len(reference)
+    rtl_origin = observed[0][1]
+    for row, expected in zip(observed, reference):
+        group, first_req, last_req, compute_start, compute_end = row
+        assert group == expected.group_index
+        assert last_req - first_req + 1 == len(expected.issue_cycles)
+        assert compute_start - rtl_origin == expected.compute_start_cycle
+        assert compute_end - rtl_origin == expected.compute_end_cycle
+
+
+def test_independent_bank_and_compute_backpressure_preserve_exact_data(tmp_path: Path) -> None:
+    result = _run(tmp_path, "+BACKPRESSURE")
+    assert "PASS k_window backpressure=1 requests=1024 responses=1024 compute=128" in result.stdout
+    assert "request_stalls=" in result.stdout
+    assert "compute_stalls=" in result.stdout
+
+
+def test_malformed_response_metadata_fails_closed(tmp_path: Path) -> None:
+    result = _run(tmp_path, "+MALFORMED")
+    assert "PASS k_window malformed_response" in result.stdout
+
+
+def test_rtl_has_two_concrete_16kib_windows_and_wide_compute_boundary() -> None:
+    rtl = RTL.read_text(encoding="utf-8")
+    assert "reg [1023:0] buffer_mem [0:(2*WORDS_PER_GROUP)-1]" in rtl
+    assert "output wire [(WORDS_PER_GROUP*64)-1:0] compute_k_beats" in rtl
+    assert "response_batch_error" in rtl
+    assert "issued_bitmap_q" in rtl

--- a/tests/test_attention_shared_sram_read_group_adapter.py
+++ b/tests/test_attention_shared_sram_read_group_adapter.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RTL = REPO_ROOT / "npu/sim/rtl/attention_shared_sram_read_group_adapter.sv"
+TB = REPO_ROOT / "tests/attention_shared_sram_read_group_adapter_tb.sv"
+
+
+def _tool(name: str) -> str | None:
+    return shutil.which(name) or (
+        f"/oss-cad-suite/bin/{name}" if Path(f"/oss-cad-suite/bin/{name}").exists() else None
+    )
+
+
+def _run(
+    tmp_path: Path,
+    *,
+    beat_w: int = 256,
+    group_slots: int = 2,
+    test_groups: int = 4,
+    plusargs: tuple[str, ...] = (),
+) -> subprocess.CompletedProcess[str]:
+    sim = tmp_path / f"adapter-{beat_w}-{group_slots}.vvp"
+    subprocess.run(
+        [
+            _tool("iverilog"),
+            "-g2012",
+            "-s",
+            "attention_shared_sram_read_group_adapter_tb",
+            f"-Pattention_shared_sram_read_group_adapter_tb.BEAT_W={beat_w}",
+            f"-Pattention_shared_sram_read_group_adapter_tb.GROUP_SLOTS={group_slots}",
+            f"-Pattention_shared_sram_read_group_adapter_tb.TEST_GROUPS={test_groups}",
+            "-o",
+            str(sim),
+            str(RTL),
+            str(TB),
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return subprocess.run(
+        [_tool("vvp"), str(sim), *plusargs],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+pytestmark = pytest.mark.skipif(
+    _tool("iverilog") is None or _tool("vvp") is None,
+    reason="iverilog/vvp unavailable",
+)
+
+
+def test_default_256b_depth2_streams_one_response_per_cycle(tmp_path: Path) -> None:
+    run = _run(tmp_path, beat_w=256, group_slots=2, test_groups=2, plusargs=("+STEADY",))
+    assert "PASS adapter BEAT_W=256 GROUP_SLOTS=2 requests=8 macro_reads=2 responses=8" in run.stdout
+    assert "steady_interval=1" in run.stdout
+    assert "request_stalls=" in run.stdout
+
+
+def test_locality_aware_512b_depth2_streams_one_response_per_cycle(tmp_path: Path) -> None:
+    run = _run(tmp_path, beat_w=512, group_slots=2, test_groups=2, plusargs=("+STEADY",))
+    assert "PASS adapter BEAT_W=512 GROUP_SLOTS=2 requests=4 macro_reads=2 responses=4" in run.stdout
+    assert "steady_interval=1" in run.stdout
+
+
+def test_depth1_serial_comparison_preserves_exact_access_ratio(tmp_path: Path) -> None:
+    run = _run(tmp_path, beat_w=256, group_slots=1, plusargs=("+STEADY",))
+    assert "PASS adapter BEAT_W=256 GROUP_SLOTS=1 requests=16 macro_reads=4 responses=16" in run.stdout
+
+
+def test_depth1_512b_comparison_preserves_exact_access_ratio(tmp_path: Path) -> None:
+    run = _run(tmp_path, beat_w=512, group_slots=1)
+    assert "PASS adapter BEAT_W=512 GROUP_SLOTS=1 requests=8 macro_reads=4 responses=8" in run.stdout
+
+
+def test_nonsequential_request_fails_closed(tmp_path: Path) -> None:
+    run = _run(tmp_path, plusargs=("+MALFORMED",))
+    assert "PASS adapter malformed_sequence BEAT_W=256" in run.stdout
+
+
+def test_macro_response_without_request_fails_closed(tmp_path: Path) -> None:
+    run = _run(tmp_path, plusargs=("+ORPHAN",))
+    assert "PASS adapter orphan_response BEAT_W=256" in run.stdout
+
+
+def test_invalid_macro_metadata_fails_closed(tmp_path: Path) -> None:
+    run = _run(tmp_path, plusargs=("+INVALID_META",))
+    assert "PASS adapter invalid_metadata BEAT_W=256" in run.stdout
+
+
+def test_depth2_multiple_consecutive_groups_and_backpressure(tmp_path: Path) -> None:
+    run = _run(tmp_path, beat_w=512, group_slots=2, test_groups=4)
+    assert "PASS adapter BEAT_W=512 GROUP_SLOTS=2 requests=8 macro_reads=4 responses=8" in run.stdout
+    assert "request_stalls=" in run.stdout
+    assert "response_stalls=" in run.stdout
+
+
+def test_256b_multiple_consecutive_groups_and_backpressure(tmp_path: Path) -> None:
+    run = _run(tmp_path, beat_w=256, group_slots=2, test_groups=4)
+    assert "PASS adapter BEAT_W=256 GROUP_SLOTS=2 requests=16 macro_reads=4 responses=16" in run.stdout
+    assert "request_stalls=" in run.stdout
+    assert "response_stalls=" in run.stdout

--- a/tests/test_attention_shared_sram_read_group_adapter_ppa_harness.py
+++ b/tests/test_attention_shared_sram_read_group_adapter_ppa_harness.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from npu.rtlgen.gen_attention_shared_sram_read_group_adapter_ppa_harness import generate
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONFIGS = (
+    (256, 1),
+    (256, 2),
+    (512, 1),
+    (512, 2),
+)
+
+
+def _tool(name: str) -> str | None:
+    return shutil.which(name) or (
+        f"/oss-cad-suite/bin/{name}" if Path(f"/oss-cad-suite/bin/{name}").exists() else None
+    )
+
+
+@pytest.mark.parametrize(("beat_width", "group_slots"), CONFIGS)
+def test_generator_manifest_and_rtl_compile(tmp_path: Path, beat_width: int, group_slots: int) -> None:
+    top_name = f"attention_shared_sram_read_group_adapter_w{beat_width}_s{group_slots}"
+    config_path = REPO_ROOT / "runs/designs/npu_blocks" / top_name / "config.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    generate(config, tmp_path)
+    manifest = json.loads(
+        (tmp_path / "attention_shared_sram_read_group_adapter_ppa_harness_manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert manifest["top_name"] == top_name
+    assert manifest["beat_width"] == beat_width
+    assert manifest["group_slots"] == group_slots
+    assert manifest["segments_per_macro_read"] == 1024 // beat_width
+    assert manifest["buffer_payload_bits"] == 1024 * group_slots
+    assert manifest["payload_reset_required"] is False
+    assert manifest["full_capacity_macro_area_included"] is False
+    assert manifest["synthetic_response_profile"] == "metadata_lane_replicated_v1"
+    assert manifest["synthetic_response_generator_is_dut"] is False
+    assert manifest["narrow_io_harness_overhead_included"] is True
+    assert manifest["response_bus_retention"] == "kept_full_bus_endpoint_lane_fold_v1"
+    rtl = (tmp_path / "top.v").read_text(encoding="utf-8")
+    assert '(* keep = "true" *) reg [MACRO_W-1:0] slot_data' in rtl
+    assert "slot_data[reset_i] <=" not in rtl
+    assert "build_macro_word = {32{lane}};" in rtl
+    assert '(* keep = "true" *) wire [BEAT_W-1:0] rsp_data;' in rtl
+    assert "fold_beat = value[31:0] ^ value[BEAT_W-1 -: 32];" in rtl
+    assert "32'h9e37_79b9 *" not in rtl
+
+    if _tool("iverilog") is not None:
+        subprocess.run(
+            [_tool("iverilog"), "-g2012", "-s", top_name, "-o", str(tmp_path / "top.vvp"), str(tmp_path / "top.v")],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+
+@pytest.mark.skipif(_tool("iverilog") is None or _tool("vvp") is None, reason="iverilog/vvp unavailable")
+def test_generated_harness_completes_and_proves_four_to_one_access_reduction(tmp_path: Path) -> None:
+    top_name = "attention_shared_sram_read_group_adapter_w256_s2"
+    config = json.loads(
+        (REPO_ROOT / "runs/designs/npu_blocks" / top_name / "config.json").read_text(encoding="utf-8")
+    )
+    generate(config, tmp_path)
+    tb = f"""`timescale 1ns/1ps
+module tb;
+  reg clk = 0, rst_n = 0, start = 0;
+  wire done, protocol_error, access_reduction_proven;
+  wire [31:0] folded_result, cycle_count, beat_request_count, macro_read_count, beat_response_count;
+  {top_name} dut(
+    .clk(clk), .rst_n(rst_n), .start(start), .seed(32'h12345678),
+    .done(done), .folded_result(folded_result), .cycle_count(cycle_count),
+    .beat_request_count(beat_request_count), .macro_read_count(macro_read_count),
+    .beat_response_count(beat_response_count), .protocol_error(protocol_error),
+    .access_reduction_proven(access_reduction_proven));
+  always #5 clk = ~clk;
+  initial begin
+    repeat (3) @(negedge clk); rst_n = 1; start = 1;
+    @(negedge clk); start = 0;
+    wait(done); @(posedge clk);
+    if (protocol_error || !access_reduction_proven || beat_request_count != 256 ||
+        macro_read_count != 64 || beat_response_count != 256) $fatal(1, "harness contract failed");
+    $display("PASS harness cycles=%0d fold=%h", cycle_count, folded_result);
+    $finish;
+  end
+  initial begin #200000; $fatal(1, "timeout"); end
+endmodule
+"""
+    (tmp_path / "tb.sv").write_text(tb, encoding="utf-8")
+    sim = tmp_path / "harness.vvp"
+    subprocess.run(
+        [_tool("iverilog"), "-g2012", "-s", "tb", "-o", str(sim), str(tmp_path / "top.v"), str(tmp_path / "tb.sv")],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    run = subprocess.run(
+        [_tool("vvp"), str(sim)],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert "PASS harness" in run.stdout

--- a/tests/test_attention_shared_stream_context_admission.py
+++ b/tests/test_attention_shared_stream_context_admission.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RTL = REPO_ROOT / "npu/sim/rtl/attention_shared_stream_context_admission.sv"
+TB = REPO_ROOT / "tests/attention_shared_stream_context_admission_tb.sv"
+
+
+def _tool(name: str) -> str | None:
+    return shutil.which(name) or (
+        f"/oss-cad-suite/bin/{name}" if Path(f"/oss-cad-suite/bin/{name}").exists() else None
+    )
+
+
+@pytest.mark.skipif(_tool("iverilog") is None or _tool("vvp") is None, reason="iverilog/vvp unavailable")
+def test_shared_stream_admission_round_robin_and_metadata(tmp_path: Path) -> None:
+    sim = tmp_path / "admission.vvp"
+    subprocess.run(
+        [_tool("iverilog"), "-g2012", "-s", "attention_shared_stream_context_admission_tb",
+         "-o", str(sim), str(RTL), str(TB)],
+        cwd=REPO_ROOT, check=True, capture_output=True, text=True,
+    )
+    run = subprocess.run([_tool("vvp"), str(sim)], cwd=REPO_ROOT, check=True,
+                         capture_output=True, text=True, timeout=30)
+    assert "PASS admission contexts=112" in run.stdout
+
+
+@pytest.mark.skipif(_tool("iverilog") is None or _tool("vvp") is None, reason="iverilog/vvp unavailable")
+def test_shared_stream_admission_rejects_local_and_duplicate_events(tmp_path: Path) -> None:
+    sim = tmp_path / "admission-errors.vvp"
+    subprocess.run(
+        [_tool("iverilog"), "-g2012", "-s", "attention_shared_stream_context_admission_tb",
+         "-o", str(sim), str(RTL), str(TB)],
+        cwd=REPO_ROOT, check=True, capture_output=True, text=True,
+    )
+    run = subprocess.run([_tool("vvp"), str(sim), "+ERROR_CASE"], cwd=REPO_ROOT,
+                         check=True, capture_output=True, text=True, timeout=30)
+    assert "PASS admission invalid_event_fail_closed" in run.stdout
+
+
+@pytest.mark.skipif(_tool("iverilog") is None or _tool("vvp") is None, reason="iverilog/vvp unavailable")
+def test_shared_stream_admission_duplicate_event_fails_closed(tmp_path: Path) -> None:
+    sim = tmp_path / "admission-duplicate.vvp"
+    subprocess.run(
+        [_tool("iverilog"), "-g2012", "-s", "attention_shared_stream_context_admission_tb",
+         "-o", str(sim), str(RTL), str(TB)],
+        cwd=REPO_ROOT, check=True, capture_output=True, text=True,
+    )
+    run = subprocess.run([_tool("vvp"), str(sim), "+DUPLICATE_CASE"], cwd=REPO_ROOT,
+                         check=True, capture_output=True, text=True, timeout=30)
+    assert "PASS admission duplicate_event_fail_closed" in run.stdout
+
+
+@pytest.mark.skipif(_tool("iverilog") is None or _tool("vvp") is None, reason="iverilog/vvp unavailable")
+def test_shared_stream_admission_zero_expected_contexts_completes_without_transport(tmp_path: Path) -> None:
+    sim = tmp_path / "admission-empty.vvp"
+    subprocess.run(
+        [_tool("iverilog"), "-g2012", "-s", "attention_shared_stream_context_admission_tb",
+         "-o", str(sim), str(RTL), str(TB)],
+        cwd=REPO_ROOT, check=True, capture_output=True, text=True,
+    )
+    run = subprocess.run([_tool("vvp"), str(sim), "+EMPTY_CASE"], cwd=REPO_ROOT,
+                         check=True, capture_output=True, text=True, timeout=30)
+    assert "PASS admission empty_layer" in run.stdout

--- a/tests/test_attention_shared_stream_context_engine.py
+++ b/tests/test_attention_shared_stream_context_engine.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RTL_SOURCES = [
+    REPO_ROOT / "npu/sim/rtl/noc_ready_valid_fifo.sv",
+    REPO_ROOT / "npu/sim/rtl/noc_segmented_mesh_router.sv",
+    REPO_ROOT / "npu/sim/rtl/noc_segmented_mesh4x4.sv",
+    REPO_ROOT / "npu/sim/rtl/noc_sram_packet_endpoint.sv",
+    REPO_ROOT / "npu/sim/rtl/noc_sram_packet_mesh4x4.sv",
+    REPO_ROOT / "npu/sim/rtl/attention_shared_stream_context_engine.sv",
+]
+TB = REPO_ROOT / "tests/attention_shared_stream_context_engine_tb.sv"
+
+
+def _tool(name: str) -> str | None:
+    return shutil.which(name) or (
+        f"/oss-cad-suite/bin/{name}" if Path(f"/oss-cad-suite/bin/{name}").exists() else None
+    )
+
+
+def _run(
+    tmp_path: Path,
+    *,
+    max_packets: int = 68,
+    packet_index_w: int = 7,
+    context_count: int = 112,
+    plusargs: tuple[str, ...] = (),
+) -> subprocess.CompletedProcess[str]:
+    sim = tmp_path / ("engine-" + str(max_packets) + ".vvp")
+    subprocess.run(
+        [_tool("iverilog"), "-g2012", "-s", "attention_shared_stream_context_engine_tb",
+         f"-Pattention_shared_stream_context_engine_tb.MAX_PACKETS_PER_CONTEXT={max_packets}",
+         f"-Pattention_shared_stream_context_engine_tb.PACKET_INDEX_W={packet_index_w}",
+         f"-Pattention_shared_stream_context_engine_tb.TEST_CONTEXT_COUNT={context_count}",
+         "-o", str(sim), *[str(path) for path in RTL_SOURCES], str(TB)],
+        cwd=REPO_ROOT, check=True, capture_output=True, text=True,
+    )
+    return subprocess.run([_tool("vvp"), str(sim), *plusargs], cwd=REPO_ROOT,
+                          check=True, capture_output=True, text=True, timeout=180)
+
+
+@pytest.mark.skipif(
+    os.environ.get("RTLGEN_RUN_SLOW_RTL") != "1",
+    reason="set RTLGEN_RUN_SLOW_RTL=1 for the exhaustive 112-context replay",
+)
+@pytest.mark.skipif(_tool("iverilog") is None or _tool("vvp") is None, reason="iverilog/vvp unavailable")
+def test_shared_stream_engine_exact_112_contexts_and_parallel_descriptors(tmp_path: Path) -> None:
+    run = _run(tmp_path)
+    assert "PASS engine contexts=112 descriptors=7616 flits=60928" in run.stdout
+
+
+@pytest.mark.skipif(_tool("iverilog") is None or _tool("vvp") is None, reason="iverilog/vvp unavailable")
+def test_shared_stream_engine_reduced_packet_smoke(tmp_path: Path) -> None:
+    run = _run(tmp_path, max_packets=3, packet_index_w=2, context_count=2)
+    assert "PASS engine contexts=2 descriptors=6 flits=48" in run.stdout
+
+
+@pytest.mark.skipif(_tool("iverilog") is None or _tool("vvp") is None, reason="iverilog/vvp unavailable")
+def test_shared_stream_engine_latches_variable_packet_counts_including_over_256(tmp_path: Path) -> None:
+    run = _run(tmp_path, max_packets=300, packet_index_w=9, context_count=2,
+               plusargs=("+VARIABLE_COUNT_CASE",))
+    assert "PASS engine contexts=2 descriptors=260 flits=2080" in run.stdout
+
+
+@pytest.mark.skipif(_tool("iverilog") is None or _tool("vvp") is None, reason="iverilog/vvp unavailable")
+def test_shared_stream_engine_rejects_invalid_command_without_wedging(tmp_path: Path) -> None:
+    run = _run(tmp_path, plusargs=("+INVALID_CASE",))
+    assert "PASS engine invalid_command_fail_closed" in run.stdout
+
+
+@pytest.mark.skipif(_tool("iverilog") is None or _tool("vvp") is None, reason="iverilog/vvp unavailable")
+def test_shared_stream_engine_issues_sixteen_endpoint_disjoint_descriptors(tmp_path: Path) -> None:
+    run = _run(tmp_path, context_count=16, plusargs=("+PARALLEL_CASE",))
+    assert "PASS engine parallel_descriptors rx_lead=16 tx=16 rx=16" in run.stdout


### PR DESCRIPTION
## Summary

- define exact shared-stream tensor layout, addressing, and transport contracts
- embody context admission, stream execution, read-group adaptation, and K-round scheduling in RTL and the performance model
- add equivalence tests, SRAM residency and energy audits, guarded Nangate45 harnesses, and remote PPA requests
- identify remaining SRAM-macro and HBM/DRAM boundaries explicitly

## Impact

This replaces abstract shared-SRAM scheduling assumptions with cycle-level implementations suitable for equivalence checks and physical calibration. Routed PPA remains a remote evaluator task.

## Validation

- focused package regression: 106 passed, 1 skipped
- run metadata validation: passed
- git diff --check: clean
- bounded local Nangate45 mapping retained all architectural storage with zero structural errors

The full historical L1 task-generator suite still has five unrelated baseline failures caused by mutable status drift in older proposals. Scoped tests for the new requests pass.